### PR TITLE
fix(security/blockaid): pair swap diffs across all asset diffs in EVM simulations

### DIFF
--- a/.changeset/fix-blockaid-evm-router-mediated-swap-pair.md
+++ b/.changeset/fix-blockaid-evm-router-mediated-swap-pair.md
@@ -1,0 +1,7 @@
+---
+'@vultisig/core-chain': patch
+---
+
+fix(security/blockaid): pair swap diffs across all asset diffs in EVM simulations
+
+`parseBlockaidEvmSimulation` previously destructured only `assetDiffs[0]` and `assetDiffs[1]`. For router-mediated flows like `permitAndCall`, Blockaid returns three diffs with the user's `in` side at `assetDiffs[2]` and an empty intermediate leg at `assetDiffs[1]`, causing the parser to bail and the simulation hero to render nothing. The parser now scans all diffs for the user-side `out` and `in` legs (preferring an in-asset different from the out-asset), matching the iOS `BlockaidSimulationParser` behaviour.

--- a/packages/core/chain/security/blockaid/tx/simulation/api/core.test.ts
+++ b/packages/core/chain/security/blockaid/tx/simulation/api/core.test.ts
@@ -1,0 +1,155 @@
+import { EvmChain } from '@vultisig/core-chain/Chain'
+import { describe, expect, it } from 'vitest'
+
+import { BlockaidEVMSimulation, parseBlockaidEvmSimulation } from './core'
+
+type AssetDiff = BlockaidEVMSimulation['account_summary']['assets_diffs'][number]
+type Asset = AssetDiff['asset']
+type Side = AssetDiff['in'][number]
+
+const asset = (overrides: Partial<Asset> = {}): Asset => ({
+  type: 'ERC20',
+  chain_name: 'ethereum',
+  decimals: 18,
+  chain_id: 1,
+  address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+  logo_url: 'https://logos.example/usdc.png',
+  name: 'USD Coin',
+  symbol: 'USDC',
+  ...overrides,
+})
+
+const side = (rawValue: string): Side => ({
+  usd_price: 1,
+  summary: '',
+  value: 1,
+  raw_value: rawValue,
+})
+
+const diff = (parts: Partial<AssetDiff> & Pick<AssetDiff, 'asset'>): AssetDiff => ({
+  asset_type: 'ERC20',
+  in: [],
+  out: [],
+  balance_changes: {
+    before: { usd_price: 0, value: 0, raw_value: '0' },
+    after: { usd_price: 0, value: 0, raw_value: '0' },
+  },
+  ...parts,
+})
+
+const buildSimulation = (diffs: AssetDiff[]): BlockaidEVMSimulation => ({
+  account_summary: { assets_diffs: diffs },
+})
+
+const TOKEN_A = asset({
+  address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  symbol: 'A',
+  name: 'Token A',
+  decimals: 18,
+})
+const TOKEN_B = asset({
+  address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  symbol: 'B',
+  name: 'Token B',
+  decimals: 6,
+})
+
+describe('parseBlockaidEvmSimulation', () => {
+  it('returns a transfer for a single-diff simulation', async () => {
+    const result = await parseBlockaidEvmSimulation(
+      buildSimulation([diff({ asset: TOKEN_A, out: [side('1000')] })]),
+      EvmChain.Ethereum
+    )
+
+    expect(result).toEqual({
+      transfer: {
+        fromCoin: {
+          decimals: TOKEN_A.decimals,
+          logo: TOKEN_A.logo_url,
+          ticker: TOKEN_A.symbol,
+          id: TOKEN_A.address,
+          chain: EvmChain.Ethereum,
+        },
+        fromAmount: 1000n,
+      },
+    })
+  })
+
+  it('pairs swap diffs across a router-mediated permitAndCall flow (3 diffs)', async () => {
+    // Reproduces the issue: user sends Token A, receives Token B, with an
+    // empty intermediate router/permit leg between them.
+    const result = await parseBlockaidEvmSimulation(
+      buildSimulation([
+        diff({ asset: TOKEN_A, out: [side('5000')] }),
+        diff({ asset: asset({ address: '0xcccc' }) }),
+        diff({ asset: TOKEN_B, in: [side('42')] }),
+      ]),
+      EvmChain.Ethereum
+    )
+
+    expect(result).toMatchObject({
+      swap: {
+        fromCoin: { id: TOKEN_A.address, ticker: 'A' },
+        toCoin: { id: TOKEN_B.address, ticker: 'B' },
+        fromAmount: 5000n,
+        toAmount: 42n,
+      },
+    })
+  })
+
+  it('preserves the standard 2-diff swap shape', async () => {
+    const result = await parseBlockaidEvmSimulation(
+      buildSimulation([diff({ asset: TOKEN_A, out: [side('100')] }), diff({ asset: TOKEN_B, in: [side('200')] })]),
+      EvmChain.Ethereum
+    )
+
+    expect(result).toMatchObject({
+      swap: {
+        fromCoin: { id: TOKEN_A.address },
+        toCoin: { id: TOKEN_B.address },
+        fromAmount: 100n,
+        toAmount: 200n,
+      },
+    })
+  })
+
+  it('treats EIP-55 checksum casing as the same asset when picking the in-side', async () => {
+    const tokenAChecksum = asset({
+      address: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      symbol: 'A',
+    })
+    const result = await parseBlockaidEvmSimulation(
+      buildSimulation([
+        diff({ asset: TOKEN_A, out: [side('1')] }),
+        diff({ asset: tokenAChecksum, in: [side('1')] }),
+        diff({ asset: TOKEN_B, in: [side('2')] }),
+      ]),
+      EvmChain.Ethereum
+    )
+
+    expect(result).toMatchObject({
+      swap: {
+        fromCoin: { id: TOKEN_A.address },
+        toCoin: { id: TOKEN_B.address },
+      },
+    })
+  })
+
+  it('returns null when there is no out-side diff', async () => {
+    const result = await parseBlockaidEvmSimulation(
+      buildSimulation([diff({ asset: TOKEN_A, in: [side('1')] }), diff({ asset: TOKEN_B, in: [side('2')] })]),
+      EvmChain.Ethereum
+    )
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null when the only in-side diff is the same asset as the out-side (refund-shaped)', async () => {
+    const result = await parseBlockaidEvmSimulation(
+      buildSimulation([diff({ asset: TOKEN_A, out: [side('1')] }), diff({ asset: TOKEN_A, in: [side('1')] })]),
+      EvmChain.Ethereum
+    )
+
+    expect(result).toBeNull()
+  })
+})

--- a/packages/core/chain/security/blockaid/tx/simulation/api/core.test.ts
+++ b/packages/core/chain/security/blockaid/tx/simulation/api/core.test.ts
@@ -152,4 +152,25 @@ describe('parseBlockaidEvmSimulation', () => {
 
     expect(result).toBeNull()
   })
+
+  it('returns null when in/out share an address but Blockaid returns inconsistent symbol metadata', async () => {
+    // Address is the canonical token identity. Blockaid occasionally returns
+    // the same contract with mismatched symbols (different casing, stale
+    // metadata, etc.) — those still represent a refund-shaped self-swap.
+    const tokenAUppercaseSymbol = asset({
+      address: TOKEN_A.address,
+      symbol: 'TOKENA',
+      name: 'Token A (alt metadata)',
+    })
+
+    const result = await parseBlockaidEvmSimulation(
+      buildSimulation([
+        diff({ asset: TOKEN_A, out: [side('1')] }),
+        diff({ asset: tokenAUppercaseSymbol, in: [side('1')] }),
+      ]),
+      EvmChain.Ethereum
+    )
+
+    expect(result).toBeNull()
+  })
 })

--- a/packages/core/chain/security/blockaid/tx/simulation/api/core.ts
+++ b/packages/core/chain/security/blockaid/tx/simulation/api/core.ts
@@ -2,10 +2,7 @@ import { EvmChain } from '@vultisig/core-chain/Chain'
 import { isChainOfKind } from '@vultisig/core-chain/ChainKind'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 
-import {
-  BlockaidEvmSimulationInfo,
-  BlockaidSolanaSimulationInfo,
-} from '../core'
+import { BlockaidEvmSimulationInfo, BlockaidSolanaSimulationInfo } from '../core'
 
 export type BlockaidSolanaSimulation = {
   account_summary: {
@@ -86,9 +83,7 @@ export const parseBlockaidSolanaSimulation = async (
   // The native SOL is likely the transaction fee, not part of the swap itself.
   let relevantDiffs = assetDiffs
   if (assetDiffs.length === 3) {
-    const nativeSolIndex = assetDiffs.findIndex(
-      diff => diff.asset.type === 'SOL' || diff.asset_type === 'SOL'
-    )
+    const nativeSolIndex = assetDiffs.findIndex(diff => diff.asset.type === 'SOL' || diff.asset_type === 'SOL')
     if (nativeSolIndex !== -1) {
       relevantDiffs = assetDiffs.filter((_, index) => index !== nativeSolIndex)
     }
@@ -137,13 +132,9 @@ export const parseBlockaidSolanaSimulation = async (
       return {
         swap: {
           fromMint:
-            outAsset.type === 'SOL'
-              ? 'So11111111111111111111111111111111111111112'
-              : shouldBePresent(outAsset.address),
+            outAsset.type === 'SOL' ? 'So11111111111111111111111111111111111111112' : shouldBePresent(outAsset.address),
           toMint:
-            inAsset.type === 'SOL'
-              ? 'So11111111111111111111111111111111111111112'
-              : shouldBePresent(inAsset.address),
+            inAsset.type === 'SOL' ? 'So11111111111111111111111111111111111111112' : shouldBePresent(inAsset.address),
           fromAmount: BigInt(shouldBePresent(outValue).raw_value),
           toAmount: BigInt(shouldBePresent(inValue).raw_value),
           toAssetDecimal: inAsset.decimals,
@@ -153,9 +144,7 @@ export const parseBlockaidSolanaSimulation = async (
       return {
         transfer: {
           fromMint:
-            outAsset.type === 'SOL'
-              ? 'So11111111111111111111111111111111111111112'
-              : shouldBePresent(outAsset.address),
+            outAsset.type === 'SOL' ? 'So11111111111111111111111111111111111111112' : shouldBePresent(outAsset.address),
           fromAmount: BigInt(shouldBePresent(outValue).raw_value),
         },
       }
@@ -169,9 +158,7 @@ export const parseBlockaidEvmSimulation = async (
   chain: EvmChain
 ): Promise<BlockaidEvmSimulationInfo> => {
   if (!isChainOfKind(chain, 'evm')) {
-    throw new Error(
-      `parseBlockaidEvmSimulation only supports EVM chains, got: ${chain}`
-    )
+    throw new Error(`parseBlockaidEvmSimulation only supports EVM chains, got: ${chain}`)
   }
 
   const assetDiffs = simulation.account_summary.assets_diffs
@@ -196,32 +183,36 @@ export const parseBlockaidEvmSimulation = async (
       },
     }
   } else if (assetDiffs.length > 1) {
-    const [potentialOutAsset, potentialInAsset] = assetDiffs
-    const { inAsset, inValue } =
-      potentialInAsset.in.length > 0
-        ? {
-            inAsset: potentialInAsset.asset,
-            inValue: potentialInAsset.in,
-          }
-        : {
-            inAsset: potentialOutAsset.asset,
-            inValue: potentialOutAsset.in,
-          }
-
-    const { outAsset, outValue } =
-      potentialOutAsset.out.length > 0
-        ? {
-            outAsset: potentialOutAsset.asset,
-            outValue: potentialOutAsset.out,
-          }
-        : {
-            outAsset: potentialInAsset.asset,
-            outValue: potentialInAsset.out,
-          }
-
-    if (outValue.length === 0 || inValue.length === 0) {
+    // Router-mediated flows (e.g. `permitAndCall`) often return three diffs
+    // with an intermediate permit/allowance leg between the user's `out` and
+    // `in` sides. Scan all diffs instead of using positional destructuring so
+    // the user-side pair is recovered regardless of order, and prefer an
+    // in-side asset that differs from the out-side asset (case-insensitive,
+    // since EIP-55 checksums vary by casing). Mirrors the iOS parser.
+    const outDiff = assetDiffs.find(diff => diff.out.length > 0)
+    if (!outDiff) {
       return null
     }
+
+    const outAddress = outDiff.asset.address?.toLowerCase()
+    const inDiff =
+      assetDiffs.find(diff => diff.in.length > 0 && diff.asset.address?.toLowerCase() !== outAddress) ??
+      assetDiffs.find(diff => diff.in.length > 0)
+
+    if (!inDiff) {
+      return null
+    }
+
+    const inAddress = inDiff.asset.address?.toLowerCase()
+    const isSameAsset = outAddress === inAddress && outDiff.asset.symbol === inDiff.asset.symbol
+    if (isSameAsset) {
+      return null
+    }
+
+    const outAsset = outDiff.asset
+    const outValue = outDiff.out
+    const inAsset = inDiff.asset
+    const inValue = inDiff.in
 
     return {
       swap: {

--- a/packages/core/chain/security/blockaid/tx/simulation/api/core.ts
+++ b/packages/core/chain/security/blockaid/tx/simulation/api/core.ts
@@ -203,9 +203,13 @@ export const parseBlockaidEvmSimulation = async (
       return null
     }
 
+    // Address is the primary identity for a token; symbol is just metadata
+    // and Blockaid sometimes returns inconsistent casing (`USDC` vs `usdc`)
+    // for the same contract. Reject refund-shaped pairs by address alone so
+    // we don't render a nonsense `A → A` swap when the in-side fallback
+    // matches the out-side asset.
     const inAddress = inDiff.asset.address?.toLowerCase()
-    const isSameAsset = outAddress === inAddress && outDiff.asset.symbol === inDiff.asset.symbol
-    if (isSameAsset) {
+    if (outAddress === inAddress) {
       return null
     }
 


### PR DESCRIPTION
## Summary

- `parseBlockaidEvmSimulation` was destructuring only the first two entries of `assets_diffs` positionally. For router-mediated EVM flows like `permitAndCall`, Blockaid returns **three** diffs (user `out` → empty intermediate permit/router leg → user `in`), so the parser fell back to an empty `in` array and returned `null`, leaving the simulation hero empty even though the user is effectively swapping `A → B`.
- Replaced the positional destructuring with a `find`-style scan: pick the first diff with a non-empty `out`, then the first diff with a non-empty `in` whose asset address differs from the out-asset (case-insensitive — EIP-55 checksums vary by casing), falling back to any diff with `in`. Adds a final guard that rejects refund-shaped same-asset pairs so we don't render a nonsense `A → A` swap. Mirrors the iOS [`BlockaidSimulationParser`](https://github.com/vultisig/vultisig-ios/blob/main/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidSimulationParser.swift) `parseSwap` logic.
- Added a `.changeset` patch bump for `@vultisig/core-chain` so vultisig-windows / consumers can pick up the fix on the next release.

Closes vultisig/vultisig-windows#3799

## Repro shape (before)

```
diffs[0]: out=[tokenA], in=[]      // user sends
diffs[1]: out=[],       in=[]      // intermediate permit/router leg
diffs[2]: out=[],       in=[tokenB] // user receives
```

Old code: `[potentialOutAsset, potentialInAsset] = diffs` → `potentialInAsset.in.length === 0` → fallback to `diffs[0].in` (also empty) → returns `null` → simulation hero blank.

New code: `outDiff = diffs.find(d => d.out.length > 0)` → `diffs[0]`; `inDiff = diffs.find(d => d.in.length > 0 && d.asset.address ≠ outDiff.address) ?? diffs.find(d => d.in.length > 0)` → `diffs[2]`; renders `A → B` correctly.

## Test plan

Added [`core.test.ts`](../tree/fix/blockaid-evm-router-mediated-swap-pair/packages/core/chain/security/blockaid/tx/simulation/api/core.test.ts) with 6 cases:

- [x] Single-diff transfer renders correctly
- [x] Standard 2-diff swap shape preserved (no behaviour regression)
- [x] **3-diff `permitAndCall` flow with empty intermediate leg → swap rendered** (the bug)
- [x] EIP-55 checksum-only address difference treated as same asset when picking the in-side
- [x] Returns `null` when no diff has an `out` side
- [x] Returns `null` when the only `in` side is the same asset as the `out` side (refund-shaped)

Full `yarn test:core` (242 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed EVM router-mediated simulation pairing so swap simulations render correctly by selecting the correct out/in asset diffs and avoiding refund-shaped false positives.

* **Tests**
  * Added comprehensive tests covering multi-asset simulation scenarios, intermediate router legs, checksum casing variants, and refund/self-swap edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->