### PR TITLE
feat: thorchain lp primitives in @vultisig/core-chain

### DIFF
--- a/packages/core/chain/chains/cosmos/thor/lp/affiliate.ts
+++ b/packages/core/chain/chains/cosmos/thor/lp/affiliate.ts
@@ -1,0 +1,15 @@
+/**
+ * Vultisig affiliate identifier on THORChain.
+ *
+ * THORName "vi" is the Vultisig affiliate, used across iOS, Windows, and now
+ * the agent stack to attribute swaps and LP actions on Midgard.
+ *
+ * Source of truth: VultisigApp/.../THORChainSwaps.swift uses
+ * `affiliateFeeAddress = "vi"` and the production memo fixtures
+ * (vultisig-ios/.../TestData/thorchainswap.json) carry `:vi:0`.
+ *
+ * v1 LP ships at 0 bps so we get Midgard affiliate-stats tracking without
+ * taking a fee. Bump the bps constant when product agrees.
+ */
+export const VULTISIG_AFFILIATE_NAME = 'vi'
+export const VULTISIG_AFFILIATE_LP_BPS = 0

--- a/packages/core/chain/chains/cosmos/thor/lp/index.ts
+++ b/packages/core/chain/chains/cosmos/thor/lp/index.ts
@@ -1,0 +1,38 @@
+/**
+ * THORChain liquidity-pool primitives.
+ *
+ * Pure-function memo + payload builders alongside thin Midgard / thornode
+ * fetchers. Used by `vultisig-mcp-ts` (which exposes them as MCP tools) and
+ * eventually by `vultiagent-poc` once the SDK migration (VA-133) lands.
+ *
+ * v1 surface is intentionally narrow: asymmetric RUNE-side adds and
+ * removes only. Asset-side adds (BTC/ETH/etc → inbound vault) and explicit
+ * symmetric pairing are deferred until the end-to-end chat flow has shipped.
+ */
+export {
+  VULTISIG_AFFILIATE_LP_BPS,
+  VULTISIG_AFFILIATE_NAME,
+} from './affiliate'
+export type { AddLpMemoInput, RemoveLpMemoInput } from './memo'
+export { addLpMemo, removeLpMemo } from './memo'
+export type {
+  BuildThorchainLpAddPayloadInput,
+  BuildThorchainLpRemovePayloadInput,
+  ThorchainLpAddPayload,
+  ThorchainLpRemovePayload,
+} from './payload'
+export {
+  buildThorchainLpAddPayload,
+  buildThorchainLpRemovePayload,
+} from './payload'
+export type {
+  GetThorchainPoolsOptions,
+  ThorchainPoolSummary,
+} from './pools'
+export { getThorchainPools, THORCHAIN_MIDGARD_BASE_URL } from './pools'
+export type {
+  GetThorchainLpPositionInput,
+  ThorchainLpPosition,
+} from './position'
+export { getThorchainLpPosition } from './position'
+export { assertPoolDepositable } from './validation'

--- a/packages/core/chain/chains/cosmos/thor/lp/index.ts
+++ b/packages/core/chain/chains/cosmos/thor/lp/index.ts
@@ -29,7 +29,7 @@ export type {
   GetThorchainPoolsOptions,
   ThorchainPoolSummary,
 } from './pools'
-export { getThorchainPools, THORCHAIN_MIDGARD_BASE_URL } from './pools'
+export { getThorchainPools, thorchainMidgardBaseUrl } from './pools'
 export type {
   GetThorchainLpPositionInput,
   ThorchainLpPosition,

--- a/packages/core/chain/chains/cosmos/thor/lp/memo.test.ts
+++ b/packages/core/chain/chains/cosmos/thor/lp/memo.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  VULTISIG_AFFILIATE_LP_BPS,
+  VULTISIG_AFFILIATE_NAME,
+} from './affiliate'
+import { addLpMemo, removeLpMemo } from './memo'
+
+describe('addLpMemo', () => {
+  it('emits the asym RUNE-side default memo with vultisig affiliate at 0 bps', () => {
+    expect(addLpMemo({ pool: 'BTC.BTC' })).toBe('+:BTC.BTC::vi:0')
+  })
+
+  it('emits a symmetric memo when a paired address is provided', () => {
+    expect(
+      addLpMemo({
+        pool: 'BTC.BTC',
+        pairedAddress: 'bc1qaddress',
+      })
+    ).toBe('+:BTC.BTC:bc1qaddress:vi:0')
+  })
+
+  it('honors caller-provided affiliate and bps overrides', () => {
+    expect(
+      addLpMemo({
+        pool: 'ETH.USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48',
+        affiliate: 'ss',
+        affiliateBps: 60,
+      })
+    ).toBe(
+      '+:ETH.USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48::ss:60'
+    )
+  })
+
+  it('uses the affiliate constants from the affiliate module', () => {
+    const memo = addLpMemo({ pool: 'BTC.BTC' })
+    expect(memo).toContain(`:${VULTISIG_AFFILIATE_NAME}:`)
+    expect(memo).toMatch(new RegExp(`:${VULTISIG_AFFILIATE_LP_BPS}$`))
+  })
+})
+
+describe('removeLpMemo', () => {
+  it('emits a 100% withdraw memo for 10000 bps', () => {
+    expect(removeLpMemo({ pool: 'BTC.BTC', basisPoints: 10000 })).toBe(
+      '-:BTC.BTC:10000'
+    )
+  })
+
+  it('emits a partial withdraw memo for 2500 bps', () => {
+    expect(removeLpMemo({ pool: 'ETH.ETH', basisPoints: 2500 })).toBe(
+      '-:ETH.ETH:2500'
+    )
+  })
+
+  it.each([0, -1, 10001, 1.5, NaN])(
+    'rejects out-of-range or non-integer basisPoints (%s)',
+    bps => {
+      expect(() =>
+        removeLpMemo({ pool: 'BTC.BTC', basisPoints: bps })
+      ).toThrow(/basisPoints/)
+    }
+  )
+
+  it('does not append an affiliate suffix to withdraws', () => {
+    const memo = removeLpMemo({ pool: 'BTC.BTC', basisPoints: 10000 })
+    expect(memo).not.toContain('vi')
+    expect(memo.split(':')).toHaveLength(3)
+  })
+})

--- a/packages/core/chain/chains/cosmos/thor/lp/memo.ts
+++ b/packages/core/chain/chains/cosmos/thor/lp/memo.ts
@@ -1,0 +1,67 @@
+import {
+  VULTISIG_AFFILIATE_LP_BPS,
+  VULTISIG_AFFILIATE_NAME,
+} from './affiliate'
+
+export type AddLpMemoInput = {
+  /** Canonical pool id, e.g. `BTC.BTC` or `ETH.USDC-0X...`. */
+  pool: string
+  /**
+   * Paired L1 address. Omit for asymmetric adds (the v1 path). When set,
+   * THORChain will hold the deposit pending and pair it with a matching
+   * deposit from the other side, producing a symmetric position.
+   */
+  pairedAddress?: string
+  /** Affiliate THORName. Defaults to `VULTISIG_AFFILIATE_NAME`. */
+  affiliate?: string
+  /** Affiliate fee in basis points. Defaults to `VULTISIG_AFFILIATE_LP_BPS`. */
+  affiliateBps?: number
+}
+
+/**
+ * Build a THORChain liquidity-pool add memo.
+ *
+ * Format: `+:POOL:PAIRED_ADDR:AFFILIATE:BPS`
+ *
+ * For an asymmetric RUNE-side add with the default Vultisig affiliate at
+ * 0 bps the memo looks like `+:BTC.BTC::vi:0`. The empty paired-address slot
+ * is intentional — that is what tells THORChain to register the position as
+ * asymmetric.
+ */
+export const addLpMemo = (input: AddLpMemoInput): string => {
+  const affiliate = input.affiliate ?? VULTISIG_AFFILIATE_NAME
+  const bps = input.affiliateBps ?? VULTISIG_AFFILIATE_LP_BPS
+  const paired = input.pairedAddress ?? ''
+  return `+:${input.pool}:${paired}:${affiliate}:${bps}`
+}
+
+export type RemoveLpMemoInput = {
+  pool: string
+  /** Withdraw fraction in basis points: 1..10000 (10000 = 100%). */
+  basisPoints: number
+}
+
+/**
+ * Build a THORChain liquidity-pool remove memo.
+ *
+ * Format: `-:POOL:BPS`
+ *
+ * Withdraws do not include an affiliate suffix per the THORChain memo spec.
+ * THORChain enforces a 1-hour lockup after the most recent add — broadcasting
+ * a withdraw inside that window will fail at the chain level.
+ */
+export const removeLpMemo = ({
+  pool,
+  basisPoints,
+}: RemoveLpMemoInput): string => {
+  if (
+    !Number.isInteger(basisPoints) ||
+    basisPoints < 1 ||
+    basisPoints > 10000
+  ) {
+    throw new Error(
+      `removeLpMemo: basisPoints must be an integer in [1, 10000], got ${basisPoints}`
+    )
+  }
+  return `-:${pool}:${basisPoints}`
+}

--- a/packages/core/chain/chains/cosmos/thor/lp/memo.ts
+++ b/packages/core/chain/chains/cosmos/thor/lp/memo.ts
@@ -2,6 +2,7 @@ import {
   VULTISIG_AFFILIATE_LP_BPS,
   VULTISIG_AFFILIATE_NAME,
 } from './affiliate'
+import { assertValidPoolId } from './pools'
 
 export type AddLpMemoInput = {
   /** Canonical pool id, e.g. `BTC.BTC` or `ETH.USDC-0X...`. */
@@ -29,6 +30,7 @@ export type AddLpMemoInput = {
  * asymmetric.
  */
 export const addLpMemo = (input: AddLpMemoInput): string => {
+  assertValidPoolId(input.pool)
   const affiliate = input.affiliate ?? VULTISIG_AFFILIATE_NAME
   const bps = input.affiliateBps ?? VULTISIG_AFFILIATE_LP_BPS
   const paired = input.pairedAddress ?? ''
@@ -54,6 +56,7 @@ export const removeLpMemo = ({
   pool,
   basisPoints,
 }: RemoveLpMemoInput): string => {
+  assertValidPoolId(pool)
   if (
     !Number.isInteger(basisPoints) ||
     basisPoints < 1 ||

--- a/packages/core/chain/chains/cosmos/thor/lp/payload.test.ts
+++ b/packages/core/chain/chains/cosmos/thor/lp/payload.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildThorchainLpAddPayload,
+  buildThorchainLpRemovePayload,
+} from './payload'
+
+describe('buildThorchainLpAddPayload', () => {
+  it('produces a flat payload with the correct shape for a 0.01 RUNE add', () => {
+    const payload = buildThorchainLpAddPayload({
+      pool: 'BTC.BTC',
+      amountRuneBaseUnits: '1000000',
+    })
+    expect(payload).toEqual({
+      kind: 'thorchain_lp_add',
+      chain: 'THORChain',
+      denom: 'rune',
+      amount: '1000000',
+      memo: '+:BTC.BTC::vi:0',
+      pool: 'BTC.BTC',
+      affiliate: 'vi',
+      affiliateBps: 0,
+    })
+  })
+
+  it('keeps the payload single-nesting-level (no nested objects)', () => {
+    const payload = buildThorchainLpAddPayload({
+      pool: 'ETH.ETH',
+      amountRuneBaseUnits: '50000000',
+    })
+    for (const value of Object.values(payload)) {
+      expect(typeof value).not.toBe('object')
+    }
+  })
+
+  it.each(['0', '-1', '1.5', '', 'abc'])(
+    'rejects invalid amountRuneBaseUnits (%s)',
+    amount => {
+      expect(() =>
+        buildThorchainLpAddPayload({ pool: 'BTC.BTC', amountRuneBaseUnits: amount })
+      ).toThrow(/amountRuneBaseUnits/)
+    }
+  )
+})
+
+describe('buildThorchainLpRemovePayload', () => {
+  it('produces a flat payload with the dust amount and bps memo', () => {
+    const payload = buildThorchainLpRemovePayload({
+      pool: 'BTC.BTC',
+      basisPoints: 10000,
+    })
+    expect(payload).toEqual({
+      kind: 'thorchain_lp_remove',
+      chain: 'THORChain',
+      denom: 'rune',
+      amount: '2000000',
+      memo: '-:BTC.BTC:10000',
+      pool: 'BTC.BTC',
+      basisPoints: 10000,
+    })
+  })
+
+  it('uses the dust amount regardless of bps for partial withdraws', () => {
+    const partial = buildThorchainLpRemovePayload({
+      pool: 'ETH.ETH',
+      basisPoints: 2500,
+    })
+    expect(partial.amount).toBe('2000000')
+    expect(partial.memo).toBe('-:ETH.ETH:2500')
+  })
+
+  it('rejects out-of-range basis points via the underlying memo builder', () => {
+    expect(() =>
+      buildThorchainLpRemovePayload({ pool: 'BTC.BTC', basisPoints: 0 })
+    ).toThrow(/basisPoints/)
+  })
+})

--- a/packages/core/chain/chains/cosmos/thor/lp/payload.ts
+++ b/packages/core/chain/chains/cosmos/thor/lp/payload.ts
@@ -1,0 +1,99 @@
+import {
+  VULTISIG_AFFILIATE_LP_BPS,
+  VULTISIG_AFFILIATE_NAME,
+} from './affiliate'
+import { addLpMemo, removeLpMemo } from './memo'
+
+/**
+ * Flat unsigned-transaction payload for an asymmetric RUNE-side LP add.
+ *
+ * Shape stays single-nesting-level on purpose: this object is what flows
+ * through the agent backend's SSE `tx_ready` event, and the audit
+ * (2026-04-09) flagged tool result flattening as a known wire-level hazard
+ * for nested fields. Every consumer (MCP tool result, backend SSE emit, app
+ * `parseServerTx`) reads the same flat keys.
+ */
+export type ThorchainLpAddPayload = {
+  kind: 'thorchain_lp_add'
+  chain: 'THORChain'
+  denom: 'rune'
+  /** RUNE base units; 1 RUNE = 100000000 (8 decimals). */
+  amount: string
+  /** Pre-built memo via `addLpMemo`. */
+  memo: string
+  /** Canonical pool id, denormalized for display. */
+  pool: string
+  /** Affiliate THORName, denormalized for display. */
+  affiliate: string
+  /** Affiliate fee in basis points, denormalized for display. */
+  affiliateBps: number
+}
+
+export type ThorchainLpRemovePayload = {
+  kind: 'thorchain_lp_remove'
+  chain: 'THORChain'
+  denom: 'rune'
+  /** Dust amount in RUNE base units. The withdraw fraction lives in the memo. */
+  amount: string
+  /** Pre-built memo via `removeLpMemo`. */
+  memo: string
+  pool: string
+  basisPoints: number
+}
+
+/**
+ * Dust amount used for LP removes.
+ *
+ * Reference: vultisig-windows/core/ui/vault/deposit/keysignPayload/build.ts
+ * sends 0.02 RUNE on LP remove transactions — the on-chain amount is just
+ * dust to make the cosmos message valid; the actual withdraw fraction lives
+ * inside the memo (`-:POOL:BPS`).
+ */
+const LP_REMOVE_DUST_RUNE_BASE_UNITS = '2000000'
+
+const isPositiveBaseUnitString = (value: string): boolean =>
+  /^\d+$/.test(value) && BigInt(value) > 0n
+
+export type BuildThorchainLpAddPayloadInput = {
+  pool: string
+  amountRuneBaseUnits: string
+}
+
+export const buildThorchainLpAddPayload = ({
+  pool,
+  amountRuneBaseUnits,
+}: BuildThorchainLpAddPayloadInput): ThorchainLpAddPayload => {
+  if (!isPositiveBaseUnitString(amountRuneBaseUnits)) {
+    throw new Error(
+      `buildThorchainLpAddPayload: amountRuneBaseUnits must be a positive integer string, got ${amountRuneBaseUnits}`
+    )
+  }
+  return {
+    kind: 'thorchain_lp_add',
+    chain: 'THORChain',
+    denom: 'rune',
+    amount: amountRuneBaseUnits,
+    memo: addLpMemo({ pool }),
+    pool,
+    affiliate: VULTISIG_AFFILIATE_NAME,
+    affiliateBps: VULTISIG_AFFILIATE_LP_BPS,
+  }
+}
+
+export type BuildThorchainLpRemovePayloadInput = {
+  pool: string
+  basisPoints: number
+}
+
+export const buildThorchainLpRemovePayload = ({
+  pool,
+  basisPoints,
+}: BuildThorchainLpRemovePayloadInput): ThorchainLpRemovePayload => ({
+  kind: 'thorchain_lp_remove',
+  chain: 'THORChain',
+  denom: 'rune',
+  amount: LP_REMOVE_DUST_RUNE_BASE_UNITS,
+  memo: removeLpMemo({ pool, basisPoints }),
+  pool,
+  basisPoints,
+})

--- a/packages/core/chain/chains/cosmos/thor/lp/pools.test.ts
+++ b/packages/core/chain/chains/cosmos/thor/lp/pools.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import { assertValidPoolId, isValidPoolId } from './pools'
+
+describe('assertValidPoolId / isValidPoolId', () => {
+  describe('accepts canonical THORChain pool ids', () => {
+    const valid = [
+      'BTC.BTC',
+      'LTC.LTC',
+      'BCH.BCH',
+      'DOGE.DOGE',
+      'ETH.ETH',
+      'BSC.BNB',
+      'AVAX.AVAX',
+      'GAIA.ATOM',
+      // ERC-20-style with contract suffix (uppercase 0x... preserved)
+      'ETH.USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48',
+      'ETH.USDT-0XDAC17F958D2EE523A2206206994597C13D831EC7',
+      'BSC.BUSD-0XE9E7CEA3DEDCA5984780BAFC599BD69ADD087D56',
+      // Numbers in chain or asset section are valid
+      'ETH.4OWL',
+    ]
+    for (const pool of valid) {
+      it(`accepts ${pool}`, () => {
+        expect(isValidPoolId(pool)).toBe(true)
+        expect(() => assertValidPoolId(pool)).not.toThrow()
+      })
+    }
+  })
+
+  describe('rejects malformed ids', () => {
+    const invalid: { input: unknown; reason: string }[] = [
+      { input: 'btc.btc', reason: 'lowercase' },
+      { input: 'BTC.btc', reason: 'mixed case' },
+      { input: 'BTC/BTC', reason: 'slash separator' },
+      { input: 'BTC', reason: 'no asset section' },
+      { input: '.BTC', reason: 'no chain section' },
+      { input: 'BTC.', reason: 'no asset section' },
+      { input: 'BTC.BTC.BTC', reason: 'extra section' },
+      { input: 'BTC.BTC ', reason: 'trailing space' },
+      { input: ' BTC.BTC', reason: 'leading space' },
+      { input: '', reason: 'empty string' },
+      { input: 'eth.usdc-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', reason: 'lowercase contract section' },
+      { input: 'BTC.BTC-', reason: 'trailing dash' },
+      { input: undefined as unknown as string, reason: 'undefined' },
+      { input: null as unknown as string, reason: 'null' },
+      { input: 42 as unknown as string, reason: 'number' },
+    ]
+    for (const { input, reason } of invalid) {
+      it(`rejects ${reason}: ${JSON.stringify(input)}`, () => {
+        expect(isValidPoolId(input as string)).toBe(false)
+        expect(() => assertValidPoolId(input as string)).toThrow()
+      })
+    }
+  })
+
+  it('error message includes the offending value for diagnostics', () => {
+    expect(() => assertValidPoolId('btc.btc')).toThrow(/btc\.btc/)
+  })
+})

--- a/packages/core/chain/chains/cosmos/thor/lp/pools.ts
+++ b/packages/core/chain/chains/cosmos/thor/lp/pools.ts
@@ -4,7 +4,7 @@ import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
  * Midgard base URL used by every helper in this module. Matches what
  * vultisig-ios and the rujira package use as the default mainnet endpoint.
  */
-export const THORCHAIN_MIDGARD_BASE_URL = 'https://midgard.ninerealms.com'
+export const thorchainMidgardBaseUrl = 'https://midgard.ninerealms.com'
 
 /**
  * Subset of the Midgard `/v2/pools` shape that the agent stack actually
@@ -58,8 +58,13 @@ export const getThorchainPools = async (
   const status = options.status === undefined ? 'available' : options.status
   const url =
     status === null
-      ? `${THORCHAIN_MIDGARD_BASE_URL}/v2/pools`
-      : `${THORCHAIN_MIDGARD_BASE_URL}/v2/pools?status=${encodeURIComponent(status)}`
-  const raw = await queryUrl<RawPool[]>(url)
-  return raw.map(normalizePool)
+      ? `${thorchainMidgardBaseUrl}/v2/pools`
+      : `${thorchainMidgardBaseUrl}/v2/pools?status=${encodeURIComponent(status)}`
+  const raw = await queryUrl<unknown>(url)
+  if (!Array.isArray(raw)) {
+    throw new Error(
+      `getThorchainPools: expected an array from ${url}, got ${typeof raw}`
+    )
+  }
+  return (raw as RawPool[]).map(normalizePool)
 }

--- a/packages/core/chain/chains/cosmos/thor/lp/pools.ts
+++ b/packages/core/chain/chains/cosmos/thor/lp/pools.ts
@@ -1,0 +1,65 @@
+import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+
+/**
+ * Midgard base URL used by every helper in this module. Matches what
+ * vultisig-ios and the rujira package use as the default mainnet endpoint.
+ */
+export const THORCHAIN_MIDGARD_BASE_URL = 'https://midgard.ninerealms.com'
+
+/**
+ * Subset of the Midgard `/v2/pools` shape that the agent stack actually
+ * cares about. The full Midgard response carries dozens of fields per pool;
+ * we narrow to the ones the LLM needs to pick a pool and present quotes.
+ */
+export type ThorchainPoolSummary = {
+  asset: string
+  status: string
+  assetDepth: string
+  runeDepth: string
+  liquidityUnits: string
+  volume24h: string
+  annualPercentageRate: string
+}
+
+type RawPool = {
+  asset?: string
+  status?: string
+  assetDepth?: string
+  runeDepth?: string
+  liquidityUnits?: string
+  volume24h?: string
+  annualPercentageRate?: string
+}
+
+const normalizePool = (raw: RawPool): ThorchainPoolSummary => ({
+  asset: raw.asset ?? '',
+  status: raw.status ?? '',
+  assetDepth: raw.assetDepth ?? '0',
+  runeDepth: raw.runeDepth ?? '0',
+  liquidityUnits: raw.liquidityUnits ?? '0',
+  volume24h: raw.volume24h ?? '0',
+  annualPercentageRate: raw.annualPercentageRate ?? '0',
+})
+
+export type GetThorchainPoolsOptions = {
+  /** Defaults to `'available'`. Pass `null` to skip the filter. */
+  status?: string | null
+}
+
+/**
+ * Fetch THORChain pools from Midgard.
+ *
+ * By default returns only `status=available` pools — the only ones that
+ * accept LP adds. Pass `{ status: null }` to fetch every pool regardless.
+ */
+export const getThorchainPools = async (
+  options: GetThorchainPoolsOptions = {}
+): Promise<ThorchainPoolSummary[]> => {
+  const status = options.status === undefined ? 'available' : options.status
+  const url =
+    status === null
+      ? `${THORCHAIN_MIDGARD_BASE_URL}/v2/pools`
+      : `${THORCHAIN_MIDGARD_BASE_URL}/v2/pools?status=${encodeURIComponent(status)}`
+  const raw = await queryUrl<RawPool[]>(url)
+  return raw.map(normalizePool)
+}

--- a/packages/core/chain/chains/cosmos/thor/lp/pools.ts
+++ b/packages/core/chain/chains/cosmos/thor/lp/pools.ts
@@ -7,6 +7,64 @@ import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 export const thorchainMidgardBaseUrl = 'https://midgard.ninerealms.com'
 
 /**
+ * Canonical THORChain pool-id format: `CHAIN.ASSET` for native assets
+ * (e.g. `BTC.BTC`, `ETH.ETH`) or `CHAIN.ASSET-CONTRACT` for ERC-20-style
+ * tokens (e.g. `ETH.USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48`).
+ *
+ * THORChain itself stores pool ids in uppercase. Lowercase variants
+ * round-trip through Midgard but several internal lookups (and the
+ * thornode `/thorchain/pool/{asset}` endpoint) are case-sensitive on the
+ * chain prefix and contract section, so we enforce uppercase + the
+ * documented separators here to fail fast on typos.
+ *
+ * Examples accepted:
+ *   BTC.BTC
+ *   LTC.LTC
+ *   ETH.USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48
+ *   BSC.BNB
+ *
+ * Examples rejected:
+ *   "btc.btc" (lowercase)
+ *   "BTC/BTC" (wrong separator)
+ *   "BTC" (no asset section)
+ *   "BTC.BTC.BTC" (extra section)
+ */
+const POOL_ID_RE = /^[A-Z0-9]+\.[A-Z0-9]+(-[A-Z0-9]+)?$/
+
+/**
+ * Validate a THORChain pool id is in the canonical format.
+ *
+ * Throws `Error` with the offending value embedded so callers up the
+ * stack can surface it to the user. Use this at every public entry
+ * point that accepts a pool id from the LLM or external code: it is
+ * cheaper than discovering at the build / broadcast / Midgard call
+ * that the id is malformed.
+ */
+export const assertValidPoolId = (pool: string): void => {
+  if (typeof pool !== 'string' || pool.length === 0) {
+    throw new Error(
+      `assertValidPoolId: pool id must be a non-empty string, got ${typeof pool} ${pool === '' ? '""' : ''}`
+    )
+  }
+  if (!POOL_ID_RE.test(pool)) {
+    throw new Error(
+      `assertValidPoolId: ${JSON.stringify(pool)} is not a valid THORChain pool id. ` +
+        `Expected uppercase CHAIN.ASSET (e.g. "BTC.BTC") or CHAIN.ASSET-CONTRACT ` +
+        `(e.g. "ETH.USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48").`
+    )
+  }
+}
+
+/**
+ * Boolean variant of `assertValidPoolId` for callers that just want to
+ * filter / branch instead of throwing.
+ */
+export const isValidPoolId = (pool: string): boolean => {
+  if (typeof pool !== 'string' || pool.length === 0) return false
+  return POOL_ID_RE.test(pool)
+}
+
+/**
  * Subset of the Midgard `/v2/pools` shape that the agent stack actually
  * cares about. The full Midgard response carries dozens of fields per pool;
  * we narrow to the ones the LLM needs to pick a pool and present quotes.

--- a/packages/core/chain/chains/cosmos/thor/lp/position.ts
+++ b/packages/core/chain/chains/cosmos/thor/lp/position.ts
@@ -1,6 +1,7 @@
+import { HttpResponseError } from '@vultisig/lib-utils/fetch/HttpResponseError'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
-import { thorchainMidgardBaseUrl } from './pools'
+import { assertValidPoolId, thorchainMidgardBaseUrl } from './pools'
 
 /**
  * Subset of a Midgard `/v2/member/{address}` pool entry. Midgard returns
@@ -78,26 +79,19 @@ export type GetThorchainLpPositionInput = {
  *   - the address has positions but none in the requested pool.
  */
 /**
- * Detect a 404 error from queryUrl. The current `@vultisig/lib-utils`
- * `queryUrl` + `assertFetchResponse` API surfaces non-2xx responses as
- * generic `Error` instances whose message contains the HTTP status. There
- * is no structured `status` property to read, so we string-match.
- *
- * TODO: when `assertFetchResponse` is hardened to expose a numeric status
- * (or to throw a typed `HttpError`), switch to that — see CodeRabbit
- * feedback on PR vultisig-sdk#236.
+ * Detect a 404 from queryUrl by reading the typed `HttpResponseError.status`
+ * field that `@vultisig/lib-utils` `assertFetchResponse` now throws. The
+ * previous implementation string-matched the error message; that worked
+ * but was brittle to wording changes. See NeoMakinG's PR #236 review note.
  */
-const isMidgardNotFoundError = (err: unknown): boolean => {
-  if (!(err instanceof Error)) return false
-  // Match `HTTP 404 …` or `… 404 Not Found …` to be permissive about the
-  // exact wording assertFetchResponse uses.
-  return /(?:^|\s)(?:HTTP\s+)?404(?:\s|:|$)/.test(err.message)
-}
+const isMidgardNotFoundError = (err: unknown): boolean =>
+  err instanceof HttpResponseError && err.status === 404
 
 export const getThorchainLpPosition = async ({
   thorAddress,
   pool,
 }: GetThorchainLpPositionInput): Promise<ThorchainLpPosition | null> => {
+  assertValidPoolId(pool)
   const url = `${thorchainMidgardBaseUrl}/v2/member/${encodeURIComponent(thorAddress)}`
   let raw: RawMemberResponse
   try {

--- a/packages/core/chain/chains/cosmos/thor/lp/position.ts
+++ b/packages/core/chain/chains/cosmos/thor/lp/position.ts
@@ -1,6 +1,6 @@
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
-import { THORCHAIN_MIDGARD_BASE_URL } from './pools'
+import { thorchainMidgardBaseUrl } from './pools'
 
 /**
  * Subset of a Midgard `/v2/member/{address}` pool entry. Midgard returns
@@ -77,18 +77,35 @@ export type GetThorchainLpPositionInput = {
  *   - the address has no positions at all (Midgard returns 404), or
  *   - the address has positions but none in the requested pool.
  */
+/**
+ * Detect a 404 error from queryUrl. The current `@vultisig/lib-utils`
+ * `queryUrl` + `assertFetchResponse` API surfaces non-2xx responses as
+ * generic `Error` instances whose message contains the HTTP status. There
+ * is no structured `status` property to read, so we string-match.
+ *
+ * TODO: when `assertFetchResponse` is hardened to expose a numeric status
+ * (or to throw a typed `HttpError`), switch to that — see CodeRabbit
+ * feedback on PR vultisig-sdk#236.
+ */
+const isMidgardNotFoundError = (err: unknown): boolean => {
+  if (!(err instanceof Error)) return false
+  // Match `HTTP 404 …` or `… 404 Not Found …` to be permissive about the
+  // exact wording assertFetchResponse uses.
+  return /(?:^|\s)(?:HTTP\s+)?404(?:\s|:|$)/.test(err.message)
+}
+
 export const getThorchainLpPosition = async ({
   thorAddress,
   pool,
 }: GetThorchainLpPositionInput): Promise<ThorchainLpPosition | null> => {
-  const url = `${THORCHAIN_MIDGARD_BASE_URL}/v2/member/${encodeURIComponent(thorAddress)}`
+  const url = `${thorchainMidgardBaseUrl}/v2/member/${encodeURIComponent(thorAddress)}`
   let raw: RawMemberResponse
   try {
     raw = await queryUrl<RawMemberResponse>(url)
   } catch (err) {
-    // Midgard returns 404 for any address it has not indexed yet.
-    // queryUrl bubbles fetch errors as Error — we treat 404 as "no position".
-    if (err instanceof Error && /\b404\b/.test(err.message)) return null
+    // Midgard returns 404 for any address it has not indexed yet — treat as
+    // "no position". Other errors bubble.
+    if (isMidgardNotFoundError(err)) return null
     throw err
   }
   const found = raw.pools?.find(p => p.pool === pool)

--- a/packages/core/chain/chains/cosmos/thor/lp/position.ts
+++ b/packages/core/chain/chains/cosmos/thor/lp/position.ts
@@ -108,6 +108,7 @@ export const getThorchainLpPosition = async ({
     if (isMidgardNotFoundError(err)) return null
     throw err
   }
-  const found = raw.pools?.find(p => p.pool === pool)
+  const pools = Array.isArray(raw.pools) ? raw.pools : []
+  const found = pools.find(p => p.pool === pool)
   return found ? normalizeMemberPool(found) : null
 }

--- a/packages/core/chain/chains/cosmos/thor/lp/position.ts
+++ b/packages/core/chain/chains/cosmos/thor/lp/position.ts
@@ -1,0 +1,96 @@
+import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+
+import { THORCHAIN_MIDGARD_BASE_URL } from './pools'
+
+/**
+ * Subset of a Midgard `/v2/member/{address}` pool entry. Midgard returns
+ * many more fields per position — we keep just the ones the agent stack
+ * surfaces in chat (units, added amounts, pending state, last-add timestamp).
+ */
+export type ThorchainLpPosition = {
+  pool: string
+  liquidityUnits: string
+  runeAdded: string
+  assetAdded: string
+  runePending: string
+  assetPending: string
+  runeAddress: string
+  assetAddress: string
+  /** Unix seconds (Midgard returns it as a string). */
+  dateLastAdded: string
+  /**
+   * True when either side has a non-zero pending amount. Common for
+   * asymmetric adds that THORChain has not yet credited.
+   */
+  isPending: boolean
+}
+
+type RawMemberPool = {
+  pool?: string
+  liquidityUnits?: string
+  runeAdded?: string
+  assetAdded?: string
+  runePending?: string
+  assetPending?: string
+  runeAddress?: string
+  assetAddress?: string
+  dateLastAdded?: string
+}
+
+type RawMemberResponse = {
+  pools?: RawMemberPool[]
+}
+
+const isNonZero = (s: string | undefined): boolean => {
+  if (!s) return false
+  try {
+    return BigInt(s) > 0n
+  } catch {
+    return false
+  }
+}
+
+const normalizeMemberPool = (raw: RawMemberPool): ThorchainLpPosition => ({
+  pool: raw.pool ?? '',
+  liquidityUnits: raw.liquidityUnits ?? '0',
+  runeAdded: raw.runeAdded ?? '0',
+  assetAdded: raw.assetAdded ?? '0',
+  runePending: raw.runePending ?? '0',
+  assetPending: raw.assetPending ?? '0',
+  runeAddress: raw.runeAddress ?? '',
+  assetAddress: raw.assetAddress ?? '',
+  dateLastAdded: raw.dateLastAdded ?? '0',
+  isPending: isNonZero(raw.runePending) || isNonZero(raw.assetPending),
+})
+
+export type GetThorchainLpPositionInput = {
+  /** bech32 thor1... address (the RUNE side of the position). */
+  thorAddress: string
+  /** Canonical pool id to look up. */
+  pool: string
+}
+
+/**
+ * Fetch a single LP position from Midgard.
+ *
+ * Returns `null` when:
+ *   - the address has no positions at all (Midgard returns 404), or
+ *   - the address has positions but none in the requested pool.
+ */
+export const getThorchainLpPosition = async ({
+  thorAddress,
+  pool,
+}: GetThorchainLpPositionInput): Promise<ThorchainLpPosition | null> => {
+  const url = `${THORCHAIN_MIDGARD_BASE_URL}/v2/member/${encodeURIComponent(thorAddress)}`
+  let raw: RawMemberResponse
+  try {
+    raw = await queryUrl<RawMemberResponse>(url)
+  } catch (err) {
+    // Midgard returns 404 for any address it has not indexed yet.
+    // queryUrl bubbles fetch errors as Error — we treat 404 as "no position".
+    if (err instanceof Error && /\b404\b/.test(err.message)) return null
+    throw err
+  }
+  const found = raw.pools?.find(p => p.pool === pool)
+  return found ? normalizeMemberPool(found) : null
+}

--- a/packages/core/chain/chains/cosmos/thor/lp/validation.ts
+++ b/packages/core/chain/chains/cosmos/thor/lp/validation.ts
@@ -1,0 +1,28 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { cosmosRpcUrl } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
+import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+
+type RawPoolStatus = {
+  status?: string
+}
+
+/**
+ * Verify a THORChain pool is currently depositable.
+ *
+ * Hits the thornode `/thorchain/pool/{asset}` endpoint and asserts the
+ * `status` field is `Available`. Throws on `Staged`, `Suspended`, or any
+ * other non-Available state, and on network failures.
+ *
+ * Use this as the fail-fast gate before building an LP add payload — it is
+ * cheaper than building the payload first and discovering at broadcast time
+ * that the pool is paused.
+ */
+export const assertPoolDepositable = async (pool: string): Promise<void> => {
+  const url = `${cosmosRpcUrl[Chain.THORChain]}/thorchain/pool/${encodeURIComponent(pool)}`
+  const raw = await queryUrl<RawPoolStatus>(url)
+  if (raw.status !== 'Available') {
+    throw new Error(
+      `assertPoolDepositable: pool ${pool} status is ${raw.status ?? 'unknown'}, must be Available for LP add`
+    )
+  }
+}

--- a/packages/core/chain/chains/cosmos/thor/lp/validation.ts
+++ b/packages/core/chain/chains/cosmos/thor/lp/validation.ts
@@ -2,8 +2,12 @@ import { Chain } from '@vultisig/core-chain/Chain'
 import { cosmosRpcUrl } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
-type RawPoolStatus = {
-  status?: string
+const extractPoolStatus = (raw: unknown): string | undefined => {
+  if (raw && typeof raw === 'object' && 'status' in raw) {
+    const status = (raw as { status: unknown }).status
+    return typeof status === 'string' ? status : undefined
+  }
+  return undefined
 }
 
 /**
@@ -11,7 +15,7 @@ type RawPoolStatus = {
  *
  * Hits the thornode `/thorchain/pool/{asset}` endpoint and asserts the
  * `status` field is `Available`. Throws on `Staged`, `Suspended`, or any
- * other non-Available state, and on network failures.
+ * other non-Available state, and on network failures or unexpected payloads.
  *
  * Use this as the fail-fast gate before building an LP add payload — it is
  * cheaper than building the payload first and discovering at broadcast time
@@ -19,10 +23,16 @@ type RawPoolStatus = {
  */
 export const assertPoolDepositable = async (pool: string): Promise<void> => {
   const url = `${cosmosRpcUrl[Chain.THORChain]}/thorchain/pool/${encodeURIComponent(pool)}`
-  const raw = await queryUrl<RawPoolStatus>(url)
-  if (raw.status !== 'Available') {
+  const raw = await queryUrl<unknown>(url)
+  const status = extractPoolStatus(raw)
+  if (status === undefined) {
     throw new Error(
-      `assertPoolDepositable: pool ${pool} status is ${raw.status ?? 'unknown'}, must be Available for LP add`
+      `assertPoolDepositable: pool ${pool} response from ${url} did not include a string \`status\` field`
+    )
+  }
+  if (status !== 'Available') {
+    throw new Error(
+      `assertPoolDepositable: pool ${pool} status is ${status}, must be Available for LP add`
     )
   }
 }

--- a/packages/core/chain/chains/cosmos/thor/lp/validation.ts
+++ b/packages/core/chain/chains/cosmos/thor/lp/validation.ts
@@ -2,6 +2,8 @@ import { Chain } from '@vultisig/core-chain/Chain'
 import { cosmosRpcUrl } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
+import { assertValidPoolId } from './pools'
+
 const extractPoolStatus = (raw: unknown): string | undefined => {
   if (raw && typeof raw === 'object' && 'status' in raw) {
     const status = (raw as { status: unknown }).status
@@ -22,6 +24,7 @@ const extractPoolStatus = (raw: unknown): string | undefined => {
  * that the pool is paused.
  */
 export const assertPoolDepositable = async (pool: string): Promise<void> => {
+  assertValidPoolId(pool)
   const url = `${cosmosRpcUrl[Chain.THORChain]}/thorchain/pool/${encodeURIComponent(pool)}`
   const raw = await queryUrl<unknown>(url)
   const status = extractPoolStatus(raw)

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -184,6 +184,41 @@
       "import": "./dist/chains/cosmos/thor/kujira-merge/kujiraCoinsOnThorChain.js",
       "default": "./dist/chains/cosmos/thor/kujira-merge/kujiraCoinsOnThorChain.js"
     },
+    "./chains/cosmos/thor/lp": {
+      "types": "./dist/chains/cosmos/thor/lp/index.d.ts",
+      "import": "./dist/chains/cosmos/thor/lp/index.js",
+      "default": "./dist/chains/cosmos/thor/lp/index.js"
+    },
+    "./chains/cosmos/thor/lp/affiliate": {
+      "types": "./dist/chains/cosmos/thor/lp/affiliate.d.ts",
+      "import": "./dist/chains/cosmos/thor/lp/affiliate.js",
+      "default": "./dist/chains/cosmos/thor/lp/affiliate.js"
+    },
+    "./chains/cosmos/thor/lp/memo": {
+      "types": "./dist/chains/cosmos/thor/lp/memo.d.ts",
+      "import": "./dist/chains/cosmos/thor/lp/memo.js",
+      "default": "./dist/chains/cosmos/thor/lp/memo.js"
+    },
+    "./chains/cosmos/thor/lp/payload": {
+      "types": "./dist/chains/cosmos/thor/lp/payload.d.ts",
+      "import": "./dist/chains/cosmos/thor/lp/payload.js",
+      "default": "./dist/chains/cosmos/thor/lp/payload.js"
+    },
+    "./chains/cosmos/thor/lp/pools": {
+      "types": "./dist/chains/cosmos/thor/lp/pools.d.ts",
+      "import": "./dist/chains/cosmos/thor/lp/pools.js",
+      "default": "./dist/chains/cosmos/thor/lp/pools.js"
+    },
+    "./chains/cosmos/thor/lp/position": {
+      "types": "./dist/chains/cosmos/thor/lp/position.d.ts",
+      "import": "./dist/chains/cosmos/thor/lp/position.js",
+      "default": "./dist/chains/cosmos/thor/lp/position.js"
+    },
+    "./chains/cosmos/thor/lp/validation": {
+      "types": "./dist/chains/cosmos/thor/lp/validation.d.ts",
+      "import": "./dist/chains/cosmos/thor/lp/validation.js",
+      "default": "./dist/chains/cosmos/thor/lp/validation.js"
+    },
     "./chains/cosmos/thor/rujira/config": {
       "types": "./dist/chains/cosmos/thor/rujira/config.d.ts",
       "import": "./dist/chains/cosmos/thor/rujira/config.js",

--- a/packages/lib/utils/fetch/HttpResponseError.ts
+++ b/packages/lib/utils/fetch/HttpResponseError.ts
@@ -1,0 +1,32 @@
+/**
+ * Typed error thrown by `assertFetchResponse` for non-2xx HTTP responses.
+ *
+ * Carries the numeric `status` so callers can branch cleanly on it
+ * (`err.status === 404`) instead of regex-matching the message string. The
+ * `statusText`, `url`, and parsed `body` fields are preserved for logging
+ * and richer error reporting.
+ *
+ * The constructor still falls through to `Error.message` so existing
+ * callers that only read `err.message` keep working unchanged.
+ */
+export class HttpResponseError extends Error {
+  readonly status: number
+  readonly statusText: string
+  readonly url: string
+  readonly body: unknown
+
+  constructor(opts: {
+    message: string
+    status: number
+    statusText: string
+    url: string
+    body: unknown
+  }) {
+    super(opts.message)
+    this.name = 'HttpResponseError'
+    this.status = opts.status
+    this.statusText = opts.statusText
+    this.url = opts.url
+    this.body = opts.body
+  }
+}

--- a/packages/lib/utils/fetch/assertFetchResponse.ts
+++ b/packages/lib/utils/fetch/assertFetchResponse.ts
@@ -1,16 +1,32 @@
 import { extractErrorMsg } from '../error/extractErrorMsg'
 import { asyncFallbackChain } from '../promise/asyncFallbackChain'
+import { HttpResponseError } from './HttpResponseError'
 
+/**
+ * Asserts a fetch Response is OK. On non-2xx, throws `HttpResponseError`
+ * carrying the numeric status, statusText, url, and parsed body so
+ * callers can branch on `err.status` instead of string-matching `err.message`.
+ *
+ * The thrown error's `message` still includes the same human-readable
+ * format as before (`HTTP <status> <statusText>: ...`) so callers that
+ * only log `err.message` see no change.
+ */
 export const assertFetchResponse = async (response: Response) => {
   if (!response.ok) {
-    const error = await asyncFallbackChain(
+    const body = await asyncFallbackChain(
       async () => response.json(),
       async () => response.text(),
       async () =>
         `HTTP ${response.status} ${response.statusText || 'Error'}: Request failed for ${response.url}`
     )
-    const msg = extractErrorMsg(error)
+    const msg = extractErrorMsg(body)
 
-    throw new Error(msg)
+    throw new HttpResponseError({
+      message: msg,
+      status: response.status,
+      statusText: response.statusText,
+      url: response.url,
+      body,
+    })
   }
 }

--- a/packages/lib/utils/package.json
+++ b/packages/lib/utils/package.json
@@ -269,6 +269,11 @@
       "import": "./dist/fetch/assertFetchResponse.js",
       "default": "./dist/fetch/assertFetchResponse.js"
     },
+    "./fetch/HttpResponseError": {
+      "types": "./dist/fetch/HttpResponseError.d.ts",
+      "import": "./dist/fetch/HttpResponseError.js",
+      "default": "./dist/fetch/HttpResponseError.js"
+    },
     "./file/initiateFileDownload": {
       "types": "./dist/file/initiateFileDownload.d.ts",
       "import": "./dist/file/initiateFileDownload.js",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -184,6 +184,9 @@ export {
   vultDiscountTiers,
 } from '@vultisig/core-chain/swap/affiliate/config'
 
+// THORChain LP primitives (asym RUNE-side, v1)
+export * from '@vultisig/core-chain/chains/cosmos/thor/lp'
+
 // ============================================================================
 // PUBLIC API - Token Registry & Chain Data
 // ============================================================================


### PR DESCRIPTION
## Summary

Asym RUNE-side THORChain LP primitives, lifted to a shared `@vultisig/core-chain` module so future consumers (mcp-ts, vultisig-windows, the agent app once it migrates to the SDK) all read from one source of truth instead of hand-rolling memo formats.

**Stacked PR**: vultisig/mcp-ts#12 wires these primitives into 4 MCP tools (`query_thorchain_pools`, `build_thorchain_lp_add`, `build_thorchain_lp_remove`, `query_thorchain_lp_position`) and validates them end-to-end with curl against live mainnet midgard + thornode.

This PR ships only the **building blocks**. v1 is intentionally narrow: asym RUNE-side adds + removes, no asset-side, no explicit symmetric pairing.

## What's in the box

New module at `packages/core/chain/chains/cosmos/thor/lp/`:

- **`affiliate.ts`** — `VULTISIG_AFFILIATE_NAME = 'vi'`, `VULTISIG_AFFILIATE_LP_BPS = 0`. Sourced from `vultisig-ios/.../THORChainSwaps.swift:27` and confirmed against the production memo fixtures (`TestData/thorchainswap.json` carries `:vi:0`).
- **`memo.ts`** — `addLpMemo({ pool, pairedAddress?, affiliate?, affiliateBps? })` and `removeLpMemo({ pool, basisPoints })`. For the asym RUNE-side default the memo looks like `+:BTC.BTC::vi:0` — empty paired-address slot is intentional, that's how THORChain registers the asymmetric position. Withdraws don't include affiliate per spec.
- **`payload.ts`** — `buildThorchainLpAddPayload` / `buildThorchainLpRemovePayload`. Returns flat `ThorchainLpAddPayload` / `ThorchainLpRemovePayload` shapes that flow through the agent backend's `tx_ready` SSE event. Single nesting level on purpose — the 2026-04-09 audit flagged tool result flattening as a known wire-level hazard for nested fields. Uses `0.02 RUNE` dust for removes (matches `vultisig-windows/core/ui/vault/deposit/keysignPayload/build.ts:325`).
- **`pools.ts`** — `getThorchainPools()` over Midgard `/v2/pools`, available-only by default. `THORCHAIN_MIDGARD_BASE_URL` constant exported.
- **`position.ts`** — `getThorchainLpPosition({ thorAddress, pool })` over Midgard `/v2/member/{addr}`. Returns `null` on 404 (expected for fresh addresses) or when the address has no position in the requested pool. Computes `isPending` from `runePending`/`assetPending`.
- **`validation.ts`** — `assertPoolDepositable(pool)` fail-fast gate over thornode `/thorchain/pool/{asset}`. Throws on anything other than `Available`.
- **`index.ts`** — barrel re-export for the whole module.

Plus 7 new entries in `packages/core/chain/package.json` exports (one per file + the barrel).

## Tests

22 unit tests, all passing locally:

```
✓ packages/core/chain/chains/cosmos/thor/lp/memo.test.ts (12 tests)
✓ packages/core/chain/chains/cosmos/thor/lp/payload.test.ts (10 tests)
```

Pure-function tests only — no fetch in the test path. Pools/position/validation are thin wrappers over `@vultisig/lib-utils/queryUrl`, matching the existing thor sibling style (`getThorchainInboundAddress`, `getThorNetworkInfo`).

## Risk

Low. New module, no consumers yet, no migration of existing code. Build is clean (`yarn build:all` ran end-to-end) so I haven't broken any downstream sdk/rujira consumers.

The one thing worth a second look: the `vi` affiliate THORName is registered on mainnet via the iOS app already, but if it's somehow not, removes still work and adds will succeed (memo just won't be tracked in Midgard's affiliate stats). Not a correctness bug.

## What's next (separate PRs, not this one)

- `vultisig-mcp-ts`: 4 MCP tools wrapping these primitives (`query_thorchain_pools`, `build_thorchain_lp_add`, `build_thorchain_lp_remove`, `query_thorchain_lp_position`). Already in flight.
- `vultisig-agent-backend`: register the tools, system prompt teaching, emit `tx_ready` (deferred until app can sign).
- `vultiagent-poc`: THORChain MsgDeposit signing path. Blocked on VA-133 (SDK migration into the app).

## Test plan

- [x] `yarn workspace @vultisig/core-chain build` — clean
- [x] `yarn build:all` — clean (no downstream regressions)
- [x] `yarn vitest run packages/core/chain/chains/cosmos/thor/lp` — 22/22 passing
- [ ] CodeRabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added THORChain liquidity-pool support: add/remove liquidity, pool listing, user LP positions, depositability checks, default affiliate settings, and standardized payloads/memos.
  * SDK now exposes THORChain LP primitives at the top level.

* **Chores**
  * Improved HTTP fetch error reporting with a typed error object and updated package exports.

* **Tests**
  * Added comprehensive tests for memo generation, payload builders, pools, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
