### PR TITLE
Split getSevenZip for browser vs Node and improve browser keygen UX

### DIFF
--- a/.changeset/getsevenzip-browser-node-exports.md
+++ b/.changeset/getsevenzip-browser-node-exports.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/core-mpc': patch
+---
+
+Split `getSevenZip` into browser and Node builds so browser bundles never pull `node:module`, wire conditional `exports` via `generate-shared-exports`, and improve the browser partner example (StrictMode-safe init, dev QR logging, copyable QR textarea, Vite env types).

--- a/examples/browser/src/App.tsx
+++ b/examples/browser/src/App.tsx
@@ -33,6 +33,9 @@ type AppState = {
   error: string | null
 }
 
+/** Dev StrictMode runs mount effects twice; avoid double SDK adapter init + duplicate event log lines. */
+let appInitStarted = false
+
 function App() {
   const [appState, setAppState] = useState<AppState>({
     sdkAdapter: null,
@@ -63,6 +66,11 @@ function App() {
 
   // Initialize app and load vaults from SDK
   useEffect(() => {
+    if (appInitStarted) {
+      return
+    }
+    appInitStarted = true
+
     const init = async () => {
       try {
         const sdk = getSDK()
@@ -100,7 +108,7 @@ function App() {
       }
     }
 
-    init()
+    void init()
   }, [addEvent])
 
   // Subscribe to SDK adapter events

--- a/examples/browser/src/App.tsx
+++ b/examples/browser/src/App.tsx
@@ -33,9 +33,6 @@ type AppState = {
   error: string | null
 }
 
-/** Dev StrictMode runs mount effects twice; avoid double SDK adapter init + duplicate event log lines. */
-let appInitStarted = false
-
 function App() {
   const [appState, setAppState] = useState<AppState>({
     sdkAdapter: null,
@@ -64,12 +61,10 @@ function App() {
     []
   )
 
-  // Initialize app and load vaults from SDK
+  // Initialize app and load vaults from SDK (StrictMode-safe: abort in-flight work on cleanup)
   useEffect(() => {
-    if (appInitStarted) {
-      return
-    }
-    appInitStarted = true
+    const controller = new AbortController()
+    const { signal } = controller
 
     const init = async () => {
       try {
@@ -79,6 +74,10 @@ function App() {
 
         // Load all existing vaults
         const existingVaults = await sdkAdapter.listVaults()
+        if (signal.aborted) {
+          return
+        }
+
         const openVaultsMap = new Map<string, VaultInfo>()
         existingVaults.forEach((vault: VaultInfo) => {
           openVaultsMap.set(vault.id, vault)
@@ -87,6 +86,9 @@ function App() {
         // Set first vault as active if any exist
         if (existingVaults.length > 0) {
           await sdkAdapter.setActiveVault(existingVaults[0].id)
+        }
+        if (signal.aborted) {
+          return
         }
 
         setAppState(prev => ({
@@ -99,6 +101,9 @@ function App() {
 
         addEvent('success', 'sdk', `SDK initialized, ${existingVaults.length} vault(s) loaded`)
       } catch (error) {
+        if (signal.aborted) {
+          return
+        }
         setAppState(prev => ({
           ...prev,
           isLoading: false,
@@ -109,6 +114,7 @@ function App() {
     }
 
     void init()
+    return () => controller.abort()
   }, [addEvent])
 
   // Subscribe to SDK adapter events

--- a/examples/browser/src/adapters/BrowserSDKAdapter.ts
+++ b/examples/browser/src/adapters/BrowserSDKAdapter.ts
@@ -206,7 +206,13 @@ export class BrowserSDKAdapter implements ISDKAdapter {
             })
           }
         : undefined,
-      onQRCodeReady: options.onQRCodeReady,
+      onQRCodeReady: (qrPayload: string) => {
+        if (import.meta.env.DEV) {
+          ;(window as Window & { __VULTISIG_LAST_KEYGEN_QR__?: string }).__VULTISIG_LAST_KEYGEN_QR__ = qrPayload
+          console.info('VULTISIG_KEYGEN_QR', qrPayload)
+        }
+        options.onQRCodeReady?.(qrPayload)
+      },
       onDeviceJoined: options.onDeviceJoined,
     })
     this.vaultCache.set(result.vault.id, result.vault)

--- a/examples/browser/src/vite-env.d.ts
+++ b/examples/browser/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/shared/src/components/common/QRCodeModal.tsx
+++ b/examples/shared/src/components/common/QRCodeModal.tsx
@@ -76,12 +76,13 @@ export default function QRCodeModal({
 
         {/* Copyable URL */}
         <div className="w-full">
-          <div className="flex items-center gap-2">
-            <input
-              type="text"
+          <div className="flex items-start gap-2">
+            <textarea
               value={qrData}
               readOnly
-              className="flex-1 text-xs bg-gray-50 border border-gray-200 rounded px-3 py-2 font-mono truncate"
+              rows={4}
+              spellCheck={false}
+              className="flex-1 min-h-[5.5rem] text-xs bg-gray-50 border border-gray-200 rounded px-3 py-2 font-mono break-all resize-y max-h-40"
             />
             <button
               type="button"

--- a/packages/core/mpc/compression/getSevenZip.browser.ts
+++ b/packages/core/mpc/compression/getSevenZip.browser.ts
@@ -1,0 +1,9 @@
+import { memoizeAsync } from '@vultisig/lib-utils/memoizeAsync'
+import SevenZip from '7z-wasm'
+
+/** Browser / Vite: `7zz.wasm` is served from site root (see `@vultisig/sdk/vite`). */
+export const getSevenZip = memoizeAsync(() => {
+  return SevenZip({
+    locateFile: (file: string) => `/${file}`,
+  }).catch(() => SevenZip())
+})

--- a/packages/core/mpc/compression/getSevenZip.node.ts
+++ b/packages/core/mpc/compression/getSevenZip.node.ts
@@ -1,0 +1,16 @@
+import { memoizeAsync } from '@vultisig/lib-utils/memoizeAsync'
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import SevenZip from '7z-wasm'
+
+function locateSevenZipWasmFile(file: string): string {
+  const require = createRequire(import.meta.url)
+  const pkgDir = path.dirname(require.resolve('7z-wasm/package.json'))
+  return pathToFileURL(path.join(pkgDir, file)).href
+}
+
+export const getSevenZip = memoizeAsync(() => {
+  const opts = { locateFile: locateSevenZipWasmFile }
+  return SevenZip(opts).catch(() => SevenZip(opts))
+})

--- a/packages/core/mpc/compression/getSevenZip.ts
+++ b/packages/core/mpc/compression/getSevenZip.ts
@@ -1,8 +1,2 @@
-import { memoizeAsync } from '@vultisig/lib-utils/memoizeAsync'
-import SevenZip from '7z-wasm'
-
-export const getSevenZip = memoizeAsync(() => {
-  return SevenZip({
-    locateFile: (file: any) => `/${file}`,
-  }).catch(() => SevenZip())
-})
+/** Re-export for bundlers / default resolution; `package.json` `exports` maps `browser` and `node` to split builds. */
+export { getSevenZip } from './getSevenZip.browser.js'

--- a/packages/core/mpc/package.json
+++ b/packages/core/mpc/package.json
@@ -21,6 +21,8 @@
     },
     "./compression/getSevenZip": {
       "types": "./dist/compression/getSevenZip.d.ts",
+      "browser": "./dist/compression/getSevenZip.browser.js",
+      "node": "./dist/compression/getSevenZip.node.js",
       "import": "./dist/compression/getSevenZip.js",
       "default": "./dist/compression/getSevenZip.js"
     },

--- a/scripts/generate-shared-exports.mjs
+++ b/scripts/generate-shared-exports.mjs
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 
 /**
@@ -56,6 +56,21 @@ export function applySharedExports(packageJsonPath, distDir) {
   const exportsField = Object.fromEntries(
     [...byKey.entries()].sort(([a], [b]) => a.localeCompare(b))
   )
+
+  const sevenShim = path.join(distDir, 'compression/getSevenZip.js')
+  const sevenBrowser = path.join(distDir, 'compression/getSevenZip.browser.js')
+  const sevenNode = path.join(distDir, 'compression/getSevenZip.node.js')
+  if (existsSync(sevenShim) && existsSync(sevenBrowser) && existsSync(sevenNode)) {
+    delete exportsField['./compression/getSevenZip.browser']
+    delete exportsField['./compression/getSevenZip.node']
+    exportsField['./compression/getSevenZip'] = {
+      types: './dist/compression/getSevenZip.d.ts',
+      browser: './dist/compression/getSevenZip.browser.js',
+      node: './dist/compression/getSevenZip.node.js',
+      import: './dist/compression/getSevenZip.js',
+      default: './dist/compression/getSevenZip.js',
+    }
+  }
 
   pkg.exports = exportsField
   writeFileSync(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dev-only QR logging and a copyable QR textarea in the browser example.
  * Added Vite environment type support for the browser example.

* **Bug Fixes**
  * Made browser example initialization safe for React StrictMode.
  * Ensured browser bundles no longer pull Node-only dependencies.

* **Chores**
  * Updated package exports to provide separate browser/node build entry points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->