### PR TITLE
Handle non-array input for chains in BalanceService

### DIFF
--- a/packages/sdk/src/vault/VaultBase.ts
+++ b/packages/sdk/src/vault/VaultBase.ts
@@ -842,7 +842,7 @@ export abstract class VaultBase extends UniversalEventEmitter<VaultEvents> {
    */
   async balances(chains?: Chain[], includeTokens = false): Promise<Record<string, Balance>> {
     const chainsToFetch = chains || this._userChains
-    return this.balanceService.getBalances(chainsToFetch, includeTokens)
+    return this.balanceService.getBalances({ chains: chainsToFetch, includeTokens })
   }
 
   /**
@@ -857,7 +857,7 @@ export abstract class VaultBase extends UniversalEventEmitter<VaultEvents> {
    */
   async updateBalances(chains?: Chain[], includeTokens = false): Promise<Record<string, Balance>> {
     const chainsToUpdate = chains || this._userChains
-    return this.balanceService.updateBalances(chainsToUpdate, includeTokens)
+    return this.balanceService.updateBalances({ chains: chainsToUpdate, includeTokens })
   }
 
   // ===== GAS ESTIMATION =====

--- a/packages/sdk/src/vault/services/BalanceService.ts
+++ b/packages/sdk/src/vault/services/BalanceService.ts
@@ -81,10 +81,15 @@ export class BalanceService {
   /**
    * Get balances for multiple chains
    */
-  async getBalances(chains: Chain[], includeTokens = false): Promise<Record<string, Balance>> {
+  async getBalances({
+    chains,
+    includeTokens = false,
+  }: {
+    chains: Chain | Chain[]
+    includeTokens?: boolean
+  }): Promise<Record<string, Balance>> {
     const result: Record<string, Balance> = {}
-
-    const chainsList = Array.isArray(chains) ? chains : [chains as unknown as Chain]
+    const chainsList = Array.isArray(chains) ? chains : [chains]
 
     for (const chain of chainsList) {
       try {
@@ -119,9 +124,16 @@ export class BalanceService {
   /**
    * Force refresh multiple balances
    */
-  async updateBalances(chains: Chain[], includeTokens = false): Promise<Record<string, Balance>> {
+  async updateBalances({
+    chains,
+    includeTokens = false,
+  }: {
+    chains: Chain | Chain[]
+    includeTokens?: boolean
+  }): Promise<Record<string, Balance>> {
+    const chainsList = Array.isArray(chains) ? chains : [chains]
+
     // Invalidate cache for all chains
-    const chainsList = Array.isArray(chains) ? chains : [chains as unknown as Chain]
     for (const chain of chainsList) {
       const key = `${chain.toLowerCase()}:native`
       await this.cacheService.invalidateScoped(key, CacheScope.BALANCE)
@@ -135,7 +147,7 @@ export class BalanceService {
       }
     }
 
-    return this.getBalances(chainsList, includeTokens)
+    return this.getBalances({ chains: chainsList, includeTokens })
   }
 
   /**


### PR DESCRIPTION
Updated getBalances and updateBalances methods to support both array and single Chain inputs by normalizing to an array. This improves robustness and prevents errors when a single chain is provided.

## Description

Please include a summary of the change and which issue is fixed.

Fixes #<issue-number>

## Which feature is affected?

- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature - Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Balance handling now accepts either a single chain or multiple chains uniformly, improving flexibility for balance retrieval and updates.
  * Consistent behavior when including token balances across fetch and refresh operations.

* **Refactor**
  * Streamlined input normalization and internal flow for balance retrieval/update to ensure consistent results and simpler integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->