### PR TITLE
fix: upload shared package dists in release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,19 @@ jobs:
           path: packages/rujira/dist
           retention-days: 1
 
+      - name: Upload shared packages dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: shared-dist
+          path: |
+            packages/mpc-types/dist
+            packages/mpc-wasm/dist
+            packages/core/mpc/dist
+            packages/core/chain/dist
+            packages/core/config/dist
+            packages/lib/utils/dist
+          retention-days: 1
+
   # ============ JOB 2: Run Tests (parallel with build) ============
   test:
     name: Run Tests
@@ -188,6 +201,11 @@ jobs:
         with:
           name: rujira-dist
           path: packages/rujira/dist
+
+      - name: Download shared packages dist
+        uses: actions/download-artifact@v4
+        with:
+          name: shared-dist
 
       - name: Publish to NPM
         run: yarn changeset:publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,7 @@ jobs:
             packages/core/chain/dist
             packages/core/config/dist
             packages/lib/utils/dist
+          if-no-files-found: error
           retention-days: 1
 
   # ============ JOB 2: Run Tests (parallel with build) ============
@@ -206,6 +207,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: shared-dist
+          path: packages
 
       - name: Publish to NPM
         run: yarn changeset:publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,18 @@ jobs:
           path: packages/rujira/dist
           retention-days: 1
 
+      # Assert each shared dist dir is non-empty before upload
+      # (if-no-files-found: error only fires if ALL paths yield zero files)
+      - name: Assert shared dist dirs are non-empty
+        run: |
+          for dir in packages/mpc-types/dist packages/mpc-wasm/dist packages/core/mpc/dist packages/core/chain/dist packages/core/config/dist packages/lib/utils/dist; do
+            if [ -z "$(ls -A "$dir" 2>/dev/null)" ]; then
+              echo "::error::$dir is empty — build:shared did not produce output"
+              exit 1
+            fi
+          done
+
+      # KEEP IN SYNC WITH scripts/build-shared-packages.mjs syncTargets
       - name: Upload shared packages dist
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Problem
mpc-types@0.1.1 published to npm without `dist/` — only `src/` files in the tarball. This breaks all consumers because `main: "dist/index.js"` doesn't exist.

## Root Cause
The release CI build job runs `build:shared` which produces `dist/` for mpc-types, mpc-wasm, core-mpc, core-chain, core-config, and lib-utils. But only sdk, cli, and rujira dists are uploaded as artifacts. The publish job (separate runner) does a fresh checkout + yarn install, downloads only those 3 artifacts, and runs `changeset:publish`. The shared packages have no `dist/` at publish time.

## Fix
Add `shared-dist` artifact upload in the build job and download in the publish job, covering all 6 shared packages that `build:shared` produces.

## Impact
After this merges + next release: mpc-types and all shared packages will correctly include `dist/` in their npm tarballs. This unblocks vultiagent-app PR #33.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow to ensure pre-built distribution artifacts are properly transferred between build and publish stages for more reliable releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->