### PR TITLE
docs: add transaction signing guide and complete chains table

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,12 @@ await vault.sign(payload, {
 
 > **WARNING — Storage & Vault Backups:** The SDK auto-configures persistent storage for your platform (FileStorage on Node.js, BrowserStorage in browsers). Do **not** use `MemoryStorage` in production — it is non-persistent and all vault keyshares are lost when the process exits. Loss of keyshares means **permanent loss of funds**. Always back up your vaults using `vault.export()`.
 
-## API Documentation
+## Documentation
 
-API documentation is auto-generated and available at:
-- https://vultisig.github.io/vultisig-sdk/
-
-For detailed usage, see the [SDK Users Guide](docs/SDK-USERS-GUIDE.md).
+- [SDK API Reference & Examples](packages/sdk/README.md) — Full API docs with code examples
+- [SDK Users Guide](docs/SDK-USERS-GUIDE.md) — Detailed usage guide with advanced topics
+- [CLI Documentation](clients/cli/README.md) — Command-line interface
+- [docs.vultisig.com](https://docs.vultisig.com/developer-docs/vultisig-sdk/) — Online documentation
 
 ## Security
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -599,7 +599,13 @@ The SDK requires three WASM files to be available in your application's public d
 - `dkls.wasm` - ECDSA threshold signatures (DKLS protocol)
 - `schnorr.wasm` - EdDSA threshold signatures (Schnorr protocol)
 
-For bundled applications (Vite, webpack, etc.), place these files in the `public/` directory.
+These files are included in the npm package. Copy them to your public directory:
+
+```bash
+cp node_modules/@vultisig/sdk/dist/*.wasm public/
+```
+
+For Node.js and Electron, WASM files are loaded automatically from the package.
 
 ## API Reference
 


### PR DESCRIPTION
## Summary
- Added full transaction signing tutorial with prepare → hash → sign → broadcast workflow
- Added examples for ETH native, ERC-20 tokens, and Bitcoin UTXO signing
- Documented `prepareSendTx()`, `extractMessageHashes()`, `sign()`, `broadcastTx()` in API reference section
- Replaced incomplete chains table ("...And many more") with all 37 supported chains grouped by type (EVM, UTXO, Cosmos, Other)

## Context
An AI agent audit found that the SDK README showed `vault.sign(transactionPayload)` without explaining how to build `transactionPayload`. This was the #1 blocker for agents and developers trying to use the SDK for actual transactions. The chains table was also incomplete, forcing users to read source code to discover supported chains.

## Test plan
- [ ] Verify code examples match current SDK API signatures
- [ ] Verify chain values match `packages/core/chain/Chain.ts`
- [ ] Docs sync workflow will propagate to `vultisig/docs` on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated SDK docs and README links; adjusted multi-chain support claim to 37 networks and listed them by EVM/UTXO/Cosmos/Other; added guidance for required WASM files in browser builds.

* **New Features**
  * Reworked signing guides to a transaction-oriented prepare → extract → sign → (optional) broadcast flow and added a QR-based device signing example plus expanded token/UTXO handling and broadcasting examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->