### PR TITLE
docs: clarify browser example setup

### DIFF
--- a/examples/browser/README.md
+++ b/examples/browser/README.md
@@ -20,25 +20,31 @@ Browser-based example application demonstrating the Vultisig SDK for fast vault 
 
 ### Prerequisites
 
-- Node.js 18+
-- Yarn
+- Node.js 20+
+- Yarn 4.x (via Corepack or your preferred install)
+- A built SDK bundle (`packages/sdk/dist/`), generated from the repo root with `yarn build:sdk`
 
 ### Installation
 
+From the repository root:
+
 ```bash
-cd examples/browser
 yarn install
+yarn build:sdk
 ```
 
-### Development
+Then start the browser example:
 
 ```bash
+cd examples/browser
 yarn dev
 ```
 
 Open http://localhost:3000
 
 ### Build
+
+> Note: `yarn build` also assumes the root SDK bundle already exists at `packages/sdk/dist/`. If you see missing WASM or SDK artifact errors, run `yarn build:sdk` from the repository root first.
 
 ```bash
 yarn build


### PR DESCRIPTION
## Summary\n- Update browser example prerequisites to Node 20+\n- Document the required root `yarn install` + `yarn build:sdk` flow\n- Note that `yarn build` depends on the SDK dist artifacts\n\n## Why\nThe browser example currently assumes built SDK artifacts from `packages/sdk/dist/`, so a fresh clone can fail unless the repo root build step is run first. This PR makes that requirement explicit.\n\n## Test plan\n- Docs-only change; no runtime behavior changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions for Node.js 20+ and Yarn 4.x compatibility
  * Clarified SDK prebuild requirements and build process dependencies
  * Restructured installation and development startup steps for improved clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->