### PR TITLE
fix(thorchain): swap ninerealms → thorchain.network for resilience

### DIFF
--- a/packages/core/chain/chains/cosmos/thor/lp/pools.ts
+++ b/packages/core/chain/chains/cosmos/thor/lp/pools.ts
@@ -4,7 +4,7 @@ import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
  * Midgard base URL used by every helper in this module. Matches what
  * vultisig-ios and the rujira package use as the default mainnet endpoint.
  */
-export const thorchainMidgardBaseUrl = 'https://midgard.ninerealms.com'
+export const thorchainMidgardBaseUrl = 'https://midgard.thorchain.network'
 
 /**
  * Canonical THORChain pool-id format: `CHAIN.ASSET` for native assets

--- a/packages/rujira/src/config.ts
+++ b/packages/rujira/src/config.ts
@@ -38,9 +38,9 @@ export type RujiraConfig = {
 export const MAINNET_CONFIG: RujiraConfig = {
   network: 'mainnet',
   chainId: 'thorchain-1',
-  rpcEndpoint: 'https://rpc.ninerealms.com',
-  restEndpoint: 'https://thornode.ninerealms.com',
-  midgardEndpoint: 'https://midgard.ninerealms.com/v2',
+  rpcEndpoint: 'https://rpc.thorchain.network',
+  restEndpoint: 'https://thornode.thorchain.network',
+  midgardEndpoint: 'https://midgard.thorchain.network/v2',
   graphqlWsEndpoint: 'wss://api.rujira.network/socket',
   gasPrice: DEFAULT_GAS_PRICE,
   gasLimit: 500000,

--- a/packages/rujira/src/discovery/discovery.ts
+++ b/packages/rujira/src/discovery/discovery.ts
@@ -204,7 +204,7 @@ export class RujiraDiscovery {
     const fin: Record<string, string> = {}
 
     const baseUrl = this.rpcEndpoint.replace(':26657', '').replace('rpc', 'thornode')
-    const restUrl = baseUrl.includes('thornode') ? baseUrl : 'https://thornode.ninerealms.com'
+    const restUrl = baseUrl.includes('thornode') ? baseUrl : 'https://thornode.thorchain.network'
 
     try {
       // Paginate through all contracts for this code ID


### PR DESCRIPTION
## Summary

ninerealms.com had a DNS outage on 2026-04-27 that took down `midgard`, `thornode`, AND `rpc` subdomains for multiple hours. The whole agent-backend MCP THORChain surface (`get_thor_balance`, `build_thor_send`, `query_thorchain_pools`, Rujira swap discovery) returned `fetch failed`.

Switch to the THORChain Foundation endpoints — drop-in replacements with identical JSON shapes:

| ninerealms | thorchain.network | what's behind |
|---|---|---|
| `midgard.ninerealms.com` | `midgard.thorchain.network` | Midgard pools/positions API |
| `thornode.ninerealms.com` | `thornode.thorchain.network` | cosmos REST (bank/auth, broadcast) |
| `rpc.ninerealms.com` | `rpc.thorchain.network` | Tendermint RPC |

## Compat receipts (curl during outage)

```
$ curl https://midgard.ninerealms.com/v2/pools
curl: (6) Could not resolve host: midgard.ninerealms.com

$ nslookup midgard.ninerealms.com 8.8.8.8
*** Can't find midgard.ninerealms.com: No answer

$ curl https://midgard.thorchain.network/v2/pools | jq 'length'
43

$ curl https://thornode.thorchain.network/cosmos/bank/v1beta1/balances/thor1xghvhe4p50aqh5zq2t2vls938as0dkr2mzgpgh
{"balances":[{"denom":"thor.mimir","amount":"300000000000"}],"pagination":{"next_key":null,"total":"1"}}

$ curl https://thornode.thorchain.network/cosmos/auth/v1beta1/accounts/thor1xghvhe4p50aqh5zq2t2vls938as0dkr2mzgpgh
{"account":{"@type":"/cosmos.auth.v1beta1.BaseAccount","address":"thor1...","pub_key":{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"..."},"account_number":"3","sequence":"512"}}

$ curl https://rpc.thorchain.network/status
{"jsonrpc":"2.0","result":{"node_info":{"network":"thorchain-1", "version":"0.38.19", ...}}}
```

All shapes match cosmos SDK + Midgard standards — drop-in.

## End-to-end verified

After SDK + companion mcp-ts fix (`vultisig/mcp-ts#TBD`) loaded:

```
$ curl <local-mcp> tools/call query_thorchain_pools filterAsset=BTC.BTC
{"pools":[{"asset":"BTC.BTC",
           "status":"available",
           "runeDepth_display":"31,379,181.66 RUNE",
           "assetDepth_display":"203.90 (asset base units)",
           ...}]}
```

(Pre-fix: `{"isError":true, "content":[{"text":"fetch failed"}]}`)

## Touch list

Production code only — kept tests and docs as-is so the historical "ninerealms" context stays searchable.

- `packages/core/chain/chains/cosmos/thor/lp/pools.ts`
- `packages/rujira/src/config.ts` (rpc + rest + midgard endpoints)
- `packages/rujira/src/discovery/discovery.ts`

## Sister-repo precedent

- `vultisig-windows` already uses `midgard.thorchain.network` + `thornode.thorchain.network` in `core/ui/defi/chain/queries/constants.ts`
- `vultisig-android` uses `thornode.thorchain.network/cosmos/tx/v1beta1/txs` for broadcasts
- `vultisig-ios` mirrors

This change just brings the SDK in line with what mobile already does, so `agent-backend` (which leans on the SDK) inherits that resilience too.

## Risk

LOW. ninerealms.com is well-known + reliable when it works, but today's 4h+ outage shows it's a single point of failure. thorchain.network is the Foundation-run primary, and it's what the mobile clients already trust.

## Follow-up (out of scope)

Plumb a multi-provider fallback list so the SDK races both providers and fails over automatically. Skipping in this PR to keep scope small + match mobile precedent (mobile is currently single-endpoint too).

🤖 Generated with [Claude Code](https://claude.com/claude-code) — DNS outage triage during PR vultisig/agent-backend#183 → repro + curl-verified compat → end-to-end test against patched SDK + MCP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated THORChain network service endpoints to the latest infrastructure configuration, affecting pools, mainnet configuration, and chain discovery modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->