### PR TITLE
feat: default agent backend URL to https://abe.vultisig.com

### DIFF
--- a/clients/cli/README.md
+++ b/clients/cli/README.md
@@ -668,7 +668,7 @@ explorer:https://etherscan.io/tx/0x9f8e7d6c...
 
 **Agent ask options:**
 - `--session <id>` - Continue an existing conversation
-- `--backend-url <url>` - Agent backend URL (default: http://localhost:9998)
+- `--backend-url <url>` - Agent backend URL (default: https://abe.vultisig.com)
 - `--password <password>` - Vault password for signing
 - `--verbose` - Show tool calls and debug info on stderr
 - `--json` - Output structured JSON

--- a/clients/cli/src/commands/agent.ts
+++ b/clients/cli/src/commands/agent.ts
@@ -32,7 +32,7 @@ export async function executeAgent(ctx: CommandContext, options: AgentCommandOpt
   const vault = await ctx.ensureActiveVault()
 
   const config: AgentConfig = {
-    backendUrl: options.backendUrl || process.env.VULTISIG_AGENT_URL || 'http://localhost:9998',
+    backendUrl: options.backendUrl || process.env.VULTISIG_AGENT_URL || 'https://abe.vultisig.com',
     vaultName: vault.name,
     password: options.password,
     viaAgent: options.viaAgent,
@@ -117,7 +117,7 @@ export async function executeAgentAsk(
       backendUrl:
         options.backendUrl ||
         process.env.VULTISIG_AGENT_URL ||
-        'http://localhost:9998',
+        'https://abe.vultisig.com',
       vaultName: vault.name,
       password: options.password,
       sessionId: options.session,
@@ -185,7 +185,7 @@ export type AgentSessionsListOptions = {
 
 export async function executeAgentSessionsList(ctx: CommandContext, options: AgentSessionsListOptions): Promise<void> {
   const vault = await ctx.ensureActiveVault()
-  const backendUrl = options.backendUrl || process.env.VULTISIG_AGENT_URL || 'http://localhost:9998'
+  const backendUrl = options.backendUrl || process.env.VULTISIG_AGENT_URL || 'https://abe.vultisig.com'
   const client = await createAuthenticatedClient(backendUrl, vault, options.password)
 
   const publicKey = vault.publicKeys.ecdsa
@@ -250,7 +250,7 @@ export async function executeAgentSessionsDelete(
   options: AgentSessionsDeleteOptions
 ): Promise<void> {
   const vault = await ctx.ensureActiveVault()
-  const backendUrl = options.backendUrl || process.env.VULTISIG_AGENT_URL || 'http://localhost:9998'
+  const backendUrl = options.backendUrl || process.env.VULTISIG_AGENT_URL || 'https://abe.vultisig.com'
   const client = await createAuthenticatedClient(backendUrl, vault, options.password)
 
   const publicKey = vault.publicKeys.ecdsa

--- a/clients/cli/src/index.ts
+++ b/clients/cli/src/index.ts
@@ -1063,7 +1063,7 @@ const agentCmd = program
   .description('AI-powered chat interface for wallet operations')
   .option('--via-agent', 'Use NDJSON pipe mode for agent-to-agent communication')
   .option('--verbose', 'Show detailed tool call parameters and debug output')
-  .option('--backend-url <url>', 'Agent backend URL (default: http://localhost:9998)')
+  .option('--backend-url <url>', 'Agent backend URL (default: https://abe.vultisig.com)')
   .option('--password <password>', 'Vault password for signing operations')
   .option('--password-ttl <ms>', 'Password cache TTL in milliseconds (default: 300000, 86400000/24h for --via-agent)')
   .option('--session-id <id>', 'Resume an existing session')
@@ -1096,7 +1096,7 @@ agentCmd
   .command('ask <message>')
   .description('Send a single message and get the response (for AI agent integration)')
   .option('--session <id>', 'Continue an existing conversation')
-  .option('--backend-url <url>', 'Agent backend URL (default: http://localhost:9998)')
+  .option('--backend-url <url>', 'Agent backend URL (default: https://abe.vultisig.com)')
   .option('--password <password>', 'Vault password for signing operations')
   .option('--verbose', 'Show tool calls and debug info on stderr')
   .option('--json', 'Output structured JSON instead of text')
@@ -1131,7 +1131,7 @@ const sessionsCmd = agentCmd.command('sessions').description('Manage agent chat 
 sessionsCmd
   .command('list')
   .description('List chat sessions for the current vault')
-  .option('--backend-url <url>', 'Agent backend URL (default: http://localhost:9998)')
+  .option('--backend-url <url>', 'Agent backend URL (default: https://abe.vultisig.com)')
   .option('--password <password>', 'Vault password for authentication')
   .action(
     withExit(async (options: { backendUrl?: string; password?: string }) => {
@@ -1147,7 +1147,7 @@ sessionsCmd
 sessionsCmd
   .command('delete <id>')
   .description('Delete a chat session')
-  .option('--backend-url <url>', 'Agent backend URL (default: http://localhost:9998)')
+  .option('--backend-url <url>', 'Agent backend URL (default: https://abe.vultisig.com)')
   .option('--password <password>', 'Vault password for authentication')
   .action(
     withExit(async (id: string, options: { backendUrl?: string; password?: string }) => {


### PR DESCRIPTION
Changes the default `--backend-url` from `http://localhost:9998` to `https://abe.vultisig.com` (production agent backend).

Users can still override with `--backend-url` flag or `VULTISIG_AGENT_URL` env var for local development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default backend URL for CLI agent commands to `https://abe.vultisig.com`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->