### PR TITLE
fix(core): fix Cardano signing — manual CBOR compilation and forceFee

### DIFF
--- a/packages/core/chain/tx/hash/resolvers/cardano.ts
+++ b/packages/core/chain/tx/hash/resolvers/cardano.ts
@@ -1,15 +1,19 @@
 import { OtherChain } from '@vultisig/core-chain/Chain'
 import { blake2b } from '@noble/hashes/blake2.js'
 import { decode, encode } from 'cbor-x'
-import { toHex } from 'viem'
 
 import { TxHashResolver } from '../resolver'
 
-export const getCardanoTxHash: TxHashResolver<OtherChain.Cardano> = ({
-  encoded,
-}) => {
-  const tx = decode(encoded)
-  const bodyCbor = encode(tx[0])
+export const getCardanoTxHash: TxHashResolver<OtherChain.Cardano> = tx => {
+  // Prefer pre-computed txId (set by compileTx to avoid cbor-x
+  // re-encoding which can alter byte representation).
+  if (tx.txId && tx.txId.length > 0) {
+    return Buffer.from(tx.txId).toString('hex')
+  }
+
+  const decoded = decode(tx.encoded)
+  const bodyCbor = encode(decoded[0])
   const digest = blake2b(bodyCbor, { dkLen: 32 })
-  return toHex(digest)
+
+  return Buffer.from(digest).toString('hex')
 }

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cardano.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cardano.ts
@@ -10,7 +10,7 @@ export const getCardanoSigningInputs: SigningInputsResolver<'cardano'> = ({
   keysignPayload,
   walletCore,
 }) => {
-  const { sendMaxAmount, ttl } = getBlockchainSpecificValue(
+  const { sendMaxAmount, ttl, byteFee } = getBlockchainSpecificValue(
     keysignPayload.blockchainSpecific,
     'cardano'
   )
@@ -23,6 +23,7 @@ export const getCardanoSigningInputs: SigningInputsResolver<'cardano'> = ({
       changeAddress: coin.address,
       amount: Long.fromString(keysignPayload.toAmount),
       useMaxAmount: sendMaxAmount,
+      forceFee: Long.fromString(byteFee.toString()),
     }),
     ttl: Long.fromString(ttl.toString()),
 

--- a/packages/core/mpc/package.json
+++ b/packages/core/mpc/package.json
@@ -760,6 +760,11 @@
       "import": "./dist/swap/utils/getSwapTrackingUrl.js",
       "default": "./dist/swap/utils/getSwapTrackingUrl.js"
     },
+    "./tx/compile/cardano/buildSignedCardanoTx": {
+      "types": "./dist/tx/compile/cardano/buildSignedCardanoTx.d.ts",
+      "import": "./dist/tx/compile/cardano/buildSignedCardanoTx.js",
+      "default": "./dist/tx/compile/cardano/buildSignedCardanoTx.js"
+    },
     "./tx/compile/compileTx": {
       "types": "./dist/tx/compile/compileTx.d.ts",
       "import": "./dist/tx/compile/compileTx.js",

--- a/packages/core/mpc/tx/compile/cardano/buildSignedCardanoTx.ts
+++ b/packages/core/mpc/tx/compile/cardano/buildSignedCardanoTx.ts
@@ -1,0 +1,100 @@
+/**
+ * Wrap a WalletCore-produced Cardano tx body with witness CBOR.
+ *
+ * compileWithSignatures() calls encodeTransactionWithSig() which hits
+ * AddressV2::isValid() — crashing under WASM DISABLE_EXCEPTION_CATCHING.
+ * This module manually wraps the pre-signed tx body (from preImageHashes)
+ * with a CBOR witness set, producing a valid signed Cardano transaction.
+ *
+ * The tx body bytes are embedded verbatim (not re-encoded) because the
+ * MPC signature covers Blake2b of the exact bytes. Re-encoding could
+ * change key ordering or integer widths, invalidating the signature.
+ *
+ * The witness set is hand-encoded because common JS CBOR libraries tag
+ * Maps or encode object keys as text strings — Cardano requires plain
+ * CBOR maps with unsigned-integer keys.
+ */
+
+type BuildSignedCardanoTxInput = {
+  /** CBOR-encoded transaction body from PreSigningOutput.data */
+  txBodyCbor: Uint8Array
+  /** 32-byte Ed25519 spending public key */
+  publicKey: Uint8Array
+  /** 64-byte Ed25519 signature (r || s, each little-endian) */
+  signature: Uint8Array
+}
+
+/**
+ * Encode a CBOR byte string: major type 2, then length, then data.
+ * Supports lengths up to 65535 (two-byte length).
+ */
+const cborBytes = (data: Uint8Array): Uint8Array => {
+  if (data.length < 24) {
+    const out = new Uint8Array(1 + data.length)
+    out[0] = 0x40 | data.length
+    out.set(data, 1)
+    return out
+  }
+  if (data.length < 256) {
+    const out = new Uint8Array(2 + data.length)
+    out[0] = 0x58
+    out[1] = data.length
+    out.set(data, 2)
+    return out
+  }
+  const out = new Uint8Array(3 + data.length)
+  out[0] = 0x59
+  out[1] = (data.length >> 8) & 0xff
+  out[2] = data.length & 0xff
+  out.set(data, 3)
+  return out
+}
+
+/**
+ * Build the witness set CBOR: a1 00 81 82 5820<vkey> 5840<sig>
+ * = map(1) { 0 => [ [bytes(32), bytes(64)] ] }
+ */
+const buildWitnessCbor = (
+  publicKey: Uint8Array,
+  signature: Uint8Array
+): Uint8Array => {
+  const vkeyCbor = cborBytes(publicKey)
+  const sigCbor = cborBytes(signature)
+
+  // inner array [vkey, sig]: 0x82 = array(2)
+  const pair = concat([new Uint8Array([0x82]), vkeyCbor, sigCbor])
+
+  // outer array [[vkey, sig]]: 0x81 = array(1)
+  const arr = concat([new Uint8Array([0x81]), pair])
+
+  // map {0 => arr}: 0xa1 = map(1), 0x00 = uint(0)
+  return concat([new Uint8Array([0xa1, 0x00]), arr])
+}
+
+const concat = (parts: Uint8Array[]): Uint8Array => {
+  const totalLen = parts.reduce((sum, p) => sum + p.length, 0)
+  const result = new Uint8Array(totalLen)
+  let offset = 0
+  for (const p of parts) {
+    result.set(p, offset)
+    offset += p.length
+  }
+  return result
+}
+
+/** Returns the full signed Cardano transaction as CBOR bytes. */
+export const buildSignedCardanoTx = ({
+  txBodyCbor,
+  publicKey,
+  signature,
+}: BuildSignedCardanoTxInput): Uint8Array => {
+  const witnessCbor = buildWitnessCbor(publicKey, signature)
+
+  // Signed tx: 0x83 [tx_body, witnesses, null]
+  return concat([
+    new Uint8Array([0x83]),
+    txBodyCbor,
+    witnessCbor,
+    new Uint8Array([0xf6]), // CBOR null
+  ])
+}

--- a/packages/core/mpc/tx/compile/cardano/buildSignedCardanoTx.ts
+++ b/packages/core/mpc/tx/compile/cardano/buildSignedCardanoTx.ts
@@ -90,11 +90,12 @@ export const buildSignedCardanoTx = ({
 }: BuildSignedCardanoTxInput): Uint8Array => {
   const witnessCbor = buildWitnessCbor(publicKey, signature)
 
-  // Signed tx: 0x83 [tx_body, witnesses, null]
+  // Signed tx: 0x84 [tx_body, witnesses, isValid, auxiliary_data]
   return concat([
-    new Uint8Array([0x83]),
+    new Uint8Array([0x84]),
     txBodyCbor,
     witnessCbor,
-    new Uint8Array([0xf6]), // CBOR null
+    new Uint8Array([0xf5]), // CBOR true (is_valid)
+    new Uint8Array([0xf6]), // CBOR null (no auxiliary data)
   ])
 }

--- a/packages/core/mpc/tx/compile/compileTx.ts
+++ b/packages/core/mpc/tx/compile/compileTx.ts
@@ -10,6 +10,7 @@ import { signatureFormats } from '@vultisig/core-chain/signing/SignatureFormat'
 import { assertSignature } from '@vultisig/core-chain/utils/assertSignature'
 
 import { getQBTCSignedTransaction } from '../../chains/cosmos/qbtc/QBTCHelper'
+import { buildSignedCardanoTx } from './cardano/buildSignedCardanoTx'
 import { getBlockchainSpecificValue } from '../../keysign/chainSpecific/KeysignChainSpecific'
 import { KeysignSignature } from '../../keysign/KeysignSignature'
 import { decodeBittensorTxInput } from '../../keysign/signingInputs/resolvers/bittensor'
@@ -99,6 +100,48 @@ export const compileTx = ({
     return TW.Polkadot.Proto.SigningOutput.encode(
       TW.Polkadot.Proto.SigningOutput.create({
         encoded: extrinsic,
+      })
+    ).finish()
+  }
+
+  if (chain === Chain.Cardano) {
+    const hash = hashes[0]
+    const hashHex = Buffer.from(hash).toString('hex')
+
+    const sig = generateSignature({
+      walletCore,
+      signature: keysignSignatures[hashHex],
+      signatureFormat,
+    })
+
+    assertSignature({
+      publicKey,
+      message: hash,
+      signature: sig,
+      signatureFormat,
+    })
+
+    // preOutput.data is the CBOR-encoded tx body
+    const preOutput = TW.TxCompiler.Proto.PreSigningOutput.decode(
+      walletCore.TransactionCompiler.preImageHashes(
+        getCoinType({ chain, walletCore }),
+        txInputData
+      )
+    )
+
+    const spendingKey = new Uint8Array(publicKey.data()).slice(0, 32)
+    const encoded = buildSignedCardanoTx({
+      txBodyCbor: preOutput.data,
+      publicKey: spendingKey,
+      signature: new Uint8Array(sig),
+    })
+
+    return TW.Cardano.Proto.SigningOutput.encode(
+      TW.Cardano.Proto.SigningOutput.create({
+        encoded,
+        // Embed the correct tx hash so downstream code doesn't need to
+        // re-encode the body (cbor-x round-trip can alter bytes).
+        txId: preOutput.dataHash,
       })
     ).finish()
   }


### PR DESCRIPTION
## Summary
- Bypass WalletCore's Cardano compiler which produces invalid transactions — manually build the signed CBOR envelope from pre-image body, public key, and EdDSA signature
- Use `forceFee` in signing inputs so the fee matches the pre-computed value
- Pass pre-computed `txId` through `SigningOutput` to avoid cbor-x re-encoding altering body bytes during tx hash resolution
- Remove `viem` dependency from Cardano tx hash resolver

Closes vultisig/vultisig-windows#3680

## Test plan
- [ ] `yarn build:shared` succeeds
- [ ] Sign an ADA transfer on Windows and verify the transaction broadcasts successfully
- [ ] Verify tx hash matches what the blockchain reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exported a Cardano signed-transaction builder for producing fully-signed CBOR transactions.
  * Added a Cardano-specific compilation path that returns built signed transactions and tx IDs.
  * Enhanced Cardano transaction hash resolution to use pre-computed tx IDs when available.
  * Added byte-fee support to the Cardano signing flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->