### PR TITLE
fix(core/chain): default Cosmos account info to 0/0 for unknown addresses

### DIFF
--- a/packages/core/chain/chains/cosmos/account/getCosmosAccountInfo.ts
+++ b/packages/core/chain/chains/cosmos/account/getCosmosAccountInfo.ts
@@ -1,14 +1,13 @@
 import { CosmosChain } from '@vultisig/core-chain/Chain'
 import { ChainAccount } from '@vultisig/core-chain/ChainAccount'
 import { getCosmosClient } from '@vultisig/core-chain/chains/cosmos/client'
-import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 
 export const getCosmosAccountInfo = async ({
   chain,
   address,
 }: ChainAccount<CosmosChain>) => {
   const client = await getCosmosClient(chain)
-  const accountInfo = shouldBePresent(await client.getAccount(address))
+  const accountInfo = await client.getAccount(address)
   const block = await client.getBlock()
   const blockTimestampStr = block.header.time
   const blockTimestampNs =
@@ -18,7 +17,10 @@ export const getCosmosAccountInfo = async ({
   const latestBlock = `${block.header.height}_${timeoutNs}`
 
   return {
-    ...accountInfo,
+    address,
+    pubkey: accountInfo?.pubkey ?? null,
+    accountNumber: accountInfo?.accountNumber ?? 0,
+    sequence: accountInfo?.sequence ?? 0,
     latestBlock,
   }
 }


### PR DESCRIPTION
## Summary
- Addresses vultisig/vultisig-windows#3790.
- `getCosmosAccountInfo` previously wrapped `client.getAccount(address)` in `shouldBePresent`, throwing `"value is required"` whenever the queried address had no on-chain history. This blew up the Vultisig extension popup before the user ever saw the signing UI for any brand-new Cosmos address (signAmino / signDirect via `window.vultisig.keplr`).
- Now treats a missing account as a normal Cosmos state and returns `accountNumber: 0`, `sequence: 0`, `pubkey: null` — matching the existing `'0' / '0'` fallback already used by `buildCosmosPayload` when `skipChainSpecificFetch` is set, and matching how Keplr / Leap / Cosmostation behave (sign whatever the dApp provides; let the chain reject at broadcast if the account truly can't pay).
- Address-with-history behavior is unchanged: same account number / sequence / pubkey are returned as before.
- Affects all three resolvers that consume this helper (`cosmos`, `thor`, `maya`) plus `buildCosmosPayload` — they only read `accountNumber` / `sequence` / `latestBlock`, so the safe defaults flow through unchanged.

Closes [vultisig/vultisig-windows#3790](https://github.com/vultisig/vultisig-windows/issues/3790)

## Test plan
- [ ] `yarn typecheck` passes (only the pre-existing unrelated CLI errors remain).
- [ ] In a Vultisig extension build that pulls this SDK change: signAmino against an unfunded `cosmoshub-4` address opens the signing UI instead of failing with "value is required" (repro from the linked issue).
- [ ] signAmino against a funded address still produces a valid, broadcastable transaction (no regression).
- [ ] Same outcome for `signDirect`.
- [ ] Spot-checked across `cosmoshub-4`, `osmosis-1`, `kaiyo-1`, `dydx-1`, `thorchain-1` via the playground.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced resilience when retrieving account information by gracefully handling missing or undefined data with sensible default values, ensuring more reliable operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->