### PR TITLE
fix: add Subscan API key for Polkadot queries

### DIFF
--- a/packages/core/chain/coin/balance/resolvers/polkadot.ts
+++ b/packages/core/chain/coin/balance/resolvers/polkadot.ts
@@ -17,6 +17,7 @@ export const getPolkadotCoinBalance: CoinBalanceResolver = async input => {
   const { data } = await queryUrl<PolkadotAccountBalance>(
     'https://assethub-polkadot.api.subscan.io/api/v2/scan/search',
     {
+      headers: { 'X-API-Key': 'e3dd77cbcfb642aca70f1c7d539766ea' },
       body: { key: input.address },
     }
   )

--- a/packages/core/chain/tx/status/resolvers/polkadot.ts
+++ b/packages/core/chain/tx/status/resolvers/polkadot.ts
@@ -25,6 +25,7 @@ export const getPolkadotTxStatus: TxStatusResolver<
 > = async ({ hash }) => {
   const { data: response, error } = await attempt(
     queryUrl<SubscanExtrinsicResponse>(subscanExtrinsicUrl, {
+      headers: { 'X-API-Key': 'e3dd77cbcfb642aca70f1c7d539766ea' },
       body: { hash },
     })
   )


### PR DESCRIPTION
## Summary
- Subscan now enforces authentication for API access
- Added `X-API-Key` header to both the balance resolver and tx status resolver for Polkadot
- Previously all Polkadot balance queries and tx status checks failed

## Test plan
- [ ] Verify Polkadot balance query returns non-zero for funded address
- [ ] Verify Polkadot send transaction succeeds

**Stack**: PR #132 → fix/sei-chain-id → fix/osmosis-gas → fix/tron-broadcast → **this**