### PR TITLE
fix(cli): cache --password against resolved vault for active-vault path

### DIFF
--- a/clients/cli/src/index.ts
+++ b/clients/cli/src/index.ts
@@ -232,6 +232,23 @@ async function init(vaultOverride?: string, unlockPassword?: string, passwordTTL
     if (vault) {
       await ctx.setActiveVault(vault)
       setupVaultEvents(vault)
+
+      // Cache --password against the resolved vault's id+name so the SDK's
+      // onPasswordRequired callback (called when its PasswordCacheService
+      // 5-min TTL expires mid-session) finds the user-supplied password
+      // instead of dropping to an interactive prompt. Mirrors what
+      // session.ts/initialize already does with this.config.password —
+      // unlock the resolved vault unconditionally — so this just makes
+      // the no-TTL fallback consistent. The earlier
+      // `cachePassword(vaultSelector, ...)` covers the explicit-vault
+      // case before SDK init; this covers the active-vault fallback path
+      // (no --vault, no VULTISIG_VAULT) and the partial-id-prefix case
+      // where vaultSelector !== vault.id and getCachedPassword(vault.id)
+      // would otherwise miss.
+      if (unlockPassword) {
+        cachePassword(vault.id, unlockPassword)
+        if (vault.name) cachePassword(vault.name, unlockPassword)
+      }
     }
   }
   return ctx


### PR DESCRIPTION
## Summary

`vsig agent --password X` (and other agent-family subcommands) silently drops the password from the CLI's no-TTL cache when `--vault` isn't passed. After the SDK's internal `PasswordCacheService` 5-min TTL elapses, the next sign fires an interactive password prompt — even though the user already supplied the password at launch.

This causes two real failure modes:

1. **In CI / non-interactive contexts**: `inquirer.prompt` blocks on stdin that never comes — silent hang.
2. **In TTY sessions**: the prompt can race against the chat readline (observed in agent-backend PR #193 E2E on 2026-04-30 — Withdrawal 2 collided at nonce 578 because my password input got typed as a chat message after the prompt timed out, triggering a parallel turn).

## Root cause

In `init()` at `clients/cli/src/index.ts:201-204`:

```ts
const vaultSelector = vaultOverride || process.env.VULTISIG_VAULT
if (unlockPassword && vaultSelector) {
    cachePassword(vaultSelector, unlockPassword)   // ← skipped if no --vault
}
```

The eager-cache only fires when a vault selector is known up front. The active-vault fallback path (`sdk.getActiveVault()` further down) and the partial-id-prefix path (where `vaultSelector !== vault.id`) never get a cache entry. So:

- Place 1 (SDK's `PasswordCacheService`, 5-min TTL) — populated by `session.ts/initialize`'s `vault.unlock(this.config.password)` regardless of `--vault`. First few signs work.
- Place 2 (CLI's password-manager Map, no TTL) — empty for active-vault path. After Place 1's TTL: `onPasswordRequired` → `getPassword(vault.id, vault.name)` → miss → interactive prompt.

## The fix

After active-vault resolution, populate the password-manager cache keyed by the resolved vault's id+name:

```diff
@@ async function init(vaultOverride, unlockPassword, passwordTTL)
   if (vault) {
     await ctx.setActiveVault(vault)
     setupVaultEvents(vault)
+    // Cache --password against the resolved vault's id+name so
+    // onPasswordRequired finds it after SDK's 5-min cache expires.
+    if (unlockPassword) {
+      cachePassword(vault.id, unlockPassword)
+      if (vault.name) cachePassword(vault.name, unlockPassword)
+    }
   }
```

`session.ts/initialize` already treats `--password` as applying to the resolved vault (it calls `vault.unlock(this.config.password)` unconditionally for whichever vault was picked). This just makes the no-TTL fallback consistent with that contract — so subsequent signs after Place 1 expires resolve from Place 2 instead of prompting.

## What's NOT changed

- `password-manager.ts` and `PasswordCacheService` — implementations untouched
- `session.ts` and `executor.ts` — already do the right thing with `config.password`; no edits
- The 5-min default on Place 1 — that's the SDK's policy; configurable via `--password-ttl` and `--via-agent` (24h)
- The eager `cachePassword(vaultSelector, ...)` at line 203 stays — covers the explicit-vault case before SDK init; harmless overlap with the new late-cache (idempotent `Map.set`)

## Why both id and name keys

`getCachedPassword(vaultId, vaultName)` in `password-manager.ts` checks name first then id; caching against both ensures the lookup hits regardless of which the SDK passes through.

## Why not require `--vault` when `--password` is given

Considered but rejected:
- `session.ts/initialize` uses `this.config.password` unconditionally for unlock. If the original author meant "--password requires --vault," that path would be guarded too. It isn't.
- The interactive prompt fallback is `password = this.config.password || (await ui.requestPassword())` — meaning `--password` is meant to short-circuit the prompt, not require `--vault`.

The active-vault interpretation matches every other callsite. Wrong-vault risk is bounded: `vault.unlock()` verifies the password and throws on mismatch — the password is never silently applied to the wrong vault.

## Test plan

- [x] `yarn workspace @vultisig/cli typecheck` — passes
- [ ] E2E: launch with `--password X` no `--vault`, sign tx, idle 6+ min, sign again → no prompt fires
- [ ] E2E partial-id case: `--password X --vault <partial-id-prefix>` → no prompt
- [ ] CI: confirm `vsig agent ask` in a script doesn't hang silently at the 5-min mark
- [ ] Unit (if test infra cooperates): `init(undefined, "X")` then `getCachedPassword(activeVault.id, activeVault.name)` returns `"X"` — currently CLI vitest blocked on pre-existing `@vultisig/mpc-wasm` resolution issue on `main`

## Related

- vultisig/agent-backend PR #193 — E2E testing on this stack surfaced this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password caching behavior in the CLI during vault initialization. Passwords supplied when selecting and activating a vault are now properly cached, reducing the need to re-enter credentials in subsequent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->