### PR TITLE
fix: increase Osmosis gas fee to meet chain minimum

### DIFF
--- a/packages/core/chain/chains/cosmos/gas.ts
+++ b/packages/core/chain/chains/cosmos/gas.ts
@@ -4,7 +4,7 @@ const defaultGas = 7500n
 
 export const cosmosGasRecord: Record<IbcEnabledCosmosChain, bigint> = {
   [Chain.Cosmos]: defaultGas,
-  [Chain.Osmosis]: defaultGas,
+  [Chain.Osmosis]: 9000n,
   [Chain.Kujira]: defaultGas,
   [Chain.Terra]: defaultGas,
   [Chain.Dydx]: 2500000000000000n,


### PR DESCRIPTION
## Summary
- `cosmosGasRecord` used `defaultGas` (7500n) for Osmosis but chain minimum is 9000 uosmo
- All Osmosis transactions failed with "insufficient fees"
- Updated to `9000n`

## Test plan
- [x] Verified on mainnet: [`AD92C2DCE7D195AFB8E94528D2B4CAAACC8C17C67C9AEE937762D98753836029`](https://www.mintscan.io/osmosis/tx/AD92C2DCE7D195AFB8E94528D2B4CAAACC8C17C67C9AEE937762D98753836029)

**Stack**: PR #132 → #133 → **this** → #135 → #137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated gas configuration parameters for Osmosis chain transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->