### PR TITLE
fix: cli build for non bash shells. properly copy secp256k1.wasm

### DIFF
--- a/clients/cli/scripts/build-final.sh
+++ b/clients/cli/scripts/build-final.sh
@@ -34,9 +34,18 @@ fi
 
 # Copy missing WASM files
 echo -e "${YELLOW}📦 Copying WASM files...${NC}"
-if [ -f "../clients/extension/dist/assets/secp256k1.wasm" ]; then
-    cp "../clients/extension/dist/assets/secp256k1.wasm" "dist/"
-    cp "../clients/extension/dist/assets/secp256k1.wasm" "dist/wasm/"
+
+# Ensure dist/wasm directory exists
+mkdir -p "dist/wasm"
+
+# Copy secp256k1.wasm from tiny-secp256k1 package
+if [ -f "../node_modules/tiny-secp256k1/lib/secp256k1.wasm" ]; then
+    echo -e "${BLUE}  Copying secp256k1.wasm from tiny-secp256k1 package...${NC}"
+    cp "../node_modules/tiny-secp256k1/lib/secp256k1.wasm" "dist/"
+    cp "../node_modules/tiny-secp256k1/lib/secp256k1.wasm" "dist/wasm/"
+    echo -e "${GREEN}  ✓ secp256k1.wasm copied successfully${NC}"
+else
+    echo -e "${YELLOW}  ⚠️  Warning: secp256k1.wasm not found in node_modules/tiny-secp256k1/lib/${NC}"
 fi
 
 echo -e "${GREEN}✅ SDK built successfully ($(du -h dist/index.node.cjs | cut -f1))${NC}"

--- a/clients/cli/scripts/install.sh
+++ b/clients/cli/scripts/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Vultisig CLI Install Script
 set -e
@@ -10,78 +10,74 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-echo -e "${BLUE}🚀 Installing Vultisig CLI...${NC}"
-echo ""
+printf "${BLUE}🚀 Installing Vultisig CLI...${NC}\n"
+printf "\n"
 
 # Get the directory where this script is located
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 BIN_DIR="$PROJECT_DIR/bin"
 BINARY_PATH="$BIN_DIR/vultisig"
 
 # Check if binary exists
 if [ ! -f "$BINARY_PATH" ]; then
-    echo -e "${RED}❌ Binary not found at: $BINARY_PATH${NC}"
-    echo -e "${YELLOW}💡 Run ./scripts/build-final.sh first${NC}"
+    printf "${RED}❌ Binary not found at: $BINARY_PATH${NC}\n"
+    printf "${YELLOW}💡 Run ./scripts/build-final.sh first${NC}\n"
     exit 1
 fi
 
+# Make sure the binary is executable
+chmod +x "$BINARY_PATH"
+
 # Detect shell and config file
 SHELL_NAME=$(basename "$SHELL")
-if [ "$SHELL_NAME" = "zsh" ]; then
-    SHELL_CONFIG="$HOME/.zshrc"
-elif [ "$SHELL_NAME" = "bash" ]; then
-    if [ -f "$HOME/.bashrc" ]; then
-        SHELL_CONFIG="$HOME/.bashrc"
-    else
-        SHELL_CONFIG="$HOME/.bash_profile"
-    fi
-else
-    echo -e "${YELLOW}⚠️  Unknown shell: $SHELL_NAME${NC}"
-    echo -e "${YELLOW}💡 Please manually add this to your shell config:${NC}"
-    echo -e "   export PATH=\"$BIN_DIR:\$PATH\""
-    exit 1
-fi
+case "$SHELL_NAME" in
+    zsh)
+        SHELL_CONFIG="$HOME/.zshrc"
+        ;;
+    bash)
+        if [ -f "$HOME/.bashrc" ]; then
+            SHELL_CONFIG="$HOME/.bashrc"
+        else
+            SHELL_CONFIG="$HOME/.bash_profile"
+        fi
+        ;;
+    fish)
+        SHELL_CONFIG="$HOME/.config/fish/config.fish"
+        ;;
+    *)
+        printf "${YELLOW}⚠️  Unknown shell: $SHELL_NAME${NC}\n"
+        printf "${YELLOW}💡 Please manually add this to your shell config:${NC}\n"
+        printf "   export PATH=\"$BIN_DIR:\$PATH\"\n"
+        exit 1
+        ;;
+esac
 
 # Check if already in PATH
 PATH_EXPORT="export PATH=\"$BIN_DIR:\$PATH\""
 if grep -q "$BIN_DIR" "$SHELL_CONFIG" 2>/dev/null; then
-    echo -e "${GREEN}✅ Vultisig CLI is already in PATH${NC}"
-    echo -e "${BLUE}ℹ️  Found in: $SHELL_CONFIG${NC}"
+    printf "${GREEN}✅ Vultisig CLI is already in PATH${NC}\n"
+    printf "${BLUE}ℹ️  Found in: $SHELL_CONFIG${NC}\n"
 else
     # Add to PATH
-    echo -e "${YELLOW}📝 Adding Vultisig CLI to PATH...${NC}"
-    echo "" >> "$SHELL_CONFIG"
-    echo "# Vultisig CLI" >> "$SHELL_CONFIG"
-    echo "$PATH_EXPORT" >> "$SHELL_CONFIG"
-    echo -e "${GREEN}✅ Added to: $SHELL_CONFIG${NC}"
+    printf "${YELLOW}📝 Adding Vultisig CLI to PATH...${NC}\n"
+    printf "\n" >> "$SHELL_CONFIG"
+    printf "# Vultisig CLI\n" >> "$SHELL_CONFIG"
+    printf "%s\n" "$PATH_EXPORT" >> "$SHELL_CONFIG"
+    printf "${GREEN}✅ Added to: $SHELL_CONFIG${NC}\n"
 fi
 
-echo ""
-echo -e "${BLUE}📋 Verification:${NC}"
-
-# Source the config and test
-if [ -f "$SHELL_CONFIG" ]; then
-    source "$SHELL_CONFIG"
-fi
-
-if command -v vultisig &> /dev/null; then
-    vultisig --version
-    echo ""
-    echo -e "${GREEN}🎉 Installation successful!${NC}"
-    echo ""
-    echo -e "${BLUE}💡 To use immediately in this terminal:${NC}"
-    echo -e "   source $SHELL_CONFIG"
-    echo ""
-    echo -e "${BLUE}💡 Example usage:${NC}"
-    echo -e "   vultisig init         # Initialize directories"
-    echo -e "   vultisig create       # Create a new vault"
-    echo -e "   vultisig list         # List keyshare files"
-    echo -e "   vultisig run          # Start daemon"
-    echo -e "   vultisig address      # Show addresses"
-else
-    echo -e "${YELLOW}⚠️  Command not found yet in current shell${NC}"
-    echo -e "${BLUE}💡 Run this to activate:${NC}"
-    echo -e "   source $SHELL_CONFIG"
-    echo -e "${BLUE}💡 Or open a new terminal${NC}"
-fi
+printf "\n"
+printf "${GREEN}🎉 Installation successful!${NC}\n"
+printf "\n"
+printf "${BLUE}💡 To use Vultisig CLI in this terminal, run:${NC}\n"
+printf "   source $SHELL_CONFIG\n"
+printf "\n"
+printf "${BLUE}💡 Or open a new terminal window${NC}\n"
+printf "\n"
+printf "${BLUE}💡 Example usage:${NC}\n"
+printf "   vultisig init         # Initialize directories\n"
+printf "   vultisig create       # Create a new vault\n"
+printf "   vultisig list         # List keyshare files\n"
+printf "   vultisig run          # Start daemon\n"
+printf "   vultisig address      # Show addresses\n"

--- a/src/rollup.node.config.js
+++ b/src/rollup.node.config.js
@@ -16,50 +16,57 @@ const external = [
   'stream',
   'events',
   'os',
-  
+
   // Runtime globals that should not be bundled
   'fetch',
-  
+
   // External npm packages
   'axios',
-  'viem', 
+  'viem',
   'zod',
   '@trustwallet/wallet-core',
   '@solana/web3.js',
-  
+
   // React (not needed for CLI)
   'react',
   'react-dom',
   'react-i18next',
-  'i18next'
+  'i18next',
 ]
 
 const plugins = [
   // Handle JSON imports
   json(),
-  
+
   // Resolve modules
   resolve({
     preferBuiltins: true,
     browser: false,
     exportConditions: ['node', 'default'],
     // Don't skip workspace packages - we want to bundle them
-    skip: external
+    skip: external,
   }),
-  
+
   // Handle CommonJS modules
   commonjs({
     include: [/node_modules/, /\.\.\/core\//, /\.\.\/lib\//],
-    requireReturnsDefault: 'auto'
+    requireReturnsDefault: 'auto',
   }),
-  
+
   // TypeScript compilation
   typescript({
     tsconfig: './tsconfig.json',
     outputToFilesystem: true,
     exclude: ['**/*.test.*', '**/*.stories.*'],
     // Include workspace packages
-    include: ['**/*.ts', '**/*.tsx', '../core/**/*.ts', '../core/**/*.tsx', '../lib/**/*.ts', '../lib/**/*.tsx'],
+    include: [
+      '**/*.ts',
+      '**/*.tsx',
+      '../core/**/*.ts',
+      '../core/**/*.tsx',
+      '../lib/**/*.ts',
+      '../lib/**/*.tsx',
+    ],
     compilerOptions: {
       target: 'ES2020',
       module: 'ESNext',
@@ -73,31 +80,43 @@ const plugins = [
       baseUrl: '.',
       paths: {
         '@core/*': ['../core/*'],
-        '@lib/*': ['../lib/*']
-      }
-    }
-  })
+        '@lib/*': ['../lib/*'],
+      },
+    },
+  }),
 ]
 
 const wasmCopyPlugin = copy({
   targets: [
-    { 
-      src: '../lib/dkls/vs_wasm_bg.wasm', 
+    {
+      src: '../lib/dkls/vs_wasm_bg.wasm',
       dest: './dist/wasm/',
-      rename: 'dkls.wasm'
+      rename: 'dkls.wasm',
     },
-    { 
-      src: '../lib/schnorr/vs_schnorr_wasm_bg.wasm', 
+    {
+      src: '../lib/schnorr/vs_schnorr_wasm_bg.wasm',
       dest: './dist/wasm/',
-      rename: 'schnorr.wasm' 
+      rename: 'schnorr.wasm',
     },
     // Try to copy wallet-core WASM
-    { 
-      src: '../node_modules/@trustwallet/wallet-core/dist/lib/wallet-core.wasm', 
+    {
+      src: '../node_modules/@trustwallet/wallet-core/dist/lib/wallet-core.wasm',
       dest: './dist/wasm/',
-      rename: 'wallet-core.wasm'
-    }
-  ]
+      rename: 'wallet-core.wasm',
+    },
+    // Copy secp256k1 WASM from tiny-secp256k1
+    {
+      src: '../node_modules/tiny-secp256k1/lib/secp256k1.wasm',
+      dest: './dist/wasm/',
+      rename: 'secp256k1.wasm',
+    },
+    // Also copy to dist root for compatibility
+    {
+      src: '../node_modules/tiny-secp256k1/lib/secp256k1.wasm',
+      dest: './dist/',
+      rename: 'secp256k1.wasm',
+    },
+  ],
 })
 
 export default defineConfig([
@@ -110,7 +129,7 @@ export default defineConfig([
       sourcemap: false,
       exports: 'named',
       interop: 'auto',
-      inlineDynamicImports: true
+      inlineDynamicImports: true,
     },
     external,
     plugins: [...plugins, wasmCopyPlugin],
@@ -121,6 +140,6 @@ export default defineConfig([
       if (warning.code === 'UNRESOLVED_IMPORT') return
       if (warning.code === 'CIRCULAR_DEPENDENCY') return
       warn(warning)
-    }
-  }
+    },
+  },
 ])


### PR DESCRIPTION
 ## Summary

  This PR resolves critical issues with building and installing the Vultisig CLI when using shell environments other than
  bash, and fixes the WebAssembly module import for cryptographic operations.

  ## Changes

  - Shell compatibility: Migrated install script from bash-specific syntax to POSIX-compliant shell (#!/bin/sh), ensuring
  compatibility with zsh, dash, and other shells
  - Fixed secp256k1.wasm import: Updated build process to correctly copy the WASM file from node_modules/tiny-secp256k1/lib/
   instead of relying on the extension build artifacts, ensuring the cryptographic library loads properly at runtime
  - Improved error handling: Added proper directory creation and validation checks during the build process

  ## Why these changes are necessary

  1. Shell portability: The previous bash-specific syntax (echo -e, BASH_SOURCE) caused installation failures on systems
  using alternative shells as defaults (e.g., macOS with zsh, Ubuntu with dash)
  2. secp256k1.wasm fix: The WASM module is essential for Bitcoin/Ethereum cryptographic operations. The previous path was incorrect, causing runtime failures when the CLI attempted to perform signing operations. By sourcing it directly from the tiny-secp256k1 package, we ensure it's always available regardless of whether the extension has been built.

  Testing

  - ✅ Tested installation on zsh, bash, and sh shells
  - ✅ Verified WASM module loads correctly at runtime
  - ✅ Confirmed Bitcoin signing operations work as expected