### PR TITLE
chore: version packages (fix CLI)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -13,6 +13,7 @@
     "@vultisig/sdk": "0.1.0"
   },
   "changesets": [
-    "fix-alpha-release"
+    "fix-alpha-release",
+    "fix-workspace-protocol"
   ]
 }

--- a/clients/cli/CHANGELOG.md
+++ b/clients/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vultisig/cli
 
+## 0.1.1-alpha.1
+
+### Patch Changes
+
+- [`0985a37`](https://github.com/vultisig/vultisig-sdk/commit/0985a375c6009e2550231d759e84b576454ce759) - fix: use workspace:^ for SDK dependency to resolve correctly when publishing
+
 ## 0.1.1-alpha.0
 
 ### Patch Changes

--- a/clients/cli/package.json
+++ b/clients/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vultisig/cli",
-  "version": "0.1.1-alpha.0",
+  "version": "0.1.1-alpha.1",
   "description": "Command-line wallet for Vultisig - multi-chain MPC wallet management",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump @vultisig/cli to 0.1.1-alpha.1

Fix workspace:^ resolution for SDK dependency.