### PR TITLE
chore: changeset for mpc-types 0.1.2 republish

### DIFF
--- a/.changeset/fix-mpc-types-dist-rebuild.md
+++ b/.changeset/fix-mpc-types-dist-rebuild.md
@@ -1,5 +1,6 @@
 ---
 "@vultisig/mpc-types": patch
+"@vultisig/mpc-wasm": patch
 ---
 
-fix: republish with dist/ included (previous 0.1.1 release published without compiled output due to missing CI artifact upload)
+fix: republish with dist/ included (previous releases published without compiled output due to missing CI artifact upload)

--- a/.changeset/fix-mpc-types-dist-rebuild.md
+++ b/.changeset/fix-mpc-types-dist-rebuild.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/mpc-types": patch
+---
+
+fix: republish with dist/ included (previous 0.1.1 release published without compiled output due to missing CI artifact upload)


### PR DESCRIPTION
## Why
mpc-types@0.1.1 was published without `dist/` because the release CI didn't upload shared package build artifacts. PR #255 fixed the CI pipeline.

## What
This changeset triggers a patch bump (0.1.1 → 0.1.2) so the bot opens a version PR and the fixed CI publishes mpc-types with `dist/` included.

## After merge
1. Bot opens "chore: version packages" PR (bumps mpc-types to 0.1.2)
2. Merge that PR
3. release.yml fires with fixed artifact pipeline
4. mpc-types@0.1.2 publishes to npm WITH dist/index.js
5. vultiagent-app #33 can install and build