### PR TITLE
fix: resolve Sei EVM chain ID as 1329

### DIFF
--- a/packages/core/mpc/keysign/tw/getTwChainId.ts
+++ b/packages/core/mpc/keysign/tw/getTwChainId.ts
@@ -2,6 +2,7 @@ import { Chain } from '@core/chain/Chain'
 import { hyperliquid } from '@core/chain/chains/evm/chainInfo'
 import { getCoinType } from '@core/chain/coin/coinType'
 import { WalletCore } from '@trustwallet/wallet-core'
+import { sei } from 'viem/chains'
 
 type Input = {
   walletCore: WalletCore
@@ -15,6 +16,10 @@ export const getTwChainId = ({ walletCore, chain }: Input) => {
 
   if (chain === Chain.Hyperliquid) {
     return hyperliquid.id.toString()
+  }
+
+  if (chain === Chain.Sei) {
+    return sei.id.toString()
   }
 
   const coinType = getCoinType({


### PR DESCRIPTION
## Summary
- `getTwChainId()` resolved Sei via `CoinType.ethereum` → chain ID 1 instead of 1329
- Added special case returning `sei.id` (same pattern as Hyperliquid)

## Test plan
- [x] Verified on mainnet: [`0x6aef468d2f0d185b12c5762a472fc77c386a69761db5b160b494701c6474d7b7`](https://seitrace.com/tx/0x6aef468d2f0d185b12c5762a472fc77c386a69761db5b160b494701c6474d7b7)

**Stack**: PR #132 → **this** → #134 → #135 → #137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Sei blockchain in the app's signing functionality, enabling transactions and signatures for Sei accounts alongside existing supported networks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->