### PR TITLE
chore(changeset): republish @vultisig/mpc-types with R8 EXPO_PUBLIC fallback

### DIFF
--- a/.changeset/mpc-types-expo-public-fallback.md
+++ b/.changeset/mpc-types-expo-public-fallback.md
@@ -1,0 +1,7 @@
+---
+"@vultisig/mpc-types": patch
+---
+
+Add `EXPO_PUBLIC_VULTISIG_STRICT_SINGLETON` env-var fallback alongside `VULTISIG_STRICT_SINGLETON` so Expo / React Native consumers can bypass the dev-mode duplicate-MPC-engine guard via Metro-inlined env vars (Expo only inlines `EXPO_PUBLIC_*`). `VULTISIG_STRICT_SINGLETON` retains precedence; production builds (`NODE_ENV=production`) are unaffected.
+
+Originally landed via vultisig/vultisig-sdk#306 R8 (commit 964df08), but the corresponding changeset was missed at release time — this republish ships the fix to npm.


### PR DESCRIPTION
## Why

The R8 fix from #306 — `EXPO_PUBLIC_VULTISIG_STRICT_SINGLETON` env-var fallback in `packages/mpc-types/src/runtime.ts` — is **on `main`** (commit [`964df08`](https://github.com/vultisig/vultisig-sdk/commit/964df08)) but **is not on npm**.

The corresponding changeset for `@vultisig/mpc-types` was missed at release time. The version-packages PR (#343) consumed only the `@vultisig/sdk` changesets and republished `@vultisig/sdk`, leaving `@vultisig/mpc-types` at `0.2.1` without the fallback.

**Verification — tarball grep:**

```
$ npm pack @vultisig/mpc-types@0.2.1
$ tar xzf vultisig-mpc-types-0.2.1.tgz
$ grep -rn "EXPO_PUBLIC_VULTISIG_STRICT_SINGLETON" package/
(no matches)
```

Without this republish, downstream Expo / React Native consumers installing `@vultisig/mpc-types@0.2.1` (transitively via `@vultisig/sdk@0.x`) cannot use the documented `EXPO_PUBLIC_*` escape hatch and continue to hit the dev-mode duplicate-MPC-engine guard.

## What ships once merged

1. The changesets bot opens (or refreshes) the `changeset-release/main` PR.
2. That PR bumps `@vultisig/mpc-types` from `0.2.1` → `0.2.2` (patch).
3. On merge, GitHub Actions publishes `@vultisig/mpc-types@0.2.2` to npm with the EXPO_PUBLIC fallback.

`@vultisig/sdk` will receive a normal patch bump as a downstream consumer of the `mpc-types` peer dep.

## Risk

**Zero.** No source-code changes — pure release-metadata patch (single file under `.changeset/`). The behavior was already audited and merged via #306; this PR just unblocks its publication path.

## Why not the standard release flow

The R8 commit landed after the `@vultisig/sdk` changeset for #306 had already been written, so when the changeset bot ran it consumed the existing changeset queue and shipped sdk without `mpc-types`. This is a manual catch-up changeset on top of `main` to plug the gap.

---

cc @gomesalexandre — small one-file PR, would appreciate a fast eyes-on so we can republish before more consumers hit this.

🤖 Agent-generated (vultisig-ops orchestrator). No code changes; pure changeset add.