### PR TITLE
fix: skip error tx_ready events to prevent signing failures

### DIFF
--- a/clients/cli/src/agent/session.ts
+++ b/clients/cli/src/agent/session.ts
@@ -229,6 +229,12 @@ export class AgentSession {
           ui.onSuggestions(suggestions)
         },
         onTxReady: tx => {
+          // Skip error tx_ready events (MCP build failures)
+          const txData = tx?.swap_tx || tx?.send_tx || tx?.tx
+          if (txData?.status === 'error' || txData?.error) {
+            if (this.config.verbose) process.stderr.write(`[session] skipping error tx_ready: ${txData.error || 'unknown error'}\n`)
+            return
+          }
           // Store server-built transaction so sign_tx can find it
           this.executor.storeServerTransaction(tx)
           if (this.config.password) {


### PR DESCRIPTION
## Summary

- Skip `tx_ready` SSE events that contain error status/data, preventing the CLI from attempting to sign failed server-built transactions
- Previously, when MCP `build_swap_tx` returned an error, the backend still emitted a `tx_ready` event with `status: "error"`. The CLI stored this and attempted to sign it, causing "Server transaction missing required fields (to)" errors.

This is a companion fix to https://github.com/vultisig/agent-backend/pull/58 — when the SDK-first swap path succeeds but the MCP fallback was triggered and failed, the error `tx_ready` event would previously corrupt the signing flow.

## Change

In `session.ts` `onTxReady` handler, check for `status === 'error'` or `error` field on the transaction data (`swap_tx`, `send_tx`, or `tx` sub-objects) before storing. If it's an error event, log it (in verbose mode) and skip.

## Verified with swap transactions

All swaps verified working with this fix in place:

| Swap | Amount | Source Chain TX | THORChain |
|------|--------|-----------------|-----------|
| ETH → BTC | 0.003 ETH | [etherscan.io](https://etherscan.io/tx/0x7399d1ae891ec8b0b6e658966231da9bba2ed3bd7a4443c71c295f1501cc34d5) | [thorchain.net](https://thorchain.net/tx/7399D1AE891EC8B0B6E658966231DA9BBA2ED3BD7A4443C71C295F1501CC34D5) |
| BCH → ETH | 0.001 BCH | [blockchair.com](https://blockchair.com/bitcoin-cash/transaction/65fd613a8786d59f926cce23867950d674640d29698f61c29737394c3c57ce15) | [thorchain.net](https://thorchain.net/tx/65FD613A8786D59F926CCE23867950D674640D29698F61C29737394C3C57CE15) |
| BTC → ETH | 0.0001 BTC | [mempool.space](https://mempool.space/tx/9b12c78f4bd476728dd3abaa28c3c39c0c60bbdf92b808f0795fa4857cdc8fbf) | [thorchain.net](https://thorchain.net/tx/9B12C78F4BD476728DD3ABAA28C3C39C0C60BBDF92B808F0795FA4857CDC8FBF) |
| DOGE → ETH | 10 DOGE | [blockchair.com](https://blockchair.com/dogecoin/transaction/bb08f988b6d0b21f47cb2bcce3dc6081e9c8ca174405937d542d4436c44c27d4) | [thorchain.net](https://thorchain.net/tx/BB08F988B6D0B21F47CB2BCCE3DC6081E9C8CA174405937D542D4436C44C27D4) |
| LTC → ETH | 0.01 LTC | [blockchair.com](https://blockchair.com/litecoin/transaction/e39d34c4c18e8cca9e5e1019e6ec07a02f7d33071c15938cf65383e073e7797d) | [thorchain.net](https://thorchain.net/tx/E39D34C4C18E8CCA9E5E1019E6EC07A02F7D33071C15938CF65383E073E7797D) |
| ATOM → ETH | 1 ATOM | [mintscan.io](https://www.mintscan.io/cosmos/tx/306EAF2FBC859F4C82AD840474DEF9228B3A2FC639C376D66BBF4908377B6F29) | [thorchain.net](https://thorchain.net/tx/306EAF2FBC859F4C82AD840474DEF9228B3A2FC639C376D66BBF4908377B6F29) |
| ETH → USDC | 0.003 ETH | [etherscan.io](https://etherscan.io/tx/0x8bb883fbf5c9fac330d959fedf08a508a414403f5cb980bac0c537884b239289) | [thorchain.net](https://thorchain.net/tx/8BB883FBF5C9FAC330D959FEDF08A508A414403F5CB980BAC0C537884B239289) |
| SOL → ETH | 0.01 SOL | [solscan.io](https://solscan.io/tx/4goJzi8c7o4vxyFmtuTy8fmA5oqiNZ7q3YUoupcVkCmpfpbf5BmELtgDmuTKstFzZPZNpJsA7TGPNAvAMqiARKjL) | [thorchain.net](https://thorchain.net/tx/4goJzi8c7o4vxyFmtuTy8fmA5oqiNZ7q3YUoupcVkCmpfpbf5BmELtgDmuTKstFzZPZNpJsA7TGPNAvAMqiARKjL) |

## Test plan

- [x] Error `tx_ready` events are skipped (no signing attempt)
- [x] Valid `tx_ready` events are still stored and signed correctly
- [x] Verified with 8 swap transactions across multiple chains

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction error handling improved—transactions with error status are now properly skipped during processing instead of being unconditionally stored.
  * Verbose mode now logs skipped error transactions to stderr for better visibility into transaction processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->