### PR TITLE
Fix MPC engine singleton for core-mpc / mpc-types across bundler chunks (#287)

### DIFF
--- a/.changeset/fix-mpc-engine-singleton.md
+++ b/.changeset/fix-mpc-engine-singleton.md
@@ -1,0 +1,14 @@
+---
+'@vultisig/mpc-types': minor
+'@vultisig/core-mpc': patch
+'@vultisig/sdk': patch
+---
+
+Fix MPC engine singleton so direct `@vultisig/core-mpc` / `@vultisig/mpc-types` / `@vultisig/mpc-wasm` imports register correctly across bundler chunks and Vite `optimizeDeps` scenarios.
+
+- Runtime singletons (MPC engine, WASM WalletCore getter, default storage factory, platform crypto) now live in a `globalThis`-anchored store keyed by `Symbol.for('vultisig.runtime.store.v1')`, eliminating duplicate-module-instance bugs.
+- `ensureMpcEngine()` added (async) — lazily registers the default `WasmMpcEngine` when no engine has been configured, so consumers that import only `@vultisig/core-mpc` no longer need to bootstrap the SDK.
+- `@vultisig/sdk` `sideEffects` narrowed from `false` to an allowlist of platform entry dist files, preventing tree-shakers from dropping the platform bootstrap.
+- `@vultisig/mpc-wasm` declared as an optional peer dependency of `@vultisig/mpc-types`.
+
+Closes #287.

--- a/packages/core/mpc/dkls/dkls.ts
+++ b/packages/core/mpc/dkls/dkls.ts
@@ -1,4 +1,4 @@
-import { getMpcEngine, type MpcKeyshare, type MpcSession } from '@vultisig/mpc-types'
+import { ensureMpcEngine, type MpcKeyshare, type MpcSession } from '@vultisig/mpc-types'
 import { base64Encode } from '@vultisig/lib-utils/base64Encode'
 
 import { getKeygenThreshold } from '../getKeygenThreshold'
@@ -185,7 +185,7 @@ export class DKLS {
     }
     if (this.isInitiateDevice) {
       const threshold = getKeygenThreshold(this.keygenCommittee.length)
-      this.setupMessage = getMpcEngine().dkls.keygenSetup(
+      this.setupMessage = (await ensureMpcEngine()).dkls.keygenSetup(
         undefined,
         threshold,
         this.keygenCommittee
@@ -235,7 +235,7 @@ export class DKLS {
           )
         }
       }
-      const engine = getMpcEngine().dkls
+      const engine = (await ensureMpcEngine()).dkls
       let session: MpcSession<MpcKeyshare>
       if ('create' in this.keygenOperation) {
         session = await engine.createKeygenSession(this.setupMessage, this.localPartyId)
@@ -308,7 +308,7 @@ export class DKLS {
     this.isKeygenComplete = false
     this.inboundSequenceNo = 0
     this.onInboundSequenceNoChange?.(this.inboundSequenceNo)
-    const engine = getMpcEngine().dkls
+    const engine = (await ensureMpcEngine()).dkls
     let localKeyshare: MpcKeyshare | null = null
     if (dklsKeyshare !== undefined && dklsKeyshare.length > 0) {
       localKeyshare = engine.keyshareFromBytes(Buffer.from(dklsKeyshare, 'base64'))
@@ -426,7 +426,7 @@ export class DKLS {
     const privateKey = Buffer.from(hexPrivateKey, 'hex')
     const chainCode = Buffer.from(hexChainCode, 'hex')
 
-    const keyImportResult = await getMpcEngine().dkls.createKeyImportInitiator(
+    const keyImportResult = await (await ensureMpcEngine()).dkls.createKeyImportInitiator(
       Uint8Array.from(privateKey),
       Uint8Array.from(chainCode),
       threshold,
@@ -458,7 +458,7 @@ export class DKLS {
   ) {
     console.log('startKeyImport attempt:', attempt)
     this.isKeygenComplete = false
-    const engine = getMpcEngine().dkls
+    const engine = (await ensureMpcEngine()).dkls
     try {
       let session: MpcSession<MpcKeyshare> | null = null
       if (this.isInitiateDevice) {

--- a/packages/core/mpc/lib/initialize.ts
+++ b/packages/core/mpc/lib/initialize.ts
@@ -1,13 +1,15 @@
 import { SignatureAlgorithm } from '@vultisig/core-chain/signing/SignatureAlgorithm'
-import { getMpcEngine } from '@vultisig/mpc-types'
+import { ensureMpcEngine } from '@vultisig/mpc-types'
 import { memoizeAsync } from '@vultisig/lib-utils/memoizeAsync'
 import { prefixErrorWith } from '@vultisig/lib-utils/error/prefixErrorWith'
 import { transformError } from '@vultisig/lib-utils/error/transformError'
 
 const initializeEngine = memoizeAsync(() =>
-  transformError(
-    getMpcEngine().initialize(),
-    prefixErrorWith('Failed to initialize MPC lib')
+  ensureMpcEngine().then(engine =>
+    transformError(
+      engine.initialize(),
+      prefixErrorWith('Failed to initialize MPC lib')
+    )
   )
 )
 

--- a/packages/core/mpc/lib/signSession.ts
+++ b/packages/core/mpc/lib/signSession.ts
@@ -1,5 +1,5 @@
 import { SignatureAlgorithm } from '@vultisig/core-chain/signing/SignatureAlgorithm'
-import { getMpcEngine } from '@vultisig/mpc-types'
+import { ensureMpcEngine, getMpcEngine } from '@vultisig/mpc-types'
 
 import { toMpcLibKeyshare } from './keyshare'
 
@@ -69,8 +69,9 @@ export const makeSignSession = async ({
   keyShare,
   signatureAlgorithm,
 }: MakeSignSessionInput) => {
+  const mpc = await ensureMpcEngine()
   const engineKey = getEngineKey(signatureAlgorithm)
-  return getMpcEngine()[engineKey].createSignSession(
+  return mpc[engineKey].createSignSession(
     setupMessage,
     localPartyId,
     toMpcLibKeyshare({

--- a/packages/core/mpc/schnorr/schnorrKeygen.ts
+++ b/packages/core/mpc/schnorr/schnorrKeygen.ts
@@ -1,4 +1,4 @@
-import { getMpcEngine, type MpcKeyshare, type MpcSession } from '@vultisig/mpc-types'
+import { ensureMpcEngine, type MpcKeyshare, type MpcSession } from '@vultisig/mpc-types'
 import { base64Encode } from '@vultisig/lib-utils/base64Encode'
 
 import { getKeygenThreshold } from '../getKeygenThreshold'
@@ -182,7 +182,7 @@ export class Schnorr {
     console.log('session id:', this.sessionId)
     this.isKeygenComplete = false
     try {
-      const engine = getMpcEngine().schnorr
+      const engine = (await ensureMpcEngine()).schnorr
       let session: MpcSession<MpcKeyshare>
       if ('create' in this.keygenOperation) {
         session = await engine.createKeygenSession(this.setupMessage, this.localPartyId)
@@ -245,7 +245,7 @@ export class Schnorr {
   ) {
     console.log('startReshare schnorr, attempt:', attempt)
     this.isKeygenComplete = false
-    const engine = getMpcEngine().schnorr
+    const engine = (await ensureMpcEngine()).schnorr
     let localKeyshare: MpcKeyshare | null = null
     if (rawSchnorrKeyshare !== undefined && rawSchnorrKeyshare.length > 0) {
       localKeyshare = engine.keyshareFromBytes(
@@ -362,7 +362,7 @@ export class Schnorr {
       return
     }
 
-    const engine = getMpcEngine().schnorr
+    const engine = (await ensureMpcEngine()).schnorr
     const privateKey = Buffer.from(hexPrivateKey, 'hex')
     const chainCode = Buffer.from(hexChainCode, 'hex')
     const importResult = await engine.createKeyImportInitiator(
@@ -398,7 +398,7 @@ export class Schnorr {
     console.log('startKeyImport schnorr, attempt:', attempt)
     this.isKeygenComplete = false
     try {
-      const engine = getMpcEngine().schnorr
+      const engine = (await ensureMpcEngine()).schnorr
       let session: MpcSession<MpcKeyshare> | null = null
       const effectiveSetupId = setupMessageId ?? 'eddsa_key_import'
       if (this.isInitiateDevice) {

--- a/packages/mpc-types/package.json
+++ b/packages/mpc-types/package.json
@@ -16,12 +16,29 @@
       "types": "./dist/runtime.d.ts",
       "import": "./dist/runtime.js",
       "default": "./dist/runtime.js"
+    },
+    "./store": {
+      "types": "./dist/store.d.ts",
+      "import": "./dist/store.js",
+      "default": "./dist/store.js"
     }
   },
   "files": [
     "dist",
     "src"
   ],
+  "sideEffects": [
+    "./dist/runtime.js",
+    "./dist/store.js"
+  ],
+  "peerDependencies": {
+    "@vultisig/mpc-wasm": ">=0.1.0"
+  },
+  "peerDependenciesMeta": {
+    "@vultisig/mpc-wasm": {
+      "optional": true
+    }
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/mpc-types/src/index.ts
+++ b/packages/mpc-types/src/index.ts
@@ -333,4 +333,5 @@ export interface MpcEngine {
 }
 
 // Runtime configuration
-export { configureMpc, getMpcEngine } from './runtime'
+export { configureMpc, ensureMpcEngine, getMpcEngine } from './runtime'
+export { runtimeStore, __resetRuntimeStoreForTesting } from './store'

--- a/packages/mpc-types/src/runtime.ts
+++ b/packages/mpc-types/src/runtime.ts
@@ -6,7 +6,7 @@
  */
 import type { MpcEngine } from './index'
 
-let mpcEngine: MpcEngine | null = null
+import { runtimeStore } from './store'
 
 /**
  * Validate that an engine object satisfies the minimum MpcEngine contract.
@@ -30,7 +30,7 @@ function validateEngine(engine: MpcEngine): void {
     if (maybeEngine['mldsa'] === engine.dkls) {
       throw new Error(
         'MPC engine: engine.mldsa must not alias engine.dkls. ' +
-        'MLDSA requires a dedicated signing path, not ECDSA/DKLS.'
+          'MLDSA requires a dedicated signing path, not ECDSA/DKLS.'
       )
     }
   }
@@ -45,13 +45,14 @@ function validateEngine(engine: MpcEngine): void {
  */
 export function configureMpc(engine: MpcEngine): void {
   validateEngine(engine)
-  if (mpcEngine !== null) {
+  const s = runtimeStore()
+  if (s.mpcEngine !== null) {
     console.warn(
       'configureMpc: overwriting an already-configured MPC engine. ' +
-      'This is usually a mistake — ensure configureMpc is called only once per process.'
+        'This is usually a mistake — ensure configureMpc is called only once per process.'
     )
   }
-  mpcEngine = engine
+  s.mpcEngine = engine
 }
 
 /**
@@ -61,6 +62,7 @@ export function configureMpc(engine: MpcEngine): void {
  * @throws Error if no engine has been configured via {@link configureMpc}.
  */
 export function getMpcEngine(): MpcEngine {
+  const mpcEngine = runtimeStore().mpcEngine as MpcEngine | null
   if (!mpcEngine) {
     throw new Error(
       'MPC engine not configured. Import from a platform entry point ' +
@@ -68,4 +70,28 @@ export function getMpcEngine(): MpcEngine {
     )
   }
   return mpcEngine
+}
+
+/**
+ * Returns the configured engine, or lazily installs {@link WasmMpcEngine} from
+ * `@vultisig/mpc-wasm` when none is set (browser/Node/Electron consumers).
+ */
+export async function ensureMpcEngine(): Promise<MpcEngine> {
+  const s = runtimeStore()
+  if (s.mpcEngine) {
+    return s.mpcEngine as MpcEngine
+  }
+  let mod: { WasmMpcEngine: new () => MpcEngine }
+  try {
+    mod = await import('@vultisig/mpc-wasm')
+  } catch (cause) {
+    throw new Error(
+      'MPC engine not configured and @vultisig/mpc-wasm is not installed. ' +
+        'Either install @vultisig/mpc-wasm, or call configureMpc(...) before any MPC operation. ' +
+        'See https://github.com/vultisig/vultisig-sdk/issues/287.',
+      { cause: cause as Error }
+    )
+  }
+  configureMpc(new mod.WasmMpcEngine())
+  return runtimeStore().mpcEngine as MpcEngine
 }

--- a/packages/mpc-types/src/store.ts
+++ b/packages/mpc-types/src/store.ts
@@ -1,0 +1,31 @@
+/**
+ * Process-wide runtime configuration anchored on `globalThis` so duplicate
+ * bundled copies of `@vultisig/mpc-types` still share one registry.
+ */
+
+type PlatformCryptoLike = { randomUUID: () => string; validateCrypto?: () => void }
+type StorageLike = unknown
+
+export type RuntimeStore = {
+  mpcEngine: unknown | null
+  walletCore: (() => Promise<unknown>) | null
+  storageFactory: (() => StorageLike) | null
+  crypto: PlatformCryptoLike | null
+}
+
+const STORE_KEY = Symbol.for('vultisig.runtime.store.v1')
+
+export function runtimeStore(): RuntimeStore {
+  const g = globalThis as Record<PropertyKey, unknown>
+  let s = g[STORE_KEY] as RuntimeStore | undefined
+  if (!s) {
+    s = { mpcEngine: null, walletCore: null, storageFactory: null, crypto: null }
+    g[STORE_KEY] = s
+  }
+  return s
+}
+
+/** Test-only: clears the process-wide store. */
+export function __resetRuntimeStoreForTesting(): void {
+  delete (globalThis as Record<PropertyKey, unknown>)[STORE_KEY]
+}

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -146,6 +146,7 @@
     "@solana/spl-token": "^0.4.14",
     "@solana/web3.js": "^1.98.4",
     "@trustwallet/wallet-core": "^4.6.0",
+    "@vultisig/mpc-types": "workspace:*",
     "axios": "^1.8.3",
     "bip32": "^5.0.0",
     "bitcoinjs-lib": "^7.0.0",
@@ -196,7 +197,14 @@
       "optional": true
     }
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "./dist/index.node.esm.js",
+    "./dist/index.node.cjs",
+    "./dist/index.browser.js",
+    "./dist/index.chrome-extension.js",
+    "./dist/index.react-native.js",
+    "./dist/index.electron-main.cjs"
+  ],
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"

--- a/packages/sdk/src/context/defaultStorage.ts
+++ b/packages/sdk/src/context/defaultStorage.ts
@@ -6,15 +6,15 @@
  * to auto-create storage when none is provided.
  */
 
-import type { Storage } from '../storage/types'
+import { runtimeStore } from '@vultisig/mpc-types'
 
-let defaultStorageFactory: (() => Storage) | null = null
+import type { Storage } from '../storage/types'
 
 /**
  * Configure the default storage factory (called by platform entry points on module load)
  */
 export function configureDefaultStorage(factory: () => Storage): void {
-  defaultStorageFactory = factory
+  runtimeStore().storageFactory = factory
 }
 
 /**
@@ -22,6 +22,7 @@ export function configureDefaultStorage(factory: () => Storage): void {
  * @throws Error if storage not configured (wrong import path used)
  */
 export function getDefaultStorage(): Storage {
+  const defaultStorageFactory = runtimeStore().storageFactory as (() => Storage) | null
   if (!defaultStorageFactory) {
     throw new Error(
       'Default storage not configured. Import from @vultisig/sdk (not /node or /browser subpaths directly).'

--- a/packages/sdk/src/context/wasmRuntime.ts
+++ b/packages/sdk/src/context/wasmRuntime.ts
@@ -6,13 +6,13 @@
  * the SdkContext.wasmProvider which calls getWalletCore().
  */
 
-let walletCoreGetter: (() => Promise<any>) | null = null
+import { runtimeStore } from '@vultisig/mpc-types'
 
 /**
  * Configure the WASM getter (called by platform entry points on module load)
  */
 export function configureWasm(getter: () => Promise<any>): void {
-  walletCoreGetter = getter
+  runtimeStore().walletCore = getter
 }
 
 /**
@@ -20,6 +20,7 @@ export function configureWasm(getter: () => Promise<any>): void {
  * Also initializes DKLS and Schnorr WASM modules.
  */
 export function getWalletCore(): Promise<any> {
+  const walletCoreGetter = runtimeStore().walletCore as (() => Promise<any>) | null
   if (!walletCoreGetter) {
     throw new Error('WASM not configured. Import from @vultisig/sdk/browser or @vultisig/sdk/node')
   }

--- a/packages/sdk/src/crypto/index.ts
+++ b/packages/sdk/src/crypto/index.ts
@@ -3,17 +3,16 @@
  * Each platform bundle configures this with their crypto implementation
  */
 
-import type { PlatformCrypto } from '../platforms/types'
+import { runtimeStore } from '@vultisig/mpc-types'
 
-// Module-level state
-let platformCrypto: PlatformCrypto | null = null
+import type { PlatformCrypto } from '../platforms/types'
 
 /**
  * Configure the platform crypto implementation
  * Called automatically by platform bundles at module load time
  */
 export function configureCrypto(crypto: PlatformCrypto): void {
-  platformCrypto = crypto
+  runtimeStore().crypto = crypto
 
   // Validate immediately for React Native (checks polyfills are installed)
   if (crypto.validateCrypto) {
@@ -26,6 +25,7 @@ export function configureCrypto(crypto: PlatformCrypto): void {
  * @throws Error if crypto not configured
  */
 function getCrypto(): PlatformCrypto {
+  const platformCrypto = runtimeStore().crypto as PlatformCrypto | null
   if (!platformCrypto) {
     throw new Error(
       'Crypto not configured. This should be configured automatically by platform bundles. ' +

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -39,4 +39,4 @@ export { configureWasm, getWalletCore } from '../../context/wasmRuntime'
 
 // MPC engine access (for advanced usage)
 export type { MpcEngine, MpcKeyshare, MpcMessage, MpcSession } from '@vultisig/mpc-types'
-export { configureMpc, getMpcEngine } from '@vultisig/mpc-types'
+export { configureMpc, ensureMpcEngine, getMpcEngine } from '@vultisig/mpc-types'

--- a/packages/sdk/tests/integration/bundler-isolation.test.ts
+++ b/packages/sdk/tests/integration/bundler-isolation.test.ts
@@ -1,0 +1,27 @@
+import { __resetRuntimeStoreForTesting, type MpcEngine } from '@vultisig/mpc-types'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const repoRuntimeHref = new URL('../../../mpc-types/src/runtime.ts', import.meta.url).href
+
+function minimalEngine(id: string): MpcEngine {
+  return {
+    initialize: async () => {},
+    dkls: { _id: id } as unknown as MpcEngine['dkls'],
+    schnorr: { _id: id } as unknown as MpcEngine['schnorr'],
+  }
+}
+
+describe('bundler isolation (#287)', () => {
+  afterEach(() => {
+    __resetRuntimeStoreForTesting()
+  })
+
+  it('shares the MPC engine across two isolated runtime module instances', async () => {
+    const modA = await import(`${repoRuntimeHref}?bundlerIsolation=a`)
+    const modB = await import(`${repoRuntimeHref}?bundlerIsolation=b`)
+
+    const engine = minimalEngine('integration-dup')
+    modA.configureMpc(engine)
+    expect(modB.getMpcEngine()).toBe(engine)
+  })
+})

--- a/packages/sdk/tests/unit/ensureMpcEngine.test.ts
+++ b/packages/sdk/tests/unit/ensureMpcEngine.test.ts
@@ -1,0 +1,52 @@
+import { __resetRuntimeStoreForTesting, configureMpc, ensureMpcEngine, type MpcEngine } from '@vultisig/mpc-types'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const wasmCtor = vi.hoisted(() => vi.fn())
+
+vi.mock('@vultisig/mpc-wasm', () => ({
+  WasmMpcEngine: class WasmMpcEngine {
+    constructor() {
+      wasmCtor()
+    }
+
+    initialize = async () => {}
+
+    dkls = {} as MpcEngine['dkls']
+
+    schnorr = {} as MpcEngine['schnorr']
+  },
+}))
+
+function minimalConfiguredEngine(label: string): MpcEngine {
+  return {
+    initialize: async () => {},
+    dkls: { _label: label } as unknown as MpcEngine['dkls'],
+    schnorr: { _label: label } as unknown as MpcEngine['schnorr'],
+  }
+}
+
+describe('ensureMpcEngine', () => {
+  beforeEach(() => {
+    wasmCtor.mockClear()
+  })
+
+  afterEach(() => {
+    __resetRuntimeStoreForTesting()
+  })
+
+  it('returns configured engine without constructing WasmMpcEngine', async () => {
+    const configured = minimalConfiguredEngine('pre')
+    configureMpc(configured)
+    const out = await ensureMpcEngine()
+    expect(out).toBe(configured)
+    expect(wasmCtor).not.toHaveBeenCalled()
+  })
+
+  it('dynamic-imports mpc-wasm and registers WasmMpcEngine when unset', async () => {
+    const out = await ensureMpcEngine()
+    expect(wasmCtor).toHaveBeenCalledTimes(1)
+    expect(out.initialize).toBeTypeOf('function')
+    expect(out.dkls).toBeDefined()
+    expect(out.schnorr).toBeDefined()
+  })
+})

--- a/packages/sdk/tests/unit/runtimeStore.test.ts
+++ b/packages/sdk/tests/unit/runtimeStore.test.ts
@@ -1,0 +1,36 @@
+import { __resetRuntimeStoreForTesting, type MpcEngine, runtimeStore } from '@vultisig/mpc-types'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const repoRuntimeHref = new URL('../../../mpc-types/src/runtime.ts', import.meta.url).href
+
+function minimalEngine(id: string): MpcEngine {
+  return {
+    initialize: async () => {},
+    dkls: { _id: id } as unknown as MpcEngine['dkls'],
+    schnorr: { _id: id } as unknown as MpcEngine['schnorr'],
+  }
+}
+
+describe('runtimeStore', () => {
+  afterEach(() => {
+    __resetRuntimeStoreForTesting()
+  })
+
+  it('returns the same object on repeat calls', () => {
+    expect(runtimeStore()).toBe(runtimeStore())
+  })
+
+  it('uses Symbol.for key vultisig.runtime.store.v1', () => {
+    const key = Symbol.for('vultisig.runtime.store.v1')
+    expect(Symbol.keyFor(key)).toBe('vultisig.runtime.store.v1')
+  })
+
+  it('shares mpc engine across duplicate module instances (simulated bundler copies)', async () => {
+    const modA = await import(`${repoRuntimeHref}?runtimeDup=a`)
+    const modB = await import(`${repoRuntimeHref}?runtimeDup=b`)
+
+    const engine = minimalEngine('dup-test')
+    modA.configureMpc(engine)
+    expect(modB.getMpcEngine()).toBe(engine)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -7114,6 +7114,11 @@ __metadata:
 "@vultisig/mpc-types@workspace:*, @vultisig/mpc-types@workspace:^0.1.2, @vultisig/mpc-types@workspace:packages/mpc-types":
   version: 0.0.0-use.local
   resolution: "@vultisig/mpc-types@workspace:packages/mpc-types"
+  peerDependencies:
+    "@vultisig/mpc-wasm": ">=0.1.0"
+  peerDependenciesMeta:
+    "@vultisig/mpc-wasm":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -7175,6 +7180,7 @@ __metadata:
     "@types/chrome": "npm:^0.1.27"
     "@types/node": "npm:^22.13.10"
     "@vitest/coverage-v8": "npm:3.2.4"
+    "@vultisig/mpc-types": "workspace:*"
     axios: "npm:^1.8.3"
     bip32: "npm:^5.0.0"
     bitcoinjs-lib: "npm:^7.0.0"


### PR DESCRIPTION
Closes #287

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `ensureMpcEngine()` async function for safe MPC engine initialization.
  * New `./store` export path in `@vultisig/mpc-types` package.

* **Bug Fixes**
  * Fixed MPC engine registration to work correctly across different bundler configurations and module import scenarios.

* **Tests**
  * Added comprehensive test coverage for engine initialization and runtime store functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->