### PR TITLE
ci: pin agent-backend to main and remove continue-on-error

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -47,6 +47,7 @@ jobs:
       MCP_SERVER_URL: http://localhost:8888
       VERIFIER_URL: ""
       SERVER_PORT: "9998"
+      PROTOCOL_STATE_ENCRYPTION_KEY: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
     steps:
       # ── Checkout repos ──


### PR DESCRIPTION
## Summary
- Remove `ref: fix/agent-tool-calls` from agent-backend checkout — branch already merged (PR #51), now defaults to `main`
- Remove `continue-on-error: true` so integration test failures show as red checks on PRs (not a required check, won't block merges)

## Test plan
- This PR itself will trigger the integration test workflow — check that it runs and reports status correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enforced stricter failure handling in the integration test workflow so test failures now fail the workflow.
  * Standardized repository checkout behavior for integration runs.
  * Added a fixed environment variable available to the integration test job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->