### PR TITLE
Expand @vultisig/sdk/vite browser preset (issue #322)

### DIFF
--- a/.changeset/sdk-vite-browser-preset.md
+++ b/.changeset/sdk-vite-browser-preset.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/sdk": minor
+---
+
+Expand `@vultisig/sdk/vite` into a browser preset: wasm plugin, polyfill shim resolution, `optimizeDeps` tuning, and serve/emit `7zz.wasm` at `/7zz.wasm` without writing into consumers' `public/` folders. Update docs and the browser example.

--- a/docs/SDK-USERS-GUIDE.md
+++ b/docs/SDK-USERS-GUIDE.md
@@ -40,20 +40,30 @@ yarn add @vultisig/sdk
 - **Electron**: Version 20 or higher (for desktop applications)
 - **TypeScript**: Optional but recommended
 
-### Browser Setup: WASM Files
+### Browser setup: Vite and WASM
 
-For browser environments, you need to serve the WASM files from your public directory:
+**Vite (recommended for SPAs):** add `@vultisig/sdk/vite` to `plugins` as a single entry (Vite flattens nested plugin lists). The preset serves `7zz.wasm` in dev, emits it into the build output, and keeps wasm packages out of `optimizeDeps` so `import.meta.url` resolves. It does not write SDK artifacts into your source `public/` directory. Example:
 
-1. Copy WASM files to your public directory:
-   ```bash
-   cp node_modules/@vultisig/sdk/dist/*.wasm public/
-   ```
+```ts
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import vultisig from '@vultisig/sdk/vite'
 
-2. The SDK will automatically load these files from the root path (`/`)
+export default defineConfig({
+  plugins: [react(), vultisig()],
+})
+```
+
+MPC WebAssembly (DKLS, Schnorr, ML-DSA) and Trust Wallet Core load from your installed npm packages, not from hand-copied `sdk/dist` paths. The old `cp node_modules/@vultisig/sdk/dist/*.wasm public/` recipe does **not** match current package layout.
+
+`nodePolyfills` in `vultisig()` defaults to `false` for Vite 8 (Rolldown) compatibility; on older Vite versions you can pass `nodePolyfills: true` to enable the full `vite-plugin-node-polyfills` layer.
+
+**Next.js / Webpack:** there is no official plugin. Keep `@vultisig/lib-*`, `@trustwallet/wallet-core`, and `7z-wasm` from being re-bundled in a way that breaks wasm paths; emit or host `7zz.wasm` at `/7zz.wasm` (or adjust your hosting) and add Node shims (Buffer, `process`, `crypto`/`stream` browserify) comparable to the Vite example. See the SDK README “Web apps: Next.js, Webpack” section.
 
 ### Basic Initialization
 
 The SDK automatically uses the appropriate storage for your platform:
+
 - **Node.js**: `FileStorage` (stores in `~/.vultisig` by default)
 - **Browser**: `BrowserStorage` (uses IndexedDB with localStorage fallback)
 - **Electron**: `FileStorage` (same as Node.js, shared with CLI)
@@ -61,7 +71,7 @@ The SDK automatically uses the appropriate storage for your platform:
 ```typescript
 import { Vultisig } from '@vultisig/sdk'
 
-const sdk = new Vultisig()  // Storage is auto-configured for your platform
+const sdk = new Vultisig() // Storage is auto-configured for your platform
 
 await sdk.initialize()
 
@@ -77,7 +87,7 @@ sdk.dispose()
 import { Vultisig, MemoryStorage } from '@vultisig/sdk'
 
 const sdk = new Vultisig({
-  storage: new MemoryStorage(),  // TESTING ONLY — not persistent, will lose vault data
+  storage: new MemoryStorage(), // TESTING ONLY — not persistent, will lose vault data
 })
 
 await sdk.initialize()
@@ -102,8 +112,8 @@ const sdk = new Vultisig({
   },
 
   passwordCache: {
-    defaultTTL: 300000  // Cache password for 5 minutes
-  }
+    defaultTTL: 300000, // Cache password for 5 minutes
+  },
 })
 
 await sdk.initialize()
@@ -111,12 +121,12 @@ await sdk.initialize()
 // Step 2: Create a fast vault (server-assisted, always encrypted)
 // Returns the vaultId - vault is returned from verifyVault()
 const vaultId = await sdk.createFastVault({
-  name: "My Wallet",
-  email: "user@example.com",
-  password: "SecurePassword123!",
-  onProgress: (step) => {
+  name: 'My Wallet',
+  email: 'user@example.com',
+  password: 'SecurePassword123!',
+  onProgress: step => {
     console.log(`${step.message} (${step.progress}%)`)
-  }
+  },
 })
 
 // Step 3: Verify with email code and get the vault
@@ -153,12 +163,12 @@ The SDK supports two types of vaults:
 - **FastVault**: 2-of-2 MPC with VultiServer assistance. Always encrypted with password. Best for quick setup and individual use.
 - **SecureVault**: Multi-device N-of-M MPC with configurable thresholds. Optionally encrypted. Best for maximum security, teams, and multi-device scenarios.
 
-| Feature | FastVault | SecureVault |
-|---------|-----------|-------------|
-| **Threshold** | 2-of-2 (fixed) | N-of-M (configurable) |
-| **Setup** | Server-assisted, instant | Multi-device, requires QR pairing |
-| **Signing** | Instant via VultiServer | Requires device coordination |
-| **Password** | Required | Optional |
+| Feature       | FastVault                     | SecureVault                          |
+| ------------- | ----------------------------- | ------------------------------------ |
+| **Threshold** | 2-of-2 (fixed)                | N-of-M (configurable)                |
+| **Setup**     | Server-assisted, instant      | Multi-device, requires QR pairing    |
+| **Signing**   | Instant via VultiServer       | Requires device coordination         |
+| **Password**  | Required                      | Optional                             |
 | **Use Cases** | Personal wallets, development | Team wallets, high security, custody |
 
 ### Supported Chains
@@ -205,7 +215,7 @@ import * as fs from 'fs'
 
 // Create SDK with in-memory storage (no persistence)
 const sdk = new Vultisig({
-  storage: new MemoryStorage()
+  storage: new MemoryStorage(),
 })
 await sdk.initialize()
 
@@ -223,6 +233,7 @@ sdk.dispose()
 ```
 
 **Use cases for stateless usage:**
+
 - **One-off signing**: Sign a transaction without persisting vault state
 - **Address derivation**: Generate addresses without storing vault data
 - **Testing**: Unit and integration tests without filesystem side effects
@@ -230,6 +241,7 @@ sdk.dispose()
 - **CLI tools**: Command-line utilities that operate on vault files
 
 **What works in stateless mode:**
+
 - ✅ Address derivation
 - ✅ Balance checking
 - ✅ Transaction signing (FastVault)
@@ -238,6 +250,7 @@ sdk.dispose()
 - ✅ Token/chain management (in-memory only)
 
 **What doesn't persist:**
+
 - ❌ Vault preferences (chains, tokens, currency)
 - ❌ Cached balances/addresses (recreated each session)
 - ❌ Password cache (must provide password each time)
@@ -269,18 +282,18 @@ import { Vultisig, MemoryStorage } from '@vultisig/sdk'
 const sdk = new Vultisig({
   storage: new MemoryStorage(),
   onPasswordRequired: async (vaultId: string, vaultName: string) => {
-    return new Promise((resolve) => {
+    return new Promise(resolve => {
       // Show modal to user
       const modal = createPasswordModal({
         title: `Enter password for ${vaultName}`,
-        onSubmit: (password) => {
+        onSubmit: password => {
           closeModal()
           resolve(password)
-        }
+        },
       })
       modal.show()
     })
-  }
+  },
 })
 ```
 
@@ -295,16 +308,16 @@ const sdk = new Vultisig({
   onPasswordRequired: async (vaultId: string, vaultName: string) => {
     const rl = readline.createInterface({
       input: process.stdin,
-      output: process.stdout
+      output: process.stdout,
     })
 
-    return new Promise((resolve) => {
-      rl.question(`Enter password for ${vaultName}: `, (password) => {
+    return new Promise(resolve => {
+      rl.question(`Enter password for ${vaultName}: `, password => {
         rl.close()
         resolve(password)
       })
     })
-  }
+  },
 })
 ```
 
@@ -316,7 +329,7 @@ const sdk = new Vultisig({
   onPasswordRequired: async (vaultId: string, vaultName: string) => {
     // Retrieve from OS keychain, secure enclave, etc.
     return await secureStorage.getPassword(vaultId)
-  }
+  },
 })
 ```
 
@@ -328,8 +341,8 @@ Cache passwords to avoid repeated prompts during a session:
 const sdk = new Vultisig({
   storage: new MemoryStorage(),
   passwordCache: {
-    defaultTTL: 300000  // Cache for 5 minutes (in milliseconds)
-  }
+    defaultTTL: 300000, // Cache for 5 minutes (in milliseconds)
+  },
 })
 ```
 
@@ -337,16 +350,24 @@ Common TTL configurations:
 
 ```typescript
 // 5 minutes (recommended for balance of security and UX)
-passwordCache: { defaultTTL: 300000 }
+passwordCache: {
+  defaultTTL: 300000
+}
 
 // 15 minutes
-passwordCache: { defaultTTL: 900000 }
+passwordCache: {
+  defaultTTL: 900000
+}
 
 // 1 hour
-passwordCache: { defaultTTL: 3600000 }
+passwordCache: {
+  defaultTTL: 3600000
+}
 
 // Session only (no expiry, cleared on app close)
-passwordCache: { defaultTTL: Infinity }
+passwordCache: {
+  defaultTTL: Infinity
+}
 ```
 
 ### Manual Lock/Unlock
@@ -446,12 +467,12 @@ Create a new vault with server assistance:
 ```typescript
 // Step 1: Create vault - returns vaultId (vault not returned yet)
 const vaultId = await sdk.createFastVault({
-  name: "My Wallet",
-  email: "user@example.com",
-  password: "SecurePassword123!",
-  onProgress: (step) => {
+  name: 'My Wallet',
+  email: 'user@example.com',
+  password: 'SecurePassword123!',
+  onProgress: step => {
     console.log(`Progress: ${step.message} (${step.progress}%)`)
-  }
+  },
 })
 
 // Step 2: Verify with email code - returns the vault
@@ -479,30 +500,30 @@ Secure vaults use multi-device MPC with configurable N-of-M thresholds. Creation
 ```typescript
 // Create a 2-of-3 secure vault
 const { vault, vaultId, sessionId } = await sdk.createSecureVault({
-  name: "Team Wallet",
-  devices: 3,                    // Total number of devices
-  threshold: 2,                  // Signing threshold (defaults to ceil((devices+1)/2))
-  password: "OptionalPassword",  // Optional encryption password
+  name: 'Team Wallet',
+  devices: 3, // Total number of devices
+  threshold: 2, // Signing threshold (defaults to ceil((devices+1)/2))
+  password: 'OptionalPassword', // Optional encryption password
 
   // Called when QR code is ready for device pairing
-  onQRCodeReady: (qrPayload) => {
+  onQRCodeReady: qrPayload => {
     // Display this QR for other devices to scan with Vultisig app
-    displayQRCode(qrPayload);
+    displayQRCode(qrPayload)
   },
 
   // Called each time a device joins
   onDeviceJoined: (deviceId, totalJoined, required) => {
-    console.log(`Device joined: ${totalJoined}/${required}`);
+    console.log(`Device joined: ${totalJoined}/${required}`)
   },
 
   // Called with creation progress updates
-  onProgress: (step) => {
-    console.log(`${step.step}: ${step.message} (${step.progress}%)`);
-  }
-});
+  onProgress: step => {
+    console.log(`${step.step}: ${step.message} (${step.progress}%)`)
+  },
+})
 
-console.log('Secure vault created:', vault.name);
-console.log('Vault ID:', vaultId);
+console.log('Secure vault created:', vault.name)
+console.log('Vault ID:', vaultId)
 ```
 
 **Creation Flow:**
@@ -519,32 +540,32 @@ console.log('Vault ID:', vaultId);
 The threshold determines how many devices must participate in signing:
 
 | Devices | Default Threshold | Can Sign With |
-|---------|-------------------|---------------|
-| 2 | 2 | Both devices |
-| 3 | 2 | Any 2 of 3 |
-| 4 | 3 | Any 3 of 4 |
-| 5 | 4 | Any 4 of 5 |
+| ------- | ----------------- | ------------- |
+| 2       | 2                 | Both devices  |
+| 3       | 2                 | Any 2 of 3    |
+| 4       | 3                 | Any 3 of 4    |
+| 5       | 4                 | Any 4 of 5    |
 
 Formula: `threshold = Math.ceil((devices * 2) / 3)`
 
 **Cancellation Support:**
 
 ```typescript
-const controller = new AbortController();
+const controller = new AbortController()
 
 // Allow user to cancel
-cancelButton.onclick = () => controller.abort();
+cancelButton.onclick = () => controller.abort()
 
 try {
   const { vault } = await sdk.createSecureVault({
-    name: "Team Wallet",
+    name: 'Team Wallet',
     devices: 3,
     signal: controller.signal,
-    onQRCodeReady: displayQRCode
-  });
+    onQRCodeReady: displayQRCode,
+  })
 } catch (error) {
   if (error.name === 'AbortError') {
-    console.log('Vault creation cancelled');
+    console.log('Vault creation cancelled')
   }
 }
 ```
@@ -558,34 +579,34 @@ Signing with a secure vault requires coordination with other devices. The thresh
 const keysignPayload = await vault.prepareSendTx({
   coin,
   receiver: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0',
-  amount: '100000000000000000'
-});
+  amount: '100000000000000000',
+})
 
 // Sign with device coordination
 const signature = await vault.sign(keysignPayload, {
   // Called when QR is ready for devices to join signing session
-  onQRCodeReady: (qrPayload) => {
-    displayQRCode(qrPayload);
-    console.log('Scan with other devices to approve transaction');
+  onQRCodeReady: qrPayload => {
+    displayQRCode(qrPayload)
+    console.log('Scan with other devices to approve transaction')
   },
 
   // Called as devices join the signing session
   onDeviceJoined: (deviceId, total, required) => {
-    console.log(`Signing: ${total}/${required} devices ready`);
+    console.log(`Signing: ${total}/${required} devices ready`)
   },
 
   // Called with signing progress updates
-  onProgress: (step) => {
-    console.log(`${step.step}: ${step.message}`);
-  }
-});
+  onProgress: step => {
+    console.log(`${step.step}: ${step.message}`)
+  },
+})
 
 // Broadcast once signature is obtained
 const txHash = await vault.broadcastTx({
   chain: Chain.Ethereum,
   keysignPayload,
-  signature
-});
+  signature,
+})
 ```
 
 **Signing Flow:**
@@ -601,15 +622,18 @@ const txHash = await vault.broadcastTx({
 
 ```typescript
 // Sign pre-hashed data (useful for custom transaction construction)
-const signature = await vault.signBytes({
-  chain: Chain.Ethereum,
-  messages: [transactionHash]  // Uint8Array, Buffer, or hex string
-}, {
-  onQRCodeReady: displayQRCode,
-  onDeviceJoined: (id, total, required) => {
-    console.log(`${total}/${required} ready`);
+const signature = await vault.signBytes(
+  {
+    chain: Chain.Ethereum,
+    data: transactionHash, // Uint8Array, Buffer, or hex string
+  },
+  {
+    onQRCodeReady: displayQRCode,
+    onDeviceJoined: (id, total, required) => {
+      console.log(`${total}/${required} ready`)
+    },
   }
-});
+)
 ```
 
 **Timeout Behavior:**
@@ -630,10 +654,7 @@ const vultContent = fs.readFileSync('MyWallet-local-party-1-share1of2.vult', 'ut
 const isEncrypted = sdk.isVaultEncrypted(vultContent)
 
 // Import with password if needed
-const vault = await sdk.importVault(
-  vultContent,
-  isEncrypted ? 'VaultPassword123!' : undefined
-)
+const vault = await sdk.importVault(vultContent, isEncrypted ? 'VaultPassword123!' : undefined)
 
 console.log('Vault imported:', vault.name)
 ```
@@ -750,7 +771,7 @@ Before importing, you can scan chains to find existing balances:
 const { results, usePhantomSolanaPath } = await sdk.discoverChainsFromSeedphrase(
   mnemonic,
   [Chain.Bitcoin, Chain.Ethereum, Chain.THORChain, Chain.Solana],
-  (progress) => {
+  progress => {
     console.log(`${progress.phase}: ${progress.chain}`)
     console.log(`Progress: ${progress.chainsProcessed}/${progress.chainsTotal}`)
     console.log(`Found balances on: ${progress.chainsWithBalance.join(', ')}`)
@@ -773,6 +794,7 @@ if (usePhantomSolanaPath) {
 ```
 
 **Progress Phases:**
+
 - `validating` - Validating the mnemonic
 - `deriving` - Deriving addresses for each chain
 - `fetching` - Fetching balances from blockchain
@@ -805,12 +827,12 @@ const vaultId = await sdk.createFastVaultFromSeedphrase({
   // usePhantomSolanaPath: true,
 
   // Progress callbacks
-  onProgress: (step) => {
+  onProgress: step => {
     console.log(`${step.step}: ${step.message} (${step.progress}%)`)
   },
-  onChainDiscovery: (progress) => {
+  onChainDiscovery: progress => {
     console.log(`Discovering ${progress.chain}: ${progress.phase}`)
-  }
+  },
 })
 
 // Complete with email verification
@@ -832,27 +854,27 @@ Import a seedphrase with multi-device MPC (N-of-M threshold):
 const { vault, vaultId, sessionId } = await sdk.createSecureVaultFromSeedphrase({
   mnemonic: 'abandon abandon abandon...',
   name: 'Team Wallet',
-  devices: 3,      // Total devices
-  threshold: 2,    // Signing threshold
+  devices: 3, // Total devices
+  threshold: 2, // Signing threshold
   password: 'OptionalPassword',
   discoverChains: true,
 
   // Use Phantom wallet derivation path for Solana (auto-detected if discoverChains is true)
   // usePhantomSolanaPath: true,
 
-  onProgress: (step) => {
+  onProgress: step => {
     console.log(`${step.step}: ${step.message}`)
   },
-  onQRCodeReady: (qrPayload) => {
+  onQRCodeReady: qrPayload => {
     // Display QR for other devices to scan
     displayQRCode(qrPayload)
   },
   onDeviceJoined: (deviceId, total, required) => {
     console.log(`Device joined: ${total}/${required}`)
   },
-  onChainDiscovery: (progress) => {
+  onChainDiscovery: progress => {
     console.log(`Discovering: ${progress.message}`)
-  }
+  },
 })
 
 console.log('SecureVault imported:', vault.name)
@@ -871,17 +893,19 @@ const promise1 = sdk1.createSecureVault({
   name: 'Shared Vault',
   devices: 3,
   password: 'optional',
-  onQRCodeReady: (qr) => { qrPayload = qr }
+  onQRCodeReady: qr => {
+    qrPayload = qr
+  },
 })
 
 // Device 2 joins (no mnemonic needed for keygen)
 const promise2 = sdk2.joinSecureVault(qrPayload, {
-  devices: 3
+  devices: 3,
 })
 
 // Device 3 joins
 const promise3 = sdk3.joinSecureVault(qrPayload, {
-  devices: 3
+  devices: 3,
 })
 
 // Wait for all to complete
@@ -898,19 +922,21 @@ const promise1 = sdk1.createSecureVaultFromSeedphrase({
   mnemonic: seedphrase,
   name: 'Shared Wallet',
   devices: 3,
-  onQRCodeReady: (qr) => { qrPayload = qr }
+  onQRCodeReady: qr => {
+    qrPayload = qr
+  },
 })
 
 // Device 2 joins (mnemonic required - must match!)
 const promise2 = sdk2.joinSecureVault(qrPayload, {
   mnemonic: seedphrase,
-  devices: 3
+  devices: 3,
 })
 
 // Device 3 joins
 const promise3 = sdk3.joinSecureVault(qrPayload, {
   mnemonic: seedphrase,
-  devices: 3
+  devices: 3,
 })
 
 const [result1, result2, result3] = await Promise.all([promise1, promise2, promise3])
@@ -920,14 +946,14 @@ const [result1, result2, result3] = await Promise.all([promise1, promise2, promi
 
 ### Creation Flow Comparison
 
-| Feature | FastVault from Seedphrase | SecureVault from Seedphrase |
-|---------|---------------------------|------------------------------|
-| **Method** | `createFastVaultFromSeedphrase()` | `createSecureVaultFromSeedphrase()` |
-| **Threshold** | 2-of-2 (with VultiServer) | N-of-M (configurable) |
-| **Verification** | Email code required | Device pairing via QR or `joinSecureVault()` |
-| **Password** | Required | Optional |
-| **Signing** | Instant | Requires device coordination |
-| **Joiner Method** | N/A (server auto-joins) | `joinSecureVault()` |
+| Feature           | FastVault from Seedphrase         | SecureVault from Seedphrase                  |
+| ----------------- | --------------------------------- | -------------------------------------------- |
+| **Method**        | `createFastVaultFromSeedphrase()` | `createSecureVaultFromSeedphrase()`          |
+| **Threshold**     | 2-of-2 (with VultiServer)         | N-of-M (configurable)                        |
+| **Verification**  | Email code required               | Device pairing via QR or `joinSecureVault()` |
+| **Password**      | Required                          | Optional                                     |
+| **Signing**       | Instant                           | Requires device coordination                 |
+| **Joiner Method** | N/A (server auto-joins)           | `joinSecureVault()`                          |
 
 ### Security Considerations
 
@@ -954,11 +980,7 @@ const btcAddress = await vault.address(Chain.Bitcoin)
 console.log('Bitcoin:', btcAddress) // "bc1q..."
 
 // Multiple addresses
-const addresses = await vault.addresses([
-  Chain.Bitcoin,
-  Chain.Ethereum,
-  Chain.Solana
-])
+const addresses = await vault.addresses([Chain.Bitcoin, Chain.Ethereum, Chain.Solana])
 
 console.log(addresses)
 // {
@@ -1017,16 +1039,21 @@ const { signature: solSig } = await vault.signMessage('verify me', Chain.Solana)
 
 // Swap tokens (handles quote, approval, and broadcast)
 const swap = await vault.swap({
-  fromChain: Chain.Ethereum, fromSymbol: 'ETH',
-  toChain: Chain.Bitcoin, toSymbol: 'BTC',
+  fromChain: Chain.Ethereum,
+  fromSymbol: 'ETH',
+  toChain: Chain.Bitcoin,
+  toSymbol: 'BTC',
   amount: '0.5',
 })
 
 // Swap dry run
 const quote = await vault.swap({
-  fromChain: Chain.Ethereum, fromSymbol: 'ETH',
-  toChain: Chain.Bitcoin, toSymbol: 'BTC',
-  amount: '0.5', dryRun: true,
+  fromChain: Chain.Ethereum,
+  fromSymbol: 'ETH',
+  toChain: Chain.Bitcoin,
+  toSymbol: 'BTC',
+  amount: '0.5',
+  dryRun: true,
 })
 
 // Portfolio overview
@@ -1053,7 +1080,7 @@ const coin = new AccountCoin({
   address: await vault.address(Chain.Ethereum),
   decimals: 18,
   priceUSD: '3000.00',
-  isNativeToken: true
+  isNativeToken: true,
 })
 
 // Step 2: Prepare transaction
@@ -1064,7 +1091,7 @@ const keysignPayload = await vault.prepareSendTx({
   memo: 'Payment for services',
   feeSettings: {
     gasPrice: '50000000000', // 50 gwei (optional, uses estimate if not provided)
-  }
+  },
 })
 
 // Step 3: Sign transaction (may trigger password prompt)
@@ -1074,7 +1101,7 @@ const signature = await vault.sign(keysignPayload)
 const txHash = await vault.broadcastTx({
   chain: Chain.Ethereum,
   keysignPayload,
-  signature
+  signature,
 })
 
 console.log('Transaction broadcast:', txHash)
@@ -1107,8 +1134,8 @@ const { balance, fee, maxSendable } = await vault.getMaxSendAmount({
   receiver: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0',
 })
 
-console.log('Balance:', balance)        // e.g., 5000000000000000000n (5 ETH)
-console.log('Fee:', fee)                // e.g., 21000000000000n
+console.log('Balance:', balance) // e.g., 5000000000000000000n (5 ETH)
+console.log('Fee:', fee) // e.g., 21000000000000n
 console.log('Max sendable:', maxSendable) // e.g., 4999979000000000000n
 
 // Use maxSendable as the amount for a "send max" transaction
@@ -1165,7 +1192,7 @@ const tx = Transaction.from({
   maxPriorityFeePerGas: 2000000000n,
   nonce: 42,
   chainId: 1,
-  type: 2  // EIP-1559
+  type: 2, // EIP-1559
 })
 
 // Step 2: Get the unsigned transaction hash
@@ -1174,7 +1201,7 @@ const unsignedHash = keccak256(tx.unsignedSerialized)
 // Step 3: Sign the hash with signBytes
 const signature = await vault.signBytes({
   data: unsignedHash,
-  chain: Chain.Ethereum
+  chain: Chain.Ethereum,
 })
 
 // Step 4: Apply signature to transaction
@@ -1182,13 +1209,13 @@ const signedTx = tx.clone()
 signedTx.signature = {
   r: '0x' + signature.signature.slice(0, 64),
   s: '0x' + signature.signature.slice(64, 128),
-  v: signature.recovery! + 27
+  v: signature.recovery! + 27,
 }
 
 // Step 5: Broadcast using SDK
 const txHash = await vault.broadcastRawTx({
   chain: Chain.Ethereum,
-  rawTx: signedTx.serialized
+  rawTx: signedTx.serialized,
 })
 console.log('Transaction hash:', txHash)
 ```
@@ -1204,25 +1231,25 @@ const psbt = new bitcoin.Psbt({ network: bitcoin.networks.bitcoin })
 psbt.addInput({
   hash: 'previous-txid...',
   index: 0,
-  witnessUtxo: { script: Buffer.from('...'), value: 100000 }
+  witnessUtxo: { script: Buffer.from('...'), value: 100000 },
 })
 psbt.addOutput({
   address: 'bc1q...',
-  value: 90000
+  value: 90000,
 })
 
 // Step 2: Get sighash for each input
 const sighash = psbt.getTxForSigning().hashForWitnessV0(
-  0,  // input index
-  Buffer.from('...'),  // scriptCode
-  100000,  // value
+  0, // input index
+  Buffer.from('...'), // scriptCode
+  100000, // value
   bitcoin.Transaction.SIGHASH_ALL
 )
 
 // Step 3: Sign with signBytes
 const signature = await vault.signBytes({
   data: sighash,
-  chain: Chain.Bitcoin
+  chain: Chain.Bitcoin,
 })
 
 // Step 4: Apply signature to PSBT
@@ -1233,7 +1260,7 @@ psbt.finalizeAllInputs()
 const rawTx = psbt.extractTransaction().toHex()
 const txHash = await vault.broadcastRawTx({
   chain: Chain.Bitcoin,
-  rawTx
+  rawTx,
 })
 console.log('Transaction hash:', txHash)
 ```
@@ -1242,8 +1269,8 @@ console.log('Transaction hash:', txHash)
 
 ```typescript
 type Signature = {
-  signature: string   // Hex-encoded signature (r || s for ECDSA, full sig for EdDSA)
-  recovery?: number   // Recovery byte for ECDSA (0 or 1), undefined for EdDSA
+  signature: string // Hex-encoded signature (r || s for ECDSA, full sig for EdDSA)
+  recovery?: number // Recovery byte for ECDSA (0 or 1), undefined for EdDSA
 }
 ```
 
@@ -1256,27 +1283,28 @@ The `broadcastRawTx()` method broadcasts pre-signed raw transactions to the bloc
 ```typescript
 const txHash = await vault.broadcastRawTx({
   chain: Chain.Ethereum,
-  rawTx: '0x02f8...'  // hex-encoded signed transaction
+  rawTx: '0x02f8...', // hex-encoded signed transaction
 })
 ```
 
 **Supported Input Formats:**
 
-| Chain Family | Input Format |
-|--------------|--------------|
-| EVM (Ethereum, Polygon, BSC, etc.) | Hex-encoded signed tx (with/without 0x) |
-| UTXO (Bitcoin, Litecoin, etc.) | Hex-encoded raw tx |
-| Solana | Base58 or Base64 encoded tx bytes |
+| Chain Family                              | Input Format                             |
+| ----------------------------------------- | ---------------------------------------- |
+| EVM (Ethereum, Polygon, BSC, etc.)        | Hex-encoded signed tx (with/without 0x)  |
+| UTXO (Bitcoin, Litecoin, etc.)            | Hex-encoded raw tx                       |
+| Solana                                    | Base58 or Base64 encoded tx bytes        |
 | Cosmos (Cosmos, Osmosis, THORChain, etc.) | JSON `{tx_bytes}` or raw base64 protobuf |
-| TON | BOC (Bag of Cells) as base64 string |
-| Polkadot | Hex-encoded extrinsic |
-| Ripple | Hex-encoded tx blob |
-| Sui | JSON `{unsignedTx, signature}` |
-| Tron | JSON tx object |
+| TON                                       | BOC (Bag of Cells) as base64 string      |
+| Polkadot                                  | Hex-encoded extrinsic                    |
+| Ripple                                    | Hex-encoded tx blob                      |
+| Sui                                       | JSON `{unsignedTx, signature}`           |
+| Tron                                      | JSON tx object                           |
 
 **Error Handling:**
 
 The method throws `VaultError` with these codes:
+
 - `BroadcastFailed` - Transaction failed to broadcast (may include "already submitted" errors)
 - `UnsupportedChain` - Chain not yet supported for raw broadcast
 
@@ -1322,6 +1350,7 @@ const checkStatus = async () => {
 **Supported chains:** All chain families (EVM, UTXO, Cosmos, Solana, Sui, Polkadot, Ripple, Tron, Cardano, TON).
 
 **Return type (`TxStatusResult`):**
+
 - `status: 'pending' | 'success' | 'error'` - Current on-chain status
 - `receipt?: TxReceiptInfo` - Fee details when available:
   - `feeAmount: bigint` - Fee paid in base units
@@ -1365,14 +1394,16 @@ const payload = await vault.prepareSignAminoTx({
     decimals: 6,
     ticker: 'ATOM',
   },
-  msgs: [{
-    type: 'cosmos-sdk/MsgVote',
-    value: JSON.stringify({
-      proposal_id: '123',
-      voter: cosmosAddress,
-      option: 'VOTE_OPTION_YES',
-    }),
-  }],
+  msgs: [
+    {
+      type: 'cosmos-sdk/MsgVote',
+      value: JSON.stringify({
+        proposal_id: '123',
+        voter: cosmosAddress,
+        option: 'VOTE_OPTION_YES',
+      }),
+    },
+  ],
   fee: {
     amount: [{ denom: 'uatom', amount: '5000' }],
     gas: '200000',
@@ -1451,18 +1482,18 @@ const signature = await vault.sign(payload)
 
 #### Supported Cosmos Chains
 
-| Chain | Chain ID | Native Denom |
-|-------|----------|--------------|
-| Cosmos | cosmoshub-4 | uatom |
-| Osmosis | osmosis-1 | uosmo |
-| THORChain | thorchain-1 | rune |
-| MayaChain | mayachain-1 | cacao |
-| Dydx | dydx-mainnet-1 | adydx |
-| Kujira | kaiyo-1 | ukuji |
-| Terra | phoenix-1 | uluna |
-| TerraClassic | columbus-5 | uluna |
-| Noble | noble-1 | uusdc |
-| Akash | akashnet-2 | uakt |
+| Chain        | Chain ID       | Native Denom |
+| ------------ | -------------- | ------------ |
+| Cosmos       | cosmoshub-4    | uatom        |
+| Osmosis      | osmosis-1      | uosmo        |
+| THORChain    | thorchain-1    | rune         |
+| MayaChain    | mayachain-1    | cacao        |
+| Dydx         | dydx-mainnet-1 | adydx        |
+| Kujira       | kaiyo-1        | ukuji        |
+| Terra        | phoenix-1      | uluna        |
+| TerraClassic | columbus-5     | uluna        |
+| Noble        | noble-1        | uusdc        |
+| Akash        | akashnet-2     | uakt         |
 
 #### Common Message Types
 
@@ -1516,7 +1547,7 @@ await vault.addToken(Chain.Ethereum, {
   name: 'Tether USD',
   decimals: 6,
   contractAddress: '0xdac17f958d2ee523a2206206994597c13d831ec7',
-  chainId: 'ethereum'
+  chainId: 'ethereum',
 })
 
 // Get tokens for a chain
@@ -1542,12 +1573,7 @@ Manage which chains are active for the vault:
 await vault.addChain(Chain.Polygon)
 
 // Add multiple chains
-await vault.setChains([
-  Chain.Bitcoin,
-  Chain.Ethereum,
-  Chain.Polygon,
-  Chain.Solana
-])
+await vault.setChains([Chain.Bitcoin, Chain.Ethereum, Chain.Polygon, Chain.Solana])
 
 // Remove a chain
 await vault.removeChain(Chain.Litecoin)
@@ -1585,11 +1611,11 @@ The SDK supports token swaps across multiple chains and protocols, including cro
 
 ### Supported Swap Routes
 
-| Route Type | Provider | Example |
-| ---------- | -------- | ------- |
-| Cross-chain (BTC, ETH, Cosmos) | THORChain | BTC → ETH, ETH → ATOM |
-| Same-chain EVM | 1inch | ETH → USDC on Ethereum |
-| Cross-chain EVM | LiFi | Polygon → Arbitrum |
+| Route Type                     | Provider  | Example                |
+| ------------------------------ | --------- | ---------------------- |
+| Cross-chain (BTC, ETH, Cosmos) | THORChain | BTC → ETH, ETH → ATOM  |
+| Same-chain EVM                 | 1inch     | ETH → USDC on Ethereum |
+| Cross-chain EVM                | LiFi      | Polygon → Arbitrum     |
 
 ### Checking Swap Support
 
@@ -1612,16 +1638,16 @@ Get a quote before executing a swap:
 const quote = await vault.getSwapQuote({
   fromCoin: { chain: Chain.Ethereum },
   toCoin: { chain: Chain.Bitcoin },
-  amount: 0.1  // 0.1 ETH
+  amount: 0.1, // 0.1 ETH
 })
 
-console.log(`Provider: ${quote.provider}`)           // e.g., 'thorchain'
-console.log(`Output: ${quote.estimatedOutput} BTC`)  // e.g., '0.00234 BTC'
+console.log(`Provider: ${quote.provider}`) // e.g., 'thorchain'
+console.log(`Output: ${quote.estimatedOutput} BTC`) // e.g., '0.00234 BTC'
 console.log(`Expires: ${new Date(quote.expiresAt)}`)
 console.log(`Fees: ${quote.fees.total}`)
 
 // Balance + max swappable amount (included automatically)
-console.log(`Balance: ${quote.balance}`)         // Source coin balance in base units
+console.log(`Balance: ${quote.balance}`) // Source coin balance in base units
 console.log(`Max swapable: ${quote.maxSwapable}`) // balance - network fee (native), or full balance (tokens)
 
 // Check if approval is needed (ERC-20 tokens)
@@ -1639,10 +1665,10 @@ For ERC-20 tokens, specify the token contract address:
 const quote = await vault.getSwapQuote({
   fromCoin: {
     chain: Chain.Ethereum,
-    token: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'  // USDC
+    token: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', // USDC
   },
-  toCoin: { chain: Chain.Ethereum },  // Native ETH
-  amount: 100  // 100 USDC
+  toCoin: { chain: Chain.Ethereum }, // Native ETH
+  amount: 100, // 100 USDC
 })
 
 // Or use full AccountCoin format
@@ -1653,15 +1679,15 @@ const quote = await vault.getSwapQuote({
     address: ethAddress,
     id: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
     ticker: 'USDC',
-    decimals: 6
+    decimals: 6,
   },
   toCoin: {
     chain: Chain.Ethereum,
     address: ethAddress,
     ticker: 'ETH',
-    decimals: 18
+    decimals: 18,
   },
-  amount: 100
+  amount: 100,
 })
 ```
 
@@ -1674,7 +1700,7 @@ Complete swap flow with signing and broadcasting:
 const quote = await vault.getSwapQuote({
   fromCoin: { chain: Chain.Ethereum },
   toCoin: { chain: Chain.Bitcoin },
-  amount: 0.1
+  amount: 0.1,
 })
 
 // Step 2: Prepare transaction
@@ -1682,7 +1708,7 @@ const { keysignPayload, approvalPayload } = await vault.prepareSwapTx({
   fromCoin: { chain: Chain.Ethereum },
   toCoin: { chain: Chain.Bitcoin },
   amount: 0.1,
-  swapQuote: quote
+  swapQuote: quote,
 })
 
 // Step 3: Handle approval if needed (ERC-20 tokens only)
@@ -1691,7 +1717,7 @@ if (approvalPayload) {
   const approvalTxHash = await vault.broadcastTx({
     chain: Chain.Ethereum,
     keysignPayload: approvalPayload,
-    signature: approvalSignature
+    signature: approvalSignature,
   })
   console.log('Approval tx:', approvalTxHash)
   // Wait for approval confirmation before proceeding
@@ -1702,7 +1728,7 @@ const signature = await vault.sign(keysignPayload)
 const txHash = await vault.broadcastTx({
   chain: Chain.Ethereum,
   keysignPayload,
-  signature
+  signature,
 })
 
 console.log('Swap tx:', txHash)
@@ -1720,11 +1746,11 @@ const allowance = await vault.getTokenAllowance(
   {
     chain: Chain.Ethereum,
     address: ethAddress,
-    id: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',  // USDC
+    id: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', // USDC
     ticker: 'USDC',
-    decimals: 6
+    decimals: 6,
   },
-  '0x1111111254fb6c44bAC0beD2854e76F90643097d'  // 1inch router
+  '0x1111111254fb6c44bAC0beD2854e76F90643097d' // 1inch router
 )
 
 console.log(`Current USDC allowance: ${allowance}`)
@@ -1745,7 +1771,7 @@ vault.on('swapQuoteReceived', ({ quote }) => {
 const quote = await vault.getSwapQuote({
   fromCoin: { chain: Chain.Ethereum },
   toCoin: { chain: Chain.Bitcoin },
-  amount: 0.1
+  amount: 0.1,
 })
 ```
 
@@ -1758,7 +1784,7 @@ try {
   const quote = await vault.getSwapQuote({
     fromCoin: { chain: Chain.Ethereum },
     toCoin: { chain: Chain.Bitcoin },
-    amount: 0.001  // Very small amount
+    amount: 0.001, // Very small amount
   })
 } catch (error) {
   if (error.message.includes('No swap route')) {
@@ -1777,15 +1803,15 @@ The SDK automatically applies affiliate fee discounts based on your VULT token a
 
 #### Discount Tier Levels
 
-| Tier | Min VULT | Affiliate Fee |
-|------|----------|---------------|
-| None | 0 | 0.50% (50 bps) |
-| Bronze | 1,500 | 0.45% (45 bps) |
-| Silver | 3,000 | 0.40% (40 bps) |
-| Gold | 7,500 | 0.30% (30 bps) |
-| Platinum | 15,000 | 0.25% (25 bps) |
-| Diamond | 100,000 | 0.15% (15 bps) |
-| Ultimate | 1,000,000 | 0.00% (0 bps) |
+| Tier     | Min VULT  | Affiliate Fee  |
+| -------- | --------- | -------------- |
+| None     | 0         | 0.50% (50 bps) |
+| Bronze   | 1,500     | 0.45% (45 bps) |
+| Silver   | 3,000     | 0.40% (40 bps) |
+| Gold     | 7,500     | 0.30% (30 bps) |
+| Platinum | 15,000    | 0.25% (25 bps) |
+| Diamond  | 100,000   | 0.15% (15 bps) |
+| Ultimate | 1,000,000 | 0.00% (0 bps)  |
 
 **Thorguard NFT Bonus:** Holders of the Thorguard NFT receive a free tier upgrade (one level higher), except for platinum tier and above.
 
@@ -1829,10 +1855,7 @@ for (const token of tokens) {
 }
 
 // Look up a specific token by contract address (case-insensitive)
-const usdc = Vultisig.getKnownToken(
-  Chain.Ethereum,
-  '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
-)
+const usdc = Vultisig.getKnownToken(Chain.Ethereum, '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48')
 if (usdc) {
   console.log(`${usdc.ticker} - ${usdc.decimals} decimals`)
 }
@@ -1869,16 +1892,10 @@ Resolve token metadata by contract address. Checks the built-in registry first (
 
 ```typescript
 // Known token → instant, no network call
-const usdc = await vault.resolveToken(
-  Chain.Ethereum,
-  '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
-)
+const usdc = await vault.resolveToken(Chain.Ethereum, '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48')
 
 // Unknown token → fetches from chain API
-const customToken = await vault.resolveToken(
-  Chain.Ethereum,
-  '0x6982508145454Ce325dDbE47a25d4ec3d2311933'
-)
+const customToken = await vault.resolveToken(Chain.Ethereum, '0x6982508145454Ce325dDbE47a25d4ec3d2311933')
 console.log(`${customToken.ticker} - ${customToken.decimals} decimals`)
 ```
 
@@ -1890,17 +1907,17 @@ The SDK exports `CosmosMsgType` constants for constructing Cosmos transactions:
 import { CosmosMsgType } from '@vultisig/sdk'
 
 // Amino-style type strings
-CosmosMsgType.MsgSend              // 'cosmos-sdk/MsgSend'
-CosmosMsgType.ThorchainMsgSend     // 'thorchain/MsgSend'
-CosmosMsgType.MsgExecuteContract   // 'wasm/MsgExecuteContract'
-CosmosMsgType.ThorchainMsgDeposit  // 'thorchain/MsgDeposit'
+CosmosMsgType.MsgSend // 'cosmos-sdk/MsgSend'
+CosmosMsgType.ThorchainMsgSend // 'thorchain/MsgSend'
+CosmosMsgType.MsgExecuteContract // 'wasm/MsgExecuteContract'
+CosmosMsgType.ThorchainMsgDeposit // 'thorchain/MsgDeposit'
 
 // URL-style type strings (for SignDirect / protobuf)
-CosmosMsgType.MsgSendUrl              // '/cosmos.bank.v1beta1.MsgSend'
-CosmosMsgType.MsgTransferUrl          // '/ibc.applications.transfer.v1.MsgTransfer'
-CosmosMsgType.MsgExecuteContractUrl   // '/cosmwasm.wasm.v1.MsgExecuteContract'
-CosmosMsgType.ThorchainMsgDepositUrl  // '/types.MsgDeposit'
-CosmosMsgType.ThorchainMsgSendUrl     // '/types.MsgSend'
+CosmosMsgType.MsgSendUrl // '/cosmos.bank.v1beta1.MsgSend'
+CosmosMsgType.MsgTransferUrl // '/ibc.applications.transfer.v1.MsgTransfer'
+CosmosMsgType.MsgExecuteContractUrl // '/cosmwasm.wasm.v1.MsgExecuteContract'
+CosmosMsgType.ThorchainMsgDepositUrl // '/types.MsgDeposit'
+CosmosMsgType.ThorchainMsgSendUrl // '/types.MsgSend'
 ```
 
 ---
@@ -1914,15 +1931,15 @@ import { Vultisig } from '@vultisig/sdk'
 
 // Fetch prices (static method, no vault needed)
 const prices = await Vultisig.getCoinPrices({
-  ids: ['bitcoin', 'ethereum', 'solana']
+  ids: ['bitcoin', 'ethereum', 'solana'],
 })
-console.log(`BTC: $${prices.bitcoin}`)  // BTC: $50000
+console.log(`BTC: $${prices.bitcoin}`) // BTC: $50000
 console.log(`ETH: $${prices.ethereum}`) // ETH: $3000
 
 // Use a different fiat currency
 const eurPrices = await Vultisig.getCoinPrices({
   ids: ['bitcoin'],
-  fiatCurrency: 'eur'
+  fiatCurrency: 'eur',
 })
 ```
 
@@ -2049,7 +2066,7 @@ Register a callback, then forward raw push data from your platform's handler:
 
 ```typescript
 // Register handler
-const unsubscribe = sdk.notifications.onSigningRequest((notification) => {
+const unsubscribe = sdk.notifications.onSigningRequest(notification => {
   console.log(`Signing request for vault: ${notification.vaultName}`)
   // Use notification.qrCodeData to join the signing session
 })
@@ -2063,15 +2080,15 @@ unsubscribe()
 
 ### Consumer Responsibilities
 
-| Responsibility | Owner |
-|---|---|
-| Obtain push token (APNs / FCM / Web Push) | **Consumer** |
-| Register token with notification server | SDK |
-| Trigger notification to vault members | SDK |
+| Responsibility                                       | Owner        |
+| ---------------------------------------------------- | ------------ |
+| Obtain push token (APNs / FCM / Web Push)            | **Consumer** |
+| Register token with notification server              | SDK          |
+| Trigger notification to vault members                | SDK          |
 | Wire platform push handler to `handleIncomingPush()` | **Consumer** |
-| Parse incoming notification data | SDK |
-| Display notification to user | **Consumer** |
-| Route to signing flow using `qrCodeData` | **Consumer** |
+| Parse incoming notification data                     | SDK          |
+| Display notification to user                         | **Consumer** |
+| Route to signing flow using `qrCodeData`             | **Consumer** |
 
 ### WebSocket Real-Time Delivery
 
@@ -2082,7 +2099,7 @@ For environments where platform push isn't available (browser extensions, Electr
 await sdk.notifications.registerDevice({
   vaultId: vault.publicKeys.ecdsa,
   partyName: vault.localPartyId,
-  token: myDeviceToken,       // Any stable unique identifier
+  token: myDeviceToken, // Any stable unique identifier
   deviceType: 'web',
 })
 
@@ -2090,17 +2107,17 @@ await sdk.notifications.registerDevice({
 sdk.notifications.connect({
   vaultId: vault.publicKeys.ecdsa,
   partyName: vault.localPartyId,
-  token: myDeviceToken,       // Same token used for registerDevice()
+  token: myDeviceToken, // Same token used for registerDevice()
 })
 
 // Step 3: Handle notifications (same callback as platform push)
-const unsubscribe = sdk.notifications.onSigningRequest((notification) => {
+const unsubscribe = sdk.notifications.onSigningRequest(notification => {
   console.log(`Signing request for vault: ${notification.vaultName}`)
   // Use notification.qrCodeData to join the signing session
 })
 
 // Step 4: Monitor connection state (optional)
-const unsubState = sdk.notifications.onConnectionStateChange((state) => {
+const unsubState = sdk.notifications.onConnectionStateChange(state => {
   // state: 'disconnected' | 'connecting' | 'connected' | 'reconnecting'
   console.log('WebSocket state:', state)
 })
@@ -2176,7 +2193,7 @@ import { Vultisig, Chain } from '@vultisig/sdk'
 
 const sdk = new Vultisig({
   // Required: Storage implementation
-  storage: new FileStorage(),  // Or MemoryStorage, or custom implementation
+  storage: new FileStorage(), // Or MemoryStorage, or custom implementation
 
   // Optional: Default chains for new vaults
   defaultChains: [Chain.Bitcoin, Chain.Ethereum, Chain.Solana],
@@ -2191,20 +2208,20 @@ const sdk = new Vultisig({
 
   // Optional: Password cache settings
   passwordCache: {
-    defaultTTL: 300000  // 5 minutes
+    defaultTTL: 300000, // 5 minutes
   },
 
   // Optional: Cache configuration
   cacheConfig: {
-    balanceTTL: 300000,  // 5 minutes (default)
-    priceTTL: 300000,    // 5 minutes (default)
+    balanceTTL: 300000, // 5 minutes (default)
+    priceTTL: 300000, // 5 minutes (default)
   },
 
   // Optional: Custom server endpoints (advanced)
   serverEndpoints: {
     fastVault: 'https://custom-api.example.com',
-    messageRelay: 'https://custom-relay.example.com'
-  }
+    messageRelay: 'https://custom-relay.example.com',
+  },
 })
 
 await sdk.initialize()
@@ -2282,7 +2299,7 @@ class CustomStorage implements Storage {
 
 // Use custom storage
 const sdk = new Vultisig({
-  storage: new CustomStorage('./vaults')
+  storage: new CustomStorage('./vaults'),
 })
 
 await sdk.initialize()
@@ -2334,9 +2351,9 @@ Configure cache TTLs:
 const sdk = new Vultisig({
   storage: new FileStorage(),
   cacheConfig: {
-    balanceTTL: 300000,  // 5 minutes (default)
-    priceTTL: 300000,    // 5 minutes (default)
-  }
+    balanceTTL: 300000, // 5 minutes (default)
+    priceTTL: 300000, // 5 minutes (default)
+  },
 })
 ```
 
@@ -2348,8 +2365,8 @@ Passwords are cached to avoid repeated prompts (see [Password Management](#passw
 const sdk = new Vultisig({
   storage: new FileStorage(),
   passwordCache: {
-    defaultTTL: 300000  // 5 minutes
-  }
+    defaultTTL: 300000, // 5 minutes
+  },
 })
 
 // Manually clear password cache
@@ -2492,7 +2509,7 @@ vault.on('keygenProgress', ({ phase, message }) => {
 })
 
 // Error Events
-vault.on('error', (error) => {
+vault.on('error', error => {
   console.error('Vault error:', error.message)
 })
 ```
@@ -2531,7 +2548,7 @@ function BalanceDisplay({ vault, chain }) {
 **Unsubscribe from Events:**
 
 ```typescript
-const handler = (data) => console.log(data)
+const handler = data => console.log(data)
 
 vault.on('balanceUpdated', handler)
 
@@ -2549,13 +2566,13 @@ vault.off('balanceUpdated', handler)
 class Vultisig {
   // Constructor - storage uses platform default if not provided
   constructor(config?: {
-    storage?: Storage              // Optional - uses FileStorage (Node) or BrowserStorage (browser)
+    storage?: Storage // Optional - uses FileStorage (Node) or BrowserStorage (browser)
     defaultChains?: Chain[]
     defaultCurrency?: string
     onPasswordRequired?: (vaultId: string, vaultName: string) => Promise<string>
     passwordCache?: { defaultTTL: number }
-    cacheConfig?: { balanceTTL?: number, priceTTL?: number, maxMemoryCacheSize?: number }
-    serverEndpoints?: { fastVault?: string, messageRelay?: string }
+    cacheConfig?: { balanceTTL?: number; priceTTL?: number; maxMemoryCacheSize?: number }
+    serverEndpoints?: { fastVault?: string; messageRelay?: string }
   })
 
   // Initialization
@@ -2576,14 +2593,14 @@ class Vultisig {
   // Create multi-device secure vault with N-of-M threshold
   createSecureVault(options: {
     name: string
-    password?: string              // Optional encryption
-    devices: number                // Number of participating devices
-    threshold?: number             // Signing threshold (defaults to ceil(devices*2/3))
+    password?: string // Optional encryption
+    devices: number // Number of participating devices
+    threshold?: number // Signing threshold (defaults to ceil(devices*2/3))
     signal?: AbortSignal
     onProgress?: (step: VaultCreationStep) => void
     onQRCodeReady?: (qrPayload: string) => void
     onDeviceJoined?: (deviceId: string, total: number, required: number) => void
-  }): Promise<{ vault: SecureVault, vaultId: string, sessionId: string }>
+  }): Promise<{ vault: SecureVault; vaultId: string; sessionId: string }>
 
   // Vault management
   importVault(vultContent: string, password?: string): Promise<VaultBase>
@@ -2613,7 +2630,7 @@ class Vultisig {
   static getBanxaSupportedChains(): Chain[]
 
   // Price feeds (static)
-  static getCoinPrices(params: { ids: string[], fiatCurrency?: string }): Promise<Record<string, number>>
+  static getCoinPrices(params: { ids: string[]; fiatCurrency?: string }): Promise<Record<string, number>>
 
   // Security (static)
   static scanSite(url: string): Promise<SiteScanResult>
@@ -2624,7 +2641,7 @@ class Vultisig {
     mnemonic: string,
     chains?: Chain[],
     onProgress?: (progress: ChainDiscoveryProgress) => void
-  ): Promise<ChainDiscoveryAggregate>  // Returns { results, usePhantomSolanaPath }
+  ): Promise<ChainDiscoveryAggregate> // Returns { results, usePhantomSolanaPath }
   createFastVaultFromSeedphrase(options: CreateFastVaultFromSeedphraseOptions): Promise<string>
   createSecureVaultFromSeedphrase(options: CreateSecureVaultFromSeedphraseOptions): Promise<{
     vault: SecureVault
@@ -2632,7 +2649,10 @@ class Vultisig {
     sessionId: string
     discoveredChains?: ChainDiscoveryResult[]
   }>
-  joinSecureVault(qrPayload: string, options: JoinSecureVaultOptions): Promise<{
+  joinSecureVault(
+    qrPayload: string,
+    options: JoinSecureVaultOptions
+  ): Promise<{
     vault: SecureVault
     vaultId: string
   }>
@@ -2640,12 +2660,12 @@ class Vultisig {
   // Address book
   getAddressBook(chain?: Chain): Promise<AddressBook>
   addAddressBookEntry(entries: AddressBookEntry[]): Promise<void>
-  removeAddressBookEntry(addresses: Array<{ chain: Chain, address: string }>): Promise<void>
+  removeAddressBookEntry(addresses: Array<{ chain: Chain; address: string }>): Promise<void>
   updateAddressBookEntry(chain: Chain, address: string, name: string): Promise<void>
 
   // Vault verification (returns the vault on success)
   verifyVault(vaultId: string, code: string): Promise<FastVault>
-  resendVaultVerification(options: { vaultId: string, email: string, password: string }): Promise<void>
+  resendVaultVerification(options: { vaultId: string; email: string; password: string }): Promise<void>
 }
 ```
 
@@ -2669,7 +2689,7 @@ class VaultBase {
   exists(): Promise<boolean>
   loadPreferences(): Promise<void>
   rename(newName: string): Promise<void>
-  export(password?: string): Promise<{ filename: string, data: string }>
+  export(password?: string): Promise<{ filename: string; data: string }>
   delete(): Promise<void>
   lock(): void
   unlock(password: string): Promise<void>
@@ -2689,19 +2709,38 @@ class VaultBase {
 
   // Compound wrappers (recommended for most use cases)
   signMessage(message: string, chain?: Chain, options?: { signal?: AbortSignal }): Promise<MessageSignature>
-  send(params: { chain: Chain, to: string, amount: string, symbol?: string, memo?: string, dryRun?: boolean }): Promise<SendResult>
-  swap(params: { fromChain: Chain, fromSymbol: string, toChain: Chain, toSymbol: string, amount: string, dryRun?: boolean }): Promise<CompoundSwapResult>
+  send(params: {
+    chain: Chain
+    to: string
+    amount: string
+    symbol?: string
+    memo?: string
+    dryRun?: boolean
+  }): Promise<SendResult>
+  swap(params: {
+    fromChain: Chain
+    fromSymbol: string
+    toChain: Chain
+    toSymbol: string
+    amount: string
+    dryRun?: boolean
+  }): Promise<CompoundSwapResult>
   portfolio(fiatCurrency?: FiatCurrency): Promise<Portfolio>
 
   // Low-level transactions
   prepareSendTx(params: SendTxParams): Promise<KeysignPayload>
-  getMaxSendAmount(params: { coin: AccountCoin, receiver: string, memo?: string, feeSettings?: FeeSettings }): Promise<MaxSendAmount>
+  getMaxSendAmount(params: {
+    coin: AccountCoin
+    receiver: string
+    memo?: string
+    feeSettings?: FeeSettings
+  }): Promise<MaxSendAmount>
   extractMessageHashes(keysignPayload: KeysignPayload): Promise<string[]>
   sign(payload: SigningPayload, options?: SigningOptions): Promise<Signature>
   signBytes(options: SignBytesOptions, signingOptions?: SigningOptions): Promise<Signature>
   broadcastTx(params: BroadcastParams): Promise<string>
-  broadcastRawTx(params: { chain: Chain, rawTx: string }): Promise<string>
-  getTxStatus(params: { chain: Chain, txHash: string }): Promise<TxStatusResult>
+  broadcastRawTx(params: { chain: Chain; rawTx: string }): Promise<string>
+  getTxStatus(params: { chain: Chain; txHash: string }): Promise<TxStatusResult>
   gas<C extends Chain>(chain: C): Promise<GasInfoForChain<C>>
 
   // Cosmos Signing (SignAmino & SignDirect)
@@ -2838,7 +2877,7 @@ enum Chain {
   Ton = 'Ton',
   Ripple = 'Ripple',
   Tron = 'Tron',
-  Cardano = 'Cardano'
+  Cardano = 'Cardano',
 }
 ```
 
@@ -2880,9 +2919,9 @@ new Vultisig({
 ```typescript
 // SignAmino input for Cosmos SDK chains
 interface SignAminoInput {
-  chain: CosmosChain           // 'Cosmos', 'Osmosis', 'THORChain', etc.
+  chain: CosmosChain // 'Cosmos', 'Osmosis', 'THORChain', etc.
   coin: AccountCoin
-  msgs: CosmosMsgInput[]       // Array of messages to sign
+  msgs: CosmosMsgInput[] // Array of messages to sign
   fee: CosmosFeeInput
   memo?: string
 }
@@ -2891,17 +2930,17 @@ interface SignAminoInput {
 interface SignDirectInput {
   chain: CosmosChain
   coin: AccountCoin
-  bodyBytes: string            // Base64-encoded TxBody
-  authInfoBytes: string        // Base64-encoded AuthInfo
-  chainId: string              // e.g., 'cosmoshub-4'
+  bodyBytes: string // Base64-encoded TxBody
+  authInfoBytes: string // Base64-encoded AuthInfo
+  chainId: string // e.g., 'cosmoshub-4'
   accountNumber: string
   memo?: string
 }
 
 // Cosmos message format
 interface CosmosMsgInput {
-  type: string                 // e.g., 'cosmos-sdk/MsgSend'
-  value: string                // JSON-stringified message value
+  type: string // e.g., 'cosmos-sdk/MsgSend'
+  value: string // JSON-stringified message value
 }
 
 // Cosmos fee format
@@ -2914,13 +2953,13 @@ interface CosmosFeeInput {
 
 // Cosmos coin amount
 interface CosmosCoinAmount {
-  denom: string                // e.g., 'uatom'
-  amount: string               // e.g., '1000000'
+  denom: string // e.g., 'uatom'
+  amount: string // e.g., '1000000'
 }
 
 // Options for Cosmos signing
 interface CosmosSigningOptions {
-  skipChainSpecificFetch?: boolean  // Skip account/sequence fetch
+  skipChainSpecificFetch?: boolean // Skip account/sequence fetch
 }
 ```
 
@@ -2957,7 +2996,7 @@ type ChainDiscoveryResult = {
 // Aggregate result from discoverChainsFromSeedphrase()
 type ChainDiscoveryAggregate = {
   results: ChainDiscoveryResult[]
-  usePhantomSolanaPath: boolean  // True if Phantom's Solana derivation path should be used
+  usePhantomSolanaPath: boolean // True if Phantom's Solana derivation path should be used
 }
 
 type CreateFastVaultFromSeedphraseOptions = {
@@ -3014,17 +3053,7 @@ type JoinSecureVaultOptions = {
 
 ### Browser
 
-**WASM Files**: Must be served from the root path:
-
-```bash
-# Copy to public directory
-cp node_modules/@vultisig/sdk/dist/*.wasm public/
-
-# Ensure your dev server serves these files from /
-# Vite: automatically serves from public/
-# Create React App: automatically serves from public/
-# Next.js: place in public/ directory
-```
+**Vite + WASM:** use `plugins: [react(), vultisig()]` from `@vultisig/sdk/vite` so 7z wasm and `optimizeDeps` are configured without writing into your source `public/` directory (see _Browser setup: Vite and WASM_ above). **Next / Webpack:** there is no official plugin; avoid breaking wasm path resolution, serve `7zz.wasm` from your built/static output, and add the usual browser polyfills. Do **not** use `cp node_modules/@vultisig/sdk/dist/*.wasm public/`; current releases load MPC wasm from the `@vultisig/lib-*` packages instead.
 
 **IndexedDB Storage**: For persistent storage, use IndexedDB (see [examples/browser](../examples/browser) for implementation).
 
@@ -3033,11 +3062,12 @@ cp node_modules/@vultisig/sdk/dist/*.wasm public/
 ```typescript
 import { Vultisig, Chain } from '@vultisig/sdk'
 
-const sdk = new Vultisig()  // Uses BrowserStorage (IndexedDB) by default
+const sdk = new Vultisig() // Uses BrowserStorage (IndexedDB) by default
 await sdk.initialize()
 ```
 
 **Security Considerations**:
+
 - Use `type="password"` for password inputs
 - Consider using Web Crypto API for sensitive data
 - Implement Content Security Policy (CSP)
@@ -3049,7 +3079,7 @@ await sdk.initialize()
 ```typescript
 import { Vultisig, Chain } from '@vultisig/sdk'
 
-const sdk = new Vultisig()  // Uses FileStorage (~/.vultisig) by default
+const sdk = new Vultisig() // Uses FileStorage (~/.vultisig) by default
 await sdk.initialize()
 // ... use the SDK ...
 sdk.dispose()
@@ -3095,7 +3125,7 @@ let sdk: Vultisig
 
 app.whenReady().then(async () => {
   // Initialize SDK in main process
-  sdk = new Vultisig()  // Uses FileStorage (~/.vultisig)
+  sdk = new Vultisig() // Uses FileStorage (~/.vultisig)
   await sdk.initialize()
 
   // Expose SDK operations via IPC
@@ -3148,21 +3178,10 @@ vsig vault create --name "My Wallet"
 # Open Electron app → same vault is available!
 ```
 
-**WASM Files**:
-
-Include WASM files in your Electron build:
-
-```json
-// electron-builder.json
-{
-  "files": [
-    "dist/**/*",
-    "node_modules/@vultisig/sdk/dist/**/*.wasm"
-  ]
-}
-```
+**WASM files in packaged Electron apps:** include the SDK’s node_modules tree (or the wasm you rely on) so packaged builds still resolve the same files as in development, for example the `@vultisig/lib-*` and `@trustwallet/wallet-core` contents your version depends on, plus `7z-wasm` if you use the browser-style path in a renderer. Adjust paths to match your `electron-builder` (or other packager) layout; there is no single `sdk/dist/**/*.wasm` glob for this anymore.
 
 **Security Best Practices**:
+
 - Always use `contextIsolation: true` (Electron default)
 - Never use `nodeIntegration: true` in renderer
 - Keep all vault operations in main process

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "@vultisig/examples-shared": "workspace:*",
     "@vultisig/sdk": "workspace:*",
-    "isomorphic-fetch": "^3.0.0",
     "process": "^0.11.10",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.4",
@@ -30,10 +29,8 @@
     "path-browserify": "^1.0.1",
     "postcss": "^8.5.8",
     "stream-browserify": "^3.0.0",
-    "tailwindcss": "^4.2.2",
+    "tailwindcss": "^3.4.17",
     "typescript": "^5.9.3",
-    "vite": "^8.0.0",
-    "vite-plugin-node-polyfills": "^0.25.0",
-    "vite-plugin-wasm": "^3.6.0"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/browser/vite.config.ts
+++ b/examples/browser/vite.config.ts
@@ -16,7 +16,10 @@ export default defineConfig({
           if (id.includes('node_modules/react') || id.includes('node_modules/react-dom')) {
             return 'vendor'
           }
-          if (id.includes('@vultisig/sdk') || id.includes('node_modules/@vultisig')) {
+          if (
+            id.includes('@vultisig/sdk') ||
+            (id.includes('node_modules/@vultisig') && !id.includes('node_modules/@vultisig/lib-'))
+          ) {
             return 'sdk'
           }
         },

--- a/examples/browser/vite.config.ts
+++ b/examples/browser/vite.config.ts
@@ -1,146 +1,27 @@
 import react from '@vitejs/plugin-react'
-import { copyFileSync, mkdirSync } from 'fs'
+import vultisig from '@vultisig/sdk/vite'
 import path from 'path'
-import type { Plugin } from 'vite'
 import { defineConfig } from 'vite'
-import { nodePolyfills } from 'vite-plugin-node-polyfills'
-import wasm from 'vite-plugin-wasm'
-
-// Plugin to resolve vite-plugin-node-polyfills shim imports from the SDK
-function resolvePolyfillShims(): Plugin {
-  return {
-    name: 'resolve-polyfill-shims',
-    resolveId(id) {
-      if (id === 'vite-plugin-node-polyfills/shims/buffer') {
-        return { id: '\0polyfill-buffer', external: false }
-      }
-      if (id === 'vite-plugin-node-polyfills/shims/process') {
-        return { id: '\0polyfill-process', external: false }
-      }
-      if (id === 'vite-plugin-node-polyfills/shims/global') {
-        return { id: '\0polyfill-global', external: false }
-      }
-      return null
-    },
-    load(id) {
-      if (id === '\0polyfill-buffer') {
-        return 'import { Buffer } from "buffer"; export { Buffer }; export default Buffer;'
-      }
-      if (id === '\0polyfill-process') {
-        return 'import process from "process/browser"; export { process }; export default process;'
-      }
-      if (id === '\0polyfill-global') {
-        return 'export default globalThis;'
-      }
-      return null
-    },
-  }
-}
 
 export default defineConfig({
-  plugins: [
-    react(),
-    wasm(), // Required for WASM loading
-    resolvePolyfillShims(), // Handle SDK's polyfill shim imports
-    nodePolyfills({
-      exclude: ['fs'], // fs not available in browser
-      globals: {
-        Buffer: true,
-        global: true,
-        process: true,
-      },
-      protocolImports: true,
-    }),
-    // Copy WASM files from SDK to public directory
-    {
-      name: 'copy-wasm-files',
-      buildStart() {
-        const sdkLibPath = path.resolve(__dirname, '../../packages/sdk/dist/lib')
-        const publicLibPath = path.resolve(__dirname, 'public/lib')
-
-        try {
-          // Create lib directories
-          mkdirSync(path.join(publicLibPath, 'dkls'), { recursive: true })
-          mkdirSync(path.join(publicLibPath, 'mldsa'), { recursive: true })
-          mkdirSync(path.join(publicLibPath, 'schnorr'), { recursive: true })
-
-          // Copy DKLS WASM files
-          copyFileSync(path.join(sdkLibPath, 'dkls/vs_wasm_bg.wasm'), path.join(publicLibPath, 'dkls/vs_wasm_bg.wasm'))
-          copyFileSync(path.join(sdkLibPath, 'dkls/vs_wasm.js'), path.join(publicLibPath, 'dkls/vs_wasm.js'))
-
-          // Copy ML-DSA WASM files
-          copyFileSync(
-            path.join(sdkLibPath, 'mldsa/vs_wasm_bg.wasm'),
-            path.join(publicLibPath, 'mldsa/vs_wasm_bg.wasm')
-          )
-          copyFileSync(path.join(sdkLibPath, 'mldsa/vs_wasm.js'), path.join(publicLibPath, 'mldsa/vs_wasm.js'))
-
-          // Copy Schnorr WASM files
-          copyFileSync(
-            path.join(sdkLibPath, 'schnorr/vs_schnorr_wasm_bg.wasm'),
-            path.join(publicLibPath, 'schnorr/vs_schnorr_wasm_bg.wasm')
-          )
-          copyFileSync(
-            path.join(sdkLibPath, 'schnorr/vs_schnorr_wasm.js'),
-            path.join(publicLibPath, 'schnorr/vs_schnorr_wasm.js')
-          )
-
-          // Copy WalletCore WASM files (from @trustwallet/wallet-core package)
-          // Note: @trustwallet/wallet-core is hoisted to root node_modules by Yarn workspaces
-          const walletCoreLibPath = path.resolve(__dirname, '../../node_modules/@trustwallet/wallet-core/dist/lib')
-          copyFileSync(
-            path.join(walletCoreLibPath, 'wallet-core.wasm'),
-            path.join(__dirname, 'public/wallet-core.wasm')
-          )
-          copyFileSync(path.join(walletCoreLibPath, 'wallet-core.js'), path.join(__dirname, 'public/wallet-core.js'))
-
-          // Copy 7z-wasm files (used for compression during signing)
-          // Note: 7z-wasm is hoisted to root node_modules by Yarn workspaces
-          const sevenZipPath = path.resolve(__dirname, '../../node_modules/7z-wasm')
-          mkdirSync(path.join(__dirname, 'public/7z-wasm'), { recursive: true })
-          copyFileSync(path.join(sevenZipPath, '7zz.wasm'), path.join(__dirname, 'public/7z-wasm/7zz.wasm'))
-
-          console.log('✅ Copied WASM files to public/lib/, public/, and public/7z-wasm/')
-        } catch (error) {
-          console.error('Failed to copy WASM files:', error)
-        }
-      },
-    },
-  ],
+  plugins: [react(), vultisig()],
   resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-      // Polyfills for Node.js modules
-      crypto: 'crypto-browserify',
-      stream: 'stream-browserify',
-      buffer: 'buffer',
-      util: 'util',
-      path: 'path-browserify',
-      events: 'events',
-      'node-fetch': 'isomorphic-fetch',
-    },
-  },
-  optimizeDeps: {
-    include: ['buffer', 'process', 'crypto-browserify', 'stream-browserify', 'events'],
-    esbuildOptions: {
-      define: {
-        global: 'globalThis',
-      },
-    },
+    alias: { '@': path.resolve(__dirname, './src') },
   },
   build: {
     target: 'esnext',
     rollupOptions: {
       output: {
-        manualChunks: {
-          vendor: ['react', 'react-dom'],
-          sdk: ['@vultisig/sdk'],
+        manualChunks(id) {
+          if (id.includes('node_modules/react') || id.includes('node_modules/react-dom')) {
+            return 'vendor'
+          }
+          if (id.includes('@vultisig/sdk') || id.includes('node_modules/@vultisig')) {
+            return 'sdk'
+          }
         },
       },
     },
   },
-  server: {
-    port: 3000,
-    open: true,
-  },
+  server: { port: 3000, open: true },
 })

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -626,21 +626,51 @@ const sdk = new Vultisig({
 })
 ```
 
-### WASM Files
+### Web apps: Vite
 
-The SDK requires three WASM files to be available in your application's public directory:
+Install the peer dependency `vite` and add the SDK preset. It excludes wasm glue packages from the dev pre-bundler, wires wasm + node polyfills, serves `7zz.wasm` in dev, and emits `7zz.wasm` into the build output (so QR/keygen decompression can load `/7zz.wasm`). It does not write SDK artifacts into your source `public/` directory.
 
-- `wallet-core.wasm` - Trust Wallet Core for address derivation
-- `dkls.wasm` - ECDSA threshold signatures (DKLS protocol)
-- `schnorr.wasm` - EdDSA threshold signatures (Schnorr protocol)
+With `@vitejs/plugin-react` (or your UI plugin), a minimal `vite.config` looks like this:
 
-These files are included in the npm package. Copy them to your public directory:
+```ts
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import vultisig from '@vultisig/sdk/vite'
 
-```bash
-cp node_modules/@vultisig/sdk/dist/*.wasm public/
+export default defineConfig({
+  plugins: [react(), vultisig()],
+})
 ```
 
-For Node.js and Electron, WASM files are loaded automatically from the package.
+MPC WebAssembly (DKLS, Schnorr, ML-DSA) is loaded from the `@vultisig/lib-*` packages that ship with `@vultisig/sdk` — keep those packages in `node_modules` and do **not** pre-bundle them; the plugin sets `optimizeDeps.exclude` for you. You do not need to copy those `.wasm` files into `public/`.
+
+`7z-wasm` is also excluded from pre-bundling so fetches line up with the package layout. `@trustwallet/wallet-core` is intentionally left available for Vite to pre-bundle because the package is CommonJS and browser dev servers need Vite's CJS interop for exports such as `initWasm`. Install the usual browser shims the preset pre-bundles (for example `buffer`, `process`, `crypto-browserify`, `stream-browserify`, `events`, `util`, `path-browserify`); the [browser example](../../examples/browser) shows a full dependency set.
+
+`import vultisig from '@vultisig/sdk/vite'` returns a [Vite `PluginOption`](https://vite.dev/config/shared-options.html#plugins) (a small preset of plugins that Vite flattens in place). Use `plugins: [react(), vultisig()]` or `plugins: [vultisig()]` without spreading. Options: `sevenZipWasm`, `nodePolyfills`, `shimResolver`, `aliases`, `optimizeDeps`, `debug`.
+
+`nodePolyfills` defaults to **false** so Vite 8 (Rolldown) works out of the box. On **Vite 5/6/7**, you can set `nodePolyfills: true` to enable the full `vite-plugin-node-polyfills` / `node-stdlib-browser` layer if you need it.
+
+### Web apps: Next.js, Webpack, and other bundlers
+
+There is no first-party Next or Webpack plugin. You need the same **ideas** as the Vite preset:
+
+1. **Do not** pre-bundle (or mangle) `@vultisig/lib-dkls`, `@vultisig/lib-schnorr`, `@vultisig/lib-mldsa`, `@trustwallet/wallet-core`, or `7z-wasm` in a way that moves their `.wasm` or glue JS away from each other, or `import.meta.url` to the wasm will break.
+2. **Serve** the 7z payload at `/7zz.wasm` from your built/static output, or change your code path to match how you host static assets.
+3. Provide **Node polyfills** (Buffer, `process`, `crypto`/`stream` shims) in the same spirit as the Vite `vite-plugin-node-polyfills` block.
+
+`next.config` usually uses `transpilePackages: ['@vultisig/sdk', ...]`, `webpack.config.externals` or `serverExternalPackages` for server builds, and a build-time static asset emission/copy step for `7zz.wasm`. Exact values depend on your Next major version and app router; treat this as a checklist, not a drop-in.
+
+### WASM files (all platforms)
+
+| What                                 | Where it comes from in the browser                                                                                                                                          |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| DKLS / Schnorr / ML-DSA              | Installed packages `@vultisig/lib-dkls`, `@vultisig/lib-schnorr`, `@vultisig/lib-mldsa` (transitive dependencies of `@vultisig/sdk`), loaded next to the wasm-bindgen glue. |
+| Trust Wallet Core                    | Package `@trustwallet/wallet-core` (SDK dependency), wasm next to the loader.                                                                                               |
+| 7z (compressed QR / keygen payloads) | `7z-wasm` on npm; the file must be fetchable as `/7zz.wasm` unless you change `getSevenZip` in a fork. The Vite plugin serves it in dev and emits it into the build output. |
+
+**Do not** use `cp node_modules/@vultisig/sdk/dist/*.wasm public/` for modern releases — those binaries are not shipped that way. Use the Vite plugin (above) or host the `7z-wasm` asset from your built/static output.
+
+For Node.js and Electron, WASM and native libs are loaded from the package tree automatically.
 
 ## API Reference
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -178,15 +178,25 @@
     "bip32": "^5.0.0",
     "bitcoinjs-lib": "^7.0.0",
     "bs58": "^6.0.0",
+    "buffer": "^6.0.3",
     "cbor-x": "^1.6.0",
+    "crypto-browserify": "^3.12.1",
     "date-fns": "^4.1.0",
     "ethers": "^6.15.0",
+    "events": "^3.3.0",
     "i18next": "^25.8.4",
     "i18next-http-backend": "^3.0.2",
+    "isomorphic-fetch": "^3.0.0",
     "node-fetch": "^3.3.2",
+    "path-browserify": "^1.0.1",
+    "process": "^0.11.10",
+    "stream-browserify": "^3.0.0",
     "tiny-secp256k1": "^2.2.4",
+    "util": "^0.12.5",
     "uuid": "^13.0.0",
     "viem": "^2.45.1",
+    "vite-plugin-node-polyfills": "^0.26.0",
+    "vite-plugin-wasm": "^3.6.0",
     "ws": "^8.18.0",
     "xrpl": "^4.4.1",
     "zod": "^4.1.5"
@@ -201,7 +211,9 @@
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.1.1",
     "@types/chrome": "^0.1.27",
+    "@types/events": "^3",
     "@types/node": "^22.13.10",
+    "@types/path-browserify": "^1",
     "@vitest/coverage-v8": "3.2.4",
     "concurrently": "^9.2.1",
     "dotenv": "^17.2.3",
@@ -218,7 +230,7 @@
   },
   "peerDependencies": {
     "@vultisig/mpc-native": "workspace:*",
-    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
+    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "peerDependenciesMeta": {
     "@vultisig/mpc-native": {

--- a/packages/sdk/rollup.platforms.config.js
+++ b/packages/sdk/rollup.platforms.config.js
@@ -387,11 +387,9 @@ const configs = {
     }),
     onwarn,
   },
-  // The `@vultisig/sdk/vite` subpath export is a consumer-facing Vite plugin
-  // that configures `optimizeDeps.exclude` so the wasm-bindgen glue packages
-  // stay adjacent to their `.wasm` payloads at runtime. It runs in the
-  // consumer's build (Node), not in the SDK runtime, so it has no runtime
-  // deps and ships in both ESM and CJS for maximum tooling compatibility.
+  // The `@vultisig/sdk/vite` subpath export is a consumer-facing preset (wasm,
+  // optional node polyfills, shim resolution, 7z copy, optimizeDeps). It runs in
+  // the consumer's build (Node). ESM and CJS emit for `default` and `require` consumers.
   vite: [
     {
       input: './src/vite/index.ts',

--- a/packages/sdk/src/vite/index.ts
+++ b/packages/sdk/src/vite/index.ts
@@ -1,60 +1,225 @@
-import type { Plugin } from 'vite'
+import { existsSync, readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import type { Plugin, PluginOption, ResolvedConfig, UserConfig } from 'vite'
+import wasm from 'vite-plugin-wasm'
+
+const WASM_GLUE = ['@vultisig/lib-dkls', '@vultisig/lib-schnorr', '@vultisig/lib-mldsa'] as const
+const ADDITIONAL_WASM_EXCLUDES = ['7z-wasm'] as const
+
+const DEFAULT_ALIASES: Readonly<Record<string, string>> = {
+  crypto: 'crypto-browserify',
+  stream: 'stream-browserify',
+  buffer: 'buffer',
+  util: 'util',
+  path: 'path-browserify',
+  events: 'events',
+  'node-fetch': 'isomorphic-fetch',
+}
+
+const DEFAULT_OPT_INCLUDE = ['buffer', 'process', 'crypto-browserify', 'stream-browserify', 'events'] as const
+
+const sdkPackageJson = fileURLToPath(new URL('../../package.json', import.meta.url))
+const requireFromSdk = createRequire(sdkPackageJson)
+
+const nodePolyfillsPackageDir = path.dirname(path.dirname(requireFromSdk.resolve('vite-plugin-node-polyfills')))
+
+/** Absolute paths to ESM shim files (avoids package export edge cases without importing raw CJS files). */
+const BUFFER_SHIM_FILE = path.join(nodePolyfillsPackageDir, 'shims/buffer/dist/index.js')
+const PROCESS_SHIM_FILE = path.join(nodePolyfillsPackageDir, 'shims/process/dist/index.js')
+const GLOBAL_SHIM_FILE = path.join(nodePolyfillsPackageDir, 'shims/global/dist/index.js')
+
+export type VultisigViteOptions = {
+  /**
+   * Serve `7zz.wasm` from the installed `7z-wasm` package in dev and emit it
+   * as a build asset so the SDK's `getSevenZip` helper can load `/7zz.wasm`.
+   * @default true
+   */
+  sevenZipWasm?: boolean
+  /**
+   * Apply `vite-plugin-node-polyfills` with the settings the SDK browser build expects.
+   *
+   * **Vite 8 (Rolldown):** keep `false` (default) — the polyfill package’s Rolldown/alias
+   * integration is currently incompatible (alias resolution errors in some setups).
+   * The preset still adds resolve aliases, shim resolution, and `optimizeDeps` tuning.
+   *
+   * **Vite 5/6/7:** set to `true` if you need the full `node-stdlib-browser` map from
+   * that plugin.
+   *
+   * @default false
+   */
+  nodePolyfills?: boolean
+  /**
+   * Resolve `vite-plugin-node-polyfills/shims/*` the same way the hand-written example did
+   * (avoids package export edge cases in some toolchains).
+   * @default true
+   */
+  shimResolver?: boolean
+  /** Merged on top of the default browser aliases (SDK Node-ish imports). */
+  aliases?: Record<string, string>
+  /** Shallow-merged with plugin defaults; use to extend `include` / `exclude` / `rolldownOptions` (Vite 8+). */
+  optimizeDeps?: UserConfig['optimizeDeps']
+  /** Log one line when 7z wasm is served/emitted; resolution failures are always printed. @default false */
+  debug?: boolean
+}
 
 /**
- * Vite plugin for consumers of `@vultisig/sdk`.
+ * Vite plugin preset for consumers of `@vultisig/sdk` in the browser.
  *
- * Why consumers need this
- * -----------------------
- * The SDK depends on wasm-bindgen glue packages (`@vultisig/lib-dkls`,
- * `@vultisig/lib-schnorr`, `@vultisig/lib-mldsa`) that load their WebAssembly
- * binaries via `new URL('*.wasm', import.meta.url)`. The URL is evaluated
- * relative to wherever the glue module happens to live at runtime.
+ * Composes: wasm plugin, optional `vite-plugin-node-polyfills`, shim resolution, `optimizeDeps` tuning,
+ * and (by default) serving/emitting `7zz.wasm` so `@vultisig/core-mpc`'s 7z loader
+ * can fetch `/7zz.wasm` without writing into the consumer's `public` folder.
  *
- * If Vite `optimizeDeps` pre-bundles these packages, the glue ends up in
- * `node_modules/.vite/deps/`, far away from the `.wasm` payloads, and the
- * fetch returns HTML (or 404s). Excluding them from pre-bundling keeps the
- * glue adjacent to its payload inside `node_modules/@vultisig/lib-*`, so
- * the URL resolves correctly in dev, prod builds, and on CI.
+ * WASM bindgen packages (`@vultisig/lib-dkls`, `lib-schnorr`, `lib-mldsa`) are excluded
+ * from pre-bundling so glue and `.wasm` files stay in `node_modules` (see `README`).
  *
- * The plugin returns a partial Vite config from the `config()` hook; Vite
- * concatenates `optimizeDeps.exclude` with the consumer's existing array
- * (documented merge semantics), so this is additive — consumers can keep
- * their own excludes.
- *
- * Usage
- * -----
+ * **Usage:** add one entry; Vite flattens the nested plugin list.
  * ```ts
+ * import { defineConfig } from 'vite'
+ * import react from '@vitejs/plugin-react'
  * import vultisig from '@vultisig/sdk/vite'
+ *
  * export default defineConfig({
- *   plugins: [vultisig()],
+ *   plugins: [react(), vultisig()],
  * })
  * ```
- *
- * SSR
- * ---
- * `optimizeDeps` only applies to the dev pre-bundler. Consumers doing SSR
- * with `ssr.noExternal` that transitively pulls in `@vultisig/lib-*` will
- * need to add those packages to `ssr.external` themselves — it is not set
- * here to avoid clobbering consumer-side SSR config.
- *
- * Options
- * -------
- * None today. Returned as a factory so we can add options without breaking
- * existing imports.
  */
+export default function vultisig(userOptions: VultisigViteOptions = {}): PluginOption {
+  const {
+    sevenZipWasm = true,
+    nodePolyfills: useNodePolyfills = false,
+    shimResolver: useShimResolver = true,
+    aliases: userAliases = {},
+    optimizeDeps: userOptimize = {},
+    debug = false,
+  } = userOptions
 
-const WASM_GLUE_PACKAGES = ['@vultisig/lib-dkls', '@vultisig/lib-schnorr', '@vultisig/lib-mldsa'] as const
+  let configRoot = process.cwd()
+  let sevenZipWasmFile: string | undefined
+  const mergedAliases: Record<string, string> = { ...DEFAULT_ALIASES, ...userAliases }
+  const excludeList = [...WASM_GLUE, ...ADDITIONAL_WASM_EXCLUDES, ...(userOptimize.exclude ?? [])]
+  const includeList = [...DEFAULT_OPT_INCLUDE, ...(userOptimize.include ?? [])]
 
-export default function vultisigSdk(): Plugin {
-  return {
-    name: 'vultisig-sdk',
+  const resolveSevenZipWasmFile = () => {
+    if (sevenZipWasmFile) return sevenZipWasmFile
+    const requireFromRoot = createRequire(path.join(configRoot, 'package.json'))
+    const resolvers = [requireFromRoot, requireFromSdk]
+    for (const resolver of resolvers) {
+      try {
+        const pkgDir = path.dirname(resolver.resolve('7z-wasm/package.json'))
+        const file = path.join(pkgDir, '7zz.wasm')
+        if (existsSync(file)) {
+          sevenZipWasmFile = file
+          return file
+        }
+      } catch {
+        // Try the next resolver; consumers may rely on the SDK's transitive dependency.
+      }
+    }
+    return undefined
+  }
+
+  const configPlugin: Plugin = {
+    name: 'vultisig-sdk:config',
     enforce: 'pre',
     config() {
       return {
+        resolve: {
+          alias: { ...mergedAliases },
+        },
         optimizeDeps: {
-          exclude: [...WASM_GLUE_PACKAGES],
+          ...userOptimize,
+          include: includeList,
+          exclude: excludeList,
         },
       }
     },
   }
+
+  const shimPlugin: Plugin = {
+    name: 'vultisig-sdk:polyfill-shim-resolver',
+    enforce: 'pre',
+    resolveId(id) {
+      if (!useShimResolver) return null
+      if (id === 'vite-plugin-node-polyfills/shims/buffer') {
+        return BUFFER_SHIM_FILE
+      }
+      if (id === 'vite-plugin-node-polyfills/shims/process') {
+        return PROCESS_SHIM_FILE
+      }
+      if (id === 'vite-plugin-node-polyfills/shims/global') {
+        return GLOBAL_SHIM_FILE
+      }
+      return null
+    },
+  }
+
+  const sevenZipPlugin: Plugin = {
+    name: 'vultisig-sdk:7z-wasm',
+    enforce: 'pre',
+    configResolved(c: ResolvedConfig) {
+      configRoot = c.root
+    },
+    configureServer(server) {
+      if (!sevenZipWasm) return
+      server.middlewares.use((req, res, next) => {
+        if (req.url?.split('?')[0] !== '/7zz.wasm') {
+          next()
+          return
+        }
+
+        const file = resolveSevenZipWasmFile()
+        if (!file) {
+          process.stderr.write('[vultisig-sdk] Failed to resolve 7z-wasm/7zz.wasm for dev server\n')
+          res.statusCode = 404
+          res.end('7zz.wasm not found')
+          return
+        }
+
+        if (debug) {
+          process.stderr.write(`[vultisig-sdk] Serving 7zz.wasm from ${file}\n`)
+        }
+        res.statusCode = 200
+        res.setHeader('Content-Type', 'application/wasm')
+        res.setHeader('Cache-Control', 'no-cache')
+        res.end(readFileSync(file))
+      })
+    },
+    buildStart() {
+      if (!sevenZipWasm) return
+      const file = resolveSevenZipWasmFile()
+      if (!file) {
+        process.stderr.write('[vultisig-sdk] Failed to resolve 7z-wasm/7zz.wasm (7z decompression may break)\n')
+        return
+      }
+
+      this.emitFile({
+        type: 'asset',
+        fileName: '7zz.wasm',
+        source: readFileSync(file),
+      })
+      if (debug) {
+        process.stderr.write(`[vultisig-sdk] Emitted 7zz.wasm from ${file}\n`)
+      }
+    },
+  }
+
+  const out: Plugin[] = [configPlugin, wasm() as unknown as Plugin]
+  if (useShimResolver) out.push(shimPlugin)
+  if (useNodePolyfills) {
+    const { nodePolyfills: nodePolyfillsFactory } = requireFromSdk('vite-plugin-node-polyfills') as {
+      nodePolyfills: (opts: Record<string, unknown>) => Plugin
+    }
+    out.push(
+      nodePolyfillsFactory({
+        exclude: ['fs'],
+        globals: { Buffer: true, global: true, process: true },
+        protocolImports: true,
+      }) as Plugin
+    )
+  }
+  out.push(sevenZipPlugin)
+  return out
 }

--- a/packages/sdk/src/vite/index.ts
+++ b/packages/sdk/src/vite/index.ts
@@ -191,8 +191,9 @@ export default function vultisig(userOptions: VultisigViteOptions = {}): PluginO
       if (!sevenZipWasm) return
       const file = resolveSevenZipWasmFile()
       if (!file) {
-        process.stderr.write('[vultisig-sdk] Failed to resolve 7z-wasm/7zz.wasm (7z decompression may break)\n')
-        return
+        this.error(
+          '[vultisig-sdk] Failed to resolve 7z-wasm/7zz.wasm. Set `sevenZipWasm: false` only if you host `/7zz.wasm` yourself.'
+        )
       }
 
       this.emitFile({

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,6 +62,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@alloc/quick-lru@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@alloc/quick-lru@npm:5.2.0"
+  checksum: 10c0/7b878c48b9d25277d0e1a9b8b2f2312a314af806b4129dc902f2bc29ab09b58236e53964689feec187b28c80d2203aff03829754773a707a8a5987f1b7682d92
+  languageName: node
+  linkType: hard
+
 "@ampproject/remapping@npm:^2.3.0":
   version: 2.3.0
   resolution: "@ampproject/remapping@npm:2.3.0"
@@ -3379,7 +3386,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/gen-mapping@npm:^0.3.12, @jridgewell/gen-mapping@npm:^0.3.5":
+"@jridgewell/gen-mapping@npm:^0.3.12, @jridgewell/gen-mapping@npm:^0.3.2, @jridgewell/gen-mapping@npm:^0.3.5":
   version: 0.3.13
   resolution: "@jridgewell/gen-mapping@npm:0.3.13"
   dependencies:
@@ -5826,6 +5833,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/events@npm:^3":
+  version: 3.0.3
+  resolution: "@types/events@npm:3.0.3"
+  checksum: 10c0/3a56f8c51eb4ebc0d05dcadca0c6636c816acc10216ce36c976fad11e54a01f4bb979a07211355686015884753b37f17d74bfdc7aaf4ebb027c1e8a501c7b21d
+  languageName: node
+  linkType: hard
+
 "@types/filesystem@npm:*":
   version: 0.0.36
   resolution: "@types/filesystem@npm:0.0.36"
@@ -5998,6 +6012,13 @@ __metadata:
   dependencies:
     undici-types: "npm:~7.16.0"
   checksum: 10c0/710050c42f89075c4479e4e1e4c2532486b0c41b1e2a8a13ad88641c88b88cdaea87414e19224f30028719737bd70e327edcaa184d50e86b9418941edd7eb02b
+  languageName: node
+  linkType: hard
+
+"@types/path-browserify@npm:^1":
+  version: 1.0.3
+  resolution: "@types/path-browserify@npm:1.0.3"
+  checksum: 10c0/6ed6de375c210dbc20d171ab547be6065ce9904463ca8ca63443a3b23efc7234ff5400d62be05b9be36fc2e863b77592c2e607896988ad39a45276b8a7e42d70
   languageName: node
   linkType: hard
 
@@ -6534,7 +6555,6 @@ __metadata:
     buffer: "npm:^6.0.3"
     crypto-browserify: "npm:^3.12.1"
     events: "npm:^3.3.0"
-    isomorphic-fetch: "npm:^3.0.0"
     path-browserify: "npm:^1.0.1"
     postcss: "npm:^8.5.8"
     process: "npm:^0.11.10"
@@ -6542,11 +6562,9 @@ __metadata:
     react: "npm:^19.2.4"
     react-dom: "npm:^19.2.4"
     stream-browserify: "npm:^3.0.0"
-    tailwindcss: "npm:^4.2.2"
+    tailwindcss: "npm:^3.4.17"
     typescript: "npm:^5.9.3"
     vite: "npm:^8.0.0"
-    vite-plugin-node-polyfills: "npm:^0.25.0"
-    vite-plugin-wasm: "npm:^3.6.0"
   languageName: unknown
   linkType: soft
 
@@ -6718,7 +6736,9 @@ __metadata:
     "@solana/web3.js": "npm:^1.98.4"
     "@trustwallet/wallet-core": "npm:^4.6.0"
     "@types/chrome": "npm:^0.1.27"
+    "@types/events": "npm:^3"
     "@types/node": "npm:^22.13.10"
+    "@types/path-browserify": "npm:^1"
     "@vitest/coverage-v8": "npm:3.2.4"
     "@vultisig/lib-dkls": "workspace:*"
     "@vultisig/lib-mldsa": "workspace:*"
@@ -6728,33 +6748,43 @@ __metadata:
     bip32: "npm:^5.0.0"
     bitcoinjs-lib: "npm:^7.0.0"
     bs58: "npm:^6.0.0"
+    buffer: "npm:^6.0.3"
     cbor-x: "npm:^1.6.0"
     concurrently: "npm:^9.2.1"
+    crypto-browserify: "npm:^3.12.1"
     date-fns: "npm:^4.1.0"
     dotenv: "npm:^17.2.3"
     electron: "npm:^39.2.3"
     ethers: "npm:^6.15.0"
+    events: "npm:^3.3.0"
     fake-indexeddb: "npm:^6.2.5"
     i18next: "npm:^25.8.4"
     i18next-http-backend: "npm:^3.0.2"
+    isomorphic-fetch: "npm:^3.0.0"
     node-fetch: "npm:^3.3.2"
     node-localstorage: "npm:^3.0.5"
+    path-browserify: "npm:^1.0.1"
+    process: "npm:^0.11.10"
     rollup: "npm:^4.32.1"
     rollup-plugin-copy: "npm:^3.5.0"
     rollup-plugin-dts: "npm:^6.1.1"
     rollup-plugin-esbuild: "npm:^6.2.1"
+    stream-browserify: "npm:^3.0.0"
     tiny-secp256k1: "npm:^2.2.4"
     tsx: "npm:^4.19.5"
     typescript: "npm:^5.9.2"
+    util: "npm:^0.12.5"
     uuid: "npm:^13.0.0"
     viem: "npm:^2.45.1"
+    vite-plugin-node-polyfills: "npm:^0.26.0"
+    vite-plugin-wasm: "npm:^3.6.0"
     vitest: "npm:^3.2.4"
     ws: "npm:^8.18.0"
     xrpl: "npm:^4.4.1"
     zod: "npm:^4.1.5"
   peerDependencies:
     "@vultisig/mpc-native": "workspace:*"
-    vite: ^5.0.0 || ^6.0.0 || ^7.0.0
+    vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     "@vultisig/mpc-native":
       optional: true
@@ -7109,6 +7139,23 @@ __metadata:
   version: 6.2.3
   resolution: "ansi-styles@npm:6.2.3"
   checksum: 10c0/23b8a4ce14e18fb854693b95351e286b771d23d8844057ed2e7d083cd3e708376c3323707ec6a24365f7d7eda3ca00327fe04092e29e551499ec4c8b7bfac868
+  languageName: node
+  linkType: hard
+
+"any-promise@npm:^1.0.0":
+  version: 1.3.0
+  resolution: "any-promise@npm:1.3.0"
+  checksum: 10c0/60f0298ed34c74fef50daab88e8dab786036ed5a7fad02e012ab57e376e0a0b4b29e83b95ea9b5e7d89df762f5f25119b83e00706ecaccb22cfbacee98d74889
+  languageName: node
+  linkType: hard
+
+"anymatch@npm:~3.1.2":
+  version: 3.1.3
+  resolution: "anymatch@npm:3.1.3"
+  dependencies:
+    normalize-path: "npm:^3.0.0"
+    picomatch: "npm:^2.0.4"
+  checksum: 10c0/57b06ae984bc32a0d22592c87384cd88fe4511b1dd7581497831c56d41939c8a001b28e7b853e1450f2bf61992dfcaa8ae2d0d161a0a90c4fb631ef07098fbac
   languageName: node
   linkType: hard
 
@@ -7682,6 +7729,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"binary-extensions@npm:^2.0.0":
+  version: 2.3.0
+  resolution: "binary-extensions@npm:2.3.0"
+  checksum: 10c0/75a59cafc10fb12a11d510e77110c6c7ae3f4ca22463d52487709ca7f18f69d886aa387557cc9864fbdb10153d0bdb4caacabf11541f55e89ed6e18d12ece2b5
+  languageName: node
+  linkType: hard
+
 "bindings@npm:^1.3.0":
   version: 1.5.0
   resolution: "bindings@npm:1.5.0"
@@ -7844,7 +7898,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"braces@npm:^3.0.3":
+"braces@npm:^3.0.3, braces@npm:~3.0.2":
   version: 3.0.3
   resolution: "braces@npm:3.0.3"
   dependencies:
@@ -8214,6 +8268,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"camelcase-css@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "camelcase-css@npm:2.0.1"
+  checksum: 10c0/1a1a3137e8a781e6cbeaeab75634c60ffd8e27850de410c162cce222ea331cd1ba5364e8fb21c95e5ca76f52ac34b81a090925ca00a87221355746d049c6e273
+  languageName: node
+  linkType: hard
+
 "camelcase@npm:^6.2.0, camelcase@npm:^6.3.0":
   version: 6.3.0
   resolution: "camelcase@npm:6.3.0"
@@ -8330,6 +8391,25 @@ __metadata:
   version: 2.1.3
   resolution: "check-error@npm:2.1.3"
   checksum: 10c0/878e99038fb6476316b74668cd6a498c7e66df3efe48158fa40db80a06ba4258742ac3ee2229c4a2a98c5e73f5dff84eb3e50ceb6b65bbd8f831eafc8338607d
+  languageName: node
+  linkType: hard
+
+"chokidar@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "chokidar@npm:3.6.0"
+  dependencies:
+    anymatch: "npm:~3.1.2"
+    braces: "npm:~3.0.2"
+    fsevents: "npm:~2.3.2"
+    glob-parent: "npm:~5.1.2"
+    is-binary-path: "npm:~2.1.0"
+    is-glob: "npm:~4.0.1"
+    normalize-path: "npm:~3.0.0"
+    readdirp: "npm:~3.6.0"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: 10c0/8361dcd013f2ddbe260eacb1f3cb2f2c6f2b0ad118708a343a5ed8158941a39cb8fb1d272e0f389712e74ee90ce8ba864eece9e0e62b9705cb468a2f6d917462
   languageName: node
   linkType: hard
 
@@ -8612,6 +8692,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^4.0.0":
+  version: 4.1.1
+  resolution: "commander@npm:4.1.1"
+  checksum: 10c0/84a76c08fe6cc08c9c93f62ac573d2907d8e79138999312c92d4155bc2325d487d64d13f669b2000c9f8caf70493c1be2dac74fec3c51d5a04f8bc3ae1830bab
+  languageName: node
+  linkType: hard
+
 "commander@npm:^5.0.0":
   version: 5.1.0
   resolution: "commander@npm:5.1.0"
@@ -8891,6 +8978,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cssesc@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "cssesc@npm:3.0.0"
+  bin:
+    cssesc: bin/cssesc
+  checksum: 10c0/6bcfd898662671be15ae7827120472c5667afb3d7429f1f917737f3bf84c4176003228131b643ae74543f17a394446247df090c597bb9a728cce298606ed0aa7
+  languageName: node
+  linkType: hard
+
 "csstype@npm:^3.2.2":
   version: 3.2.3
   resolution: "csstype@npm:3.2.3"
@@ -9123,6 +9219,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"didyoumean@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "didyoumean@npm:1.2.2"
+  checksum: 10c0/95d0b53d23b851aacff56dfadb7ecfedce49da4232233baecfeecb7710248c4aa03f0aa8995062f0acafaf925adf8536bd7044a2e68316fd7d411477599bc27b
+  languageName: node
+  linkType: hard
+
 "diffie-hellman@npm:^5.0.3":
   version: 5.0.3
   resolution: "diffie-hellman@npm:5.0.3"
@@ -9150,6 +9253,13 @@ __metadata:
   dependencies:
     path-type: "npm:^4.0.0"
   checksum: 10c0/dcac00920a4d503e38bb64001acb19df4efc14536ada475725e12f52c16777afdee4db827f55f13a908ee7efc0cb282e2e3dbaeeb98c0993dd93d1802d3bf00c
+  languageName: node
+  linkType: hard
+
+"dlv@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "dlv@npm:1.1.3"
+  checksum: 10c0/03eb4e769f19a027fd5b43b59e8a05e3fd2100ac239ebb0bf9a745de35d449e2f25cfaf3aa3934664551d72856f4ae8b7822016ce5c42c2d27c18ae79429ec42
   languageName: node
   linkType: hard
 
@@ -10509,7 +10619,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.0.3, fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.3":
+"fast-glob@npm:^3.0.3, fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.2, fast-glob@npm:^3.3.3":
   version: 3.3.3
   resolution: "fast-glob@npm:3.3.3"
   dependencies:
@@ -11080,7 +11190,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-parent@npm:^5.1.2":
+"glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
   dependencies:
@@ -11863,6 +11973,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-binary-path@npm:~2.1.0":
+  version: 2.1.0
+  resolution: "is-binary-path@npm:2.1.0"
+  dependencies:
+    binary-extensions: "npm:^2.0.0"
+  checksum: 10c0/a16eaee59ae2b315ba36fad5c5dcaf8e49c3e27318f8ab8fa3cdb8772bf559c8d1ba750a589c2ccb096113bb64497084361a25960899cb6172a6925ab6123d38
+  languageName: node
+  linkType: hard
+
 "is-boolean-object@npm:^1.2.1":
   version: 1.2.2
   resolution: "is-boolean-object@npm:1.2.2"
@@ -11971,7 +12090,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-glob@npm:^4.0.0, is-glob@npm:^4.0.1, is-glob@npm:^4.0.3":
+"is-glob@npm:^4.0.0, is-glob@npm:^4.0.1, is-glob@npm:^4.0.3, is-glob@npm:~4.0.1":
   version: 4.0.3
   resolution: "is-glob@npm:4.0.3"
   dependencies:
@@ -12429,6 +12548,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jiti@npm:^1.21.7":
+  version: 1.21.7
+  resolution: "jiti@npm:1.21.7"
+  bin:
+    jiti: bin/jiti.js
+  checksum: 10c0/77b61989c758ff32407cdae8ddc77f85e18e1a13fc4977110dbd2e05fc761842f5f71bce684d9a01316e1c4263971315a111385759951080bbfe17cbb5de8f7a
+  languageName: node
+  linkType: hard
+
 "jiti@npm:^2.4.2, jiti@npm:^2.6.0":
   version: 2.6.1
   resolution: "jiti@npm:2.6.1"
@@ -12857,6 +12985,20 @@ __metadata:
     lightningcss-win32-x64-msvc:
       optional: true
   checksum: 10c0/70945bd55097af46fc9fab7f5ed09cd5869d85940a2acab7ee06d0117004a1d68155708a2d462531cea2fc3c67aefc9333a7068c80b0b78dd404c16838809e03
+  languageName: node
+  linkType: hard
+
+"lilconfig@npm:^3.1.1, lilconfig@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "lilconfig@npm:3.1.3"
+  checksum: 10c0/f5604e7240c5c275743561442fbc5abf2a84ad94da0f5adc71d25e31fa8483048de3dcedcb7a44112a942fed305fd75841cdf6c9681c7f640c63f1049e9a5dcc
+  languageName: node
+  linkType: hard
+
+"lines-and-columns@npm:^1.1.6":
+  version: 1.2.4
+  resolution: "lines-and-columns@npm:1.2.4"
+  checksum: 10c0/3da6ee62d4cd9f03f5dc90b4df2540fb85b352081bee77fe4bbcd12c9000ead7f35e0a38b8d09a9bb99b13223446dd8689ff3c4959807620726d788701a83d2d
   languageName: node
   linkType: hard
 
@@ -13791,6 +13933,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mz@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "mz@npm:2.7.0"
+  dependencies:
+    any-promise: "npm:^1.0.0"
+    object-assign: "npm:^4.0.1"
+    thenify-all: "npm:^1.0.0"
+  checksum: 10c0/103114e93f87362f0b56ab5b2e7245051ad0276b646e3902c98397d18bb8f4a77f2ea4a2c9d3ad516034ea3a56553b60d3f5f78220001ca4c404bd711bd0af39
+  languageName: node
+  linkType: hard
+
 "nanoid@npm:^3.3.11, nanoid@npm:^3.3.7":
   version: 3.3.11
   resolution: "nanoid@npm:3.3.11"
@@ -14061,6 +14214,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"normalize-path@npm:^3.0.0, normalize-path@npm:~3.0.0":
+  version: 3.0.0
+  resolution: "normalize-path@npm:3.0.0"
+  checksum: 10c0/e008c8142bcc335b5e38cf0d63cfd39d6cf2d97480af9abdbe9a439221fd4d749763bab492a8ee708ce7a194bb00c9da6d0a115018672310850489137b3da046
+  languageName: node
+  linkType: hard
+
 "normalize-url@npm:^6.0.1":
   version: 6.1.0
   resolution: "normalize-url@npm:6.1.0"
@@ -14096,7 +14256,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-assign@npm:^4, object-assign@npm:^4.1.1":
+"object-assign@npm:^4, object-assign@npm:^4.0.1, object-assign@npm:^4.1.1":
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
   checksum: 10c0/1f4df9945120325d041ccf7b86f31e8bcc14e73d29171e37a7903050e96b81323784ec59f93f102ec635bcf6fa8034ba3ea0a8c7e69fa202b87ae3b6cec5a414
@@ -14708,7 +14868,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
+"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
   version: 2.3.2
   resolution: "picomatch@npm:2.3.2"
   checksum: 10c0/a554d1709e59be97d1acb9eaedbbc700a5c03dbd4579807baed95100b00420bc729335440ef15004ae2378984e2487a7c1cebd743cfdb72b6fa9ab69223c0d61
@@ -14722,10 +14882,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pify@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "pify@npm:2.3.0"
+  checksum: 10c0/551ff8ab830b1052633f59cb8adc9ae8407a436e06b4a9718bcb27dc5844b83d535c3a8512b388b6062af65a98c49bdc0dd523d8b2617b188f7c8fee457158dc
+  languageName: node
+  linkType: hard
+
 "pify@npm:^4.0.1":
   version: 4.0.1
   resolution: "pify@npm:4.0.1"
   checksum: 10c0/6f9d404b0d47a965437403c9b90eca8bb2536407f03de165940e62e72c8c8b75adda5516c6b9b23675a5877cc0bcac6bdfb0ef0e39414cd2476d5495da40e7cf
+  languageName: node
+  linkType: hard
+
+"pirates@npm:^4.0.1":
+  version: 4.0.7
+  resolution: "pirates@npm:4.0.7"
+  checksum: 10c0/a51f108dd811beb779d58a76864bbd49e239fa40c7984cd11596c75a121a8cc789f1c8971d8bb15f0dbf9d48b76c05bb62fcbce840f89b688c0fa64b37e8478a
   languageName: node
   linkType: hard
 
@@ -14777,14 +14951,82 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-value-parser@npm:^4.2.0":
+"postcss-import@npm:^15.1.0":
+  version: 15.1.0
+  resolution: "postcss-import@npm:15.1.0"
+  dependencies:
+    postcss-value-parser: "npm:^4.0.0"
+    read-cache: "npm:^1.0.0"
+    resolve: "npm:^1.1.7"
+  peerDependencies:
+    postcss: ^8.0.0
+  checksum: 10c0/518aee5c83ea6940e890b0be675a2588db68b2582319f48c3b4e06535a50ea6ee45f7e63e4309f8754473245c47a0372632378d1d73d901310f295a92f26f17b
+  languageName: node
+  linkType: hard
+
+"postcss-js@npm:^4.0.1":
+  version: 4.1.0
+  resolution: "postcss-js@npm:4.1.0"
+  dependencies:
+    camelcase-css: "npm:^2.0.1"
+  peerDependencies:
+    postcss: ^8.4.21
+  checksum: 10c0/a3cf6e725f3e9ecd7209732f8844a0063a1380b718ccbcf93832b6ec2cd7e63ff70dd2fed49eb2483c7482296860a0f7badd3115b5d0fa05ea648eb6d9dfc9c6
+  languageName: node
+  linkType: hard
+
+"postcss-load-config@npm:^4.0.2 || ^5.0 || ^6.0":
+  version: 6.0.1
+  resolution: "postcss-load-config@npm:6.0.1"
+  dependencies:
+    lilconfig: "npm:^3.1.1"
+  peerDependencies:
+    jiti: ">=1.21.0"
+    postcss: ">=8.0.9"
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  peerDependenciesMeta:
+    jiti:
+      optional: true
+    postcss:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  checksum: 10c0/74173a58816dac84e44853f7afbd283f4ef13ca0b6baeba27701214beec33f9e309b128f8102e2b173e8d45ecba45d279a9be94b46bf48d219626aa9b5730848
+  languageName: node
+  linkType: hard
+
+"postcss-nested@npm:^6.2.0":
+  version: 6.2.0
+  resolution: "postcss-nested@npm:6.2.0"
+  dependencies:
+    postcss-selector-parser: "npm:^6.1.1"
+  peerDependencies:
+    postcss: ^8.2.14
+  checksum: 10c0/7f9c3f2d764191a39364cbdcec350f26a312431a569c9ef17408021424726b0d67995ff5288405e3724bb7152a4c92f73c027e580ec91e798800ed3c52e2bc6e
+  languageName: node
+  linkType: hard
+
+"postcss-selector-parser@npm:^6.1.1, postcss-selector-parser@npm:^6.1.2":
+  version: 6.1.2
+  resolution: "postcss-selector-parser@npm:6.1.2"
+  dependencies:
+    cssesc: "npm:^3.0.0"
+    util-deprecate: "npm:^1.0.2"
+  checksum: 10c0/523196a6bd8cf660bdf537ad95abd79e546d54180f9afb165a4ab3e651ac705d0f8b8ce6b3164fb9e3279ce482c5f751a69eb2d3a1e8eb0fd5e82294fb3ef13e
+  languageName: node
+  linkType: hard
+
+"postcss-value-parser@npm:^4.0.0, postcss-value-parser@npm:^4.2.0":
   version: 4.2.0
   resolution: "postcss-value-parser@npm:4.2.0"
   checksum: 10c0/f4142a4f56565f77c1831168e04e3effd9ffcc5aebaf0f538eee4b2d465adfd4b85a44257bb48418202a63806a7da7fe9f56c330aebb3cac898e46b4cbf49161
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.10, postcss@npm:^8.5.3, postcss@npm:^8.5.6, postcss@npm:^8.5.8":
+"postcss@npm:^8.4.47, postcss@npm:^8.5.10, postcss@npm:^8.5.3, postcss@npm:^8.5.6, postcss@npm:^8.5.8":
   version: 8.5.10
   resolution: "postcss@npm:8.5.10"
   dependencies:
@@ -15198,6 +15440,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"read-cache@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "read-cache@npm:1.0.0"
+  dependencies:
+    pify: "npm:^2.3.0"
+  checksum: 10c0/90cb2750213c7dd7c80cb420654344a311fdec12944e81eb912cd82f1bc92aea21885fa6ce442e3336d9fccd663b8a7a19c46d9698e6ca55620848ab932da814
+  languageName: node
+  linkType: hard
+
 "read-yaml-file@npm:^1.1.0":
   version: 1.1.0
   resolution: "read-yaml-file@npm:1.1.0"
@@ -15218,6 +15469,15 @@ __metadata:
     string_decoder: "npm:^1.1.1"
     util-deprecate: "npm:^1.0.1"
   checksum: 10c0/e37be5c79c376fdd088a45fa31ea2e423e5d48854be7a22a58869b4e84d25047b193f6acb54f1012331e1bcd667ffb569c01b99d36b0bd59658fb33f513511b7
+  languageName: node
+  linkType: hard
+
+"readdirp@npm:~3.6.0":
+  version: 3.6.0
+  resolution: "readdirp@npm:3.6.0"
+  dependencies:
+    picomatch: "npm:^2.2.1"
+  checksum: 10c0/6fa848cf63d1b82ab4e985f4cf72bd55b7dcfd8e0a376905804e48c3634b7e749170940ba77b32804d5fe93b3cc521aa95a8d7e7d725f830da6d93f3669ce66b
   languageName: node
   linkType: hard
 
@@ -15378,7 +15638,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.17.0, resolve@npm:^1.22.1, resolve@npm:^1.22.11":
+"resolve@npm:^1.1.7, resolve@npm:^1.17.0, resolve@npm:^1.22.1, resolve@npm:^1.22.11, resolve@npm:^1.22.8":
   version: 1.22.12
   resolution: "resolve@npm:1.22.12"
   dependencies:
@@ -15408,7 +15668,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.17.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.11#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.1.7#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.17.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.11#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>":
   version: 1.22.12
   resolution: "resolve@patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=c3c19d"
   dependencies:
@@ -16775,6 +17035,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sucrase@npm:^3.35.0":
+  version: 3.35.1
+  resolution: "sucrase@npm:3.35.1"
+  dependencies:
+    "@jridgewell/gen-mapping": "npm:^0.3.2"
+    commander: "npm:^4.0.0"
+    lines-and-columns: "npm:^1.1.6"
+    mz: "npm:^2.7.0"
+    pirates: "npm:^4.0.1"
+    tinyglobby: "npm:^0.2.11"
+    ts-interface-checker: "npm:^0.1.9"
+  bin:
+    sucrase: bin/sucrase
+    sucrase-node: bin/sucrase-node
+  checksum: 10c0/6fa22329c261371feb9560630d961ad0d0b9c87dce21ea74557c5f3ffbe5c1ee970ea8bcce9962ae9c90c3c47165ffa7dd41865c7414f5d8ea7a40755d612c5c
+  languageName: node
+  linkType: hard
+
 "sumchecker@npm:^3.0.1":
   version: 3.0.1
   resolution: "sumchecker@npm:3.0.1"
@@ -16963,6 +17241,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tailwindcss@npm:^3.4.17":
+  version: 3.4.19
+  resolution: "tailwindcss@npm:3.4.19"
+  dependencies:
+    "@alloc/quick-lru": "npm:^5.2.0"
+    arg: "npm:^5.0.2"
+    chokidar: "npm:^3.6.0"
+    didyoumean: "npm:^1.2.2"
+    dlv: "npm:^1.1.3"
+    fast-glob: "npm:^3.3.2"
+    glob-parent: "npm:^6.0.2"
+    is-glob: "npm:^4.0.3"
+    jiti: "npm:^1.21.7"
+    lilconfig: "npm:^3.1.3"
+    micromatch: "npm:^4.0.8"
+    normalize-path: "npm:^3.0.0"
+    object-hash: "npm:^3.0.0"
+    picocolors: "npm:^1.1.1"
+    postcss: "npm:^8.4.47"
+    postcss-import: "npm:^15.1.0"
+    postcss-js: "npm:^4.0.1"
+    postcss-load-config: "npm:^4.0.2 || ^5.0 || ^6.0"
+    postcss-nested: "npm:^6.2.0"
+    postcss-selector-parser: "npm:^6.1.2"
+    resolve: "npm:^1.22.8"
+    sucrase: "npm:^3.35.0"
+  bin:
+    tailwind: lib/cli.js
+    tailwindcss: lib/cli.js
+  checksum: 10c0/e1063daccb9e5a508b357ec73b0011354204b2366b56496d6f0cc822733a55a0551502cb85856a2257ef9b676d0026616daaaa176d391f3216df57fbd693c581
+  languageName: node
+  linkType: hard
+
 "tailwindcss@npm:^4.2.2":
   version: 4.2.3
   resolution: "tailwindcss@npm:4.2.3"
@@ -17054,6 +17365,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"thenify-all@npm:^1.0.0":
+  version: 1.6.0
+  resolution: "thenify-all@npm:1.6.0"
+  dependencies:
+    thenify: "npm:>= 3.1.0 < 4"
+  checksum: 10c0/9b896a22735e8122754fe70f1d65f7ee691c1d70b1f116fda04fea103d0f9b356e3676cb789506e3909ae0486a79a476e4914b0f92472c2e093d206aed4b7d6b
+  languageName: node
+  linkType: hard
+
+"thenify@npm:>= 3.1.0 < 4":
+  version: 3.3.1
+  resolution: "thenify@npm:3.3.1"
+  dependencies:
+    any-promise: "npm:^1.0.0"
+  checksum: 10c0/f375aeb2b05c100a456a30bc3ed07ef03a39cbdefe02e0403fb714b8c7e57eeaad1a2f5c4ecfb9ce554ce3db9c2b024eba144843cd9e344566d9fcee73b04767
+  languageName: node
+  linkType: hard
+
 "throat@npm:^5.0.0":
   version: 5.0.0
   resolution: "throat@npm:5.0.0"
@@ -17116,7 +17445,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.13, tinyglobby@npm:^0.2.14, tinyglobby@npm:^0.2.15, tinyglobby@npm:^0.2.16":
+"tinyglobby@npm:^0.2.11, tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.13, tinyglobby@npm:^0.2.14, tinyglobby@npm:^0.2.15, tinyglobby@npm:^0.2.16":
   version: 0.2.16
   resolution: "tinyglobby@npm:0.2.16"
   dependencies:
@@ -17251,6 +17580,13 @@ __metadata:
   peerDependencies:
     typescript: ">=4.8.4"
   checksum: 10c0/767849383c114e7f1971fa976b20e73ac28fd0c70d8d65c0004790bf4d8f89888c7e4cf6d5949f9c1beae9bc3c64835bef77bbe27fddf45a3c7b60cebcf85c8c
+  languageName: node
+  linkType: hard
+
+"ts-interface-checker@npm:^0.1.9":
+  version: 0.1.13
+  resolution: "ts-interface-checker@npm:0.1.13"
+  checksum: 10c0/232509f1b84192d07b81d1e9b9677088e590ac1303436da1e92b296e9be8e31ea042e3e1fd3d29b1742ad2c959e95afe30f63117b8f1bc3a3850070a5142fea7
   languageName: node
   linkType: hard
 
@@ -17641,7 +17977,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"util-deprecate@npm:^1.0.1":
+"util-deprecate@npm:^1.0.1, util-deprecate@npm:^1.0.2":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 10c0/41a5bdd214df2f6c3ecf8622745e4a366c4adced864bc3c833739791aeeeb1838119af7daed4ba36428114b5c67dcda034a79c882e97e43c03e66a4dd7389942
@@ -17814,15 +18150,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite-plugin-node-polyfills@npm:^0.25.0":
-  version: 0.25.0
-  resolution: "vite-plugin-node-polyfills@npm:0.25.0"
+"vite-plugin-node-polyfills@npm:^0.26.0":
+  version: 0.26.0
+  resolution: "vite-plugin-node-polyfills@npm:0.26.0"
   dependencies:
     "@rollup/plugin-inject": "npm:^5.0.5"
     node-stdlib-browser: "npm:^1.3.1"
   peerDependencies:
-    vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
-  checksum: 10c0/4009951255f2545ce4ec82f48f013b1c2b4509017e42c68cac6af8cc0d3f824ef2002915917c6da317c09ff0cde32eed6e98eb5be0d935a3c5cb0b412ebc1625
+    vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+  checksum: 10c0/31ce1a878519460c318ef58d6556878ce6a8692fbd125738390be9e15825bbf41792f2f89282f9bc21b2226ddcbe2e86383ec42391091bb4bb58a07e7d92b4c9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `@vultisig/sdk/vite` browser preset that handles WASM bundling, polyfills, and serves/emits 7zz.wasm at /7zz.wasm so manual copying is no longer needed.

* **Documentation**
  * Replaced legacy “copy wasm to public” guides with Vite/Next.js/Webpack guidance, updated SDK README and examples, and corrected the signBytes example payload shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->