### PR TITLE
Fix Solana SPL token transfer when recipient has no ATA

### DIFF
--- a/packages/core/mpc/keysign/chainSpecific/resolvers/solana/index.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/solana/index.ts
@@ -32,6 +32,7 @@ export const getSolanaChainSpecific: GetChainSpecificResolver<
       token: coin.id,
     })
     chainSpecific.fromTokenAssociatedAddress = fromAccount.address
+    chainSpecific.programId = fromAccount.isToken2022
     const { data } = await attempt(
       getSplAssociatedAccount({
         account: receiver,
@@ -40,7 +41,6 @@ export const getSolanaChainSpecific: GetChainSpecificResolver<
     )
     if (data) {
       chainSpecific.toTokenAssociatedAddress = data.address
-      chainSpecific.programId = data.isToken2022
     }
   }
 


### PR DESCRIPTION
## Summary
- Set `programId` (Token2022 flag) from the **sender's** ATA instead of from the receiver's ATA
- When the receiver lacks an ATA, `programId` was never set, causing `CreateAndTransferToken` to use the wrong token program and derive an incorrect recipient ATA address — resulting in silent transaction failures

## How it works
The sender always has an ATA (they hold the token), so `isToken2022` is reliably available from their account. The token program is a property of the mint, not the account holder, so it's the same regardless of which ATA you query.

Related issue: vultisig/vultisig-windows#3604
Mirrors: vultisig/vultisig-windows#3640

## Test plan
- [ ] Send SPL token to a recipient with no existing token account (no ATA) — transfer should succeed
- [ ] Send Token2022 token to a recipient with no existing token account — transfer should succeed
- [ ] Send SPL token to a recipient with an existing ATA — behavior unchanged
- [ ] Verify fee includes rent exemption when creating ATA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue with Solana Token2022 transactions where the program ID was not being properly assigned in certain scenarios. The program ID is now correctly determined based on the sender's token account information, even when receiver account resolution returns no data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->