### PR TITLE
fix(cosmos): bump TerraClassic IBC gas limit 300k → 400k

### DIFF
--- a/packages/core/chain/chains/cosmos/cosmosGasLimitRecord.ts
+++ b/packages/core/chain/chains/cosmos/cosmosGasLimitRecord.ts
@@ -10,7 +10,13 @@ const cosmosGasLimitRecord: Record<CosmosChain, bigint> = {
   [Chain.Noble]: 200000n,
   [Chain.Akash]: 200000n,
   [Chain.Terra]: 300000n,
-  [Chain.TerraClassic]: 300000n,
+  // TerraClassic default covers both bank.MsgSend (uluna ~80k) and
+  // ibc.MsgTransfer (~150-200k), with margin for chain load. uusd
+  // (USTC) MsgSend has its own 1M override below for the burn-tax /
+  // treasury post-handler path; IBC `MsgTransfer` is exempt from the
+  // burn tax (per classic-terra/core fee_tax.go::FilterMsgAndComputeTax)
+  // so it falls through to this default.
+  [Chain.TerraClassic]: 400000n,
   [Chain.THORChain]: 20000000n,
   [Chain.MayaChain]: 2000000000n,
 }


### PR DESCRIPTION
## Summary

Bumps the TerraClassic default gas limit in \`cosmosGasLimitRecord\` from 300k to 400k. The previous 300k was marginal for IBC \`MsgTransfer\` (~150-200k) under chain congestion; 400k provides a clean ~200k margin without overpaying meaningfully (~0.0002 LUNC at 28.325 uluna/gas min).

\`uusd\` (USTC) bank.MsgSend keeps its dedicated 1M override at line 19-21 (burn-tax / treasury post-handler path needs more). IBC \`MsgTransfer\` is exempt from the burn tax — verified directly in [classic-terra/core \`fee_tax.go::FilterMsgAndComputeTax\`](https://github.com/classic-terra/core/blob/main/custom/auth/ante/fee_tax.go) — so a USTC IBC bridge falls through to this 400k default and is well covered.

## Why now

V1 ships LUNC/USTC bridging columbus-5 → osmosis-1 via the existing Skip path. Live probes:
- channel-1 (terra-classic) ↔ channel-72 (osmosis-1) \`STATE_OPEN\`
- Skip /route: \`txs_required:1\`, \`does_swap:false\`, single-hop IBC

Bumping the gas default before runtime testing avoids a flaky-tx class of failure from the start.

## Companion PRs
- vultisig/agent-backend: chain registry wiring (balance fan-out + intent + validator)
- vultisig/vultiagent-app: USTC catalog + IBC pre-sign card + bridge chips + OSMO-gas callout
- (Phase 2 follow-up) vultisig/mcp-ts: \`build_ibc_transfer\` native tool

## Test plan
- [x] \`yarn test:core\` clean (349/349)

## Risk
Trivial. Single-line gas bump on an already-supported chain. Conservative direction (more headroom, never less).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased default gas limit for Terra Classic chain transactions from 300,000 to 400,000 to improve transaction success rates.

* **Documentation**
  * Added clarification on gas limit coverage for different transaction types (bank transfers and IBC transfers).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->