### PR TITLE
fix(sdk): emit dedicated react-native types bundle so consumers see keysign

### DIFF
--- a/.changeset/fix-sdk-react-native-types-bundle.md
+++ b/.changeset/fix-sdk-react-native-types-bundle.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/sdk": patch
+---
+
+fix: emit dedicated `dist/index.react-native.d.ts` from the react-native platform entry, and wire the `exports` field to resolve it under TypeScript's `react-native` custom condition — downstream consumers can now `import { keysign } from '@vultisig/sdk'` under Metro/Expo without hand-written module augmentations

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -14,7 +14,10 @@
   ],
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": {
+        "react-native": "./dist/index.react-native.d.ts",
+        "default": "./dist/index.d.ts"
+      },
       "chrome-extension": "./dist/index.chrome-extension.js",
       "browser": "./dist/index.browser.js",
       "worker": "./dist/index.browser.js",
@@ -38,7 +41,7 @@
       "import": "./dist/index.browser.js"
     },
     "./react-native": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/index.react-native.d.ts",
       "import": "./dist/index.react-native.js"
     },
     "./electron": {

--- a/packages/sdk/rollup.types.config.js
+++ b/packages/sdk/rollup.types.config.js
@@ -41,4 +41,16 @@ export default defineConfig([
     },
     plugins: [dts(dtsPluginOptions)],
   },
+  // React Native platform types — RN-specific exports (e.g. keysign) that
+  // aren't reachable from src/index.ts because that entry stays platform
+  // agnostic. Consumers resolving under the "react-native" export condition
+  // (Metro/Expo tsconfig with customConditions) get this file.
+  {
+    input: 'src/platforms/react-native/index.ts',
+    output: {
+      file: 'dist/index.react-native.d.ts',
+      format: 'es',
+    },
+    plugins: [dts(dtsPluginOptions)],
+  },
 ])


### PR DESCRIPTION
## Problem

`keysign` is exported from `packages/sdk/src/platforms/react-native/index.ts` and ships in `dist/index.react-native.js` at runtime. But its **type** declaration is unreachable from downstream apps:

- The `.` export condition's `types` field points at `./dist/index.d.ts`
- The `./react-native` export condition's `types` field *also* points at `./dist/index.d.ts`
- `dist/index.d.ts` is generated from `src/index.ts` only — that main entry deliberately stays platform-agnostic and does **not** export `keysign`

So consumers importing `keysign` from `@vultisig/sdk` under Metro/Expo get a clean runtime resolution (react-native condition fires) but `tsc --noEmit` fails with:

``\`
error TS2305: Module '\"@vultisig/sdk\"' has no exported member 'keysign'.
``\`

The downstream workaround in vultiagent-app is a [hand-written module augmentation file](https://github.com/vultisig/vultiagent-app/blob/feat/use-sdk-clean/src/types/vultisig-sdk.d.ts) that redeclares `keysign` manually. Every consumer reaching for the keysign API has to reinvent it. The types contract is the bug.

## Fix

Emit a dedicated `dist/index.react-native.d.ts` from the react-native platform source, and wire the exports field so TypeScript resolves to it under the `react-native` custom condition.

### `rollup.types.config.js`

Add a third entry alongside the existing main + node entries:

``\`js
{
  input: 'src/platforms/react-native/index.ts',
  output: {
    file: 'dist/index.react-native.d.ts',
    format: 'es',
  },
  plugins: [dts(dtsPluginOptions)],
},
``\`

### `packages/sdk/package.json`

``\`diff
 \"exports\": {
   \".\": {
-    \"types\": \"./dist/index.d.ts\",
+    \"types\": {
+      \"react-native\": \"./dist/index.react-native.d.ts\",
+      \"default\": \"./dist/index.d.ts\"
+    },
     \"chrome-extension\": \"./dist/index.chrome-extension.js\",
     ...
   },
   \"./react-native\": {
-    \"types\": \"./dist/index.d.ts\",
+    \"types\": \"./dist/index.react-native.d.ts\",
     \"import\": \"./dist/index.react-native.js\"
   }
 }
``\`

### Why the conditional `types` map?

TypeScript supports conditional `types` resolution via [customConditions](https://www.typescriptlang.org/tsconfig#customConditions). Expo's [`expo/tsconfig.base.json`](https://github.com/expo/expo/blob/main/packages/expo/tsconfig.base.json) already sets:

``\`json
{
  \"moduleResolution\": \"bundler\",
  \"customConditions\": [\"react-native\"]
}
``\`

So consumers compiling under Metro/Expo automatically resolve the `react-native` types branch and pick up `keysign`. Everything else (node, browser, electron) falls through to `default` → `./dist/index.d.ts` and gets the platform-agnostic type set with no `keysign`, preserving the intent that `keysign` is an RN-only export.

No consumer tsconfig changes needed.

## Verification

- [x] `yarn build:sdk` — produces `dist/index.react-native.d.ts` cleanly
- [x] The new file declares `keysign`:
  ``\`
  declare const keysign: ({ keyShare, signatureAlgorithm, message, chainPath, localPartyId, peers, serverUrl, sessionId, hexEncryptionKey, isInitiatingDevice, }: KeysignInput) => Promise<KeysignSignature>;
  ``\`
- [x] Re-pointed vultiagent-app at the local SDK via metro file: link, **deleted** its `src/types/vultisig-sdk.d.ts` augmentation, ran `npm run typecheck` — clean ✅
- [x] Real on-device ETH self-send through chat UI on iPhone 16e: signed + broadcast via `keysign` imported from `@vultisig/sdk` (no augmentation file): [`0x3b79c3bfe534103985a268191eef06032e72af281013a6ce2d4393179de56886`](https://etherscan.io/tx/0x3b79c3bfe534103985a268191eef06032e72af281013a6ce2d4393179de56886) ✅

## Downstream impact

After this publishes, consumers can delete their manual type augmentations. vultiagent-app [#33](https://github.com/vultisig/vultiagent-app/pull/33) specifically carries `src/types/vultisig-sdk.d.ts` today for exactly this reason — it can be `git rm`'d once a new SDK release lands.

Needs the manual `force_release` workflow after merge to land on npm.

cc @NeOMakinG

🤖 Generated with [Claude Code](https://claude.com/claude-code)