### PR TITLE
chore: add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - dependencies
+    groups:
+      vultisig:
+        patterns:
+          - "@vultisig/*"
+    open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - dependencies


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` for automated dependency updates (weekly on Mondays, grouped Vultisig deps)

Part of ai-combinator/vultihub#11 (Team Infra & Process Setup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled automated dependency updates on a weekly Monday schedule for package and workflow updates.
  * Dependency PRs are labeled "dependencies".
  * Packages matching the project scope are grouped under a single "vultisig" group.
  * Limits concurrency to a maximum of 10 open dependency pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->