### PR TITLE
feat(qbtc): add claim service functions to core-chain

### DIFF
--- a/packages/core/chain/chains/cosmos/qbtc/claim/ClaimableUtxo.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/ClaimableUtxo.ts
@@ -1,0 +1,7 @@
+/** A Bitcoin UTXO that can potentially be claimed on the QBTC chain. */
+export type ClaimableUtxo = {
+  txid: string
+  vout: number
+  /** BTC amount in satoshis. */
+  amount: number
+}

--- a/packages/core/chain/chains/cosmos/qbtc/claim/getClaimWithProofDisabled.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/getClaimWithProofDisabled.ts
@@ -1,0 +1,18 @@
+import { qbtcRestUrl } from '@vultisig/core-chain/chains/cosmos/qbtc/tendermintRpcUrl'
+import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+
+type QbtcParamsResponse = {
+  param: {
+    key: string
+    value: string
+  }
+}
+
+/** Checks whether the ClaimWithProof feature is disabled on the QBTC chain. */
+export const getClaimWithProofDisabled = async (): Promise<boolean> => {
+  const url = `${qbtcRestUrl}/qbtc/v1/params/ClaimWithProofDisabled`
+
+  const { param } = await queryUrl<QbtcParamsResponse>(url)
+
+  return Number(param.value) > 0
+}

--- a/packages/core/chain/chains/cosmos/qbtc/claim/getClaimWithProofDisabled.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/getClaimWithProofDisabled.ts
@@ -13,6 +13,13 @@ export const getClaimWithProofDisabled = async (): Promise<boolean> => {
   const url = `${qbtcRestUrl}/qbtc/v1/params/ClaimWithProofDisabled`
 
   const { param } = await queryUrl<QbtcParamsResponse>(url)
+  const parsedValue = Number(param.value)
 
-  return Number(param.value) > 0
+  if (!Number.isFinite(parsedValue)) {
+    throw new Error(
+      `Invalid ClaimWithProofDisabled value: ${String(param.value)}`
+    )
+  }
+
+  return parsedValue > 0
 }

--- a/packages/core/chain/chains/cosmos/qbtc/claim/getClaimableUtxos.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/getClaimableUtxos.ts
@@ -1,0 +1,32 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { getUtxoAddressInfo } from '@vultisig/core-chain/chains/utxo/client/getUtxoAddressInfo'
+
+import { ClaimableUtxo } from './ClaimableUtxo'
+
+type GetClaimableUtxosInput = {
+  btcAddress: string
+}
+
+/**
+ * Fetches Bitcoin UTXOs for the given address via Blockchair and returns them
+ * as claimable candidates on the QBTC chain.
+ *
+ * Note: this does not cross-check with the QBTC chain to filter
+ * already-claimed UTXOs — see btcq-org/qbtc#134.
+ */
+export const getClaimableUtxos = async ({
+  btcAddress,
+}: GetClaimableUtxosInput): Promise<ClaimableUtxo[]> => {
+  const response = await getUtxoAddressInfo({
+    address: btcAddress,
+    chain: Chain.Bitcoin,
+  })
+
+  const { utxo } = response.data[btcAddress]
+
+  return utxo.map(({ transaction_hash, index, value }) => ({
+    txid: transaction_hash,
+    vout: index,
+    amount: value,
+  }))
+}

--- a/packages/core/chain/chains/cosmos/qbtc/claim/getClaimableUtxos.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/getClaimableUtxos.ts
@@ -22,9 +22,9 @@ export const getClaimableUtxos = async ({
     chain: Chain.Bitcoin,
   })
 
-  const { utxo } = response.data[btcAddress]
+  const utxos = response.data[btcAddress]?.utxo ?? []
 
-  return utxo.map(({ transaction_hash, index, value }) => ({
+  return utxos.map(({ transaction_hash, index, value }) => ({
     txid: transaction_hash,
     vout: index,
     amount: value,

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -174,6 +174,21 @@
       "import": "./dist/chains/cosmos/qbtc/tendermintRpcUrl.js",
       "default": "./dist/chains/cosmos/qbtc/tendermintRpcUrl.js"
     },
+    "./chains/cosmos/qbtc/claim/ClaimableUtxo": {
+      "types": "./dist/chains/cosmos/qbtc/claim/ClaimableUtxo.d.ts",
+      "import": "./dist/chains/cosmos/qbtc/claim/ClaimableUtxo.js",
+      "default": "./dist/chains/cosmos/qbtc/claim/ClaimableUtxo.js"
+    },
+    "./chains/cosmos/qbtc/claim/getClaimableUtxos": {
+      "types": "./dist/chains/cosmos/qbtc/claim/getClaimableUtxos.d.ts",
+      "import": "./dist/chains/cosmos/qbtc/claim/getClaimableUtxos.js",
+      "default": "./dist/chains/cosmos/qbtc/claim/getClaimableUtxos.js"
+    },
+    "./chains/cosmos/qbtc/claim/getClaimWithProofDisabled": {
+      "types": "./dist/chains/cosmos/qbtc/claim/getClaimWithProofDisabled.d.ts",
+      "import": "./dist/chains/cosmos/qbtc/claim/getClaimWithProofDisabled.js",
+      "default": "./dist/chains/cosmos/qbtc/claim/getClaimWithProofDisabled.js"
+    },
     "./chains/cosmos/sumFeeAmountForCosmosChainFeeDenom": {
       "types": "./dist/chains/cosmos/sumFeeAmountForCosmosChainFeeDenom.d.ts",
       "import": "./dist/chains/cosmos/sumFeeAmountForCosmosChainFeeDenom.js",


### PR DESCRIPTION
## Summary
- Add `ClaimableUtxo` type definition
- Add `getClaimableUtxos` — fetches Bitcoin UTXOs from Blockchair as claimable candidates
- Add `getClaimWithProofDisabled` — queries the QBTC chain `ClaimWithProofDisabled` param
- Add package.json exports for all three modules

Closes #248

## Context
- The QBTC chain does not yet expose a UTXOs-by-address query endpoint (btcq-org/qbtc#134), so we use the existing Blockchair Bitcoin API
- These functions are currently duplicated in `vultisig-windows` (PR vultisig/vultisig-windows#3726) and will be imported from the SDK once this is merged

## Test plan
- [ ] `getClaimableUtxos({ btcAddress: "bc1q..." })` returns UTXOs matching Blockchair data
- [ ] `getClaimWithProofDisabled()` returns `false` when the live chain param is `0`
- [ ] Exports resolve correctly via `@vultisig/core-chain/chains/cosmos/qbtc/claim/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve claimable Bitcoin UTXOs for a given BTC address on the QBTC chain, returning transaction id, output index, and amount for each UTXO.
  * Query QBTC parameter status to determine if claim-with-proof is disabled, returning a clear boolean result used by chain-related flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->