### PR TITLE
feat: add @vultisig/walletcore-native Expo module

### DIFF
--- a/.config/tsconfig.json
+++ b/.config/tsconfig.json
@@ -24,7 +24,8 @@
       "@vultisig/lib-dkls/*": ["packages/lib/dkls/*"],
       "@vultisig/lib-mldsa/*": ["packages/lib/mldsa/*"],
       "@vultisig/lib-schnorr/*": ["packages/lib/schnorr/*"],
-      "@vultisig/sdk": ["packages/sdk/src/index.ts"]
+      "@vultisig/sdk": ["packages/sdk/src/index.ts"],
+      "@vultisig/walletcore-native": ["packages/walletcore-native/src/index.ts"]
     }
   },
   "references": [],
@@ -38,6 +39,7 @@
     "../packages/sdk/src/**/*.tsx",
     "../packages/core/**/*.ts",
     "../packages/lib/**/*.ts",
-    "../packages/rujira/src/**/*.ts"
+    "../packages/rujira/src/**/*.ts",
+    "../packages/walletcore-native/src/**/*.ts"
   ]
 }

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -20,9 +20,9 @@ configureWasm(async () => NativeWalletCore.getInstance())
 export { Chain } from '@vultisig/core-chain/Chain'
 
 // Address derivation and chain utilities
+export { getCoinType } from '@vultisig/core-chain/coin/coinType'
 export { deriveAddress } from '@vultisig/core-chain/publicKey/address/deriveAddress'
 export { getPublicKey } from '@vultisig/core-chain/publicKey/getPublicKey'
-export { getCoinType } from '@vultisig/core-chain/coin/coinType'
 export { isValidAddress } from '@vultisig/core-chain/utils/isValidAddress'
 
 // MPC keysign (uses MpcEngine — no direct WASM imports)


### PR DESCRIPTION
## Summary

Adds walletcore-native Expo module bridging TrustWallet WalletCore natively for React Native.

Stacks on feat/react-native-clean (MPC native support).

### Included
- packages/walletcore-native/ with JS facade, iOS Swift, Android Kotlin
- ~40 bridged functions (CoinType, PublicKey, AnyAddress, TransactionCompiler, HDWallet, etc.)
- SDK RN platform registers NativeWalletCore via configureWasm()
- Exports: deriveAddress, getPublicKey, getCoinType, isValidAddress

Zero changes to core-chain or core-mpc.

Generated with Claude Code