### PR TITLE
chore: add missing changesets for post-v0.8.0 PRs

### DIFF
--- a/.changeset/feat-solana-cross-chain-swap.md
+++ b/.changeset/feat-solana-cross-chain-swap.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/cli": minor
+---
+
+Add local SDK build path for Solana cross-chain swaps via tx_ready events in the agent executor

--- a/.changeset/fix-osmosis-gas.md
+++ b/.changeset/fix-osmosis-gas.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/sdk": patch
+---
+
+Increase Osmosis gas fee from 7500 to 9000 uosmo to meet the chain's minimum fee requirement

--- a/.changeset/fix-sei-chain-id.md
+++ b/.changeset/fix-sei-chain-id.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/sdk": patch
+---
+
+Fix Sei EVM chain ID resolution to use 1329 instead of the default 1, which caused transaction signing failures on Sei

--- a/.changeset/fix-tron-broadcast.md
+++ b/.changeset/fix-tron-broadcast.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/sdk": patch
+---
+
+Fix Tron broadcast: use secp256k1Extended key type for 65-byte uncompressed public keys, and check the Tron API response for broadcast errors instead of silently succeeding

--- a/.changeset/fix-zcash-byte-fee.md
+++ b/.changeset/fix-zcash-byte-fee.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/sdk": patch
+---
+
+Remove hardcoded 1000 sat/byte Zcash fee override — use the standard UTXO fee rate lookup instead, which returns a reasonable fee that satisfies ZIP-317


### PR DESCRIPTION
## Summary

Adds changesets for 5 PRs that were merged after v0.8.0 without version notes:

- **#133** `@vultisig/sdk` patch — Fix Sei EVM chain ID (1 → 1329)
- **#134** `@vultisig/sdk` patch — Increase Osmosis gas fee (7500 → 9000 uosmo)
- **#135** `@vultisig/sdk` patch — Fix Tron broadcast (secp256k1Extended + error checking)
- **#137** `@vultisig/sdk` patch — Remove hardcoded Zcash byte fee (1000 sat/byte)
- **#129** `@vultisig/cli` minor — Solana cross-chain swap support in agent executor

PR #138 (ML-DSA signing) already included its own changeset.

Once merged, the changesets bot will update PR #139 with the complete version notes for v0.9.0.

## Test plan

- [ ] Verify changesets bot picks up all 5 entries and updates PR #139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Solana cross-chain swap support

* **Bug Fixes**
  * Fixed Osmosis gas fee requirements
  * Fixed Sei EVM chain ID resolution
  * Fixed Tron transaction broadcasting and key handling
  * Fixed Zcash fee calculation to use dynamic network rates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->