### PR TITLE
fix(cli): stop synthesising actions from <invoke> tags

### DIFF
--- a/clients/cli/src/agent/__tests__/stripLeakedToolCallTags.test.ts
+++ b/clients/cli/src/agent/__tests__/stripLeakedToolCallTags.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+
+import { stripLeakedToolCallTags } from '../session'
+
+describe('stripLeakedToolCallTags', () => {
+  it('returns empty string for empty input', () => {
+    expect(stripLeakedToolCallTags('')).toBe('')
+  })
+
+  it('returns text unchanged when no tags are present', () => {
+    const text = 'Your balance is 1.5 ETH.'
+    expect(stripLeakedToolCallTags(text)).toBe(text)
+  })
+
+  it('preserves text that happens to contain the word "invoke" but no tags', () => {
+    const text = 'You can invoke the transfer function directly.'
+    expect(stripLeakedToolCallTags(text)).toBe(text)
+  })
+
+  it('strips a full minimax:tool_call block and returns only narrative', () => {
+    const text = [
+      'Let me build the close transaction.',
+      '<minimax:tool_call>',
+      '<invoke name="abi_encode">',
+      '<parameter name="signature">transfer(address,uint256)</parameter>',
+      '</invoke>',
+      '</minimax:tool_call>',
+    ].join('\n')
+
+    const cleaned = stripLeakedToolCallTags(text)
+    expect(cleaned).toBe('Let me build the close transaction.')
+    expect(cleaned).not.toContain('<invoke')
+    expect(cleaned).not.toContain('minimax:tool_call')
+  })
+
+  it('strips bare <invoke> blocks without the minimax wrapper', () => {
+    const text = [
+      'Position 1249931 is a USDC/WETH LP on Ethereum.',
+      '<invoke name="abi_encode">',
+      '<parameter name="signature">decreaseLiquidity((uint256,uint128,uint256,uint256,uint256))</parameter>',
+      '</invoke>',
+    ].join('\n')
+
+    const cleaned = stripLeakedToolCallTags(text)
+    expect(cleaned).toContain('Position 1249931')
+    expect(cleaned).not.toContain('<invoke')
+    expect(cleaned).not.toContain('abi_encode')
+  })
+
+  it('strips orphan closer tags without a matching opener', () => {
+    const text = 'Your balance is 1.5 ETH.</minimax:tool_call>'
+    const cleaned = stripLeakedToolCallTags(text)
+    expect(cleaned).toBe('Your balance is 1.5 ETH.')
+  })
+
+  it('strips multiple invoke blocks and preserves narrative between them', () => {
+    // Matches the exact production incident shape.
+    const text = [
+      'Close the position.',
+      '<invoke name="abi_encode">',
+      '<parameter name="signature">decreaseLiquidity(...)</parameter>',
+      '</invoke>',
+      'Then collect fees.',
+      '<invoke name="abi_encode">',
+      '<parameter name="signature">collect(...)</parameter>',
+      '</invoke>',
+      '</minimax:tool_call>',
+    ].join('\n')
+
+    const cleaned = stripLeakedToolCallTags(text)
+    expect(cleaned).toContain('Close the position.')
+    expect(cleaned).toContain('Then collect fees.')
+    expect(cleaned).not.toContain('<invoke')
+    expect(cleaned).not.toContain('minimax:tool_call')
+  })
+
+  it('collapses run of 3+ newlines left by tag removal', () => {
+    const text = [
+      'First line.',
+      '<invoke name="t"><parameter name="x">y</parameter></invoke>',
+      '',
+      '',
+      'Second line.',
+    ].join('\n')
+
+    const cleaned = stripLeakedToolCallTags(text)
+    expect(cleaned.split(/\n{3,}/).length).toBe(1) // no runs of 3+ newlines
+    expect(cleaned).toContain('First line.')
+    expect(cleaned).toContain('Second line.')
+  })
+
+  it('returns empty string when text is purely tags with nothing else', () => {
+    const text = '<minimax:tool_call><invoke name="t"></invoke></minimax:tool_call>'
+    expect(stripLeakedToolCallTags(text)).toBe('')
+  })
+})

--- a/clients/cli/src/agent/session.ts
+++ b/clients/cli/src/agent/session.ts
@@ -298,21 +298,9 @@ export class AgentSession {
     // if intermediate chunks were interrupted or dropped upstream.
     const responseText = streamResult.message?.content || streamResult.fullText || ''
 
-    // Check if the response text contains inline tool calls (XML format from the model)
-    const inlineActions = parseInlineToolCalls(responseText)
-    if (inlineActions.length > 0) {
-      // Strip the XML from the displayed text
-      const cleanText = responseText
-        .replace(/<invoke\s+name="[^"]*">[\s\S]*?<\/invoke>/g, '')
-        .replace(/<\/?minimax:tool_call>/g, '')
-        .trim()
-      if (cleanText) {
-        ui.onAssistantMessage(cleanText)
-      }
-      // Add inline actions to the stream result
-      streamResult.actions.push(...inlineActions)
-    } else if (responseText) {
-      ui.onAssistantMessage(responseText)
+    const displayText = stripLeakedToolCallTags(responseText)
+    if (displayText) {
+      ui.onAssistantMessage(displayText)
     }
 
     // Filter out sign_tx actions — signing is handled client-side automatically
@@ -452,43 +440,42 @@ export class AgentSession {
 }
 
 /**
- * Parse inline tool calls from assistant text.
- * The backend sometimes sends tool calls as raw XML in the text stream:
- *   <invoke name="add_coin"><parameter name="tokens">[...]</parameter></invoke>
+ * stripLeakedToolCallTags removes model-native tool-call syntax that leaked
+ * into assistant text content, returning only the narrative portion for
+ * display.
+ *
+ * Some models (notably MiniMax M2.x) occasionally regress from OpenAI-style
+ * structured tool_calls back to their native Harmony-style tags:
+ *
+ *   <minimax:tool_call>
+ *     <invoke name="abi_encode">
+ *       <parameter name="signature">transfer(address,uint256)</parameter>
+ *     </invoke>
+ *   </minimax:tool_call>
+ *
+ * These tags are the backend's responsibility to detect and rewrite into
+ * real tool_calls. If one leaks through anyway the CLI should strip it
+ * from the displayed text — showing raw XML to the user is confusing.
+ *
+ * We deliberately do NOT synthesise client-side actions from these tags.
+ * That used to happen (via the old `parseInlineToolCalls` function) and
+ * caused a production incident: MCP tool names inside <invoke> blocks
+ * were routed into the client action executor which doesn't implement
+ * them, failed with "not implemented locally", and eventually led the
+ * model to fabricate hallucinated calldata. The CLI only displays.
+ *
+ * Exported for unit testing.
  */
-function parseInlineToolCalls(text: string): Action[] {
-  const actions: Action[] = []
-  const invokeRegex = /<invoke\s+name="([^"]+)">([\s\S]*?)<\/invoke>/g
-  let match: RegExpExecArray | null
-
-  while ((match = invokeRegex.exec(text)) !== null) {
-    const actionType = match[1]
-    const body = match[2]
-    const params: Record<string, unknown> = {}
-
-    // Parse <parameter name="key">value</parameter> tags
-    const paramRegex = /<parameter\s+name="([^"]+)">([\s\S]*?)<\/parameter>/g
-    let paramMatch: RegExpExecArray | null
-    while ((paramMatch = paramRegex.exec(body)) !== null) {
-      const key = paramMatch[1]
-      const value = paramMatch[2]
-      try {
-        params[key] = JSON.parse(value)
-      } catch {
-        params[key] = value
-      }
-    }
-
-    actions.push({
-      id: `inline_${actionType}_${Date.now()}`,
-      type: actionType,
-      title: actionType,
-      params,
-      auto_execute: true,
-    })
+export function stripLeakedToolCallTags(text: string): string {
+  if (!text) return ''
+  if (!/<invoke\s+name="[^"]*">/.test(text) && !text.includes('minimax:tool_call')) {
+    return text
   }
-
-  return actions
+  return text
+    .replace(/<invoke\s+name="[^"]*">[\s\S]*?<\/invoke>/g, '')
+    .replace(/<\/?minimax:tool_call>/g, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
 }
 
 // ============================================================================


### PR DESCRIPTION
## Background — production incident

Tied to [vultisig/agent-backend#125](https://github.com/vultisig/agent-backend/pull/125) (full incident write-up there). Conversation `87fb9912-a10b-462e-b5d0-6943cb412eaf` (prod) ran on `minimax/minimax-m2.7` and produced two failed Uniswap V3 transactions that consumed user gas:

- [`0x0274313b…cb425`](https://etherscan.io/tx/0x0274313b16e527da73cb8c1d5b399bfbf951a939ab42287c08f87734343cb425) — sent to a hallucinated NFPM address (no-op, but gas paid).
- [`0xb04c324f…16f58`](https://etherscan.io/tx/0xb04c324fd1fb25f45fcf8a02bd89f024be6407866f823b62af5e3bb98d016f58) — sent to the real NFPM but with hallucinated calldata (reverted, gas paid).

## What the CLI contributed

`session.ts` had a function `parseInlineToolCalls` that scanned assistant text for `<invoke name="X">…</invoke>` tags and converted each one into a client-side action with `type=X`. The assumption was that if the backend ever sent tool calls as raw XML, the CLI could "rescue" them.

In practice that's exactly backwards. When a model leaks its native tool-call format (MiniMax's Harmony-style tags, Qwen's `<function_call>`, etc.) the names inside `<invoke>` are **MCP tool names** like `abi_encode`, `build_evm_tx`, `get_tx_status`. The CLI's action executor doesn't implement those — its whitelist (`executor.ts:216`) holds client-only actions like `build_send_tx`, `build_swap_tx`, `build_custom_tx`. Every synthesised action came back with `"Action type 'X' is not implemented locally. The backend may handle this action server-side."`

In the incident that error cascaded through several retries until the model gave up on real tool use and emitted a `build_custom_tx` action with fully-fabricated calldata. **That** got auto-signed and broadcast.

## Fix

The backend PR ([agent-backend#125](https://github.com/vultisig/agent-backend/pull/125)) handles this properly: it detects leaked tags, parses them into canonical `ai.ToolCall` structs, and threads them through the normal MCP execution path. The CLI shouldn't be a parallel execution pathway for the same data — it was a security liability.

This PR:

- **Deletes** `parseInlineToolCalls` outright. The action-synthesis path is gone.
- **Keeps** the display-strip path — if tags still slip through after the backend rewrite, the CLI at least doesn't show raw XML to the user.
- **Extracts** the strip logic into an exported pure `stripLeakedToolCallTags` helper so it can be unit-tested in isolation.

### Why still strip-for-display

The backend rewrite is authoritative, but:

1. During SSE streaming, the CLI sees `text_delta` events before the backend has assembled and rewritten the full response. Stripping at the end of the turn preserves a clean final display.
2. Defence-in-depth: older backends or new model variants may leak tags the backend adapter doesn't yet know about. Displaying the narrative portion cleanly is a low-risk fallback.

## Tests

9 new vitest cases for `stripLeakedToolCallTags` — all passing:

| Case | Verifies |
|---|---|
| Empty input | Returns `''` |
| No tags | Returns text unchanged |
| Word "invoke" in prose | **Not** stripped (no false positives) |
| Full `<minimax:tool_call>` block | Removed, narrative preserved |
| Bare `<invoke>` block without wrapper | Removed |
| Orphan `</minimax:tool_call>` closer | Stripped |
| Multiple blocks with interleaved narrative | All tags removed, all prose preserved |
| 3+ newlines from tag removal | Collapsed to 2 |
| Tags-only input | Returns `''` |

Full CLI test suite: `yarn workspace @vultisig/cli test` → **47/47 passing**.

## Live end-to-end verification

Ran this CLI against a local stack with the agent-backend companion PR applied (`AI_MODEL=minimax/minimax-m2.7`, served by OpenRouter as `z-ai/glm-5-20260211`). Both runs used prompts that **explicitly forced the model to emit its native MiniMax Harmony syntax**, so the full chain (model → leaked format → backend rewrite → MCP execution) actually ran, not just the hot path.

### Run 1 — Harmony-wrapped balance query

**Prompt** forced `<minimax:tool_call><invoke name="evm_get_balance">…` inside the model's response. The backend rewriter detected it, synthesised the tool call, and MCP executed `evm_get_balance`. CLI displayed the cleaned narrative: *"Your Ethereum balance is 0.003309526 ETH (~$7.64 USD)."*

### Run 2 — Harmony-wrapped self-send (produces real tx)

**Prompt** forced every tool in the send flow through Harmony syntax. Three Harmony rewrites fired (`convert_amount + evm_tx_info` → `build_evm_tx` → `get_tx_status`), the CLI signed the resulting transaction client-side, and it confirmed on-chain:

- TxID [**`0x1698b9fe…d5ff`**](https://etherscan.io/tx/0x1698b9fe6db56bfb3126299331015156f6c920f7905283942e3c8407db87d5ff) — status `0x1`, block 24891854, 2 confirmations, value 0.00001 ETH.

This is exactly the tool chain that originally broke in the production incident (`abi_encode`/`build_evm_tx`/`get_tx_status`). Now it runs cleanly through proper MCP routing, and the CLI never tries to interpret `<invoke>` tags as actionable client requests — they're just stripped from display.

## Companion PR

[vultisig/agent-backend#125](https://github.com/vultisig/agent-backend/pull/125) — the authoritative fix in the backend.
