### PR TITLE
fix(ci): unrug the ancillary release jobs (deploy-vercel, sync-docs, sync-skills, notify)

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -25,6 +25,10 @@ jobs:
       - run: corepack enable
       - run: corepack prepare yarn@4.13.0 --activate
       - run: yarn install --immutable
+      # build:shared must run before build:sdk: the SDK rollup bundle
+      # imports from packages/mpc-wasm/dist/index.js (and friends) which
+      # only exist after the shared packages are built.
+      - run: yarn build:shared
       - run: yarn build:sdk
 
       - run: npm install -g vercel

--- a/.github/workflows/notify-discord.yml
+++ b/.github/workflows/notify-discord.yml
@@ -16,8 +16,25 @@ jobs:
   notify:
     name: Discord Notify
     runs-on: ubuntu-latest
+    # Soft-fail: if DISCORD_WEBHOOK_URL is missing or Discord is down, we warn
+    # instead of blocking the overall release. A missed notification shouldn't
+    # turn a green release red.
+    continue-on-error: true
     steps:
+      - name: Check DISCORD_WEBHOOK_URL is configured
+        id: check_webhook
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK" ]; then
+            echo "::warning::DISCORD_WEBHOOK_URL secret is not set, skipping Discord notify. Add it to repo secrets to enable."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Notify Discord
+        if: steps.check_webhook.outputs.skip != 'true'
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
           VERSION: ${{ inputs.version }}

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -18,18 +18,37 @@ jobs:
   sync-docs:
     name: Sync Docs
     runs-on: ubuntu-latest
+    # Soft-fail: if DOCS_REPO_PAT is expired/revoked or the downstream
+    # vultisig/docs push fails for any reason, we warn instead of blocking
+    # the overall release. Docs sync is a nice-to-have, not a release gate.
+    continue-on-error: true
     env:
       VERSION: ${{ inputs.version }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Check DOCS_REPO_PAT is configured
+        id: check_pat
+        env:
+          DOCS_REPO_PAT: ${{ secrets.DOCS_REPO_PAT }}
+        run: |
+          if [ -z "$DOCS_REPO_PAT" ]; then
+            echo "::warning::DOCS_REPO_PAT secret is not set, skipping docs sync. Add it to repo secrets to enable."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        if: steps.check_pat.outputs.skip != 'true'
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        if: steps.check_pat.outputs.skip != 'true'
         with:
           repository: vultisig/docs
           token: ${{ secrets.DOCS_REPO_PAT }}
           path: docs-repo
 
       - name: Sync and push
+        if: steps.check_pat.outputs.skip != 'true'
         run: |
           mkdir -p docs-repo/developer-docs/vultisig-sdk
           cp packages/sdk/README.md docs-repo/developer-docs/vultisig-sdk/README.md

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -14,16 +14,35 @@ jobs:
   sync-skills:
     name: Sync Skills
     runs-on: ubuntu-latest
+    # Soft-fail: if DOCS_REPO_PAT is expired/revoked or the downstream
+    # vultisig/website-prod push fails for any reason, we warn instead of
+    # blocking the overall release. Skills sync is a nice-to-have.
+    continue-on-error: true
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Check DOCS_REPO_PAT is configured
+        id: check_pat
+        env:
+          DOCS_REPO_PAT: ${{ secrets.DOCS_REPO_PAT }}
+        run: |
+          if [ -z "$DOCS_REPO_PAT" ]; then
+            echo "::warning::DOCS_REPO_PAT secret is not set, skipping skills sync. Add it to repo secrets to enable."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        if: steps.check_pat.outputs.skip != 'true'
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        if: steps.check_pat.outputs.skip != 'true'
         with:
           repository: vultisig/website-prod
           token: ${{ secrets.DOCS_REPO_PAT }}
           path: website-repo
 
       - name: Sync skills directory
+        if: steps.check_pat.outputs.skip != 'true'
         run: |
           rm -rf website-repo/public/skills
           cp -r skills website-repo/public/skills


### PR DESCRIPTION
## tl;dr

Watching [release.yml run #24354186603](https://github.com/vultisig/vultisig-sdk/actions/runs/24354186603) for v0.14.3: publish / tag / GitHub release all went green (the stuff that matters), but the four downstream jobs everyone ignores all went red. Making them go green again because hey man it works, at this point it's all that matters, but also it was making me sad.

## What was red, why, and what this PR does about it

### 1. \`deploy-vercel\` — genuine bug, full fix

\`deploy-vercel.yml\` is a reusable workflow that does its own fresh checkout + \`yarn install --immutable\` + \`yarn build:sdk\`. Problem: it skips \`yarn build:shared\`. Which means \`packages/mpc-wasm/dist/index.js\` (and friends) don't exist when \`build:sdk\` runs rollup, and rollup dies with:

\`\`\`
[!] Error: Could not load /home/runner/work/vultisig-sdk/vultisig-sdk/packages/mpc-wasm/dist/index.js
    (imported by src/platforms/browser/index.ts): ENOENT: no such file or directory
\`\`\`

(Four variants of this error, one per platform entry point: browser, chrome-extension, electron-main, node.)

The parent \`release.yml\` \`build\` job does \`build:shared && build:all && cli:build\` in that order, so it doesn't hit this. Reusable workflow just forgot to match. Added \`yarn build:shared\` before \`yarn build:sdk\` with a comment explaining the ordering constraint so nobody re-breaks it.

### 2 & 3. \`sync-docs\` / \`sync-skills\` — bad PAT, soft-fail

Both workflows do a second \`actions/checkout\` against an external repo (\`vultisig/docs\` and \`vultisig/website-prod\` respectively) using \`\${{ secrets.DOCS_REPO_PAT }}\`. Both die at that step with:

\`\`\`
Bad credentials - https://docs.github.com/rest
\`\`\`

That's what GitHub's REST API returns when the token exists but is invalid: expired, revoked, or had its scopes changed out from under it. \`DOCS_REPO_PAT\` is set in repo secrets (otherwise we'd get a different error), it's just not a valid token anymore.

**Renewing a PAT isn't something a PR can do**, so the fix here is two-layer:

1. **Preflight check step** that reads the secret into an env var and warns+skips if it's literally empty. Handles the \"never configured\" case cleanly: skipped steps show gray in the GitHub UI, not red, and a clean \`::warning::\` annotation surfaces in the run summary telling the next person how to enable it.

2. **\`continue-on-error: true\` at job level** so that when the PAT is present-but-invalid (the current state), the checkout step's failure doesn't bubble up. The job still runs, the failure is still visible in the detailed logs, the release still finishes green. Defense in depth for the invalid-token case the preflight can't catch.

Soft-failing these is the right call because **neither sync is a release gate** — they're best-effort downstream propagations. A new SDK version on npm doesn't become invalid just because we couldn't push a README to the docs repo. If you want the sync to go green for real, renew the PAT and the preflight check will stop firing.

### 4. \`notify-discord\` — missing secret, same pattern

\`curl\` exits with code 6 (\"couldn't resolve host\") because \`\$DISCORD_WEBHOOK\` expands to an empty string. \`DISCORD_WEBHOOK_URL\` isn't set in repo secrets at all. Same two-layer fix: preflight warn-and-skip if empty, \`continue-on-error: true\` as defense in depth.

If we ever want actual Discord notifications working, set the secret and it'll just start posting. No code changes needed.

## Why the soft-fail pattern and not just \`continue-on-error\` alone

Two reasons to include the preflight check even though \`continue-on-error\` would cover both cases:

- **Gray skipped steps look better than red-but-ignored steps.** For the missing-secret case, the preflight gives a clean skip. \`continue-on-error\` alone would still show the underlying step as failed in the logs, just not block the run.
- **The \`::warning::\` annotation surfaces in the GitHub Actions run summary.** If someone looks at a release run and sees \"Sync Docs: ✓ (1 warning)\" with the annotation \"DOCS_REPO_PAT secret is not set\", they immediately know what the knob is. That's way more discoverable than \"drill into the logs to find the curl exit 6\".

## Risk

Very low. \`deploy-vercel\` fix is a one-line addition that matches what \`release.yml\` already does in its own build job. The soft-fail pattern on the other three workflows is additive: it only changes behavior when a secret is missing or when the external step fails, and the new behavior is strictly an improvement (warn instead of die).

Zero impact on publish / tag / GitHub Release / build / test jobs. The publish pipeline in \`release.yml\` is untouched.

## Testing plan

- [ ] CI on this PR goes green
- [ ] Next \`release.yml\` run (whenever the next version publish happens) lights up the Actions UI all green, with \`::warning::\` annotations on the sync/notify jobs that are still missing/invalid secrets
- [ ] \`deploy-vercel\` actually deploys to Vercel for real this time (assuming \`VERCEL_TOKEN\` / \`VERCEL_ORG_ID\` / \`VERCEL_PROJECT_ID\` secrets are healthy — haven't verified those, just that the build step that was blocking it is now fixed)

## Follow-ups for a human (not this PR)

- [ ] Renew or regenerate \`DOCS_REPO_PAT\` in repo secrets so sync-docs / sync-skills actually push for real
- [ ] Set \`DISCORD_WEBHOOK_URL\` in repo secrets if we want Discord release pings to work
- [ ] Verify \`VERCEL_TOKEN\` / \`VERCEL_ORG_ID\` / \`VERCEL_PROJECT_ID\` secrets are healthy (didn't touch deploy step auth, only the build step that was failing before it)

Stamping as \"make my OCD happy\" PR, but the deploy-vercel part is a real bug. We're gucci either way.