### PR TITLE
Fix Kyber affiliate fee propagation

### DIFF
--- a/packages/core/chain/swap/general/kyber/api/quote.test.ts
+++ b/packages/core/chain/swap/general/kyber/api/quote.test.ts
@@ -1,0 +1,76 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+import { describe, expect, it, vi } from 'vitest'
+
+import { kyberSwapAffiliateConfig } from '../config'
+import { getKyberSwapQuote } from './quote'
+
+vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
+  queryUrl: vi.fn(),
+}))
+
+describe('getKyberSwapQuote', () => {
+  it('passes affiliate fee params to route and build requests', async () => {
+    vi.mocked(queryUrl)
+      .mockResolvedValueOnce({
+        data: {
+          routeSummary: { amountOut: '10000000' },
+          routerAddress: '0xrouter',
+        },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          amountOut: '10000000',
+          data: '0xswap',
+          gas: '210000',
+          routerAddress: '0xrouter',
+        },
+      })
+
+    const quote = await getKyberSwapQuote({
+      from: {
+        chain: Chain.Ethereum,
+        address: '0xsender',
+        id: '0xsrc',
+        decimals: 18,
+        ticker: 'SRC',
+      },
+      to: {
+        chain: Chain.Ethereum,
+        address: '0xsender',
+        id: '0xdst',
+        decimals: 6,
+        ticker: 'DST',
+      },
+      amount: 1_000_000n,
+      affiliateBps: 50,
+    })
+
+    const [routeUrl, routeOptions] = vi.mocked(queryUrl).mock.calls[0]
+    expect(routeUrl).toContain('feeAmount=50')
+    expect(routeUrl).toContain('chargeFeeBy=currency_out')
+    expect(routeUrl).toContain('isInBps=true')
+    expect(routeUrl).toContain(`feeReceiver=${kyberSwapAffiliateConfig.referral}`)
+    expect(routeOptions).toMatchObject({
+      headers: { 'X-Client-Id': kyberSwapAffiliateConfig.source },
+    })
+
+    const [, buildOptions] = vi.mocked(queryUrl).mock.calls[1]
+    expect(buildOptions?.body).toMatchObject({
+      source: kyberSwapAffiliateConfig.source,
+      referral: kyberSwapAffiliateConfig.referral,
+      feeAmount: 50,
+      chargeFeeBy: 'currency_out',
+      isInBps: true,
+      feeReceiver: kyberSwapAffiliateConfig.referral,
+    })
+
+    expect('evm' in quote.tx ? quote.tx.evm.affiliateFee : undefined).toEqual({
+      chain: Chain.Ethereum,
+      id: '0xdst',
+      decimals: 6,
+      amount: 50_000n,
+    })
+  })
+})

--- a/packages/core/chain/swap/general/kyber/api/quote.test.ts
+++ b/packages/core/chain/swap/general/kyber/api/quote.test.ts
@@ -70,7 +70,7 @@ describe('getKyberSwapQuote', () => {
       chain: Chain.Ethereum,
       id: '0xdst',
       decimals: 6,
-      amount: 50_000n,
+      amount: 50_251n,
     })
   })
 })

--- a/packages/core/chain/swap/general/kyber/api/quote.ts
+++ b/packages/core/chain/swap/general/kyber/api/quote.ts
@@ -10,30 +10,31 @@ import { getKyberSwapTx } from './tx'
 
 type Input = Record<TransferDirection, AccountCoin<KyberSwapEnabledChain>> & {
   amount: bigint
-  isAffiliate: boolean
+  affiliateBps?: number
 }
 
 export const getKyberSwapQuote = async ({
   from,
   to,
   amount,
-  isAffiliate,
+  affiliateBps,
 }: Input): Promise<GeneralSwapQuote> => {
   const { routeSummary, routerAddress } = await getKyberSwapRoute({
     from,
     to,
     amount,
-    isAffiliate,
+    affiliateBps,
   })
 
   const tx = await attempt(
     getKyberSwapTx({
       from,
+      to,
       routeSummary,
       routerAddress,
       amount,
       enableGasEstimation: true,
-      isAffiliate,
+      affiliateBps,
     })
   )
 
@@ -42,11 +43,12 @@ export const getKyberSwapQuote = async ({
     if (isInError(error, 'TransferHelper')) {
       return getKyberSwapTx({
         from,
+        to,
         routeSummary,
         routerAddress,
         amount,
         enableGasEstimation: false,
-        isAffiliate,
+        affiliateBps,
       })
     }
 

--- a/packages/core/chain/swap/general/kyber/api/route.ts
+++ b/packages/core/chain/swap/general/kyber/api/route.ts
@@ -5,12 +5,17 @@ import { TransferDirection } from '@vultisig/lib-utils/TransferDirection'
 
 import { evmNativeCoinAddress } from '../../../../chains/evm/config'
 import { KyberSwapEnabledChain } from '../chains'
-import { kyberSwapAffiliateConfig, kyberSwapSlippageTolerance } from '../config'
+import {
+  KyberSwapAffiliateParams,
+  getKyberSwapAffiliateParams,
+  kyberSwapAffiliateConfig,
+  kyberSwapSlippageTolerance,
+} from '../config'
 import { getKyberSwapBaseUrl } from './baseUrl'
 
 type Input = Record<TransferDirection, AccountCoin<KyberSwapEnabledChain>> & {
   amount: bigint
-  isAffiliate: boolean
+  affiliateBps?: number
 }
 
 type KyberSwapRoute = {
@@ -32,15 +37,13 @@ type KyberSwapRouteParams = {
   saveGas: boolean
   gasInclude: boolean
   slippageTolerance: number
-  source?: string
-  referral?: string
-}
+} & Partial<KyberSwapAffiliateParams>
 
 export const getKyberSwapRoute = async ({
   from,
   to,
   amount,
-  isAffiliate,
+  affiliateBps,
 }: Input): Promise<KyberSwapRoute> => {
   const [tokenIn, tokenOut] = [from, to].map(
     ({ id }) => id || evmNativeCoinAddress
@@ -53,7 +56,7 @@ export const getKyberSwapRoute = async ({
     saveGas: true,
     gasInclude: true,
     slippageTolerance: kyberSwapSlippageTolerance,
-    ...(isAffiliate ? kyberSwapAffiliateConfig : {}),
+    ...getKyberSwapAffiliateParams(affiliateBps),
   }
 
   const routeUrl = addQueryParams(

--- a/packages/core/chain/swap/general/kyber/api/tx.ts
+++ b/packages/core/chain/swap/general/kyber/api/tx.ts
@@ -3,6 +3,7 @@ import { isInError } from '@vultisig/lib-utils/error/isInError'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 import { convertDuration } from '@vultisig/lib-utils/time/convertDuration'
 
+import { evmNativeCoinAddress } from '../../../../chains/evm/config'
 import { AccountCoin } from '../../../../coin/AccountCoin'
 import { isFeeCoin } from '../../../../coin/utils/isFeeCoin'
 import { GeneralSwapQuote } from '../../GeneralSwapQuote'
@@ -45,15 +46,22 @@ const getKyberSwapAffiliateFee = ({
   amountOut: string
   to: AccountCoin<KyberSwapEnabledChain>
   affiliateBps?: number
-}): SwapFee | undefined =>
-  affiliateBps !== undefined && affiliateBps > 0
-    ? {
-        chain: to.chain,
-        id: to.id,
-        decimals: to.decimals,
-        amount: (BigInt(amountOut) * BigInt(affiliateBps)) / 10000n,
-      }
-    : undefined
+}): SwapFee | undefined => {
+  if (affiliateBps === undefined || affiliateBps <= 0) {
+    return undefined
+  }
+
+  const netAmountOut = BigInt(amountOut)
+  const feeRate = BigInt(affiliateBps)
+  const grossAmountOut = (netAmountOut * 10000n) / (10000n - feeRate)
+
+  return {
+    chain: to.chain,
+    id: to.id ?? evmNativeCoinAddress,
+    decimals: to.decimals,
+    amount: grossAmountOut - netAmountOut,
+  }
+}
 
 export const getKyberSwapTx = async ({
   from,

--- a/packages/core/chain/swap/general/kyber/api/tx.ts
+++ b/packages/core/chain/swap/general/kyber/api/tx.ts
@@ -6,8 +6,10 @@ import { convertDuration } from '@vultisig/lib-utils/time/convertDuration'
 import { AccountCoin } from '../../../../coin/AccountCoin'
 import { isFeeCoin } from '../../../../coin/utils/isFeeCoin'
 import { GeneralSwapQuote } from '../../GeneralSwapQuote'
+import { SwapFee } from '../../SwapFee'
 import { KyberSwapEnabledChain } from '../chains'
 import {
+  getKyberSwapAffiliateParams,
   kyberSwapAffiliateConfig,
   kyberSwapSlippageTolerance,
   kyberSwapTxLifespan,
@@ -16,11 +18,12 @@ import { getKyberSwapBaseUrl } from './baseUrl'
 
 type GetKyberSwapTxInput = {
   from: AccountCoin<KyberSwapEnabledChain>
+  to: AccountCoin<KyberSwapEnabledChain>
   routeSummary: any
   routerAddress: string
   amount: bigint
   enableGasEstimation: boolean
-  isAffiliate: boolean
+  affiliateBps?: number
 }
 
 type KyberSwapBuildResponse = {
@@ -34,13 +37,32 @@ type KyberSwapBuildResponse = {
   }
 }
 
+const getKyberSwapAffiliateFee = ({
+  amountOut,
+  to,
+  affiliateBps,
+}: {
+  amountOut: string
+  to: AccountCoin<KyberSwapEnabledChain>
+  affiliateBps?: number
+}): SwapFee | undefined =>
+  affiliateBps !== undefined && affiliateBps > 0
+    ? {
+        chain: to.chain,
+        id: to.id,
+        decimals: to.decimals,
+        amount: (BigInt(amountOut) * BigInt(affiliateBps)) / 10000n,
+      }
+    : undefined
+
 export const getKyberSwapTx = async ({
   from,
+  to,
   routeSummary,
   routerAddress,
   amount,
   enableGasEstimation,
-  isAffiliate,
+  affiliateBps,
 }: GetKyberSwapTxInput): Promise<GeneralSwapQuote> => {
   const buildPayload = {
     routeSummary,
@@ -55,7 +77,7 @@ export const getKyberSwapTx = async ({
       )
     ),
     enableGasEstimation,
-    ...(isAffiliate ? kyberSwapAffiliateConfig : {}),
+    ...getKyberSwapAffiliateParams(affiliateBps),
     ignoreCappedSlippage: false,
   }
 
@@ -92,7 +114,6 @@ export const getKyberSwapTx = async ({
   }
 
   const { amountOut, data, gas } = buildResponse.data
-
   return {
     dstAmount: amountOut,
     provider: 'kyber',
@@ -103,6 +124,11 @@ export const getKyberSwapTx = async ({
         data,
         value: isFeeCoin(from) ? amount.toString() : '0',
         gasLimit: gas ? BigInt(gas) : undefined,
+        affiliateFee: getKyberSwapAffiliateFee({
+          amountOut,
+          to,
+          affiliateBps,
+        }),
       },
     },
   }

--- a/packages/core/chain/swap/general/kyber/api/tx.ts
+++ b/packages/core/chain/swap/general/kyber/api/tx.ts
@@ -1,25 +1,28 @@
 import { extractErrorMsg } from '@vultisig/lib-utils/error/extractErrorMsg'
 import { isInError } from '@vultisig/lib-utils/error/isInError'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+import { TransferDirection } from '@vultisig/lib-utils/TransferDirection'
 import { convertDuration } from '@vultisig/lib-utils/time/convertDuration'
 
 import { evmNativeCoinAddress } from '../../../../chains/evm/config'
 import { AccountCoin } from '../../../../coin/AccountCoin'
 import { isFeeCoin } from '../../../../coin/utils/isFeeCoin'
+import { SwapFee } from '../../../SwapFee'
 import { GeneralSwapQuote } from '../../GeneralSwapQuote'
-import { SwapFee } from '../../SwapFee'
 import { KyberSwapEnabledChain } from '../chains'
 import {
   getKyberSwapAffiliateParams,
+  hasAffiliateBps,
   kyberSwapAffiliateConfig,
   kyberSwapSlippageTolerance,
   kyberSwapTxLifespan,
 } from '../config'
 import { getKyberSwapBaseUrl } from './baseUrl'
 
-type GetKyberSwapTxInput = {
-  from: AccountCoin<KyberSwapEnabledChain>
-  to: AccountCoin<KyberSwapEnabledChain>
+type GetKyberSwapTxInput = Record<
+  TransferDirection,
+  AccountCoin<KyberSwapEnabledChain>
+> & {
   routeSummary: any
   routerAddress: string
   amount: bigint
@@ -47,7 +50,7 @@ const getKyberSwapAffiliateFee = ({
   to: AccountCoin<KyberSwapEnabledChain>
   affiliateBps?: number
 }): SwapFee | undefined => {
-  if (affiliateBps === undefined || affiliateBps <= 0) {
+  if (!hasAffiliateBps(affiliateBps)) {
     return undefined
   }
 

--- a/packages/core/chain/swap/general/kyber/config.ts
+++ b/packages/core/chain/swap/general/kyber/config.ts
@@ -16,10 +16,15 @@ export type KyberSwapAffiliateParams = typeof kyberSwapAffiliateConfig & {
   feeReceiver: string
 }
 
+export const hasAffiliateBps = (
+  affiliateBps?: number
+): affiliateBps is number =>
+  affiliateBps !== undefined && affiliateBps > 0 && affiliateBps < 10000
+
 export const getKyberSwapAffiliateParams = (
   affiliateBps?: number
-): Partial<KyberSwapAffiliateParams> =>
-  affiliateBps !== undefined && affiliateBps > 0
+): KyberSwapAffiliateParams | Record<string, never> =>
+  hasAffiliateBps(affiliateBps)
     ? {
         ...kyberSwapAffiliateConfig,
         feeAmount: affiliateBps,

--- a/packages/core/chain/swap/general/kyber/config.ts
+++ b/packages/core/chain/swap/general/kyber/config.ts
@@ -8,3 +8,23 @@ export const kyberSwapAffiliateConfig = {
   source: 'vultisig-v0',
   referral: '0x8E247a480449c84a5fDD25974A8501f3EFa4ABb9',
 }
+
+export type KyberSwapAffiliateParams = typeof kyberSwapAffiliateConfig & {
+  feeAmount: number
+  chargeFeeBy: 'currency_out'
+  isInBps: true
+  feeReceiver: string
+}
+
+export const getKyberSwapAffiliateParams = (
+  affiliateBps?: number
+): Partial<KyberSwapAffiliateParams> =>
+  affiliateBps !== undefined && affiliateBps > 0
+    ? {
+        ...kyberSwapAffiliateConfig,
+        feeAmount: affiliateBps,
+        chargeFeeBy: 'currency_out',
+        isInBps: true,
+        feeReceiver: kyberSwapAffiliateConfig.referral,
+      }
+    : {}

--- a/packages/core/chain/swap/quote/findSwapQuote.kyber.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.kyber.test.ts
@@ -1,0 +1,56 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { getKyberSwapQuote } from '@vultisig/core-chain/swap/general/kyber/api/quote'
+import { describe, expect, it, vi } from 'vitest'
+
+import { findSwapQuote } from './findSwapQuote'
+
+vi.mock('@vultisig/core-chain/swap/general/kyber/api/quote', () => ({
+  getKyberSwapQuote: vi.fn(),
+}))
+
+describe('findSwapQuote Kyber affiliate fee', () => {
+  it('passes effective affiliate BPS after VULT discount', async () => {
+    vi.mocked(getKyberSwapQuote).mockResolvedValue({
+      dstAmount: '10000000',
+      provider: 'kyber',
+      tx: {
+        evm: {
+          from: '0xsender',
+          to: '0xrouter',
+          data: '0xswap',
+          value: '0',
+        },
+      },
+    })
+
+    const from = {
+      chain: Chain.Ethereum,
+      address: '0xsender',
+      id: '0xsrc',
+      decimals: 18,
+      ticker: 'SRC',
+    }
+    const to = {
+      chain: Chain.Ethereum,
+      address: '0xsender',
+      id: '0xdst',
+      decimals: 6,
+      ticker: 'DST',
+    }
+
+    const quote = await findSwapQuote({
+      from,
+      to,
+      amount: 1_000_000n,
+      vultDiscountTier: 'gold',
+    })
+
+    expect(getKyberSwapQuote).toHaveBeenCalledWith({
+      from,
+      to,
+      amount: 1_000_000n,
+      affiliateBps: 30,
+    })
+    expect(quote.discounts).toEqual([{ vult: { tier: 'gold' } }])
+  })
+})

--- a/packages/core/chain/swap/quote/findSwapQuote.kyber.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.kyber.test.ts
@@ -1,4 +1,5 @@
 import { Chain } from '@vultisig/core-chain/Chain'
+import { getSwapAffiliateBps } from '@vultisig/core-chain/swap/affiliate'
 import { getKyberSwapQuote } from '@vultisig/core-chain/swap/general/kyber/api/quote'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -10,6 +11,8 @@ vi.mock('@vultisig/core-chain/swap/general/kyber/api/quote', () => ({
 
 describe('findSwapQuote Kyber affiliate fee', () => {
   it('passes effective affiliate BPS after VULT discount', async () => {
+    const expectedBps = getSwapAffiliateBps('gold')
+
     vi.mocked(getKyberSwapQuote).mockResolvedValue({
       dstAmount: '10000000',
       provider: 'kyber',
@@ -49,7 +52,7 @@ describe('findSwapQuote Kyber affiliate fee', () => {
       from,
       to,
       amount: 1_000_000n,
-      affiliateBps: 30,
+      affiliateBps: expectedBps,
     })
     expect(quote.discounts).toEqual([{ vult: { tier: 'gold' } }])
   })

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -103,10 +103,10 @@ export const findSwapQuote = async ({
             chain: toChain,
           },
           amount: chainAmount,
-          isAffiliate: !!affiliateBps,
+          affiliateBps,
         })
 
-        return { quote: { general }, discounts: [] }
+        return { quote: { general }, discounts: vultDiscount }
       })
     }
 


### PR DESCRIPTION
Restore Kyber affiliate fee propagation in the SDK swap path so Windows/extension matches iOS and Android.\n\nChanges:\n- pass Kyber affiliate BPS through route/build requests\n- include Kyber affiliate fee data in the returned EVM tx quote\n- preserve VULT discount propagation in Kyber quote selection\n- add regression coverage for Kyber affiliate params and discounted BPS handling\n\nVerification:\n- yarn test:core

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kyber swap quotes now include Vult discount tier information in discount responses.
  * Affiliate fee configuration now accepts basis points values for flexible fee amounts.

* **Refactor**
  * Improved affiliate fee calculation and parameter handling across Kyber swap APIs for more dynamic fee management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->