### PR TITLE
feat(qbtc): Bitcoin address type detection and claim hash computation

### DIFF
--- a/packages/core/chain/chains/cosmos/qbtc/claim/BtcAddressType.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/BtcAddressType.ts
@@ -1,0 +1,19 @@
+/** ZK circuit used for the claim proof. */
+export type QbtcClaimCircuit = 'ecdsa' | 'schnorr'
+
+/** Supported Bitcoin address types for QBTC claiming. */
+export type BtcAddressType =
+  | 'p2pkh'
+  | 'p2wpkh'
+  | 'p2sh-p2wpkh'
+  | 'p2wsh'
+  | 'p2tr'
+
+/** Maps a Bitcoin address type to its corresponding ZK circuit. */
+export const btcAddressTypeCircuit: Record<BtcAddressType, QbtcClaimCircuit> = {
+  p2pkh: 'ecdsa',
+  p2wpkh: 'ecdsa',
+  'p2sh-p2wpkh': 'ecdsa',
+  p2wsh: 'ecdsa',
+  p2tr: 'schnorr',
+}

--- a/packages/core/chain/chains/cosmos/qbtc/claim/computeClaimHashes.test.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/computeClaimHashes.test.ts
@@ -1,0 +1,151 @@
+import { ripemd160 } from '@noble/hashes/legacy.js'
+import { sha256 } from '@noble/hashes/sha2.js'
+import { describe, expect, it } from 'vitest'
+
+import {
+  computeAddressHash,
+  computeAllClaimHashes,
+  computeChainIdHash,
+  computeClaimMessageHash,
+  computeQbtcAddressHash,
+} from './computeClaimHashes'
+
+const hexToBytes = (hex: string) => Buffer.from(hex, 'hex')
+
+const bytesToHex = (bytes: Uint8Array) =>
+  Buffer.from(bytes).toString('hex')
+
+// A well-known compressed public key for testing
+const testCompressedPubkey = hexToBytes(
+  '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
+)
+
+describe('computeAddressHash', () => {
+  it('computes Hash160 for ECDSA circuit', () => {
+    const result = computeAddressHash({
+      compressedPubkey: testCompressedPubkey,
+      circuit: 'ecdsa',
+    })
+
+    // Hash160 = RIPEMD160(SHA256(pubkey))
+    const expected = ripemd160(sha256(testCompressedPubkey))
+    expect(bytesToHex(result)).toBe(bytesToHex(expected))
+    expect(result.length).toBe(20)
+  })
+
+  it('extracts x-only pubkey for Schnorr circuit', () => {
+    const result = computeAddressHash({
+      compressedPubkey: testCompressedPubkey,
+      circuit: 'schnorr',
+    })
+
+    // x-only = last 32 bytes of 33-byte compressed key
+    const expected = testCompressedPubkey.slice(1, 33)
+    expect(bytesToHex(result)).toBe(bytesToHex(expected))
+    expect(result.length).toBe(32)
+  })
+})
+
+describe('computeQbtcAddressHash', () => {
+  it('computes SHA256 of the qbtc address string', () => {
+    const qbtcAddress = 'qbtc1abc123'
+    const result = computeQbtcAddressHash(qbtcAddress)
+
+    const expected = sha256(new TextEncoder().encode(qbtcAddress))
+    expect(bytesToHex(result)).toBe(bytesToHex(expected))
+    expect(result.length).toBe(32)
+  })
+})
+
+describe('computeChainIdHash', () => {
+  it('computes first 8 bytes of SHA256 of chain ID', () => {
+    const result = computeChainIdHash('qbtc-1')
+
+    const fullHash = sha256(new TextEncoder().encode('qbtc-1'))
+    const expected = fullHash.slice(0, 8)
+    expect(bytesToHex(result)).toBe(bytesToHex(expected))
+    expect(result.length).toBe(8)
+  })
+})
+
+describe('computeClaimMessageHash', () => {
+  it('uses ecdsa: prefix for ECDSA circuit', () => {
+    const addressHash = new Uint8Array(20).fill(0xaa)
+    const qbtcAddressHash = new Uint8Array(32).fill(0xbb)
+    const chainIdHash = new Uint8Array(8).fill(0xcc)
+
+    const result = computeClaimMessageHash({
+      addressHash,
+      qbtcAddressHash,
+      chainIdHash,
+      circuit: 'ecdsa',
+    })
+
+    expect(result.length).toBe(32)
+
+    // Verify by manually constructing the same input
+    const encoder = new TextEncoder()
+    const input = new Uint8Array([
+      ...encoder.encode('ecdsa:'),
+      ...addressHash,
+      ...qbtcAddressHash,
+      ...chainIdHash,
+      ...encoder.encode('qbtc-claim-v1'),
+    ])
+    expect(bytesToHex(result)).toBe(bytesToHex(sha256(input)))
+  })
+
+  it('uses schnorr: prefix for Schnorr circuit', () => {
+    const addressHash = new Uint8Array(32).fill(0xaa)
+    const qbtcAddressHash = new Uint8Array(32).fill(0xbb)
+    const chainIdHash = new Uint8Array(8).fill(0xcc)
+
+    const result = computeClaimMessageHash({
+      addressHash,
+      qbtcAddressHash,
+      chainIdHash,
+      circuit: 'schnorr',
+    })
+
+    const encoder = new TextEncoder()
+    const input = new Uint8Array([
+      ...encoder.encode('schnorr:'),
+      ...addressHash,
+      ...qbtcAddressHash,
+      ...chainIdHash,
+      ...encoder.encode('qbtc-claim-v1'),
+    ])
+    expect(bytesToHex(result)).toBe(bytesToHex(sha256(input)))
+  })
+})
+
+describe('computeAllClaimHashes', () => {
+  it('computes all hashes for a P2WPKH address', () => {
+    const result = computeAllClaimHashes({
+      btcAddress: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+      compressedPubkey: testCompressedPubkey,
+      qbtcAddress: 'qbtc1test',
+      chainId: 'qbtc-1',
+    })
+
+    expect(result.circuit).toBe('ecdsa')
+    expect(result.addressHash.length).toBe(20)
+    expect(result.qbtcAddressHash.length).toBe(32)
+    expect(result.messageHash.length).toBe(32)
+  })
+
+  it('computes all hashes for a P2TR address', () => {
+    const result = computeAllClaimHashes({
+      btcAddress:
+        'bc1p5d7rjq7g6rdk2yhzks9smlaqtedr4dekq08ge8ztwac72sfr9rusxg3297',
+      compressedPubkey: testCompressedPubkey,
+      qbtcAddress: 'qbtc1test',
+      chainId: 'qbtc-1',
+    })
+
+    expect(result.circuit).toBe('schnorr')
+    expect(result.addressHash.length).toBe(32)
+    expect(result.qbtcAddressHash.length).toBe(32)
+    expect(result.messageHash.length).toBe(32)
+  })
+})

--- a/packages/core/chain/chains/cosmos/qbtc/claim/computeClaimHashes.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/computeClaimHashes.ts
@@ -1,0 +1,125 @@
+import { ripemd160 } from '@noble/hashes/legacy.js'
+import { sha256 } from '@noble/hashes/sha2.js'
+
+import { btcAddressTypeCircuit, QbtcClaimCircuit } from './BtcAddressType'
+import { detectBtcAddressType } from './detectBtcAddressType'
+
+const claimSuffix = 'qbtc-claim-v1'
+
+/** Hash160 = RIPEMD160(SHA256(data)), the standard Bitcoin hash. */
+const hash160 = (data: Uint8Array): Uint8Array => ripemd160(sha256(data))
+
+/**
+ * Computes the address hash for QBTC claiming.
+ * - ECDSA types: Hash160(compressedPubkey) — 20 bytes
+ * - Taproot (Schnorr): x-only pubkey (last 32 bytes of 33-byte compressed key)
+ */
+export const computeAddressHash = ({
+  compressedPubkey,
+  circuit,
+}: {
+  compressedPubkey: Uint8Array
+  circuit: QbtcClaimCircuit
+}): Uint8Array => {
+  if (circuit === 'schnorr') {
+    return compressedPubkey.slice(1, 33)
+  }
+  return hash160(compressedPubkey)
+}
+
+/** Computes SHA256 of the QBTC bech32 address string. */
+export const computeQbtcAddressHash = (qbtcAddress: string): Uint8Array =>
+  sha256(new TextEncoder().encode(qbtcAddress))
+
+/** Computes the first 8 bytes of SHA256 of the chain ID. */
+export const computeChainIdHash = (chainId: string): Uint8Array =>
+  sha256(new TextEncoder().encode(chainId)).slice(0, 8)
+
+type ComputeClaimMessageHashInput = {
+  addressHash: Uint8Array
+  qbtcAddressHash: Uint8Array
+  chainIdHash: Uint8Array
+  circuit: QbtcClaimCircuit
+}
+
+/**
+ * Computes the final MessageHash for the QBTC claim.
+ *
+ * ```
+ * MessageHash = SHA256(prefix + addressHash + qbtcAddressHash + chainIdHash + "qbtc-claim-v1")
+ * ```
+ *
+ * Where prefix is `"ecdsa:"` or `"schnorr:"` depending on the BTC address type.
+ */
+export const computeClaimMessageHash = ({
+  addressHash,
+  qbtcAddressHash,
+  chainIdHash,
+  circuit,
+}: ComputeClaimMessageHashInput): Uint8Array => {
+  const encoder = new TextEncoder()
+  const prefix = encoder.encode(`${circuit}:`)
+  const suffix = encoder.encode(claimSuffix)
+
+  const message = new Uint8Array(
+    prefix.length +
+      addressHash.length +
+      qbtcAddressHash.length +
+      chainIdHash.length +
+      suffix.length
+  )
+
+  let offset = 0
+  message.set(prefix, offset)
+  offset += prefix.length
+  message.set(addressHash, offset)
+  offset += addressHash.length
+  message.set(qbtcAddressHash, offset)
+  offset += qbtcAddressHash.length
+  message.set(chainIdHash, offset)
+  offset += chainIdHash.length
+  message.set(suffix, offset)
+
+  return sha256(message)
+}
+
+type ComputeAllClaimHashesInput = {
+  btcAddress: string
+  compressedPubkey: Uint8Array
+  qbtcAddress: string
+  chainId: string
+}
+
+type ClaimHashes = {
+  messageHash: Uint8Array
+  addressHash: Uint8Array
+  qbtcAddressHash: Uint8Array
+  circuit: QbtcClaimCircuit
+}
+
+/**
+ * Convenience function that computes all hashes needed for a QBTC claim
+ * in a single call.
+ */
+export const computeAllClaimHashes = ({
+  btcAddress,
+  compressedPubkey,
+  qbtcAddress,
+  chainId,
+}: ComputeAllClaimHashesInput): ClaimHashes => {
+  const addressType = detectBtcAddressType(btcAddress)
+  const circuit = btcAddressTypeCircuit[addressType]
+
+  const addressHash = computeAddressHash({ compressedPubkey, circuit })
+  const qbtcAddressHash = computeQbtcAddressHash(qbtcAddress)
+  const chainIdHash = computeChainIdHash(chainId)
+
+  const messageHash = computeClaimMessageHash({
+    addressHash,
+    qbtcAddressHash,
+    chainIdHash,
+    circuit,
+  })
+
+  return { messageHash, addressHash, qbtcAddressHash, circuit }
+}

--- a/packages/core/chain/chains/cosmos/qbtc/claim/computeClaimHashes.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/computeClaimHashes.ts
@@ -21,6 +21,15 @@ export const computeAddressHash = ({
   compressedPubkey: Uint8Array
   circuit: QbtcClaimCircuit
 }): Uint8Array => {
+  if (
+    compressedPubkey.length !== 33 ||
+    (compressedPubkey[0] !== 0x02 && compressedPubkey[0] !== 0x03)
+  ) {
+    throw new Error(
+      'compressedPubkey must be a 33-byte compressed secp256k1 key'
+    )
+  }
+
   if (circuit === 'schnorr') {
     return compressedPubkey.slice(1, 33)
   }
@@ -57,6 +66,19 @@ export const computeClaimMessageHash = ({
   chainIdHash,
   circuit,
 }: ComputeClaimMessageHashInput): Uint8Array => {
+  const expectedAddressHashLength = circuit === 'schnorr' ? 32 : 20
+  if (addressHash.length !== expectedAddressHashLength) {
+    throw new Error(
+      `addressHash must be ${expectedAddressHashLength} bytes for ${circuit}`
+    )
+  }
+  if (qbtcAddressHash.length !== 32) {
+    throw new Error('qbtcAddressHash must be 32 bytes')
+  }
+  if (chainIdHash.length !== 8) {
+    throw new Error('chainIdHash must be 8 bytes')
+  }
+
   const encoder = new TextEncoder()
   const prefix = encoder.encode(`${circuit}:`)
   const suffix = encoder.encode(claimSuffix)

--- a/packages/core/chain/chains/cosmos/qbtc/claim/detectBtcAddressType.test.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/detectBtcAddressType.test.ts
@@ -28,12 +28,14 @@ describe('detectBtcAddressType', () => {
     expect(detectBtcAddressType(addr)).toBe('p2wsh')
   })
 
-  it('detects long bc1q addresses as P2WSH', () => {
-    // Any bc1q address longer than 42 chars is P2WSH
+  it('throws for bc1q addresses with invalid length', () => {
     const addr =
       'bc1qrp33g0q5b5698ahp5jnf017nmnzs75rz9eeee5946d7jjk37n4w4qschxhz'
-    expect(addr.length).toBeGreaterThan(42)
-    expect(detectBtcAddressType(addr)).toBe('p2wsh')
+    expect(addr.length).not.toBe(42)
+    expect(addr.length).not.toBe(62)
+    expect(() => detectBtcAddressType(addr)).toThrow(
+      'Unsupported Bitcoin address format'
+    )
   })
 
   it('detects P2TR addresses starting with bc1p', () => {

--- a/packages/core/chain/chains/cosmos/qbtc/claim/detectBtcAddressType.test.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/detectBtcAddressType.test.ts
@@ -38,12 +38,17 @@ describe('detectBtcAddressType', () => {
     )
   })
 
-  it('detects P2TR addresses starting with bc1p', () => {
-    expect(
-      detectBtcAddressType(
-        'bc1p5d7rjq7g6rdk2yhzks9smlaqtedr4dekq08ge8ztwac72sfr9rusxg3297'
-      )
-    ).toBe('p2tr')
+  it('detects P2TR addresses (bc1p, 62 chars)', () => {
+    const addr =
+      'bc1p5d7rjq7g6rdk2yhzks9smlaqtedr4dekq08ge8ztwac72sfr9rusxg3297'
+    expect(addr.length).toBe(62)
+    expect(detectBtcAddressType(addr)).toBe('p2tr')
+  })
+
+  it('throws for bc1p addresses with invalid length', () => {
+    expect(() => detectBtcAddressType('bc1pshort')).toThrow(
+      'Unsupported Bitcoin address format'
+    )
   })
 
   it('throws for unsupported address format', () => {

--- a/packages/core/chain/chains/cosmos/qbtc/claim/detectBtcAddressType.test.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/detectBtcAddressType.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import { detectBtcAddressType } from './detectBtcAddressType'
+
+describe('detectBtcAddressType', () => {
+  it('detects P2PKH addresses starting with 1', () => {
+    expect(detectBtcAddressType('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa')).toBe(
+      'p2pkh'
+    )
+  })
+
+  it('detects P2SH-P2WPKH addresses starting with 3', () => {
+    expect(detectBtcAddressType('3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy')).toBe(
+      'p2sh-p2wpkh'
+    )
+  })
+
+  it('detects P2WPKH addresses (bc1q, 42 chars)', () => {
+    const addr = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4'
+    expect(addr.length).toBe(42)
+    expect(detectBtcAddressType(addr)).toBe('p2wpkh')
+  })
+
+  it('detects P2WSH addresses (bc1q, 62 chars)', () => {
+    const addr =
+      'bc1qft5p2uhsdcdc3l2ua4ap5qqfg4pjaqlp250x7us7a8qqhrxrxfsqseac85'
+    expect(addr.length).toBe(62)
+    expect(detectBtcAddressType(addr)).toBe('p2wsh')
+  })
+
+  it('detects long bc1q addresses as P2WSH', () => {
+    // Any bc1q address longer than 42 chars is P2WSH
+    const addr =
+      'bc1qrp33g0q5b5698ahp5jnf017nmnzs75rz9eeee5946d7jjk37n4w4qschxhz'
+    expect(addr.length).toBeGreaterThan(42)
+    expect(detectBtcAddressType(addr)).toBe('p2wsh')
+  })
+
+  it('detects P2TR addresses starting with bc1p', () => {
+    expect(
+      detectBtcAddressType(
+        'bc1p5d7rjq7g6rdk2yhzks9smlaqtedr4dekq08ge8ztwac72sfr9rusxg3297'
+      )
+    ).toBe('p2tr')
+  })
+
+  it('throws for unsupported address format', () => {
+    expect(() => detectBtcAddressType('tb1qtest')).toThrow(
+      'Unsupported Bitcoin address format'
+    )
+  })
+})

--- a/packages/core/chain/chains/cosmos/qbtc/claim/detectBtcAddressType.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/detectBtcAddressType.ts
@@ -1,0 +1,25 @@
+import { BtcAddressType } from './BtcAddressType'
+
+/**
+ * Detects the Bitcoin address type from the address string format.
+ *
+ * | Format              | Type        |
+ * |---------------------|-------------|
+ * | `1...`              | P2PKH       |
+ * | `3...`              | P2SH-P2WPKH |
+ * | `bc1q...` (42 chars)| P2WPKH      |
+ * | `bc1q...` (>42 chars)| P2WSH      |
+ * | `bc1p...`           | P2TR        |
+ */
+export const detectBtcAddressType = (address: string): BtcAddressType => {
+  if (address.startsWith('1')) return 'p2pkh'
+  if (address.startsWith('3')) return 'p2sh-p2wpkh'
+
+  if (address.startsWith('bc1p')) return 'p2tr'
+
+  if (address.startsWith('bc1q')) {
+    return address.length > 42 ? 'p2wsh' : 'p2wpkh'
+  }
+
+  throw new Error(`Unsupported Bitcoin address format: ${address}`)
+}

--- a/packages/core/chain/chains/cosmos/qbtc/claim/detectBtcAddressType.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/detectBtcAddressType.ts
@@ -9,13 +9,16 @@ import { BtcAddressType } from './BtcAddressType'
  * | `3...`              | P2SH-P2WPKH |
  * | `bc1q...` (42 chars)| P2WPKH      |
  * | `bc1q...` (62 chars)| P2WSH       |
- * | `bc1p...`           | P2TR        |
+ * | `bc1p...` (62 chars)| P2TR        |
  */
 export const detectBtcAddressType = (address: string): BtcAddressType => {
   if (address.startsWith('1')) return 'p2pkh'
   if (address.startsWith('3')) return 'p2sh-p2wpkh'
 
-  if (address.startsWith('bc1p')) return 'p2tr'
+  if (address.startsWith('bc1p')) {
+    if (address.length === 62) return 'p2tr'
+    throw new Error(`Unsupported Bitcoin address format: ${address}`)
+  }
 
   if (address.startsWith('bc1q')) {
     if (address.length === 42) return 'p2wpkh'

--- a/packages/core/chain/chains/cosmos/qbtc/claim/detectBtcAddressType.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/detectBtcAddressType.ts
@@ -8,7 +8,7 @@ import { BtcAddressType } from './BtcAddressType'
  * | `1...`              | P2PKH       |
  * | `3...`              | P2SH-P2WPKH |
  * | `bc1q...` (42 chars)| P2WPKH      |
- * | `bc1q...` (>42 chars)| P2WSH      |
+ * | `bc1q...` (62 chars)| P2WSH       |
  * | `bc1p...`           | P2TR        |
  */
 export const detectBtcAddressType = (address: string): BtcAddressType => {
@@ -18,7 +18,9 @@ export const detectBtcAddressType = (address: string): BtcAddressType => {
   if (address.startsWith('bc1p')) return 'p2tr'
 
   if (address.startsWith('bc1q')) {
-    return address.length > 42 ? 'p2wsh' : 'p2wpkh'
+    if (address.length === 42) return 'p2wpkh'
+    if (address.length === 62) return 'p2wsh'
+    throw new Error(`Unsupported Bitcoin address format: ${address}`)
   }
 
   throw new Error(`Unsupported Bitcoin address format: ${address}`)

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -189,6 +189,21 @@
       "import": "./dist/chains/cosmos/qbtc/claim/getClaimWithProofDisabled.js",
       "default": "./dist/chains/cosmos/qbtc/claim/getClaimWithProofDisabled.js"
     },
+    "./chains/cosmos/qbtc/claim/BtcAddressType": {
+      "types": "./dist/chains/cosmos/qbtc/claim/BtcAddressType.d.ts",
+      "import": "./dist/chains/cosmos/qbtc/claim/BtcAddressType.js",
+      "default": "./dist/chains/cosmos/qbtc/claim/BtcAddressType.js"
+    },
+    "./chains/cosmos/qbtc/claim/detectBtcAddressType": {
+      "types": "./dist/chains/cosmos/qbtc/claim/detectBtcAddressType.d.ts",
+      "import": "./dist/chains/cosmos/qbtc/claim/detectBtcAddressType.js",
+      "default": "./dist/chains/cosmos/qbtc/claim/detectBtcAddressType.js"
+    },
+    "./chains/cosmos/qbtc/claim/computeClaimHashes": {
+      "types": "./dist/chains/cosmos/qbtc/claim/computeClaimHashes.d.ts",
+      "import": "./dist/chains/cosmos/qbtc/claim/computeClaimHashes.js",
+      "default": "./dist/chains/cosmos/qbtc/claim/computeClaimHashes.js"
+    },
     "./chains/cosmos/sumFeeAmountForCosmosChainFeeDenom": {
       "types": "./dist/chains/cosmos/sumFeeAmountForCosmosChainFeeDenom.d.ts",
       "import": "./dist/chains/cosmos/sumFeeAmountForCosmosChainFeeDenom.js",


### PR DESCRIPTION
## Summary
- Add `BtcAddressType` and `QbtcClaimCircuit` types with address-to-circuit mapping
- Add `detectBtcAddressType` — detects P2PKH, P2WPKH, P2SH-P2WPKH, P2WSH, P2TR from address format
- Add `computeClaimHashes` — pure functions for Hash160, AddressHash, QBTCAddressHash, ChainIdHash, and MessageHash
- Add `computeAllClaimHashes` convenience function combining all steps
- 15 unit tests covering all address types and hash computations

Closes vultisig/vultisig-windows#3706

## Dependencies
- Builds on #249 (`feat/qbtc-claimable-utxos` branch)

## Exports added
- `@vultisig/core-chain/chains/cosmos/qbtc/claim/BtcAddressType`
- `@vultisig/core-chain/chains/cosmos/qbtc/claim/detectBtcAddressType`
- `@vultisig/core-chain/chains/cosmos/qbtc/claim/computeClaimHashes`

## Test plan
- [x] `detectBtcAddressType` identifies all 5 supported address formats
- [x] Hash160 computation matches standard Bitcoin Hash160 (RIPEMD160(SHA256))
- [x] Taproot uses x-only pubkey (32 bytes) and `schnorr:` prefix
- [x] ECDSA types use Hash160 (20 bytes) and `ecdsa:` prefix
- [x] `computeAllClaimHashes` produces correct output for both circuits
- [x] All 15 unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for P2PKH, P2WPKH, P2SH-P2WPKH, P2WSH and P2TR Bitcoin address formats
  * Bitcoin address type detection
  * Claim hash computation utilities and related public APIs for QBTC integration

* **Tests**
  * Added deterministic tests covering address detection and claim-hash computations

* **Chores**
  * Updated package exports to expose the new claim-related entry points
<!-- end of auto-generated comment: release notes by coderabbit.ai -->