### PR TITLE
Add --two-step flag for fast vault creation

### DIFF
--- a/clients/cli/src/commands/vault-management.ts
+++ b/clients/cli/src/commands/vault-management.ts
@@ -42,6 +42,8 @@ export type FastVaultOptions = {
   password: string
   email: string
   signal?: AbortSignal
+  /** Skip OTP verification and persist vault to disk for later verification */
+  twoStep?: boolean
 }
 
 export type SecureVaultOptions = {
@@ -56,7 +58,7 @@ export type SecureVaultOptions = {
  * Create a fast vault (server-assisted 2-of-2)
  */
 export async function executeCreateFast(ctx: CommandContext, options: FastVaultOptions): Promise<VaultBase> {
-  const { name, password, email, signal } = options
+  const { name, password, email, signal, twoStep } = options
 
   const spinner = createSpinner('Creating vault...')
 
@@ -66,6 +68,7 @@ export async function executeCreateFast(ctx: CommandContext, options: FastVaultO
       name,
       password,
       email: email!,
+      persistPending: twoStep,
       onProgress: step => {
         spinner.text = `${step.message} (${step.progress}%)`
       },
@@ -74,6 +77,18 @@ export async function executeCreateFast(ctx: CommandContext, options: FastVaultO
   )
 
   spinner.succeed(`Vault keys generated: ${name}`)
+
+  // Two-step mode: skip OTP verification, persist to disk and exit
+  if (twoStep) {
+    success('\n+ Vault created and saved to disk (pending verification)')
+    info(`\nVault ID: ${vaultId}`)
+    info('\nA verification code has been sent to your email.')
+    info('To complete setup, run:')
+    printResult(chalk.cyan(`  vultisig verify ${vaultId} --code <OTP>`))
+    info('\nOr to resend the verification email:')
+    printResult(chalk.cyan(`  vultisig verify ${vaultId} --resend --email ${email} --password <password>`))
+    return undefined as any
+  }
 
   // Fast vaults always require email verification
   warn('\nA verification code has been sent to your email.')
@@ -273,8 +288,9 @@ export async function executeImport(ctx: CommandContext, file: string): Promise<
 /**
  * Execute verify vault command
  *
- * Note: This command is for re-verifying a vault after initial creation failed.
- * It requires that the vault was created in the current session (pending in memory).
+ * Verifies a pending vault with an email OTP code. Works with both:
+ * - In-memory pending vaults (from interactive create in the current session)
+ * - Disk-persisted pending vaults (from --two-step create, survives process restarts)
  */
 export async function executeVerify(
   ctx: CommandContext,

--- a/clients/cli/src/index.ts
+++ b/clients/cli/src/index.ts
@@ -174,10 +174,11 @@ createCmd
   .requiredOption('--name <name>', 'Vault name')
   .requiredOption('--password <password>', 'Vault password')
   .requiredOption('--email <email>', 'Email for verification')
+  .option('--two-step', 'Create vault without verifying OTP (verify later with "vultisig verify")')
   .action(
-    withExit(async (options: { name: string; password: string; email: string }) => {
+    withExit(async (options: { name: string; password: string; email: string; twoStep?: boolean }) => {
       const context = await init(program.opts().vault)
-      await executeCreateFast(context, options)
+      await executeCreateFast(context, { ...options, twoStep: options.twoStep })
     })
   )
 

--- a/packages/sdk/src/Vultisig.ts
+++ b/packages/sdk/src/Vultisig.ts
@@ -33,7 +33,7 @@ import { JoinSecureVaultService } from './services/JoinSecureVaultService'
 import { type PerformReshareParams,SecureVaultCreationService } from './services/SecureVaultCreationService'
 import { SecureVaultFromSeedphraseService } from './services/SecureVaultFromSeedphraseService'
 import type { Storage } from './storage/types'
-import { AddressBook, AddressBookEntry, ServerStatus, VaultCreationStep } from './types'
+import { AddressBook, AddressBookEntry, ServerStatus, VaultCreationStep, VaultData } from './types'
 import type { SiteScanResult } from './types/security'
 import type { CoinPricesParams, CoinPricesResult, FeeCoinInfo, TokenInfo } from './types/tokens'
 import { createVaultBackup } from './utils/export'
@@ -308,7 +308,8 @@ export class Vultisig extends UniversalEventEmitter<SdkEvents> {
    * Verify fast vault with email code and get the vault
    *
    * On successful verification, the pending vault is saved to storage, set as active,
-   * and returned. Throws an error if verification fails or if no pending vault exists.
+   * and returned. Checks both in-memory pending vaults and disk-persisted pending vaults
+   * (created with `persistPending: true`).
    *
    * @param vaultId - The vault ID to verify
    * @param code - The verification code from email
@@ -318,7 +319,19 @@ export class Vultisig extends UniversalEventEmitter<SdkEvents> {
   async verifyVault(vaultId: string, code: string): Promise<FastVault> {
     await this.ensureInitialized()
 
-    const pendingVault = this.pendingVaults.get(vaultId)
+    // Check in-memory pending vaults first, then fall back to disk
+    let pendingVault = this.pendingVaults.get(vaultId)
+    let fromDisk = false
+
+    if (!pendingVault) {
+      // Try loading from disk (two-step flow)
+      const pendingData = await this.context.storage.get<VaultData>(`pending:${vaultId}`)
+      if (pendingData) {
+        pendingVault = this.vaultManager.createVaultInstance(pendingData) as FastVault
+        fromDisk = true
+      }
+    }
+
     if (!pendingVault) {
       throw new VaultError(
         VaultErrorCode.InvalidVault,
@@ -335,7 +348,13 @@ export class Vultisig extends UniversalEventEmitter<SdkEvents> {
     // Save and activate the vault
     await pendingVault.save()
     await this.vaultManager.setActiveVault(vaultId)
+
+    // Clean up pending state
     this.pendingVaults.delete(vaultId)
+    if (fromDisk) {
+      await this.context.storage.remove(`pending:${vaultId}`)
+    }
+
     this.emit('vaultChanged', { vaultId })
 
     return pendingVault
@@ -348,6 +367,28 @@ export class Vultisig extends UniversalEventEmitter<SdkEvents> {
   async resendVaultVerification(options: { vaultId: string; email: string; password: string }): Promise<void> {
     await this.ensureInitialized()
     return this.context.serverManager.resendVaultVerification(options)
+  }
+
+  /**
+   * List pending vaults saved to disk (from two-step creation flow)
+   * @returns Array of vault IDs that are pending verification
+   */
+  async listPendingVaults(): Promise<string[]> {
+    await this.ensureInitialized()
+    const keys = await this.context.storage.list()
+    return keys
+      .filter(k => k.startsWith('pending:'))
+      .map(k => k.slice('pending:'.length))
+  }
+
+  /**
+   * Delete a pending vault from disk storage
+   * @param vaultId - The vault ID to remove from pending storage
+   */
+  async deletePendingVault(vaultId: string): Promise<void> {
+    await this.ensureInitialized()
+    await this.context.storage.remove(`pending:${vaultId}`)
+    this.pendingVaults.delete(vaultId)
   }
 
   /**
@@ -382,12 +423,19 @@ export class Vultisig extends UniversalEventEmitter<SdkEvents> {
     email: string
     signal?: AbortSignal
     onProgress?: (step: VaultCreationStep) => void
+    /** Persist pending vault to disk so it survives process restarts (two-step creation) */
+    persistPending?: boolean
   }): Promise<string> {
     await this.ensureInitialized()
     const result = await FastVault.create(this.context, options)
 
     // Store vault in pending map - it will be saved after email verification succeeds
     this.pendingVaults.set(result.vaultId, result.vault)
+
+    // Optionally persist to disk for two-step creation (survives process exit)
+    if (options.persistPending) {
+      await result.vault.savePending()
+    }
 
     // Return vaultId - vault is returned from verifyVault() after successful verification
     return result.vaultId

--- a/packages/sdk/src/vault/VaultBase.ts
+++ b/packages/sdk/src/vault/VaultBase.ts
@@ -670,6 +670,23 @@ export abstract class VaultBase extends UniversalEventEmitter<VaultEvents> {
   }
 
   /**
+   * Save this vault as a pending vault (for two-step creation flow).
+   * Persists to storage under the `pending:` prefix so it survives process restarts.
+   * The vault will be moved to regular storage after email verification.
+   */
+  async savePending(): Promise<void> {
+    // Sync runtime state to vaultData
+    const mutableData = this.vaultData as any
+    mutableData.currency = this._currency
+    mutableData.chains = this._userChains.map(c => c.toString())
+    mutableData.tokens = this._tokens
+    mutableData.lastModified = Date.now()
+
+    // Persist under pending: prefix
+    await this.storage.set(`pending:${this.vaultData.id}`, this.vaultData)
+  }
+
+  /**
    * Rename vault
    */
   async rename(newName: string): Promise<void> {


### PR DESCRIPTION
## Summary

- Adds `--two-step` flag to `vultisig create fast` that skips the interactive OTP verification
- Pending vault is persisted to disk (`~/.vultisig/pending:<vaultId>`) so it survives process restarts
- `vultisig verify <vaultId>` now loads pending vaults from disk (not just in-memory), enabling cross-session verification
- SDK gains `listPendingVaults()` and `deletePendingVault()` methods for managing pending state
- All existing interactive behavior is unchanged — `--two-step` is purely additive

## Usage

```bash
# Step 1: Create vault (OTP email is sent, vault saved to disk)
vultisig create fast --name myvault --password secret --email me@example.com --two-step

# Step 2: Verify later (even after restarting the CLI)
vultisig verify <vaultId> --code 123456
```

## Test plan

- [ ] `vultisig create fast --name x --password y --email z` still works interactively (no regression)
- [ ] `vultisig create fast --name x --password y --email z --two-step` creates vault, prints vaultId, exits without prompting for OTP
- [ ] Pending vault file exists at `~/.vultisig/pending:<vaultId>.json` after two-step create
- [ ] `vultisig verify <vaultId> --code <OTP>` works in a fresh CLI session (loads from disk)
- [ ] After successful verification, pending file is cleaned up and vault is active

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added `--two-step` flag to fast vault creation command, enabling users to create vaults and verify them in separate steps
- Pending vault states now persist to disk and survive process restarts, allowing users to complete vault verification across multiple sessions
- New ability to list and manage pending vault creations awaiting verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->