### PR TITLE
fix(sdk/vault): wrap invalid-receiver error in VaultError

### DIFF
--- a/.changeset/fix-vault-error-invalid-receiver.md
+++ b/.changeset/fix-vault-error-invalid-receiver.md
@@ -1,0 +1,7 @@
+---
+'@vultisig/sdk': patch
+---
+
+fix(sdk/vault): wrap invalid-receiver error in VaultError
+
+`getMaxSendAmount` now throws `VaultError(InvalidConfig)` instead of a generic `Error` when the receiver address fails validation. Matches how the rest of `VaultBase`'s address validation surfaces errors, so consumers checking `error.code` or `instanceof VaultError` catch it correctly.

--- a/packages/sdk/src/vault/VaultBase.ts
+++ b/packages/sdk/src/vault/VaultBase.ts
@@ -1031,7 +1031,10 @@ export abstract class VaultBase extends UniversalEventEmitter<VaultEvents> {
     // network round-trip. computeMaxSendFromBalance re-validates for the
     // vault-free path; two checks at different layers is acceptable.
     if (!isValidAddress({ chain: params.coin.chain, address: params.receiver, walletCore })) {
-      throw new Error(`Invalid receiver address for chain ${params.coin.chain}: ${params.receiver}`)
+      throw new VaultError(
+        VaultErrorCode.InvalidConfig,
+        `Invalid receiver address for chain ${params.coin.chain}: ${params.receiver}`
+      )
     }
     // Fetch balance via BalanceService so cache / balanceUpdated event / VaultError
     // wrapping all fire. The vault-free `getMaxSendAmountFromKeys` skips these


### PR DESCRIPTION
## Summary

Fast-follow to #284 — CodeRabbit flagged that `VaultBase.getMaxSendAmount` throws a plain `Error` when receiver validation fails, while every other validation path in this file throws `VaultError(InvalidConfig)`. Consumers checking `error.code` or `instanceof VaultError` would miss this one.

Matches existing pattern at lines 504, 727, 1809.

## Test plan

- [ ] CI typecheck + tests pass (imports for `VaultError` / `VaultErrorCode` already present on line 81)
- [ ] Changeset picked up — next Version PR bumps `@vultisig/sdk` patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of error handling in validation operations. Errors now return structured error types instead of generic failures, enabling more reliable and predictable error handling for SDK users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->