### PR TITLE
fix: build:shared fails on Windows

### DIFF
--- a/scripts/build-shared-packages.mjs
+++ b/scripts/build-shared-packages.mjs
@@ -37,7 +37,13 @@ const syncTargets = [
 const tsc = spawnSync('yarn', ['exec', 'tsc', '--project', '.config/tsconfig.shared-publish.json'], {
   cwd: repoRoot,
   stdio: 'inherit',
+  shell: true,
 })
+
+if (tsc.error) {
+  console.error('Failed to spawn tsc:', tsc.error.message)
+  process.exit(1)
+}
 
 if (tsc.status !== 0) {
   process.exit(tsc.status ?? 1)


### PR DESCRIPTION
## Summary
- Fixes #188
- `build:shared` fails silently on Windows because `spawnSync('yarn', ...)` can't execute `.cmd` shims without `shell: true`
- Adds `shell: true` to the `tsc` spawn in `build-shared-packages.mjs`
- Adds `tsc.error` handling to surface spawn failures

## Root Cause
On Windows, `yarn` is a `.cmd` file (corepack shim). Node's `spawnSync` can't execute `.cmd` files directly — it needs `shell: true` to resolve them via the system shell. Without it, `tsc` never runs and the script silently exits.

## Proof
Validated in vultisig/vultisig-windows#3685 — the Windows desktop build now passes with this fix:
- `build:shared` produces `dist/` files successfully on `windows-latest`
- Full CI green: https://github.com/vultisig/vultisig-windows/actions/runs/23949417567

## Changes
- `scripts/build-shared-packages.mjs`: add `shell: true` and `tsc.error` check

## Test plan
- [x] `yarn build:shared` passes on Linux (CI)
- [x] `yarn build:shared` passes on Windows (validated by vultisig-windows CI)