### PR TITLE
feat(core-chain): add Tron USDC (TRC-20) to knownTokens registry

### DIFF
--- a/packages/core/chain/coin/knownTokens/index.ts
+++ b/packages/core/chain/coin/knownTokens/index.ts
@@ -83,6 +83,12 @@ const leanTokens: Partial<LeanChainTokensRecord> = {
       decimals: 6,
       priceProviderId: 'tether',
     },
+    TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8: {
+      ticker: 'USDC',
+      logo: 'usdc',
+      decimals: 6,
+      priceProviderId: 'usd-coin',
+    },
   },
   [Chain.Solana]: {
     JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN: {


### PR DESCRIPTION
🤖 Agent-generated (SDK migration U2)

## Summary

Adds Circle's canonical Tron USDC (TRC-20) to `knownTokens`. USDT was already registered; USDC was the one remaining gap that was blocking the planned deletion of `src/features/agent/lib/tokenPriceOverrides.ts` in `vultiagent-app`.

## Change

`packages/core/chain/coin/knownTokens/index.ts` — one additional entry under the existing `[Chain.Tron]` block:

```ts
TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8: {
  ticker: 'USDC',
  logo: 'usdc',
  decimals: 6,
  priceProviderId: 'usd-coin',
},
```

## Contract address verification

- **Address:** `TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8` (Circle's USDC on Tron, TRC-20)
- **Decimals:** 6 (TRC-20 USDC matches USDT-TRC20 precision)
- **Symbol:** `USDC` — explicitly specified by the U2 queue row (`.spikes/sdk-migration-execution-queue.md:34`)
- **priceProviderId:** `usd-coin` — same id used for every other chain's USDC entry in this file (Ethereum, Avalanche, BSC, etc.)
- **Sourcing:** the gap was identified during the vultiagent-sdk migration audit at `.spikes/vultiagent-sdk-migration-candidates.md:300-313` and re-confirmed at line 399: _"SDK's knownTokens is mostly-parity with the app's overrides, with ONE gap (Tron USDC TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8). Upstream this as a 1-line PR to `packages/core/chain/coin/knownTokens/index.ts` regardless of which direction iter 4 goes. Free win."_
- The canonical Tron public registry and Circle's own documentation list this base58 address as the TRC-20 USDC contract; `grep -r TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8 ~/Projects/vultisig` returns zero hits outside this new entry, confirming this is the first time it enters the SDK.

## No new file needed

The task description referenced `cosmos.ts` / `thorchain.ts` as the pattern. However, Tron tokens (like Solana and Ton) are already kept inline in `leanTokens` inside `index.ts` rather than in a separate module. Following the existing Tron convention avoids a superfluous single-entry file and matches how sibling chains are organized today.

## Verification

From `/Users/mini/Projects/vultisig/vultisig-sdk-wt-u2` on `feat/sdk-migration-tron-usdc-known-token`:

```
$ yarn install                 # OK (existing peer warnings only)
$ yarn build:all               # OK — all dist + d.ts emitted
$ yarn test:core
  Test Files  23 passed (23)
        Tests  211 passed (211)
     Duration  1.01s
$ yarn typecheck               # OK (exit 0)
$ yarn lint                    # OK (exit 0)
```

## Scope

- Only one file changed: `packages/core/chain/coin/knownTokens/index.ts`
- Did not create `tron.ts` (see rationale above)
- Did not touch `cosmos.ts` / `thorchain.ts` / `utils.ts` / `index.ts` re-exports
- No Chain enum change (Tron is already `Chain.Tron` at `packages/core/chain/Chain.ts:77`)

## Not for merge

Do **not** mark this PR ready for review — human approval gates that step per the SDK migration workflow.