### PR TITLE
fix(sdk): MPC keysign timeout

### DIFF
--- a/packages/sdk/src/server/ServerManager.ts
+++ b/packages/sdk/src/server/ServerManager.ts
@@ -129,7 +129,7 @@ export class ServerManager {
     // Generate session parameters
     const sessionId = randomUUID()
     const hexEncryptionKey = getHexEncodedRandomBytes(32)
-    const signingLocalPartyId = generateLocalPartyId('sdk')
+    const signingLocalPartyId = vault.localPartyId || generateLocalPartyId('sdk')
 
     console.log(`🔑 Generated signing party ID: ${signingLocalPartyId}`)
     console.log(`📡 Calling FastVault API with session ID: ${sessionId}`)
@@ -146,6 +146,15 @@ export class ServerManager {
 
     shouldBePresent(payload.chain, 'payload.chain')
 
+    // Register at relay BEFORE calling FastVault server
+    // (must be registered so server can find us when it joins)
+    // This matches the extension's flow order in fastVaultKeysign.ts
+    await joinMpcSession({
+      serverUrl: this.config.messageRelay,
+      sessionId,
+      localPartyId: signingLocalPartyId,
+    })
+
     await signWithServer({
       public_key: vault.publicKeys.ecdsa,
       messages,
@@ -158,36 +167,7 @@ export class ServerManager {
     })
     console.log(`✅ Server acknowledged session: ${sessionId}`)
 
-    // Step 2: Join relay session
-    reportProgress({
-      step: 'coordinating',
-      progress: 40,
-      message: 'Joining relay session...',
-      mode: 'fast' as import('../types').SigningMode,
-      participantCount: 2,
-      participantsReady: 1,
-    })
-
-    await joinMpcSession({
-      serverUrl: this.config.messageRelay,
-      sessionId,
-      localPartyId: signingLocalPartyId,
-    })
-
-    // Step 2.5: Register server as participant
-    try {
-      const serverSigner = vault.signers.find((signer: string) => signer.startsWith('Server-'))
-      if (serverSigner) {
-        await queryUrl(`${this.config.messageRelay}/${sessionId}`, {
-          body: [serverSigner],
-          responseType: 'none',
-        })
-      }
-    } catch {
-      // non-fatal
-    }
-
-    // Step 3: Wait for server to join
+    // Step 3: Wait for server to ACTUALLY join
     console.log('⏳ Waiting for server to join session...')
     reportProgress({
       step: 'coordinating',


### PR DESCRIPTION
## Problem

FastVault MPC keysign consistently times out. VultiServer joins the relay session but never exchanges MPC messages. The SDK sends its outbound MPC message, but VultiServer never responds — keysign fails after 1 minute.

## Root Cause

`coordinateFastSigning` in `ServerManager.ts` had a "Step 2.5" that manually registered VultiServer at the relay (`POST /{sessionId}` with `[Server-XXXX]`). This faked VultiServer's presence, causing `waitForPeers` to return immediately — before VultiServer's async worker had even picked up the asynq task.

The session then started, the SDK uploaded its setup message, but VultiServer wasn't ready yet. By the time VultiServer's worker started processing, it would find the session already started and proceed to look for the setup message — but the timing window was missed.

Additionally, the SDK was generating a random party ID (`sdk-XXXX`) instead of using the vault's `localPartyId`. The keyshare is bound to the original party ID from keygen (e.g. `extension-2104`), and VultiServer expects that party.

## Fix

Three changes to `ServerManager.coordinateFastSigning()`:

1. **Use `vault.localPartyId`** instead of `generateLocalPartyId('sdk')` — the keyshare is bound to the party ID from keygen
2. **Register at relay before calling FastVault server** — matches the extension's flow order in `fastVaultKeysign.ts`
3. **Remove fake server registration (Step 2.5)** — `waitForPeers` now waits for VultiServer to actually register, ensuring its worker is ready before the session starts

## How the extension does it (reference)

`vultisig-windows/core/ui/agent/tools/shared/fastVaultKeysign.ts`:
```
1. registerSession(relayUrl, sessionId, vault.localPartyId)  // register self
2. callFastVaultSign(...)                                      // tell server to join
3. waitForParties(relayUrl, sessionId, 2)                      // wait for REAL server
4. startSession(relayUrl, sessionId, parties)                   // start
5. keysign(...)                                                 // MPC protocol
```

The SDK now follows the same order.

## Testing

Verified with on-chain transactions:
- ETH self-send on Ethereum ✓ `0x7197952e162da565b01a174da6033a9b79493c81e90a6474fcf840937224bdcb`
- ETH→USDT swap on Ethereum ✓ `0x246db834e5a28e1ad9dd0838328bb551a7b042520de5f795cb551c8980061cc6` (approval) + `0x284d31c79f60d257998ab80bd2bf85be5510cd916dc4c3f78cfa27ee5807b032` (swap)
- WETH wrap on Ethereum ✓ `0x16a96b12ce8534c4ed8cf577297fb064f93c4e884a75da2a7cb99e48987f6619`
- BNB send on BSC ✓ `0x732f932c2f8171990550140958ae64bce8b51bd7ad5c1eb0e53ad660bf5fe15a`
- SOL self-send on Solana ✓ `ZEjBXggZnEG41SZxD31aCKwcbvT6msABKnmrQ9W2fzLDAskmh1pP3XgBxdA9x4uvXUWFEfffNK8BqDsUUBwzCxw`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized the fast signing workflow to reuse existing vault identifiers when available, reducing unnecessary ID generation.
  * Streamlined the MPC session joining process by consolidating operations and eliminating redundant registration attempts, improving signing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->