### PR TITLE
fix: MAYAChain swap decimals for non-fee tokens (MAYA, AZTEC)

### DIFF
--- a/packages/core/chain/swap/native/utils/getNativeSwapDecimals.ts
+++ b/packages/core/chain/swap/native/utils/getNativeSwapDecimals.ts
@@ -1,14 +1,31 @@
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { CoinKey } from '@vultisig/core-chain/coin/Coin'
+import { knownTokensIndex } from '@vultisig/core-chain/coin/knownTokens'
 import { isFeeCoin } from '@vultisig/core-chain/coin/utils/isFeeCoin'
 
 import { Chain } from '../../../Chain'
 
-// Use THORChain's decimals for all native swaps, except for the CACAO asset,
-// which is the only asset that uses 10 decimals.
+/**
+ * Returns the decimal precision used by the swap API for a given coin.
+ *
+ * - CACAO (MayaChain fee coin) uses 10 decimals.
+ * - Other MayaChain tokens (MAYA, AZTEC) use their native decimals
+ *   because the MAYAChain API reports amounts in native precision.
+ * - Everything else uses THORChain's 8-decimal standard.
+ */
 export const getNativeSwapDecimals = (coin: CoinKey) => {
-  if (coin.chain === Chain.MayaChain && isFeeCoin(coin)) {
-    return chainFeeCoin[coin.chain].decimals
+  if (coin.chain === Chain.MayaChain) {
+    if (isFeeCoin(coin)) {
+      return chainFeeCoin[coin.chain].decimals
+    }
+
+    const known = coin.id
+      ? knownTokensIndex[coin.chain][coin.id.toLowerCase()]
+      : undefined
+
+    if (known) {
+      return known.decimals
+    }
   }
 
   return chainFeeCoin[Chain.THORChain].decimals


### PR DESCRIPTION
## Summary
- `getNativeSwapDecimals` now looks up actual decimals from `knownTokensIndex` for MAYAChain non-fee tokens instead of defaulting to THORChain's 8.
- MAYA token (4 decimals) and AZTEC (4 decimals) were previously getting 8 decimals, causing 10,000x amount errors when swapping.
- MAYAChain API uses native decimals per-token, unlike THORChain's uniform 1e8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)