### PR TITLE
chore: version packages (alpha)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -12,5 +12,7 @@
     "@lib/utils": "0.0.1",
     "@vultisig/sdk": "0.1.0"
   },
-  "changesets": []
+  "changesets": [
+    "fix-alpha-release"
+  ]
 }

--- a/clients/cli/CHANGELOG.md
+++ b/clients/cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @vultisig/cli
 
+## 0.1.1-alpha.0
+
+### Patch Changes
+
+- [`cc96f64`](https://github.com/vultisig/vultisig-sdk/commit/cc96f64622a651eb6156f279afbbfe0aa4219179) - fix: re-release as alpha (0.1.0 was accidentally published as stable)
+
+- Updated dependencies [[`cc96f64`](https://github.com/vultisig/vultisig-sdk/commit/cc96f64622a651eb6156f279afbbfe0aa4219179)]:
+  - @vultisig/sdk@0.1.1-alpha.0
+
 ## 0.1.0
 
 ### Patch Changes

--- a/clients/cli/package.json
+++ b/clients/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vultisig/cli",
-  "version": "0.1.0",
+  "version": "0.1.1-alpha.0",
   "description": "Command-line wallet for Vultisig - multi-chain MPC wallet management",
   "type": "module",
   "bin": {

--- a/examples/browser/CHANGELOG.md
+++ b/examples/browser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @vultisig/example-browser
 
+## 0.1.2-alpha.0
+
+### Patch Changes
+
+- Updated dependencies [[`cc96f64`](https://github.com/vultisig/vultisig-sdk/commit/cc96f64622a651eb6156f279afbbfe0aa4219179)]:
+  - @vultisig/sdk@0.1.1-alpha.0
+
 ## 0.1.1
 
 ### Patch Changes

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vultisig/example-browser",
-  "version": "0.1.1",
+  "version": "0.1.2-alpha.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vultisig/sdk
 
+## 0.1.1-alpha.0
+
+### Patch Changes
+
+- [`cc96f64`](https://github.com/vultisig/vultisig-sdk/commit/cc96f64622a651eb6156f279afbbfe0aa4219179) - fix: re-release as alpha (0.1.0 was accidentally published as stable)
+
 ## 0.1.0
 
 ### Patch Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vultisig/sdk",
-  "version": "0.1.0",
+  "version": "0.1.1-alpha.0",
   "description": "TypeScript SDK for secure multi-party computation and blockchain operations",
   "type": "module",
   "main": "dist/index.node.cjs",


### PR DESCRIPTION
## Summary
- Bump @vultisig/sdk to 0.1.1-alpha.1
- Bump @vultisig/cli to 0.1.1-alpha.1

Re-release as alpha after 0.1.0 was accidentally published as stable.