### PR TITLE
feat: pluggable MpcEngine architecture for React Native support

### DIFF
--- a/packages/mpc-native/android/src/main/java/expo/modules/mpcnative/ExpoMpcNativeModule.kt
+++ b/packages/mpc-native/android/src/main/java/expo/modules/mpcnative/ExpoMpcNativeModule.kt
@@ -504,8 +504,10 @@ class ExpoMpcNativeModule : Module() {
     private fun decode(b64: String): ByteArray =
         Base64.decode(b64, Base64.NO_WRAP)
 
-    private fun decodeHex(hex: String): ByteArray =
-        hex.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+    private fun decodeHex(hex: String): ByteArray {
+        require(hex.length % 2 == 0) { "Hex string must have even length, got ${hex.length}" }
+        return hex.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+    }
 
     private fun encodeIds(ids: List<String>): ByteArray {
         val result = mutableListOf<Byte>()


### PR DESCRIPTION
## Summary

Introduces a pluggable MPC engine abstraction so the SDK can run on React Native (native Go binaries) in addition to existing browser/Node/Electron targets (WASM). Zero breaking changes for existing consumers.

## New packages

- **@vultisig/mpc-types** — Shared interfaces (`MpcEngine`, `MpcSession`, `MpcKeyshare`) that both backends implement
- **@vultisig/mpc-wasm** — WASM implementation wrapping existing wasm-bindgen (identical behavior to before)
- **@vultisig/mpc-native** — Expo native module (Swift/Kotlin) wrapping Go MPC binaries (`godkls` + `goschnorr`) via C FFI

## Core refactor

`packages/core/mpc/` now calls `getMpcEngine()` instead of importing WASM directly. Each platform entry point auto-registers the right engine:

- **Browser/Node/Electron:** `configureMpc(new WasmMpcEngine())` — uses existing WASM, zero behavior change
- **React Native:** `configureMpc(new NativeMpcEngine())` — uses native Go binaries via Expo module

## Why binaries are vendored in the native module

The Go MPC binaries (`.xcframework` for iOS, `.aar` for Android) are committed directly into `packages/mpc-native/`. The upstream Go repo doesn't publish releases or downloadable artifacts, so there's no CI-friendly way to fetch them at build time. Vendoring them keeps the build deterministic and avoids a fragile download step. If the Go repo starts publishing releases later, we can always switch to fetching them dynamically.

## Notable fixes

- C FFI calls pass `nil` for optional parameters (not empty `go_slice` pointers)
- `finishKeygen` / `finishSchnorrKeygen` return full results (`publicKey`, `chainCode`, `keyshare`) matching the old expo-dkls API
- Public keys returned as hex strings (not base64) to match existing app expectations
- Key import accepts hex-encoded private keys/chain codes matching the old API
- AES-GCM and MD5 polyfills for React Native (replaces Node.js `crypto`)

## React Native SDK entry point

New `@vultisig/sdk/react-native` export that selectively re-exports keysign + types without pulling in Node.js dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native MPC support added for iOS and Android via Expo native modules; WASM and native engines available.
  * Pluggable MPC engine API and TypeScript runtime for DKLS and Schnorr flows.
  * React Native platform now initializes and exposes the MPC backend and related SDK exports.

* **Chores**
  * New packages: mpc-types, mpc-wasm, mpc-native; workspace and package configs updated.
  * CI and release workflows updated to build and consider the new packages; .gitignore and build scripts adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->