### PR TITLE
Add repo standards (safety hooks, ISSUE_GUIDE, security tier)

### DIFF
--- a/.claude/hooks/block-dangerous.sh
+++ b/.claude/hooks/block-dangerous.sh
@@ -37,9 +37,8 @@ fi
 
 # ── Destructive git operations ─────────────────────────────────────────────
 DESTRUCTIVE_PATTERNS=(
-  "git push.*--force"
+  "git push.*--force[^-]"
   "git push.*-f "
-  "--force-with-lease"
   "--no-verify"
   "git reset --hard"
   "git checkout \."
@@ -67,7 +66,7 @@ SECRET_PATTERNS=(
   "\.key$"
   "\.p12$"
   "\.pfx$"
-  "keystore"
+  "\.keystore$"
   "\.jks$"
 )
 

--- a/.claude/hooks/block-dangerous.sh
+++ b/.claude/hooks/block-dangerous.sh
@@ -78,4 +78,11 @@ for pattern in "${SECRET_PATTERNS[@]}"; do
   fi
 done
 
+# ── Environment variable exposure ─────────────────────────────────
+if echo "$INPUT" | grep -qiE "\b(printenv|export -p)\b|echo.*(TOKEN|API_KEY|SECRET|PASSWORD|CREDENTIAL)|env\s*$|env\s*\|"; then
+  echo "BLOCKED: Environment variable exposure detected."
+  echo "Agents must not read or print secrets from the environment."
+  exit 2
+fi
+
 exit 0

--- a/.claude/hooks/block-dangerous.sh
+++ b/.claude/hooks/block-dangerous.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# PreToolUse hook: Block dangerous operations in Vultisig repos.
+
+INPUT="${1:-}"
+
+# ── Mainnet RPC endpoints ──────────────────────────────────────────────────
+MAINNET_PATTERNS=(
+  "mainnet.infura.io"
+  "eth-mainnet.g.alchemy.com"
+  "rpc.ankr.com/eth"
+  "api.etherscan.io"
+  "thornode.ninerealms.com"
+  "rpc.cosmos.network"
+  "api.solana.com"
+  "mainnet-beta"
+)
+
+for pattern in "${MAINNET_PATTERNS[@]}"; do
+  if echo "$INPUT" | grep -qi "$pattern"; then
+    echo "BLOCKED: Mainnet interaction detected (${pattern})."
+    echo "Agents must not interact with mainnet RPCs or contracts."
+    exit 2
+  fi
+done
+
+# ── Direct push to protected branches ─────────────────────────────────────
+if echo "$INPUT" | grep -qiE "git push.*(origin|upstream)?\s*(main|master)\b"; then
+  echo "BLOCKED: Direct push to main/master. Agents must work on branches and open PRs."
+  exit 2
+fi
+
+# ── PR merge (agents must never merge) ────────────────────────────────────
+if echo "$INPUT" | grep -qiE "gh pr merge|git merge (main|master)"; then
+  echo "BLOCKED: Agents must not merge PRs. Label 'agent:review' and let a human merge."
+  exit 2
+fi
+
+# ── Destructive git operations ─────────────────────────────────────────────
+DESTRUCTIVE_PATTERNS=(
+  "git push.*--force"
+  "git push.*-f "
+  "--force-with-lease"
+  "--no-verify"
+  "git reset --hard"
+  "git checkout \."
+  "git checkout -- \."
+  "git clean -f"
+  "git clean -fd"
+  "git branch -D"
+  "rm -rf"
+)
+
+for pattern in "${DESTRUCTIVE_PATTERNS[@]}"; do
+  if echo "$INPUT" | grep -qiE "$pattern"; then
+    echo "BLOCKED: Destructive operation detected (${pattern})."
+    exit 2
+  fi
+done
+
+# ── Secret/credential file edits ──────────────────────────────────────────
+SECRET_PATTERNS=(
+  "\.env$"
+  "\.env\."
+  "/secret"
+  "/credential"
+  "\.pem$"
+  "\.key$"
+  "\.p12$"
+  "\.pfx$"
+  "keystore"
+  "\.jks$"
+)
+
+for pattern in "${SECRET_PATTERNS[@]}"; do
+  if echo "$INPUT" | grep -qiE "$pattern"; then
+    echo "BLOCKED: Edit to sensitive file matching '${pattern}'."
+    echo "Agents must not modify secret/credential files."
+    exit 2
+  fi
+done
+
+exit 0

--- a/.claude/hooks/block-dangerous.sh
+++ b/.claude/hooks/block-dangerous.sh
@@ -37,8 +37,8 @@ fi
 
 # ── Destructive git operations ─────────────────────────────────────────────
 DESTRUCTIVE_PATTERNS=(
-  "git push.*--force[^-]"
-  "git push.*-f "
+  "git push.*--force([^-]|$)"
+  "git push.*-f( |$)"
   "--no-verify"
   "git reset --hard"
   "git checkout \."
@@ -62,11 +62,13 @@ SECRET_PATTERNS=(
   "\.env\."
   "/secret"
   "/credential"
+  "credentials\."
+  "secret\."
+  "keystore"
   "\.pem$"
   "\.key$"
   "\.p12$"
   "\.pfx$"
-  "\.keystore$"
   "\.jks$"
 )
 

--- a/.claude/hooks/on-failure-notify.sh
+++ b/.claude/hooks/on-failure-notify.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# PostToolUseFailure hook: surface build/lint failure context for self-correction
+
+INPUT=$(cat)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
+ERROR=$(echo "$INPUT" | jq -r '.error // empty' | head -5)
+
+if [ "$TOOL" = "Bash" ]; then
+  CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+  if echo "$CMD" | grep -qE '(yarn (lint|typecheck|test|check|build|knip))'; then
+    echo "Build/lint failure detected. Command: $CMD" >&2
+    echo "Error: $ERROR" >&2
+  fi
+fi
+
+exit 0

--- a/.claude/hooks/quality-gate.sh
+++ b/.claude/hooks/quality-gate.sh
@@ -4,7 +4,8 @@
 
 cd "$CLAUDE_PROJECT_DIR" || exit 0
 
-MODIFIED=$(git diff --name-only --diff-filter=ACMR HEAD 2>/dev/null | grep -E '\.(ts|tsx)$' || true)
+MODIFIED=$(git diff --name-only --diff-filter=ACMR origin/main...HEAD 2>/dev/null | grep -E '\.(ts|tsx)$' || true)
+MODIFIED+=$(git diff --name-only --diff-filter=ACMR HEAD 2>/dev/null | grep -E '\.(ts|tsx)$' || true)
 
 if [ -z "$MODIFIED" ]; then
   exit 0

--- a/.claude/hooks/quality-gate.sh
+++ b/.claude/hooks/quality-gate.sh
@@ -10,13 +10,15 @@ if [ -z "$MODIFIED" ]; then
   exit 0
 fi
 
-if ! yarn lint 2>/dev/null; then
+if ! LINT_OUTPUT=$(yarn lint 2>&1); then
   echo "Quality gate: ESLint violations found" >&2
+  echo "$LINT_OUTPUT" >&2
   exit 2
 fi
 
-if ! yarn typecheck 2>/dev/null; then
+if ! TYPECHECK_OUTPUT=$(yarn typecheck 2>&1); then
   echo "Quality gate: TypeScript errors found" >&2
+  echo "$TYPECHECK_OUTPUT" >&2
   exit 2
 fi
 

--- a/.claude/hooks/quality-gate.sh
+++ b/.claude/hooks/quality-gate.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# TaskCompleted hook: verify lint + typecheck pass before task completion
+# Exit 2 to block, exit 0 to allow
+
+cd "$CLAUDE_PROJECT_DIR" || exit 0
+
+MODIFIED=$(git diff --name-only --diff-filter=ACMR HEAD 2>/dev/null | grep -E '\.(ts|tsx)$' || true)
+
+if [ -z "$MODIFIED" ]; then
+  exit 0
+fi
+
+if ! yarn lint 2>/dev/null; then
+  echo "Quality gate: ESLint violations found" >&2
+  exit 2
+fi
+
+if ! yarn typecheck 2>/dev/null; then
+  echo "Quality gate: TypeScript errors found" >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,6 +27,24 @@
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-dangerous.sh\" \"$TOOL_INPUT\""
           }
         ]
+      },
+      {
+        "matcher": "MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-dangerous.sh\" \"$TOOL_INPUT\""
+          }
+        ]
+      },
+      {
+        "matcher": "NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-dangerous.sh\" \"$TOOL_INPUT\""
+          }
+        ]
       }
     ],
     "PostToolUseFailure": [

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,6 +28,28 @@
           }
         ]
       }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/on-failure-notify.sh\""
+          }
+        ]
+      }
+    ],
+    "TaskCompleted": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/quality-gate.sh\""
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,33 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-dangerous.sh\" \"$TOOL_INPUT\""
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-dangerous.sh\" \"$TOOL_INPUT\""
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-dangerous.sh\" \"$TOOL_INPUT\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/ISSUE_GUIDE.md
+++ b/.github/ISSUE_GUIDE.md
@@ -41,8 +41,8 @@ _How to fill the Vultisig issue template so agents AND humans produce great resu
 
 ## Key Rules for This Repo
 
-- **DO NOT** reference `packages/core/` or `packages/lib/` in `files.write` — those are upstream mirrors
-- SDK code lives in `packages/sdk/src/` — that's where edits go
+- SDK **owns** `packages/core/` and `packages/lib/` — edit them as needed for chain logic and shared utilities
+- SDK-level code lives in `packages/sdk/src/` and consumes logic from `packages/core/`
 - Use `yarn check:all` as the verify command (covers lint + typecheck + test + knip)
 
 ---
@@ -51,7 +51,7 @@ _How to fill the Vultisig issue template so agents AND humans produce great resu
 
 - [ ] Title starts with a verb
 - [ ] Size is tiny/small/medium (never large)
-- [ ] files.write only references packages/sdk/ (not core/ or lib/)
+- [ ] files.write references the correct package (sdk/, core/, or lib/)
 - [ ] At least 2 anti-goals in Must NOT Do
 - [ ] Every acceptance criterion is command-runnable
 - [ ] verify has at least 1 command

--- a/.github/ISSUE_GUIDE.md
+++ b/.github/ISSUE_GUIDE.md
@@ -1,0 +1,57 @@
+# Issue Writing Guide
+
+_How to fill the Vultisig issue template so agents AND humans produce great results._
+
+---
+
+## Quick Start
+
+1. Pick a template (Bug Report or Feature Request)
+2. Fill frontmatter (metadata)
+3. Fill body (spec)
+4. Run the checklist at the bottom
+5. Submit
+
+**Time to fill:** 5-10 minutes for a well-scoped issue. If it takes longer, your scope is too big — split it.
+
+---
+
+## Frontmatter Reference
+
+| Field | Required | Values | Notes |
+|-------|----------|--------|-------|
+| `type` | Yes | `feature` `bugfix` `refactor` `chore` | Pick one |
+| `priority` | Yes | `critical` `high` `medium` `low` | Critical = blocks release |
+| `size` | Yes | `tiny` `small` `medium` | **No "large".** Split it. |
+| `platform` | Yes | `ios` `android` `web` `desktop` `sdk` `server` `docs` | Can be multiple |
+| `files.read` | Yes | File paths | Files for context |
+| `files.write` | Yes | File paths | Files to modify. Be specific |
+| `verify` | Yes | Shell commands | Commands that prove the work is done |
+
+### Size Guide
+
+| Size | Files Changed | Lines of Code | Example |
+|------|--------------|---------------|---------|
+| **tiny** | 1 file | <50 lines | Fix a typo, update a constant |
+| **small** | 1-3 files | 50-200 lines | Add a function, fix a bug |
+| **medium** | 3-8 files | 200-500 lines | New feature with tests |
+| **large** | 8+ files | 500+ lines | **SPLIT THIS.** |
+
+---
+
+## Key Rules for This Repo
+
+- **DO NOT** reference `packages/core/` or `packages/lib/` in `files.write` — those are upstream mirrors
+- SDK code lives in `packages/sdk/src/` — that's where edits go
+- Use `yarn check:all` as the verify command (covers lint + typecheck + test + knip)
+
+---
+
+## Pre-Submit Checklist
+
+- [ ] Title starts with a verb
+- [ ] Size is tiny/small/medium (never large)
+- [ ] files.write only references packages/sdk/ (not core/ or lib/)
+- [ ] At least 2 anti-goals in Must NOT Do
+- [ ] Every acceptance criterion is command-runnable
+- [ ] verify has at least 1 command

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,32 +1,53 @@
 ---
-name: Bug report
-about: Create a report to help us improve
-title: "[BUG]"
-labels: ""
-assignees: ""
+name: Bug Report
+about: Report a bug for agent or human resolution
+title: "[Fix] "
+labels: bug
+assignees: ''
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+<!-- Fill in the AGENT block: priority = critical|high|medium|low, size = tiny|small|medium -->
+<!-- AGENT
+type: "bugfix"
+priority: ""
+size: ""
+platform: [sdk]
+files:
+  read: []
+  write: []
+verify: ["yarn check:all"]
+-->
 
-**To Reproduce**
-Steps to reproduce the behavior:
+# [Fix] <what's broken>
 
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+## Problem
+<!-- 2-3 sentences. What's broken? Who's affected? -->
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+## Expected Behavior
+<!-- What should happen instead? -->
 
-**Desktop (please complete the following information):**
 
-- OS: [e.g. iOS]
-- Version [e.g. 22]
+## Steps to Reproduce
+1.
+2.
+3.
 
-**Additional context**
-Add any other context about the problem here.
+## Solution
+<!-- 1 paragraph. WHAT to do and WHY this approach. Leave blank if unsure. -->
+
+
+## Scope
+
+### Must Do
+- [ ] <!-- Specific fix 1 -->
+- [ ] <!-- Specific fix 2 -->
+
+### Must NOT Do
+- Don't change unrelated code
+- Don't refactor surrounding logic
+
+## Acceptance Criteria
+- [ ] `yarn check:all` succeeds
+- [ ] <!-- Specific behavior check 1 -->
+- [ ] <!-- Specific behavior check 2 -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,19 +1,48 @@
 ---
-name: Feature request
-about: Suggest an idea for this project
-title: "[ADD]"
-labels: ""
-assignees: ""
+name: Feature Request
+about: Request a new feature for agent or human implementation
+title: "[Add] "
+labels: enhancement
+assignees: ''
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+<!-- Fill in the AGENT block: priority = critical|high|medium|low, size = tiny|small|medium -->
+<!-- AGENT
+type: "feature"
+priority: ""
+size: ""
+platform: [sdk]
+files:
+  read: []
+  write: []
+verify: ["yarn check:all"]
+-->
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+# [Add] <what to build>
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+## Problem
+<!-- 2-3 sentences. What's missing or suboptimal? -->
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+
+## Solution
+<!-- 1 paragraph. WHAT to do and WHY this approach. -->
+
+
+## Scope
+
+### Must Do
+- [ ] <!-- Specific deliverable 1 -->
+- [ ] <!-- Specific deliverable 2 -->
+- [ ] <!-- Specific deliverable 3 -->
+
+### Must NOT Do
+- Don't change existing behavior
+- Don't add extra dependencies without approval
+
+### Out of Scope
+- <!-- Related but separate work — future issue -->
+
+## Acceptance Criteria
+- [ ] `yarn check:all` succeeds
+- [ ] <!-- Specific behavior check 1 -->
+- [ ] <!-- Specific behavior check 2 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,3 +21,12 @@ Fixes #<issue-number>
 ## Screenshots (if applicable):
 
 ## Additional context
+
+<!-- Agent-authored PRs: fill in the section below -->
+<!-- Human-authored PRs: delete this section -->
+
+## Agent Metadata (if applicable)
+- **Agent**: <!-- e.g. Claude Code, OpenClaw -->
+- **Issue**: <!-- #number -->
+- **Confidence**: <!-- high / medium / low -->
+- **Needs human review for**: <!-- e.g. "crypto logic", "migration", "none" -->

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,8 @@ examples/*/dist-electron/
 .idea/
 *.swp
 *.swo
-.claude/
+# .claude/ — committed (safety hooks + settings needed for agent framework)
+!.claude/
 
 # Git hooks (Husky auto-generated)
 .husky/_

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,3 +15,13 @@ All contributor instructions, project structure, commands, code conventions, and
 | [docs/architecture/ARCHITECTURE.md](docs/architecture/ARCHITECTURE.md) | Architecture & design patterns |
 | [docs/SDK-USERS-GUIDE.md](docs/SDK-USERS-GUIDE.md) | SDK usage tutorial |
 | [clients/cli/README.md](clients/cli/README.md) | CLI documentation |
+
+## Knowledge Base
+
+For deeper context beyond this file, see [vultisig-knowledge](https://github.com/vultisig/vultisig-knowledge).
+
+Key docs for this repo:
+- [repos/vultisig-sdk.md](https://github.com/vultisig/vultisig-knowledge/blob/main/repos/vultisig-sdk.md)
+- [repos/vultisig-windows.md](https://github.com/vultisig/vultisig-knowledge/blob/main/repos/vultisig-windows.md) (upstream)
+- [coding/patterns.md](https://github.com/vultisig/vultisig-knowledge/blob/main/coding/patterns.md)
+- [coding/gotchas.md](https://github.com/vultisig/vultisig-knowledge/blob/main/coding/gotchas.md) (see "SDK core/ and lib/ are read-only")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ SDK builds to 6 bundles via Rollup:
 - Custom error classes: `VaultError`, `StorageError` with error codes
 - Event-driven: Use `UniversalEventEmitter` for progress tracking
 - PascalCase for classes, camelCase for functions/variables
+- JSDoc (`/** ... */`) on all exported functions, classes, and type definitions
 
 ## Changesets
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,3 +116,14 @@ Specific E2E tests: `yarn test:e2e:balance`, `yarn test:e2e:signing`, etc.
 - Validation: `src/seedphrase/SeedphraseValidator.ts`
 - Languages: `src/seedphrase/languages/` (10 supported)
 - Discovery: `src/seedphrase/ChainDiscoveryService.ts`
+
+## Knowledge Base
+
+For deeper context, see [vultisig-knowledge](https://github.com/vultisig/vultisig-knowledge). Read only when needed:
+
+| Situation | Read |
+|-----------|------|
+| First time in this repo | [repos/vultisig-sdk.md](https://github.com/vultisig/vultisig-knowledge/blob/main/repos/vultisig-sdk.md) |
+| Understanding upstream (windows) | [repos/vultisig-windows.md](https://github.com/vultisig/vultisig-knowledge/blob/main/repos/vultisig-windows.md) |
+| Cross-repo gotchas | [coding/gotchas.md](https://github.com/vultisig/vultisig-knowledge/blob/main/coding/gotchas.md) (see "SDK core/ and lib/ are read-only") |
+| Unsure about conventions | [coding/patterns.md](https://github.com/vultisig/vultisig-knowledge/blob/main/coding/patterns.md) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 TypeScript SDK for multi-party computation (MPC) wallet operations. Supports 40+ blockchains with secure vault creation, address derivation, and transaction signing.
 
+## Security Tier
+
+HIGH
+
 ## Shared Code: core & lib
 
 `packages/core/` and `packages/lib/` contain chain implementations, MPC protocols, and utility libraries shared with the Windows codebase. The SDK **owns** these packages — edit them freely. The Windows repo will consume the SDK as a dependency (not the other way around).


### PR DESCRIPTION
## Summary

- **CLAUDE.md** — Added Security Tier (HIGH) header to existing file
- **.claude/settings.json + hooks/block-dangerous.sh** — PreToolUse safety hooks blocking mainnet RPCs, destructive git, secret file edits, force push, direct push to main
- **.github/ISSUE_GUIDE.md** — How to write agent-friendly issues (SDK-specific: packages/sdk/ only, no upstream edits)
- **.gitignore** — Unignored .claude/ so safety hooks are tracked in repo

Existing AGENTS.md, CLAUDE.md content, .coderabbit.yaml, PR template, and issue templates left untouched.

## Why

Enables the Vultisig developer agent framework. Adds safety guardrails for both human devs (using Claude Code) and autonomous agents.

## What to review

- **.gitignore** — Changed `.claude/` from ignored to tracked. Needed so safety hooks persist.
- **ISSUE_GUIDE.md** — SDK-specific guidance useful?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pre-execution safety checks to block risky commands, a failure notifier for tooling errors, and a post-task quality gate enforcing lint/type checks.

* **Documentation**
  * Updated issue and PR templates, contributor guides, agent docs, and security/convention docs with structured workflows and a high security tier.

* **Chores**
  * Adjusted repository config to track new tooling settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->