### PR TITLE
fix(polkadot): use state_getStorage RPC instead of Subscan REST

### DIFF
--- a/packages/core/chain/coin/balance/resolvers/polkadot.ts
+++ b/packages/core/chain/coin/balance/resolvers/polkadot.ts
@@ -1,3 +1,8 @@
+// SS58 decode + blake2b are intentionally implemented with bs58 + @noble/hashes
+// rather than @polkadot/util-crypto: the latter pulls a BN.js dep that double-bundles
+// in browser/extension builds and crashes at module init with
+// "Cannot assign to read only property 'toString'" — same root cause as the
+// Bittensor revert that originally broke this resolver.
 import { blake2b } from '@noble/hashes/blake2b'
 import { bytesToHex } from '@noble/hashes/utils'
 import { polkadotRpcUrl } from '@vultisig/core-chain/chains/polkadot/client'
@@ -13,23 +18,41 @@ type RpcResponse<T> = {
   error?: { code: number; message: string }
 }
 
-// System.Account storage key prefix: twox128("System") ++ twox128("Account")
+// twox128("System") ++ twox128("Account") — well-known Substrate storage prefix
 const systemAccountPrefix = '0x26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da9'
 
+const polkadotSs58Prefix = 0
 const ss58AddressByteLength = 35
-const ss58PublicKeyOffset = 1
-const ss58PublicKeyEnd = 33
+const ss58ChecksumPreamble = new TextEncoder().encode('SS58PRE')
 
-const decodeSs58PublicKey = (address: string): Uint8Array => {
+const decodePolkadotPublicKey = (address: string): Uint8Array => {
   const decoded = bs58.decode(address)
   if (decoded.length !== ss58AddressByteLength) {
     throw new Error(`Invalid SS58 address length: expected ${ss58AddressByteLength} bytes, got ${decoded.length}`)
   }
-  return decoded.slice(ss58PublicKeyOffset, ss58PublicKeyEnd)
+  // Reject other Substrate networks (Kusama=2, generic=42, etc.) — they decode
+  // to the same length and would silently resolve to a 0 DOT balance, which
+  // looks indistinguishable from fund loss.
+  if (decoded[0] !== polkadotSs58Prefix) {
+    throw new Error(`Not a Polkadot address: SS58 network prefix ${decoded[0]}, expected ${polkadotSs58Prefix}`)
+  }
+  // SS58 checksum: blake2b-512("SS58PRE" || prefix || pubkey)[0..2] == trailing 2 bytes.
+  // Catches single-character typos that would otherwise yield a valid-shaped pubkey
+  // and a 0 balance.
+  const payload = decoded.subarray(0, 33)
+  const checksum = decoded.subarray(33)
+  const checksumInput = new Uint8Array(ss58ChecksumPreamble.length + payload.length)
+  checksumInput.set(ss58ChecksumPreamble)
+  checksumInput.set(payload, ss58ChecksumPreamble.length)
+  const expected = blake2b(checksumInput, { dkLen: 64 })
+  if (expected[0] !== checksum[0] || expected[1] !== checksum[1]) {
+    throw new Error('Invalid SS58 checksum')
+  }
+  return payload.subarray(1)
 }
 
 export const getPolkadotCoinBalance: CoinBalanceResolver = async input => {
-  const pubkey = decodeSs58PublicKey(input.address)
+  const pubkey = decodePolkadotPublicKey(input.address)
   const hash = bytesToHex(blake2b(pubkey, { dkLen: 16 }))
   const accountId = bytesToHex(pubkey)
   const storageKey = systemAccountPrefix + hash + accountId
@@ -50,8 +73,12 @@ export const getPolkadotCoinBalance: CoinBalanceResolver = async input => {
   const result = response.result
   if (!result) return BigInt(0)
 
-  // SCALE AccountInfo: nonce(4) + consumers(4) + providers(4) + sufficients(4) + free(16) + ...
-  // free balance starts at byte offset 16, encoded as u128 LE
+  // SCALE AccountInfo layout (frame_system + pallet_balances v47):
+  //   nonce(u32) + consumers(u32) + providers(u32) + sufficients(u32)
+  //   + AccountData { free(u128), reserved(u128), frozen(u128), flags(u128) }
+  // free is always at byte offset 16, length 16, encoded LE — stable across the
+  // misc_frozen/fee_frozen → frozen/flags migration, since `free` is always the
+  // first AccountData field.
   const hex = result.startsWith('0x') ? result.slice(2) : result
   if (hex.length < 64 || !/^[0-9a-fA-F]+$/.test(hex)) {
     throw new Error(`Unexpected storage response format: ${result}`)

--- a/packages/core/chain/coin/balance/resolvers/polkadot.ts
+++ b/packages/core/chain/coin/balance/resolvers/polkadot.ts
@@ -1,28 +1,66 @@
-import { toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'
-import { Chain } from '@vultisig/core-chain/Chain'
-import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
+import { blake2b } from '@noble/hashes/blake2b'
+import { bytesToHex } from '@noble/hashes/utils'
+import { polkadotRpcUrl } from '@vultisig/core-chain/chains/polkadot/client'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+import bs58 from 'bs58'
 
 import { CoinBalanceResolver } from '../resolver'
 
-type PolkadotAccountBalance = {
-  data: {
-    account: {
-      balance: number
-    }
+type RpcResponse<T> = {
+  jsonrpc: string
+  id: number
+  result?: T
+  error?: { code: number; message: string }
+}
+
+// System.Account storage key prefix: twox128("System") ++ twox128("Account")
+const systemAccountPrefix = '0x26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da9'
+
+const ss58AddressByteLength = 35
+const ss58PublicKeyOffset = 1
+const ss58PublicKeyEnd = 33
+
+const decodeSs58PublicKey = (address: string): Uint8Array => {
+  const decoded = bs58.decode(address)
+  if (decoded.length !== ss58AddressByteLength) {
+    throw new Error(`Invalid SS58 address length: expected ${ss58AddressByteLength} bytes, got ${decoded.length}`)
   }
+  return decoded.slice(ss58PublicKeyOffset, ss58PublicKeyEnd)
 }
 
 export const getPolkadotCoinBalance: CoinBalanceResolver = async input => {
-  const { data } = await queryUrl<PolkadotAccountBalance>(
-    'https://assethub-polkadot.api.subscan.io/api/v2/scan/search',
-    {
-      body: { key: input.address },
-    }
-  )
+  const pubkey = decodeSs58PublicKey(input.address)
+  const hash = bytesToHex(blake2b(pubkey, { dkLen: 16 }))
+  const accountId = bytesToHex(pubkey)
+  const storageKey = systemAccountPrefix + hash + accountId
 
-  return toChainAmount(
-    data.account.balance,
-    chainFeeCoin[Chain.Polkadot].decimals
-  )
+  const response = await queryUrl<RpcResponse<string | null>>(polkadotRpcUrl, {
+    body: {
+      jsonrpc: '2.0',
+      method: 'state_getStorage',
+      params: [storageKey],
+      id: 1,
+    },
+  })
+
+  if (response.error) {
+    throw new Error(`Polkadot balance RPC error: ${response.error.message ?? `code ${response.error.code}`}`)
+  }
+
+  const result = response.result
+  if (!result) return BigInt(0)
+
+  // SCALE AccountInfo: nonce(4) + consumers(4) + providers(4) + sufficients(4) + free(16) + ...
+  // free balance starts at byte offset 16, encoded as u128 LE
+  const hex = result.startsWith('0x') ? result.slice(2) : result
+  if (hex.length < 64 || !/^[0-9a-fA-F]+$/.test(hex)) {
+    throw new Error(`Unexpected storage response format: ${result}`)
+  }
+  const freeHex = hex.slice(32, 64)
+
+  const leBytes = freeHex.match(/.{2}/g)
+  if (!leBytes) {
+    throw new Error(`Failed to parse free balance hex: ${freeHex}`)
+  }
+  return BigInt('0x' + leBytes.reverse().join(''))
 }


### PR DESCRIPTION
## Summary

- Replace Subscan REST balance fetch with direct Substrate `state_getStorage` JSON-RPC against the existing `polkadotRpcUrl` (`api.vultisig.com/dot/`)
- No new dependency: uses `@noble/hashes/blake2b` and `bs58` (both already in `packages/core/chain`)
- Mirrors `bittensor.ts` resolver pattern — does **not** reintroduce `@polkadot/api` (so the Bittensor revert reason no longer applies)

## Why

Subscan now requires an API key for unauthenticated requests:

```
$ curl -X POST "https://assethub-polkadot.api.subscan.io/api/v2/scan/search" \
       -H "Content-Type: application/json" \
       -d '{"key":"15gTKR..."}'
{"code": 403, "message": "Subscan API strictly requires an API key. Unauthenticated access is disabled."}
```

Result: vultisig-windows (which builds SDK main on every PR) shows "Failed to load" for DOT balance. Mobile clients consuming the SDK are similarly affected.

The previous fix [#115](https://github.com/vultisig/vultisig-sdk/pull/115) (commit `12ab66d2`) used `@polkadot/api` via `getPolkadotClient()`, but was reverted as part of `53002bce` ("Revert: add Bittensor support") because the heavy `@polkadot/api` dynamic import broke other paths. This PR fixes Polkadot without bringing `@polkadot/api` back into the balance hot path.

## What changed

`packages/core/chain/coin/balance/resolvers/polkadot.ts`:

- SS58 decode (`bs58`) → 32-byte pubkey
- Storage key = `twox128("System") || twox128("Account")` (precomputed `0x26aa394e…371da9`) `|| blake2b128(pubkey) || pubkey`
- POST to `polkadotRpcUrl` with `{ method: "state_getStorage", params: [storageKey] }`
- SCALE-decode `AccountInfo`: skip 16-byte header (4× u32), read u128 LE for `free`

Identical pattern to `bittensor.ts`.

## Test plan

- [ ] CI unit + integration tests pass
- [ ] vultisig-windows DOT balance loads against this branch (built by CI)
- [ ] Manual probe: SDK returns non-zero balance for a funded DOT address
- [ ] Empty address returns `0n` instead of throwing

## Verification

End-to-end probe against the live RPC:

```
address: 15gTKR6XS9osnZKTrKVF3y9MeLJ9YBCb6TgZNigwEHyMjSnA
free balance (raw): 75863829787
free balance (DOT): 7.5863829787
```

Matches the user's wallet screenshot showing **7.586 DOT**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Polkadot balance fetching with enhanced on-chain data validation and address verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->