### PR TITLE
Add REPL-safe prompt utility and refactor CLI prompts

### DIFF
--- a/clients/cli/src/commands/settings.ts
+++ b/clients/cli/src/commands/settings.ts
@@ -4,9 +4,9 @@
 import type { FiatCurrency } from '@vultisig/sdk'
 import { Chain, fiatCurrencies, fiatCurrencyNameRecord } from '@vultisig/sdk'
 import chalk from 'chalk'
-import inquirer from 'inquirer'
 
 import type { CommandContext } from '../core'
+import { replPrompt } from '../interactive'
 import {
   createSpinner,
   error,
@@ -120,37 +120,39 @@ export async function executeAddressBook(
     let address = options.address
     let name = options.name
 
-    const prompts = []
+    // Prompt one at a time to avoid duplicate rendering issues
     if (!chain) {
-      prompts.push({
-        type: 'list',
-        name: 'chain',
-        message: 'Select chain:',
-        choices: Object.values(Chain),
-      })
+      const chainAnswer = await replPrompt([
+        {
+          type: 'list',
+          name: 'chain',
+          message: 'Select chain:',
+          choices: Object.values(Chain),
+        },
+      ])
+      chain = chainAnswer.chain
     }
     if (!address) {
-      prompts.push({
-        type: 'input',
-        name: 'address',
-        message: 'Enter address:',
-        validate: (input: string) => input.trim() !== '' || 'Address is required',
-      })
+      const addressAnswer = await replPrompt([
+        {
+          type: 'input',
+          name: 'address',
+          message: 'Enter address:',
+          validate: (input: string) => input.trim() !== '' || 'Address is required',
+        },
+      ])
+      address = addressAnswer.address?.trim()
     }
     if (!name) {
-      prompts.push({
-        type: 'input',
-        name: 'name',
-        message: 'Enter name/label:',
-        validate: (input: string) => input.trim() !== '' || 'Name is required',
-      })
-    }
-
-    if (prompts.length > 0) {
-      const answers = await inquirer.prompt(prompts)
-      chain = chain || answers.chain
-      address = address || answers.address?.trim()
-      name = name || answers.name?.trim()
+      const nameAnswer = await replPrompt([
+        {
+          type: 'input',
+          name: 'name',
+          message: 'Enter name/label:',
+          validate: (input: string) => input.trim() !== '' || 'Name is required',
+        },
+      ])
+      name = nameAnswer.name?.trim()
     }
 
     const spinner = createSpinner('Adding address to address book...')

--- a/clients/cli/src/core/password-manager.ts
+++ b/clients/cli/src/core/password-manager.ts
@@ -6,8 +6,7 @@
  * 2. VAULT_PASSWORD env var (single fallback password)
  * 3. Interactive prompt (if no env password found and not in silent/JSON mode)
  */
-import inquirer from 'inquirer'
-
+import { replPrompt } from '../interactive'
 import { isJsonOutput, isSilent } from '../lib/output'
 
 /**
@@ -63,7 +62,7 @@ export function getPasswordFromEnv(vaultId: string, vaultName?: string): string 
  */
 export async function promptForPassword(vaultName?: string, vaultId?: string): Promise<string> {
   const displayName = vaultName || vaultId || 'vault'
-  const { password } = await inquirer.prompt([
+  const { password } = await replPrompt([
     {
       type: 'password',
       name: 'password',

--- a/clients/cli/src/interactive/index.ts
+++ b/clients/cli/src/interactive/index.ts
@@ -3,6 +3,7 @@
  */
 export { createCompleter, findChainByName } from './completer'
 export { EventBuffer } from './event-buffer'
+export { isReplActive, registerReplServer, replPrompt, unregisterReplServer } from './repl-prompt'
 export { ShellSession } from './session'
 export { executeLock, executeStatus, executeUnlock, formatTimeRemaining, showHelp } from './shell-commands'
 export { createShellContext, ShellContext } from './shell-context'

--- a/clients/cli/src/interactive/repl-prompt.ts
+++ b/clients/cli/src/interactive/repl-prompt.ts
@@ -1,0 +1,125 @@
+/**
+ * REPL-Safe Prompt Utility
+ *
+ * Handles stdin conflicts between Node.js REPL and inquirer.
+ * When running in interactive mode, the REPL and inquirer both read from stdin.
+ * This utility completely disconnects the REPL from stdin during prompts,
+ * preventing "Unknown command" errors from stdin competition.
+ */
+import inquirer, { type Answers, type QuestionCollection } from 'inquirer'
+import * as readline from 'readline'
+import type * as repl from 'repl'
+
+// Singleton reference to the active REPL server
+let activeReplServer: repl.REPLServer | null = null
+
+// Store removed listeners to restore them later
+let storedLineListeners: ((...args: any[]) => void)[] = []
+let storedCloseListeners: ((...args: any[]) => void)[] = []
+
+/**
+ * Register the active REPL server for prompt coordination
+ */
+export function registerReplServer(server: repl.REPLServer): void {
+  activeReplServer = server
+}
+
+/**
+ * Unregister the REPL server (on shutdown)
+ */
+export function unregisterReplServer(): void {
+  activeReplServer = null
+}
+
+/**
+ * Check if we're in interactive REPL mode
+ */
+export function isReplActive(): boolean {
+  return activeReplServer !== null
+}
+
+/**
+ * Completely disconnect REPL from stdin before running a prompt
+ */
+function disconnectRepl(): void {
+  if (!activeReplServer) return
+
+  // Store and remove 'line' listeners (these process user input)
+  storedLineListeners = activeReplServer.listeners('line') as ((...args: any[]) => void)[]
+  activeReplServer.removeAllListeners('line')
+
+  // Store and remove 'close' listeners
+  storedCloseListeners = activeReplServer.listeners('close') as ((...args: any[]) => void)[]
+  activeReplServer.removeAllListeners('close')
+
+  // Pause the REPL
+  activeReplServer.pause()
+
+  // Disable raw mode so inquirer can control stdin
+  if (process.stdin.isTTY && (process.stdin as any).isRaw) {
+    process.stdin.setRawMode(false)
+  }
+}
+
+/**
+ * Reconnect REPL to stdin after a prompt completes
+ */
+function reconnectRepl(): void {
+  if (!activeReplServer) return
+
+  // Clear any leftover line from inquirer to prevent duplicate display
+  readline.clearLine(process.stdout, 0)
+  readline.cursorTo(process.stdout, 0)
+
+  // Restore raw mode for REPL
+  if (process.stdin.isTTY) {
+    process.stdin.setRawMode(true)
+  }
+
+  // Restore 'line' listeners
+  for (const listener of storedLineListeners) {
+    activeReplServer.on('line', listener)
+  }
+  storedLineListeners = []
+
+  // Restore 'close' listeners
+  for (const listener of storedCloseListeners) {
+    activeReplServer.on('close', listener)
+  }
+  storedCloseListeners = []
+
+  // Resume the REPL - don't call displayPrompt() here
+  // The command execution flow will handle showing the next prompt
+  activeReplServer.resume()
+}
+
+/**
+ * REPL-safe wrapper for inquirer.prompt
+ *
+ * Completely disconnects the REPL from stdin during prompts,
+ * preventing stdin conflicts that cause "Unknown command" errors.
+ *
+ * @param questions - Inquirer question configuration
+ * @returns Promise resolving to the answers
+ */
+export async function replPrompt<T extends Answers = Answers>(
+  questions: QuestionCollection<T>
+): Promise<T> {
+  const wasReplActive = isReplActive()
+
+  if (wasReplActive) {
+    disconnectRepl()
+  }
+
+  try {
+    const answers = await inquirer.prompt<T>(questions)
+    return answers
+  } finally {
+    if (wasReplActive) {
+      // Small delay to ensure inquirer has fully released stdin
+      await new Promise(resolve => setTimeout(resolve, 50))
+      reconnectRepl()
+    }
+  }
+}
+

--- a/clients/cli/src/interactive/session.ts
+++ b/clients/cli/src/interactive/session.ts
@@ -36,6 +36,7 @@ import {
 } from '../commands'
 import { createCompleter, findChainByName } from './completer'
 import { EventBuffer } from './event-buffer'
+import { registerReplServer, unregisterReplServer } from './repl-prompt'
 import { executeLock, executeStatus, executeUnlock, showHelp } from './shell-commands'
 import { createShellContext, ShellContext } from './shell-context'
 
@@ -91,6 +92,15 @@ export class ShellSession {
       terminal: true,
       useColors: true,
       completer: createCompleter(this.ctx),
+    })
+
+    // Register REPL server for prompt coordination
+    // This enables replPrompt() to pause/resume REPL input during prompts
+    registerReplServer(this.replServer)
+
+    // Unregister on exit
+    this.replServer.on('exit', () => {
+      unregisterReplServer()
     })
 
     // Setup REPL commands

--- a/clients/cli/src/interactive/shell-commands.ts
+++ b/clients/cli/src/interactive/shell-commands.ts
@@ -8,10 +8,10 @@
 import type { FiatCurrency } from '@vultisig/sdk'
 import chalk from 'chalk'
 import Table from 'cli-table3'
-import inquirer from 'inquirer'
 import ora from 'ora'
 
 import type { VaultStatus } from '../core/types'
+import { replPrompt } from './repl-prompt'
 import type { ShellContext } from './shell-context'
 
 /**
@@ -62,7 +62,7 @@ export async function executeUnlock(ctx: ShellContext): Promise<void> {
     return
   }
 
-  const { password } = await inquirer.prompt([
+  const { password } = await replPrompt([
     {
       type: 'password',
       name: 'password',

--- a/clients/cli/src/interactive/shell-context.ts
+++ b/clients/cli/src/interactive/shell-context.ts
@@ -7,10 +7,10 @@
  * - Lock/unlock support
  */
 import type { VaultBase, Vultisig } from '@vultisig/sdk'
-import inquirer from 'inquirer'
 
 import { BaseCommandContext, DEFAULT_PASSWORD_CACHE_TTL } from '../core/command-context'
 import { getPasswordFromEnv } from '../core/password-manager'
+import { replPrompt } from './repl-prompt'
 
 /**
  * Shell-specific implementation of CommandContext
@@ -82,7 +82,7 @@ export class ShellContext extends BaseCommandContext {
 
     // Prompt for password
     const displayName = vaultName || vaultId
-    const { password } = await inquirer.prompt([
+    const { password } = await replPrompt([
       {
         type: 'password',
         name: 'password',

--- a/clients/cli/src/ui.ts
+++ b/clients/cli/src/ui.ts
@@ -11,7 +11,8 @@
 import type { Balance, Chain, FiatCurrency, GasInfo, SwapQuoteResult, VaultBase } from '@vultisig/sdk'
 import { fiatCurrencyNameRecord, Vultisig } from '@vultisig/sdk'
 import chalk from 'chalk'
-import inquirer from 'inquirer'
+
+import { replPrompt } from './interactive'
 
 // Re-export types from core for backwards compatibility
 export type { PortfolioSummary, SendParams } from './core/types'
@@ -181,7 +182,7 @@ export function displayVaultsList(vaults: VaultBase[], activeVault: VaultBase | 
 // ============================================================================
 
 export async function confirmTransaction(): Promise<boolean> {
-  const { confirmed } = await inquirer.prompt([
+  const { confirmed } = await replPrompt([
     {
       type: 'confirm',
       name: 'confirmed',
@@ -193,7 +194,7 @@ export async function confirmTransaction(): Promise<boolean> {
 }
 
 export async function promptForPassword(message = 'Enter password:'): Promise<string> {
-  const { password } = await inquirer.prompt([
+  const { password } = await replPrompt([
     {
       type: 'password',
       name: 'password',
@@ -376,7 +377,7 @@ export function displaySwapChains(chains: readonly Chain[]): void {
 }
 
 export async function confirmSwap(): Promise<boolean> {
-  const { confirmed } = await inquirer.prompt([
+  const { confirmed } = await replPrompt([
     {
       type: 'confirm',
       name: 'confirmed',


### PR DESCRIPTION
Introduces a new repl-prompt utility to safely handle interactive prompts in REPL mode, preventing stdin conflicts. Refactors all CLI commands and UI components to use replPrompt instead of inquirer.prompt, ensuring compatibility with the interactive shell. Registers and unregisters the REPL server for prompt coordination in ShellSession.

## Description

Please include a summary of the change and which issue is fixed.

Fixes #<issue-number>

## Which feature is affected?

- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature - Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context
