### PR TITLE
fix(bittensor): drop polkadot dynamic import in balance resolver

### DIFF
--- a/.changeset/bittensor-balance-no-polkadot.md
+++ b/.changeset/bittensor-balance-no-polkadot.md
@@ -1,0 +1,25 @@
+---
+'@vultisig/core-chain': patch
+---
+
+fix(bittensor): drop polkadot dynamic import in balance resolver
+
+The Bittensor balance resolver dynamically imported `@polkadot/util-crypto`
+just to base58-decode an SS58 address, blake2_128-hash the pubkey, and
+hex-encode it. In browser/extension bundles this dynamic import pulls in
+a chunk that double-bundles BN.js; the second copy throws
+`TypeError: Cannot assign to read only property 'toString' of object '#<o>'`
+during module init, so every TAO balance fetch fails with no useful
+network/console signal — the chain page only renders "Failed to load".
+
+The resolver now uses the libraries already in `@vultisig/core-chain`'s
+direct dependency set: `@noble/hashes` for `blake2b` and `bytesToHex`, and
+`bs58` for the SS58 base58 decode. No polkadot, no `Buffer`, no dynamic
+imports. Bittensor uses SS58 prefix 42 (1-byte network prefix + 32-byte
+pubkey + 2-byte checksum = 35 bytes); we slice `[1, 33)` to recover the
+pubkey, then build the storage key and call `state_getStorage` exactly
+as before.
+
+Behaviour for valid SS58 addresses is unchanged. Invalid-length
+addresses now throw a clearer `Invalid SS58 address length` error
+instead of a polkadot decoding error.

--- a/packages/core/chain/coin/balance/resolvers/bittensor.ts
+++ b/packages/core/chain/coin/balance/resolvers/bittensor.ts
@@ -1,5 +1,8 @@
+import { blake2b } from '@noble/hashes/blake2b'
+import { bytesToHex } from '@noble/hashes/utils'
 import { bittensorRpcUrl } from '@vultisig/core-chain/chains/bittensor/client'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+import bs58 from 'bs58'
 
 import { CoinBalanceResolver } from '../resolver'
 
@@ -14,14 +17,24 @@ type RpcResponse<T> = {
 const systemAccountPrefix =
   '0x26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da9'
 
-export const getBittensorCoinBalance: CoinBalanceResolver = async input => {
-  // Compute blake2_128_concat storage key for the account
-  const { blake2AsHex } = await import('@polkadot/util-crypto')
-  const { decodeAddress } = await import('@polkadot/util-crypto')
+const ss58AddressByteLength = 35
+const ss58PublicKeyOffset = 1
+const ss58PublicKeyEnd = 33
 
-  const pubkey = decodeAddress(input.address)
-  const hash = blake2AsHex(pubkey, 128).slice(2) // 16 bytes = 128 bits, remove 0x
-  const accountId = Buffer.from(pubkey).toString('hex')
+const decodeSs58PublicKey = (address: string): Uint8Array => {
+  const decoded = bs58.decode(address)
+  if (decoded.length !== ss58AddressByteLength) {
+    throw new Error(
+      `Invalid SS58 address length: expected ${ss58AddressByteLength} bytes, got ${decoded.length}`
+    )
+  }
+  return decoded.slice(ss58PublicKeyOffset, ss58PublicKeyEnd)
+}
+
+export const getBittensorCoinBalance: CoinBalanceResolver = async input => {
+  const pubkey = decodeSs58PublicKey(input.address)
+  const hash = bytesToHex(blake2b(pubkey, { dkLen: 16 }))
+  const accountId = bytesToHex(pubkey)
   const storageKey = systemAccountPrefix + hash + accountId
 
   const response = await queryUrl<RpcResponse<string | null>>(bittensorRpcUrl, {


### PR DESCRIPTION
## Summary
- Bittensor balance resolver no longer dynamically imports \`@polkadot/util-crypto\`. In browser/extension bundles that import pulls a chunk that double-bundles BN.js; the second copy throws \`TypeError: Cannot assign to read only property 'toString' of object '#<o>'\` during module init, so every TAO balance fetch fails with \"Failed to load\" and no useful network/console signal.
- Replaced with libraries already in \`@vultisig/core-chain\`'s direct deps: \`@noble/hashes\` (\`blake2b\` + \`bytesToHex\`) and \`bs58\`. No polkadot, no \`Buffer\`, no dynamic imports.
- Behaviour for valid SS58 addresses is identical; invalid lengths now throw a clearer \`Invalid SS58 address length\` error.

## Why
Repro: open the Vultisig Chrome extension, navigate to the Bittensor chain page → \`Failed to load\`. Desktop Wails build is unaffected because that bundle doesn't double-bundle BN.js. The browser bundle's first BN copy initializes \`o.prototype.toString = function(b, D) {...}\` successfully; the second copy hits the same line at \`index.browser.js:52751:30\` and the assignment throws — corrupting the polkadot module init and propagating up through any code path that does \`await import('@polkadot/util-crypto')\`.

The resolver only needed three primitives from polkadot:
- \`decodeAddress\` — replaced with \`bs58.decode\` + a 35-byte length check + slice \`[1, 33)\` to recover the 32-byte pubkey from the SS58 prefix-42 layout.
- \`blake2AsHex(pubkey, 128)\` — replaced with \`bytesToHex(blake2b(pubkey, { dkLen: 16 }))\`.
- \`Buffer.from(pubkey).toString('hex')\` — replaced with \`bytesToHex(pubkey)\`. Also fixes a separate \`buffer\` polyfill issue ('Cannot assign to read only property toString') in some Vite + MV3 builds.

## Test plan
- [ ] Bittensor balance loads in the Vultisig Chrome extension on a vault with a TAO coin.
- [ ] Bittensor balance still loads in the desktop (Wails) build.
- [ ] No regression on other Substrate-family resolvers (Polkadot resolver still uses polkadot/util-crypto and is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid Bittensor SS58 addresses now return a clearer "Invalid SS58 address length" error instead of a generic decoding error. Valid addresses behave as before.

* **Improvements**
  * More robust and reliable Bittensor balance resolution with improved stability and performance in balance lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->