### PR TITLE
fix(chain): add missing package.json exports (universalRouter, verifyBroadcastByHash)

### DIFF
--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -454,6 +454,21 @@
       "import": "./dist/chains/evm/contract/call/signatures.js",
       "default": "./dist/chains/evm/contract/call/signatures.js"
     },
+    "./chains/evm/contract/universalRouter/decode": {
+      "types": "./dist/chains/evm/contract/universalRouter/decode.d.ts",
+      "import": "./dist/chains/evm/contract/universalRouter/decode.js",
+      "default": "./dist/chains/evm/contract/universalRouter/decode.js"
+    },
+    "./chains/evm/contract/universalRouter/opcodes": {
+      "types": "./dist/chains/evm/contract/universalRouter/opcodes.d.ts",
+      "import": "./dist/chains/evm/contract/universalRouter/opcodes.js",
+      "default": "./dist/chains/evm/contract/universalRouter/opcodes.js"
+    },
+    "./chains/evm/contract/universalRouter/types": {
+      "types": "./dist/chains/evm/contract/universalRouter/types.d.ts",
+      "import": "./dist/chains/evm/contract/universalRouter/types.js",
+      "default": "./dist/chains/evm/contract/universalRouter/types.js"
+    },
     "./chains/evm/erc20/getErc20Allowance": {
       "types": "./dist/chains/evm/erc20/getErc20Allowance.d.ts",
       "import": "./dist/chains/evm/erc20/getErc20Allowance.js",
@@ -1409,6 +1424,11 @@
       "types": "./dist/tx/broadcast/resolvers/utxo.d.ts",
       "import": "./dist/tx/broadcast/resolvers/utxo.js",
       "default": "./dist/tx/broadcast/resolvers/utxo.js"
+    },
+    "./tx/broadcast/verifyBroadcastByHash": {
+      "types": "./dist/tx/broadcast/verifyBroadcastByHash.d.ts",
+      "import": "./dist/tx/broadcast/verifyBroadcastByHash.js",
+      "default": "./dist/tx/broadcast/verifyBroadcastByHash.js"
     },
     "./tx/fee/evm/baseFee": {
       "types": "./dist/tx/fee/evm/baseFee.d.ts",


### PR DESCRIPTION
## Summary
- The \`exports\` field of \`@vultisig/core-chain\` was missing entries for files introduced in recent PRs:
  - \`./chains/evm/contract/universalRouter/{decode,opcodes,types}\` (added in #309)
  - \`./tx/broadcast/verifyBroadcastByHash\` (added in #286 / #302)
- Without these entries, consumer projects fail to resolve the modules. This was hitting [vultisig-windows#3797](https://github.com/vultisig/vultisig-windows/pull/3797) where the Windows wails build aborted with \`TS2307: Cannot find module '@vultisig/core-chain/chains/evm/contract/universalRouter/decode'\`.
- Regenerated by re-running \`yarn build:shared\`, which derives the \`exports\` map from \`dist\` contents via \`applySharedExports\`.

## Why this slipped through
\`build:shared\` rewrites \`packages/core/chain/package.json\` based on the freshly-built \`dist/\`. The earlier merges that introduced these source files apparently weren't followed by a build:shared run that committed the regenerated \`package.json\`, so npm-published versions (1.3.x) shipped without these subpath exports.

## Test plan
- [x] Wipe \`packages/core/chain/dist\` and \`.shared-dist-temp\`, run \`yarn build:shared\`, confirm only the four new exports are added (no stale entries).
- [x] Confirm each new export points to a file emitted into \`packages/core/chain/dist\`.
- [ ] After merge, bump version & republish; vultisig-windows#3797 Windows build should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded public module exports in the core-chain package to include EVM Universal Router utilities and transaction broadcasting features, improving accessibility of these capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->