### PR TITLE
fix(sdk): fix SecureVault relay signing for EdDSA chains

### DIFF
--- a/.changeset/fix-secure-vault-relay-signing.md
+++ b/.changeset/fix-secure-vault-relay-signing.md
@@ -1,0 +1,11 @@
+---
+"@vultisig/sdk": patch
+---
+
+fix(sdk): fix SecureVault relay signing for EdDSA chains
+
+- Fix QR payload to include full transaction details using `getJoinKeysignUrl` from core
+- Fix chainPath derivation using `getChainSigningInfo` adapter
+- Fix EdDSA signature format: use raw r||s (128 hex chars) instead of DER encoding
+
+Affected chains: Solana, Sui, Polkadot, TON, Cardano

--- a/packages/sdk/src/vault/SecureVault.ts
+++ b/packages/sdk/src/vault/SecureVault.ts
@@ -103,11 +103,14 @@ export class SecureVault extends VaultBase {
     // Ensure keyShares are loaded (will decrypt if encrypted)
     await this.ensureKeySharesLoaded()
 
+    // Get WalletCore for chain utilities
+    const walletCore = await this.wasmProvider.getWalletCore()
+
     // Create relay signing service
     const relaySigningService = new RelaySigningService()
 
     // Sign using relay service with event emission
-    const signature = await relaySigningService.signWithRelay(this.coreVault, payload, {
+    const signature = await relaySigningService.signWithRelay(this.coreVault, payload, walletCore, {
       signal: options.signal,
       onProgress: (step: SigningStep) => {
         this.emit('signingProgress', { step })
@@ -170,6 +173,9 @@ export class SecureVault extends VaultBase {
       // Ensure keyShares are loaded (will decrypt if encrypted)
       await this.ensureKeySharesLoaded()
 
+      // Get WalletCore for chain utilities
+      const walletCore = await this.wasmProvider.getWalletCore()
+
       // Create relay signing service
       const relaySigningService = new RelaySigningService()
 
@@ -180,6 +186,7 @@ export class SecureVault extends VaultBase {
           messageHashes: [messageHash],
           chain: options.chain,
         },
+        walletCore,
         {
           signal: signingOptions.signal,
           onProgress: (step: SigningStep) => {


### PR DESCRIPTION
- Use getJoinKeysignUrl from core for QR payload with full tx details
- Use getChainSigningInfo adapter for proper chainPath derivation
- Use formatSignature adapter for correct EdDSA signature format (r||s)

Fixes EdDSA signature length error (expected 128 hex, got 140) by using raw r||s format instead of DER encoding for EdDSA chains.

Affected chains: Solana, Sui, Polkadot, TON, Cardano

## Description

Please include a summary of the change and which issue is fixed.

Fixes #<issue-number>

## Which feature is affected?

- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature - Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SecureVault relay signing for EdDSA chains (Solana, Sui, Polkadot, TON, Cardano).
  * Updated EdDSA signature format to raw r||s encoding for improved compatibility.
  * Improved chain path derivation for accurate signing operations.

* **New Features**
  * Enhanced QR code payloads now include full transaction details for better relay signing support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->