### PR TITLE
fix(executor): strip parens from function_name to prevent selector doubling

### DIFF
--- a/clients/cli/src/agent/executor.ts
+++ b/clients/cli/src/agent/executor.ts
@@ -1211,8 +1211,11 @@ export class AgentExecutor {
  */
 async function encodeContractCall(functionName: string, params: Array<{ type: string; value: string }>): Promise<string> {
   // Build the function signature: e.g. "approve(address,uint256)"
+  // Strip existing parens if the LLM passed a full signature like "approve(address,uint256)"
+  // to avoid doubling: "approve(address,uint256)(address,uint256)"
+  const baseName = functionName.includes('(') ? functionName.split('(')[0] : functionName
   const types = params.map(p => p.type)
-  const sig = `${functionName}(${types.join(',')})`
+  const sig = `${baseName}(${types.join(',')})`
 
   // Compute 4-byte selector via keccak256
   const selector = await keccak256Selector(sig)


### PR DESCRIPTION
## Summary

When the LLM passes `function_name` with types included (e.g. `"approve(address,uint256)"`), `encodeContractCall` was building the signature as `"approve(address,uint256)(address,uint256)"` — producing wrong selector `0xa186e650` instead of `0x095ea7b3`.

This caused ERC-20 approve transactions to silently revert (wrong function called on token contract), leaving allowance at 0 and blocking subsequent sells.

## Fix

Extract the base name before appending types:

```typescript
const baseName = functionName.includes('(') ? functionName.split('(')[0] : functionName
const sig = `${baseName}(${types.join(',')})`
```

Both `"approve"` and `"approve(address,uint256)"` now produce the correct selector `0x095ea7b3`.

## Context

The LLM learns to include types in `function_name` from the `read_evm_contract` prompt examples (e.g. `"allowance(address,address)"`). A companion fix in agent-backend (vultisig/agent-backend#64) clarifies the prompt, but this SDK fix makes `encodeContractCall` resilient regardless of input format.

## Test plan

- [x] `keccak256("approve(address,uint256)")` = `0x095ea7b3` (both input forms)
- [x] `keccak256("transfer(address,uint256)")` = `0xa9059cbb` (both input forms)
- [x] E2E: YT-USDG approve on-chain with correct selector, allowance set to MAX_UINT256
- [x] 5/6 trades SUCCESS across 3 buy/sell pairs (PT + YT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contract call encoding to correctly process function signatures when parameter information is already included, preventing selector computation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->