### PR TITLE
fix(ton): handle Duplicate msg_seqno as idempotent broadcast

### DIFF
--- a/packages/core/chain/tx/broadcast/resolvers/ton.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/ton.ts
@@ -17,7 +17,7 @@ export const broadcastTonTx: BroadcastTxResolver<OtherChain.Ton> = async ({
     })
   )
 
-  if (error && !isInError(error, 'duplicate message')) {
+  if (error && !isInError(error, 'duplicate message', 'duplicate msg_seqno')) {
     throw error
   }
 }


### PR DESCRIPTION
## Summary
- Add `'duplicate msg_seqno'` to the idempotent error check in the TON broadcast resolver
- The TON lite server returns `"Duplicate msg_seqno"` when a tx's sequence number is already consumed on-chain, which differs from the mempool-level `"duplicate message"` error
- In multi-device (2of2) vaults, both devices broadcast independently — the second device hits this error and shows a false "Signing Error" even though the transaction succeeded

## Test plan
- [x] Sign a TON transaction with a 2of2 vault — both devices should show success
- [x] Single-device (fast vault) TON transactions still work correctly
- [x] Genuine TON broadcast errors are still surfaced to the user

Closes vultisig/vultisig-windows#3746

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved TON transaction broadcast error handling to properly identify and ignore duplicate message scenarios, enhancing transaction processing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->