### PR TITLE
fix: use native Dash RPC for UTXO fetching

### DIFF
--- a/packages/core/chain/chains/utxo/client/getDashUtxos.ts
+++ b/packages/core/chain/chains/utxo/client/getDashUtxos.ts
@@ -1,0 +1,50 @@
+import { rootApiUrl } from '@vultisig/core-config'
+import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+
+import { minUtxo } from '../minUtxo'
+import { Chain } from '../../../Chain'
+import type { ChainPlainUtxo } from '../tx/ChainPlainUtxo'
+
+type DashAddressUtxo = {
+  address: string
+  txid: string
+  outputIndex: number
+  script: string
+  satoshis: number
+  height: number
+}
+
+type DashRpcResponse = {
+  result: DashAddressUtxo[] | null
+  error: { code: number; message: string } | null
+  id: string
+}
+
+export const getDashUtxos = async (
+  address: string
+): Promise<ChainPlainUtxo[]> => {
+  const response = await queryUrl<DashRpcResponse>(`${rootApiUrl}/dash/`, {
+    body: {
+      jsonrpc: '1.0',
+      id: 'vultisig',
+      method: 'getaddressutxos',
+      params: [{ addresses: [address] }],
+    },
+  })
+
+  if (response.error) {
+    throw new Error(`Dash RPC error: ${response.error.message}`)
+  }
+
+  if (!response.result) {
+    return []
+  }
+
+  return response.result
+    .filter(({ satoshis }) => satoshis > Number(minUtxo[Chain.Dash]))
+    .map(({ txid, satoshis, outputIndex }) => ({
+      hash: txid,
+      amount: BigInt(satoshis),
+      index: outputIndex,
+    }))
+}

--- a/packages/core/chain/chains/utxo/client/getDashUtxos.ts
+++ b/packages/core/chain/chains/utxo/client/getDashUtxos.ts
@@ -2,7 +2,7 @@ import { rootApiUrl } from '@vultisig/core-config'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
 import { minUtxo } from '../minUtxo'
-import { Chain } from '../../../Chain'
+import { Chain } from '@vultisig/core-chain/Chain'
 import type { ChainPlainUtxo } from '../tx/ChainPlainUtxo'
 
 type DashAddressUtxo = {

--- a/packages/core/chain/chains/utxo/tx/getUtxos.ts
+++ b/packages/core/chain/chains/utxo/tx/getUtxos.ts
@@ -1,5 +1,6 @@
 import { ChainAccount } from '../../../ChainAccount'
-import { UtxoChain } from '../../../Chain'
+import { Chain, UtxoChain } from '../../../Chain'
+import { getDashUtxos } from '../client/getDashUtxos'
 import { getUtxoAddressInfo } from '../client/getUtxoAddressInfo'
 
 import { minUtxo } from '../minUtxo'
@@ -11,6 +12,10 @@ export type { ChainPlainUtxo } from './ChainPlainUtxo'
 export const getUtxos = async (
   account: ChainAccount<UtxoChain>
 ): Promise<ChainPlainUtxo[]> => {
+  if (account.chain === Chain.Dash) {
+    return getDashUtxos(account.address)
+  }
+
   const { data } = await getUtxoAddressInfo(account)
 
   const { utxo } = data[account.address]


### PR DESCRIPTION
## Summary
- Dash UTXOs now fetched via native RPC (`getaddressutxos` at `api.vultisig.com/dash/`) instead of Blockchair
- Blockchair returns unconfirmed UTXOs that conflict with Dash InstaSend locks, causing `tx-txlock-conflict` errors during signing
- RPC errors are thrown (not swallowed) so users see network errors instead of misleading "insufficient balance"

Replaces vultisig/vultisig-windows#3644 which targeted files deleted in the workspace refactor (#3647).

## Test plan
- [ ] Send Dash from a vault — verify UTXOs are fetched and tx signs successfully
- [ ] Verify no `tx-txlock-conflict` errors on recently received Dash
- [ ] Confirm error is shown if Dash RPC endpoint is unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Dash UTXO retrieval via RPC, returning UTXO lists for Dash addresses.
  * UTXO results are filtered by configured minimum thresholds and returned in the unified UTXO format; Dash is now integrated into the general UTXO fetch flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->