### PR TITLE
feat: enable TON jetton token selection and balance fetching

### DIFF
--- a/packages/core/chain/chains/ton/address.ts
+++ b/packages/core/chain/chains/ton/address.ts
@@ -1,0 +1,19 @@
+import { fromBase64 } from '@vultisig/lib-utils/fromBase64'
+
+/** Converts base64url encoding to standard base64 so `Buffer.from` can decode it. */
+const fromBase64Url = (value: string): Buffer => {
+  const standardBase64 = value.replace(/-/g, '+').replace(/_/g, '/')
+  return fromBase64(standardBase64)
+}
+
+/**
+ * Converts a user-friendly TON address (EQ.../UQ...) to raw format (workchain:hex).
+ * The toncenter v3 API requires raw addresses.
+ */
+export const tonAddressToRaw = (userFriendlyAddress: string): string => {
+  const decoded = fromBase64Url(userFriendlyAddress)
+  const workchain = decoded[1] >= 128 ? decoded[1] - 256 : decoded[1]
+  const hash = decoded.subarray(2, 34).toString('hex')
+
+  return `${workchain}:${hash}`
+}

--- a/packages/core/chain/chains/ton/api.ts
+++ b/packages/core/chain/chains/ton/api.ts
@@ -1,6 +1,8 @@
 import { rootApiUrl } from '@vultisig/core-config'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
+import { tonAddressToRaw } from './address'
+
 const tonApiUrl = `${rootApiUrl}/ton`
 
 type JettonWalletResponse = {
@@ -17,15 +19,29 @@ type JettonWalletResponse = {
   >
 }
 
-export const getJettonWalletAddress = async ({
-  ownerAddress,
-  jettonMasterAddress,
-}: {
+type GetJettonWalletInput = {
   ownerAddress: string
   jettonMasterAddress: string
-}): Promise<string> => {
-  const url = `${tonApiUrl}/v3/jetton/wallets?owner_address=${ownerAddress}&jetton_master_address=${jettonMasterAddress}`
-  const response = await queryUrl<JettonWalletResponse>(url)
+}
+
+/** Builds the toncenter v3 jetton wallets query URL, converting addresses to raw format. */
+const getJettonWalletsUrl = ({
+  ownerAddress,
+  jettonMasterAddress,
+}: GetJettonWalletInput): string => {
+  const rawOwner = tonAddressToRaw(ownerAddress)
+  const rawMaster = tonAddressToRaw(jettonMasterAddress)
+
+  return `${tonApiUrl}/v3/jetton/wallets?owner_address=${rawOwner}&jetton_address=${rawMaster}`
+}
+
+/** Resolves the user-friendly jetton wallet address for a given owner and jetton master. */
+export const getJettonWalletAddress = async (
+  input: GetJettonWalletInput
+): Promise<string> => {
+  const response = await queryUrl<JettonWalletResponse>(
+    getJettonWalletsUrl(input)
+  )
 
   const jettonAddress = response.jetton_wallets[0]?.address
   if (!jettonAddress) {
@@ -34,6 +50,18 @@ export const getJettonWalletAddress = async ({
 
   const addressEntry = response.address_book[jettonAddress]
   return addressEntry?.user_friendly || jettonAddress
+}
+
+/** Fetches the balance of a specific jetton for a given owner address. */
+export const getJettonBalance = async (
+  input: GetJettonWalletInput
+): Promise<bigint> => {
+  const response = await queryUrl<JettonWalletResponse>(
+    getJettonWalletsUrl(input)
+  )
+
+  const balance = response.jetton_wallets[0]?.balance
+  return BigInt(balance ?? 0)
 }
 
 type AddressInformationResponse = {

--- a/packages/core/chain/coin/balance/resolvers/ton.ts
+++ b/packages/core/chain/coin/balance/resolvers/ton.ts
@@ -1,10 +1,19 @@
 import { getTonAccountInfo } from '@vultisig/core-chain/chains/ton/account/getTonAccountInfo'
+import { getJettonBalance } from '@vultisig/core-chain/chains/ton/api'
+import { isFeeCoin } from '@vultisig/core-chain/coin/utils/isFeeCoin'
+import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { bigIntMax } from '@vultisig/lib-utils/bigint/bigIntMax'
 
 import { CoinBalanceResolver } from '../resolver'
 
 export const getTonCoinBalance: CoinBalanceResolver = async input => {
-  const { balance } = await getTonAccountInfo(input.address)
+  if (isFeeCoin(input)) {
+    const { balance } = await getTonAccountInfo(input.address)
+    return bigIntMax(BigInt(balance), BigInt(0))
+  }
 
-  return bigIntMax(BigInt(balance), BigInt(0))
+  return getJettonBalance({
+    ownerAddress: input.address,
+    jettonMasterAddress: shouldBePresent(input.id),
+  })
 }

--- a/packages/core/chain/coin/knownTokens/index.ts
+++ b/packages/core/chain/coin/knownTokens/index.ts
@@ -26,6 +26,56 @@ export const usdc: Token<CoinKey> & KnownCoinMetadata = {
 }
 
 const leanTokens: Partial<LeanChainTokensRecord> = {
+  [Chain.Ton]: {
+    EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs: {
+      ticker: 'USDT',
+      logo: 'usdt',
+      decimals: 6,
+      priceProviderId: 'tether',
+    },
+    EQAvlWFDxGF2lXm67y4yzC17wYKD9A0guwPkMs1gOsM__NOT: {
+      ticker: 'NOT',
+      logo: 'not',
+      decimals: 9,
+      priceProviderId: 'notcoin',
+    },
+    EQCvxJy4eG8hyHBFsZ7eePxrRsUQSFE_jpptRAYBmcG_DOGS: {
+      ticker: 'DOGS',
+      logo: 'dogs',
+      decimals: 9,
+      priceProviderId: 'dogs-2',
+    },
+    'EQD-cvR0Nz6XAyRBvbhz-abTrRC6sI5tvHvvpeQraV9UAAD7': {
+      ticker: 'CATI',
+      logo: 'cati',
+      decimals: 9,
+      priceProviderId: 'catizen',
+    },
+    'EQAJ8uWd7EBqsmpSWaRdf_I-8R8-XHwh3gsNKhy-UrdrPcUo': {
+      ticker: 'HMSTR',
+      logo: 'hmstr',
+      decimals: 9,
+      priceProviderId: 'hamster-kombat',
+    },
+    EQA2kCVNwVsil2EM2mB0SkXytxCqQjS4mttjDpnXmwG9T6bO: {
+      ticker: 'STON',
+      logo: 'ston',
+      decimals: 9,
+      priceProviderId: 'ston-2',
+    },
+    'EQDNhy-nxYFgUqzfUzImBEP67JqsyMIcyk2S5_RwNNEYku0k': {
+      ticker: 'stTON',
+      logo: 'https://storage.googleapis.com/milkcreek/tokens/stTON.png',
+      decimals: 9,
+      priceProviderId: 'bemo-staked-ton',
+    },
+    EQC98_qAmNEptUtPc7W6xdHh_ZHrBUFpw5Ft_IzNU20QAJav: {
+      ticker: 'tsTON',
+      logo: 'tston',
+      decimals: 9,
+      priceProviderId: 'tonstakers',
+    },
+  },
   [Chain.Tron]: {
     TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t: {
       ticker: 'USDT',

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -364,6 +364,11 @@
       "import": "./dist/chains/thorchain/ruji/services/fetchStakeView.js",
       "default": "./dist/chains/thorchain/ruji/services/fetchStakeView.js"
     },
+    "./chains/ton/address": {
+      "types": "./dist/chains/ton/address.d.ts",
+      "import": "./dist/chains/ton/address.js",
+      "default": "./dist/chains/ton/address.js"
+    },
     "./chains/ton/account/getTonAccountInfo": {
       "types": "./dist/chains/ton/account/getTonAccountInfo.d.ts",
       "import": "./dist/chains/ton/account/getTonAccountInfo.js",


### PR DESCRIPTION
## Summary

- Add `tonAddressToRaw()` utility to convert user-friendly TON addresses (EQ.../UQ...) to raw format required by toncenter v3 API
- Refactor jetton API to use raw addresses and extract shared `getJettonWalletsUrl` helper
- Add `getJettonBalance()` for fetching jetton token balances
- Update TON balance resolver to handle both native TON and jetton tokens via `isFeeCoin` check
- Register 8 TON jetton tokens in `knownTokens`: USDT, NOT, DOGS, CATI, HMSTR, STON, stTON, tsTON

## Related

Mirrors vultisig/vultisig-windows#3586

Closes #167

## Test plan

- [ ] Verify TON native balance fetching still works
- [ ] Verify jetton token balances are fetched correctly for known tokens
- [ ] Verify `tonAddressToRaw` correctly converts user-friendly addresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for TON address conversion and raw-address handling.
  * Jetton token wallet/balance retrieval added for token balances.
  * Improved balance resolution: distinguishes native TON (account) vs jetton balances.
  * Added metadata and pricing info for known TON tokens (USDT, NOT, DOGS, CATI, HMSTR, STON, stTON, tsTON).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->