### PR TITLE
fix: use dynamic priority fees for Solana transactions

### DIFF
--- a/packages/core/chain/chains/solana/getDynamicPriorityFeePrice.ts
+++ b/packages/core/chain/chains/solana/getDynamicPriorityFeePrice.ts
@@ -1,0 +1,26 @@
+import { getSolanaClient } from './client'
+import { solanaConfig } from './solanaConfig'
+
+/** Fetches the median of non-zero recent prioritization fees from the Solana RPC. Falls back to the hardcoded config value on failure. */
+export const getDynamicPriorityFeePrice = async (): Promise<number> => {
+    const client = getSolanaClient()
+
+    const recentFees = await client.getRecentPrioritizationFees()
+
+    const nonZeroFees = recentFees
+        .map(entry => entry.prioritizationFee)
+        .filter(fee => fee > 0)
+        .sort((a, b) => a - b)
+
+    if (nonZeroFees.length === 0) {
+        return solanaConfig.priorityFeePrice
+    }
+
+    const mid = Math.floor(nonZeroFees.length / 2)
+
+    if (nonZeroFees.length % 2 === 0) {
+        return Math.round((nonZeroFees[mid - 1] + nonZeroFees[mid]) / 2)
+    }
+
+    return nonZeroFees[mid]
+}

--- a/packages/core/chain/chains/solana/getDynamicPriorityFeePrice.ts
+++ b/packages/core/chain/chains/solana/getDynamicPriorityFeePrice.ts
@@ -1,7 +1,7 @@
 import { getSolanaClient } from './client'
 import { solanaConfig } from './solanaConfig'
 
-/** Fetches the median of non-zero recent prioritization fees from the Solana RPC. Falls back to the hardcoded config value on failure. */
+/** Fetches the median of non-zero recent prioritization fees from the Solana RPC. */
 export const getDynamicPriorityFeePrice = async (): Promise<number> => {
     const client = getSolanaClient()
 

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -324,6 +324,11 @@
       "import": "./dist/chains/solana/client.js",
       "default": "./dist/chains/solana/client.js"
     },
+    "./chains/solana/getDynamicPriorityFeePrice": {
+      "types": "./dist/chains/solana/getDynamicPriorityFeePrice.d.ts",
+      "import": "./dist/chains/solana/getDynamicPriorityFeePrice.js",
+      "default": "./dist/chains/solana/getDynamicPriorityFeePrice.js"
+    },
     "./chains/solana/config": {
       "types": "./dist/chains/solana/config.d.ts",
       "import": "./dist/chains/solana/config.js",

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/solana/index.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/solana/index.ts
@@ -10,7 +10,7 @@ import { attempt, withFallback } from '@vultisig/lib-utils/attempt'
 import { getKeysignCoin } from '../../../utils/getKeysignCoin'
 import { GetChainSpecificResolver } from '../../resolver'
 import { refineSolanaChainSpecific } from './refine'
-import { getDynamicPriorityFeePrice } from '../../../../../chain/chains/solana/getDynamicPriorityFeePrice'
+import { getDynamicPriorityFeePrice } from '@vultisig/core-chain/chains/solana/getDynamicPriorityFeePrice'
 
 export const getSolanaChainSpecific: GetChainSpecificResolver<
   'solanaSpecific'

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/solana/index.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/solana/index.ts
@@ -10,6 +10,7 @@ import { attempt, withFallback } from '@vultisig/lib-utils/attempt'
 import { getKeysignCoin } from '../../../utils/getKeysignCoin'
 import { GetChainSpecificResolver } from '../../resolver'
 import { refineSolanaChainSpecific } from './refine'
+import { getDynamicPriorityFeePrice } from '../../../../../chain/chains/solana/getDynamicPriorityFeePrice'
 
 export const getSolanaChainSpecific: GetChainSpecificResolver<
   'solanaSpecific'
@@ -18,11 +19,16 @@ export const getSolanaChainSpecific: GetChainSpecificResolver<
   const receiver = shouldBePresent(keysignPayload.toAddress)
   const client = getSolanaClient()
 
+  const priorityFeePrice = await withFallback(
+    attempt(getDynamicPriorityFeePrice()),
+    solanaConfig.priorityFeePrice
+  )
+
   const recentBlockHash = (await client.getLatestBlockhash()).blockhash
 
   const chainSpecific = create(SolanaSpecificSchema, {
     recentBlockHash,
-    priorityFee: solanaConfig.priorityFeePrice.toString(),
+    priorityFee: priorityFeePrice.toString(),
     computeLimit: solanaConfig.priorityFeeLimit.toString(),
   })
 
@@ -49,6 +55,7 @@ export const getSolanaChainSpecific: GetChainSpecificResolver<
       refineSolanaChainSpecific({
         keysignPayload,
         chainSpecific,
+        priorityFeePrice,
         walletCore,
       })
     ),

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/solana/refine.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/solana/refine.ts
@@ -21,12 +21,14 @@ const microLamportsPerLamport = 1_000_000n
 type RefineSolanaChainSpecificInput = {
   keysignPayload: KeysignPayload
   chainSpecific: SolanaSpecific
+  priorityFeePrice: number
   walletCore: WalletCore
 }
 
 export const refineSolanaChainSpecific = async ({
   keysignPayload,
   chainSpecific,
+  priorityFeePrice,
   walletCore,
 }: RefineSolanaChainSpecificInput): Promise<SolanaSpecific> => {
   const coin = getKeysignCoin(keysignPayload)
@@ -72,8 +74,7 @@ export const refineSolanaChainSpecific = async ({
   const rentExemptionFee = await getRentExemptionFee()
 
   const priorityFeeAmount =
-    (BigInt(solanaConfig.priorityFeePrice) *
-      BigInt(solanaConfig.priorityFeeLimit)) /
+    (BigInt(priorityFeePrice) * BigInt(solanaConfig.priorityFeeLimit)) /
     microLamportsPerLamport
 
   const totalFee = baseFee + rentExemptionFee + priorityFeeAmount


### PR DESCRIPTION
## Summary
- Query `getRecentPrioritizationFees` RPC to dynamically determine Solana priority fees based on current network conditions
- Use median of non-zero recent fees instead of the hardcoded 1,000,000 microlamports
- Fall back to the configured `solanaConfig.priorityFeePrice` if the RPC call fails or returns no non-zero fees

Closes vultisig/vultisig-windows#3606

## Test plan
- [ ] Build succeeds (`yarn build:shared`)
- [ ] Priority fee reflects network conditions when RPC is available
- [ ] Fallback to hardcoded value works when RPC is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Solana transactions now use dynamically computed priority fees derived from recent network activity, improving fee accuracy.
  * The dynamic fee is integrated into transaction preparation and falls back to the configured default when network data is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->