### PR TITLE
feat: fix react app running

### DIFF
--- a/core/chain/chains/solana/client.ts
+++ b/core/chain/chains/solana/client.ts
@@ -1,6 +1,7 @@
 import { rootApiUrl } from '@core/config'
 import { memoize } from '@lib/utils/memoize'
-import { Connection } from '@solana/web3.js'
+import * as web3 from '@solana/web3.js'
+const { Connection } = web3
 
 export const solanaRpcUrl = `${rootApiUrl}/solana/`
 

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "isomorphic-fetch": "^3.0.0",
     "process": "^0.11.10",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -23,6 +23,13 @@ function App() {
           fastVault: 'https://api.vultisig.com/vault',
           messageRelay: 'https://api.vultisig.com/router',
         },
+        wasmConfig: {
+          wasmPaths: {
+            walletCore: '/wallet-core.wasm',
+            dkls: '/dkls.wasm',
+            schnorr: '/schnorr.wasm',
+          },
+        },
       })
   )
   const [initialized, setInitialized] = useState(false)

--- a/examples/react/vite.config.ts
+++ b/examples/react/vite.config.ts
@@ -25,12 +25,16 @@ export default defineConfig({
       '@core': path.resolve(__dirname, '../../core'),
       crypto: 'crypto-browserify',
       stream: 'stream-browserify',
+      'node:stream': 'stream-browserify',
+      'node:stream/web': 'stream-browserify',
       buffer: 'buffer',
       util: 'util',
       path: 'path-browserify',
       vm: 'vm-browserify',
       process: 'process/browser',
       events: 'events',
+      // Replace node-fetch with native fetch in browser
+      'node-fetch': 'isomorphic-fetch',
     },
   },
   esbuild: {
@@ -46,6 +50,11 @@ export default defineConfig({
       'events',
       'readable-stream',
       'string_decoder',
+      '@solana/web3.js',
     ],
+    exclude: ['node-fetch', 'fetch-blob'],
+    esbuildOptions: {
+      target: 'esnext',
+    },
   },
 })

--- a/src/core/mpc/lib/initialize.ts
+++ b/src/core/mpc/lib/initialize.ts
@@ -5,14 +5,14 @@ import { prefixErrorWith } from '../../../lib/utils/error/prefixErrorWith'
 import { transformError } from '../../../lib/utils/error/transformError'
 import { memoizeAsync } from '../../../lib/utils/memoizeAsync'
 
-const initialize: Record<SignatureAlgorithm, () => Promise<unknown>> = {
+const initialize: Record<SignatureAlgorithm, (path?: string) => Promise<unknown>> = {
   ecdsa: initializeDkls,
   eddsa: initializeSchnorr,
 }
 
-export const initializeMpcLib = memoizeAsync((algo: SignatureAlgorithm) =>
+export const initializeMpcLib = memoizeAsync((algo: SignatureAlgorithm, path?: string) =>
   transformError(
-    initialize[algo](),
+    initialize[algo](path),
     prefixErrorWith('Failed to initialize MPC lib')
   )
 )

--- a/src/wasm/WASMManager.ts
+++ b/src/wasm/WASMManager.ts
@@ -63,7 +63,7 @@ export class WASMManager {
    */
   private async initializeDkls(): Promise<void> {
     try {
-      await initializeMpcLib('ecdsa')
+      await initializeMpcLib('ecdsa', this.config?.wasmPaths?.dkls)
       this.dklsReady = true
     } catch (error) {
       throw new Error(`Failed to initialize DKLS WASM: ${error}`)
@@ -75,7 +75,7 @@ export class WASMManager {
    */
   private async initializeSchnorr(): Promise<void> {
     try {
-      await initializeMpcLib('eddsa')
+      await initializeMpcLib('eddsa', this.config?.wasmPaths?.schnorr)
       this.schnorrReady = true
     } catch (error) {
       throw new Error(`Failed to initialize Schnorr WASM: ${error}`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -10519,6 +10519,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"isomorphic-fetch@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "isomorphic-fetch@npm:3.0.0"
+  dependencies:
+    node-fetch: "npm:^2.6.1"
+    whatwg-fetch: "npm:^3.4.1"
+  checksum: 10c0/511b1135c6d18125a07de661091f5e7403b7640060355d2d704ce081e019bc1862da849482d079ce5e2559b8976d3de7709566063aec1b908369c0b98a2b075b
+  languageName: node
+  linkType: hard
+
 "isomorphic-timers-promises@npm:^1.0.1":
   version: 1.0.1
   resolution: "isomorphic-timers-promises@npm:1.0.1"
@@ -12031,7 +12041,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.6.12, node-fetch@npm:^2.7.0":
+"node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.12, node-fetch@npm:^2.7.0":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
   dependencies:
@@ -16018,6 +16028,7 @@ __metadata:
     buffer: "npm:^6.0.3"
     crypto-browserify: "npm:^3.12.0"
     events: "npm:^3.3.0"
+    isomorphic-fetch: "npm:^3.0.0"
     path-browserify: "npm:^1.0.1"
     process: "npm:^0.11.10"
     react: "npm:^19.0.0"
@@ -16159,6 +16170,13 @@ __metadata:
   version: 0.6.2
   resolution: "webpack-virtual-modules@npm:0.6.2"
   checksum: 10c0/5ffbddf0e84bf1562ff86cf6fcf039c74edf09d78358a6904a09bbd4484e8bb6812dc385fe14330b715031892dcd8423f7a88278b57c9f5002c84c2860179add
+  languageName: node
+  linkType: hard
+
+"whatwg-fetch@npm:^3.4.1":
+  version: 3.6.20
+  resolution: "whatwg-fetch@npm:3.6.20"
+  checksum: 10c0/fa972dd14091321d38f36a4d062298df58c2248393ef9e8b154493c347c62e2756e25be29c16277396046d6eaa4b11bd174f34e6403fff6aaca9fb30fa1ff46d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

  - Fixed React example build errors that occurred after adding
  Node.js environment support to the SDK
  - Resolved polyfill conflicts between Node.js modules and browser
  environment

  ## Problem

  After SDK changes to support CLI usage (Node.js environment), the
  React example app failed to build with:
  1. fetch-blob trying to import node:stream/web which doesn't exist
  in browser polyfills
  2. Solana web3.js Connection import incompatibility with browser
  builds

  ## Solution

  1. Stream polyfill fix:
    - Added isomorphic-fetch to replace node-fetch in browser builds
    - Aliased Node.js stream modules to browser-compatible polyfills
    - Excluded problematic Node-specific packages from optimization
  2. Solana import fix:
    - Changed from named import to namespace import with
  destructuring to handle browser/Node export differences

  ## Test plan

  - React dev server runs without errors (yarn run dev:react)
  - Production build completes successfully (yarn workspace 
  vultisig-sdk-react-example-2 build)
  - No regression in SDK functionality