### PR TITLE
fix(qbtc): include pub_key_hash_sha256 in MsgClaimWithProof (field 7)

### DIFF
--- a/packages/core/chain/chains/cosmos/qbtc/claim/buildClaimTx.test.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/buildClaimTx.test.ts
@@ -9,6 +9,7 @@ const validInput = {
   messageHash: 'bb'.repeat(32),
   addressHash: 'cc'.repeat(20),
   qbtcAddressHash: 'dd'.repeat(32),
+  pubKeyHashSha256: 'ee'.repeat(32),
 }
 
 describe('validateClaimInput', () => {
@@ -91,6 +92,12 @@ describe('validateClaimInput', () => {
     expect(() =>
       validateClaimInput({ ...validInput, qbtcAddressHash: 'aa'.repeat(16) })
     ).toThrow('qbtc_address_hash must be 64 hex chars')
+  })
+
+  it('rejects invalid pubKeyHashSha256 length', () => {
+    expect(() =>
+      validateClaimInput({ ...validInput, pubKeyHashSha256: 'aa'.repeat(16) })
+    ).toThrow('pub_key_hash_sha256 must be 64 hex chars')
   })
 })
 

--- a/packages/core/chain/chains/cosmos/qbtc/claim/buildClaimTx.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/buildClaimTx.ts
@@ -25,6 +25,13 @@ type BuildMsgClaimWithProofInput = {
   addressHash: string
   /** 64-char hex QBTCAddressHash. */
   qbtcAddressHash: string
+  /**
+   * 64-char hex SHA256 of the 33-byte SEC-compressed BTC pubkey. The chain
+   * runs RIPEMD160 over this natively to bind the proof to the BTC address
+   * (the in-circuit Hash160 was removed in btcq-org/qbtc#148).
+   * Returned by the proof service as `pub_key_hash_sha256`.
+   */
+  pubKeyHashSha256: string
 }
 
 const isHex = (value: string) => /^[0-9a-f]+$/i.test(value)
@@ -39,7 +46,14 @@ const assertHex = (value: string, name: string, expectedLength: number) => {
 
 /** Validates the claim input against the chain's constraints (Section 5). */
 export const validateClaimInput = (input: BuildMsgClaimWithProofInput) => {
-  const { utxos, proof, messageHash, addressHash, qbtcAddressHash } = input
+  const {
+    utxos,
+    proof,
+    messageHash,
+    addressHash,
+    qbtcAddressHash,
+    pubKeyHashSha256,
+  } = input
 
   if (utxos.length === 0 || utxos.length > 50) {
     throw new Error(`UTXOs count must be 1-50, got ${utxos.length}`)
@@ -69,6 +83,7 @@ export const validateClaimInput = (input: BuildMsgClaimWithProofInput) => {
   assertHex(messageHash, 'message_hash', 64)
   assertHex(addressHash, 'address_hash', 40)
   assertHex(qbtcAddressHash, 'qbtc_address_hash', 64)
+  assertHex(pubKeyHashSha256, 'pub_key_hash_sha256', 64)
 }
 
 /** Encodes a single UTXORef as protobuf. */
@@ -87,7 +102,8 @@ const buildMsgClaimWithProof = (
     protoString(3, input.proof),
     protoString(4, input.messageHash),
     protoString(5, input.addressHash),
-    protoString(6, input.qbtcAddressHash)
+    protoString(6, input.qbtcAddressHash),
+    protoString(7, input.pubKeyHashSha256)
   )
 }
 

--- a/packages/core/chain/chains/cosmos/qbtc/claim/proofService.test.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/proofService.test.ts
@@ -93,6 +93,7 @@ describe('generateClaimProof', () => {
     message_hash: 'aa'.repeat(32),
     address_hash: 'bb'.repeat(20),
     qbtc_address_hash: 'cc'.repeat(32),
+    pub_key_hash_sha256: 'ee'.repeat(32),
     utxos: [{ txid: 'dd'.repeat(32), vout: 0 }],
     claimer_address: 'qbtc1abc',
   }
@@ -128,7 +129,16 @@ describe('generateClaimProof', () => {
     expect(result.message_hash).toBe(validResponse.message_hash)
     expect(result.address_hash).toBe(validResponse.address_hash)
     expect(result.qbtc_address_hash).toBe(validResponse.qbtc_address_hash)
+    expect(result.pub_key_hash_sha256).toBe(validResponse.pub_key_hash_sha256)
     expect(result.claimer_address).toBe('qbtc1abc')
+  })
+
+  it('throws when pub_key_hash_sha256 is missing or wrong length', async () => {
+    mockFetch({ ...validResponse, pub_key_hash_sha256: 'aa' })
+
+    await expect(generateClaimProof(validInput)).rejects.toThrow(
+      'Invalid proof service response: invalid pub_key_hash_sha256'
+    )
   })
 
   it('throws on non-OK response', async () => {

--- a/packages/core/chain/chains/cosmos/qbtc/claim/proofService.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/proofService.ts
@@ -53,6 +53,13 @@ type GenerateClaimProofResponse = {
   address_hash: string
   /** 64-char hex QBTCAddressHash. */
   qbtc_address_hash: string
+  /**
+   * 64-char hex SHA256 of the SEC-compressed BTC pubkey. Required by
+   * `MsgClaimWithProof` (proto field 7) since btcq-org/qbtc#148 — the
+   * chain runs RIPEMD160 over this natively to bind the proof to the
+   * BTC address.
+   */
+  pub_key_hash_sha256: string
   /** UTXOs included in the proof. */
   utxos: UtxoRef[]
   /** QBTC claimer address. */
@@ -82,6 +89,11 @@ const assertValidClaimProofResponse = (
   if (!isHexWithLength(data.qbtc_address_hash, 64)) {
     throw new Error(
       'Invalid proof service response: invalid qbtc_address_hash'
+    )
+  }
+  if (!isHexWithLength(data.pub_key_hash_sha256, 64)) {
+    throw new Error(
+      'Invalid proof service response: invalid pub_key_hash_sha256'
     )
   }
 }


### PR DESCRIPTION
## Summary

Adds the `pub_key_hash_sha256` field (proto field 7) to `MsgClaimWithProof`. Required by [btcq-org/qbtc#148](https://github.com/btcq-org/qbtc/pull/148) — the chain runs RIPEMD160 over it natively to bind the proof to the BTC address (the in-circuit Hash160 was removed for a ~50% prover-time win).

Without this field, the chain rejects the tx at `ValidateBasic` with:
```
code: 18 (sdk.ErrInvalidRequest)
raw_log: "pub_key_hash_sha256 must be 64 hex characters, got 0: invalid request"
```

The proof service already returns it as `pub_key_hash_sha256` in the `/prove` response.

## What changed

`packages/core/chain/chains/cosmos/qbtc/claim/proofService.ts`:
- Add `pub_key_hash_sha256: string` to `GenerateClaimProofResponse` (re-exported as `ClaimProofResult`).
- Validate it as 64 hex chars in `assertValidClaimProofResponse`.

`packages/core/chain/chains/cosmos/qbtc/claim/buildClaimTx.ts`:
- Add required `pubKeyHashSha256: string` to `BuildMsgClaimWithProofInput`.
- Validate it as 64 hex chars in `validateClaimInput`.
- Emit it as proto field 7 in `buildMsgClaimWithProof`.

## Test plan

- [x] `yarn test:unit` — 1348 / 1348 passing
- [x] `yarn check` in vultisig-windows — typecheck + lint clean against the new SDK
- [ ] E2E claim from the extension ([vultisig/vultisig-windows#3747](https://github.com/vultisig/vultisig-windows/pull/3747)) once the QBTC testnet's new circuit + VK are deployed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * QBTC claim flow now includes a required public-key-hash field (SHA-256 hex) for stronger claim verification.

* **Updates**
  * Claim transaction construction and proof responses now accept and validate a 64-character hex public-key-hash.
  * Validation tightened across claim handling to enforce the new field.

* **Tests**
  * Test coverage extended to assert presence and validation of the new public-key-hash field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->