### PR TITLE
fix(core-mpc): add missing @vultisig/mpc-types dependency

### DIFF
--- a/packages/core/mpc/package.json
+++ b/packages/core/mpc/package.json
@@ -963,6 +963,7 @@
     "@vultisig/lib-mldsa": "0.9.0",
     "@vultisig/lib-schnorr": "0.9.0",
     "@vultisig/lib-utils": "0.9.1",
+    "@vultisig/mpc-types": "0.1.0",
     "bitcoinjs-lib": "^7.0.1",
     "bs58": "^6.0.0",
     "cosmjs-types": "^0.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6750,6 +6750,7 @@ __metadata:
     "@vultisig/lib-mldsa": "npm:0.9.0"
     "@vultisig/lib-schnorr": "npm:0.9.0"
     "@vultisig/lib-utils": "npm:0.9.1"
+    "@vultisig/mpc-types": "npm:0.1.0"
     bitcoinjs-lib: "npm:^7.0.1"
     bs58: "npm:^6.0.0"
     cosmjs-types: "npm:^0.11.0"
@@ -6868,7 +6869,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@vultisig/mpc-types@workspace:*, @vultisig/mpc-types@workspace:packages/mpc-types":
+"@vultisig/mpc-types@npm:0.1.0, @vultisig/mpc-types@workspace:*, @vultisig/mpc-types@workspace:packages/mpc-types":
   version: 0.0.0-use.local
   resolution: "@vultisig/mpc-types@workspace:packages/mpc-types"
   languageName: unknown


### PR DESCRIPTION
## Summary
- `@vultisig/core-mpc` imports `getMpcEngine`, `MpcKeyshare`, and `MpcSession` from `@vultisig/mpc-types` in 5 source files but did not declare it as a dependency
- Adds `@vultisig/mpc-types: 0.1.0` to `packages/core/mpc/package.json` so the package resolves correctly when consumed outside the monorepo workspace (e.g. via `npm pack`)

## Test plan
- [x] `yarn build:shared` succeeds
- [x] `npm pack packages/core/mpc` produces a valid tarball with `@vultisig/mpc-types` listed in dependencies
- [x] Existing tests pass (`yarn test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependencies to enable expanded internal functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->