### PR TITLE
chore: version packages (alpha)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -14,6 +14,7 @@
   },
   "changesets": [
     "fix-alpha-release",
+    "fix-publish-script",
     "fix-workspace-protocol"
   ]
 }

--- a/clients/cli/CHANGELOG.md
+++ b/clients/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vultisig/cli
 
+## 0.1.1-alpha.2
+
+### Patch Changes
+
+- [`9dcfb8b`](https://github.com/vultisig/vultisig-sdk/commit/9dcfb8b4b29de73b1301f791b50dc417a8f899f3) - fix: use yarn npm publish to properly resolve workspace protocols
+
 ## 0.1.1-alpha.1
 
 ### Patch Changes

--- a/clients/cli/package.json
+++ b/clients/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vultisig/cli",
-  "version": "0.1.1-alpha.1",
+  "version": "0.1.1-alpha.2",
   "description": "Command-line wallet for Vultisig - multi-chain MPC wallet management",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump @vultisig/cli to 0.1.1-alpha.2

Fix: Use yarn npm publish to resolve workspace protocols.