### PR TITLE
fix(ci): trigger PR checks on changeset release branches

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -18,9 +18,12 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      # Use RELEASE_TOKEN so git push is not performed with the workflow GITHUB_TOKEN.
+      # GitHub does not run workflows for events triggered by the default token (recursive-run guard).
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:


### PR DESCRIPTION
## Problem
Version PRs opened/updated by `Release PR` showed required checks as **Expected — Waiting for status to be reported** forever. Pushes to `changeset-release/main` did not start the Test Suite workflow.

## Root cause
`changesets/action` was given `RELEASE_TOKEN` for the GitHub API, but `actions/checkout` still used the default workflow `GITHUB_TOKEN` for the git remote. GitHub intentionally does not run workflows for events caused by the default token (recursive workflow guard), so `pull_request` and `push` workflows never ran on those commits.

## Fix
Configure checkout with `token: ${{ secrets.RELEASE_TOKEN }}` so `git push` to the release branch uses the PAT and triggers CI like any other contributor push.

## Follow-up
After merge, `changeset-release/main` for the open version PR should be updated (merge main or let changesets push again) so checks run and the release PR can merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release process authentication configuration to use a dedicated token for improved security and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->