### PR TITLE
Harden WASM MPC duplicate registration

### DIFF
--- a/.changeset/mpc-wasm-dedupe-configure.md
+++ b/.changeset/mpc-wasm-dedupe-configure.md
@@ -1,0 +1,7 @@
+---
+'@vultisig/mpc-types': patch
+'@vultisig/mpc-wasm': patch
+'@vultisig/sdk': patch
+---
+
+Treat a second `WasmMpcEngine` `configureMpc` registration as a no-op when bundlers evaluate the platform entry in multiple chunks (Chrome extension / Vite), preventing dev-time throws and broken signing.

--- a/packages/mpc-types/package.json
+++ b/packages/mpc-types/package.json
@@ -32,7 +32,7 @@
     "./dist/store.js"
   ],
   "peerDependencies": {
-    "@vultisig/mpc-wasm": ">=0.1.4"
+    "@vultisig/mpc-wasm": ">=0.1.5"
   },
   "peerDependenciesMeta": {
     "@vultisig/mpc-wasm": {

--- a/packages/mpc-types/src/index.ts
+++ b/packages/mpc-types/src/index.ts
@@ -333,5 +333,10 @@ export interface MpcEngine {
 }
 
 // Runtime configuration
-export { configureMpc, ensureMpcEngine, getMpcEngine } from './runtime'
+export {
+  configureMpc,
+  ensureMpcEngine,
+  getMpcEngine,
+  WASM_MPC_ENGINE_KIND,
+} from './runtime'
 export { __resetRuntimeStoreForTesting, runtimeStore } from './store'

--- a/packages/mpc-types/src/runtime.ts
+++ b/packages/mpc-types/src/runtime.ts
@@ -243,12 +243,13 @@ export async function ensureMpcEngine(): Promise<MpcEngine> {
   try {
     mod = await import('@vultisig/mpc-wasm')
   } catch (cause) {
-    throw new Error(
+    const error = new Error(
       'MPC engine not configured and @vultisig/mpc-wasm is not installed. ' +
         'Either install @vultisig/mpc-wasm, or call configureMpc(...) before any MPC operation. ' +
-        'See https://github.com/vultisig/vultisig-sdk/issues/287.',
-      { cause: cause as Error }
+        'See https://github.com/vultisig/vultisig-sdk/issues/287.'
     )
+    Object.assign(error, { cause })
+    throw error
   }
   configureMpc(new mod.WasmMpcEngine())
   return runtimeStore().mpcEngine as MpcEngine

--- a/packages/mpc-types/src/runtime.ts
+++ b/packages/mpc-types/src/runtime.ts
@@ -9,6 +9,12 @@ import { runtimeStore } from './store'
 
 const MPC_ENGINE_INSTANCE_ID = Symbol.for('vultisig.mpcEngine.instanceId')
 
+/**
+ * Tag on the default WASM MPC engine (`@vultisig/mpc-wasm`) so `configureMpc` can treat a
+ * second instance as a benign duplicate when bundlers load the platform entry in multiple chunks.
+ */
+export const WASM_MPC_ENGINE_KIND = 'vultisigWasmMpcEngine' as const
+
 const MPC_SINGLETON_POSTMORTEM =
   'https://github.com/vultisig/vultisig-windows/issues/3777 (MPC runtime singleton / duplicate engine)'
 
@@ -44,6 +50,16 @@ function engineConstructorName(engine: object): string {
   const ctor = (engine as { constructor?: { name?: string } }).constructor
   const name = ctor?.name
   return typeof name === 'string' && name.length > 0 ? name : 'Object'
+}
+
+function isTaggedWasmMpcEngine(engine: object): boolean {
+  try {
+    return (
+      (engine as { _mpcEngineKind?: string })._mpcEngineKind === WASM_MPC_ENGINE_KIND
+    )
+  } catch {
+    return false
+  }
 }
 
 function duplicateConfigureOriginHint(): string {
@@ -83,6 +99,20 @@ function shouldThrowOnDuplicateMpcConfigure(): boolean {
     return true
   }
   return nodeEnv !== 'production'
+}
+
+/** `VULTISIG_STRICT_SINGLETON=1` / Expo alias — not the default dev NODE_ENV strictness. */
+function isExplicitStrictSingletonDuplicateMode(): boolean {
+  try {
+    if (typeof process !== 'undefined' && process.env) {
+      const strict =
+        process.env.VULTISIG_STRICT_SINGLETON ?? process.env.EXPO_PUBLIC_VULTISIG_STRICT_SINGLETON
+      return strict === '1'
+    }
+  } catch {
+    // ignore
+  }
+  return false
 }
 
 function reportDuplicateMpcEngine(existing: object, incoming: MpcEngine): void {
@@ -142,6 +172,29 @@ export function configureMpc(engine: MpcEngine): void {
   const s = runtimeStore()
   const prev = s.mpcEngine as MpcEngine | null
   if (prev === engine) {
+    return
+  }
+  // Dual tagged WasmMpcEngine: keep the first registration when not in strict duplicate
+  // mode. (Non-tagged duplicate engines below still follow the legacy rule: production
+  // overwrites with the incoming engine.)
+  if (
+    prev !== null &&
+    isTaggedWasmMpcEngine(prev as object) &&
+    isTaggedWasmMpcEngine(engine as object)
+  ) {
+    if (isExplicitStrictSingletonDuplicateMode()) {
+      reportDuplicateMpcEngine(prev as object, engine)
+      throw new Error(
+        'configureMpc: duplicate MPC engine instance. ' +
+          `Unset process.env.VULTISIG_STRICT_SINGLETON=1 (or EXPO_PUBLIC_VULTISIG_STRICT_SINGLETON=1 for Expo / React Native consumers) to allow duplicate WasmMpcEngine registrations to warn and keep the first engine. ${MPC_SINGLETON_POSTMORTEM}`
+      )
+    }
+    // Two WasmMpcEngine instances (e.g. duplicate Vite/Rollup chunks each importing the
+    // platform entry) are redundant — keep the first registered engine.
+    console.warn(
+      'configureMpc: ignoring duplicate WasmMpcEngine registration (bundler duplicate chunk / repeated platform init). ' +
+        MPC_SINGLETON_POSTMORTEM
+    )
     return
   }
   if (prev !== null) {

--- a/packages/mpc-wasm/src/index.ts
+++ b/packages/mpc-wasm/src/index.ts
@@ -5,31 +5,31 @@
  * Wraps the existing wasm-bindgen JS wrappers (vs_wasm.js, vs_schnorr_wasm.js).
  * Used by browser, Node.js, Electron, and Chrome Extension platforms.
  */
-import type {
-  MpcEngine,
-  DklsEngine,
-  SchnorrEngine,
-  MpcSession,
-  MpcKeyshare,
-  MpcMessage,
+import {
+  WASM_MPC_ENGINE_KIND,
+  type DklsEngine,
+  type MpcEngine,
+  type MpcKeyshare,
+  type MpcMessage,
+  type MpcSession,
+  type SchnorrEngine,
 } from '@vultisig/mpc-types'
 
 import initDkls, {
   KeygenSession as DklsKeygenSession,
-  SignSession as DklsSignSession,
-  Keyshare as DklsKeyshare,
-  QcSession as DklsQcSession,
   KeyImportInitiator as DklsKeyImportInitiator,
   KeyImportSession as DklsKeyImportSession,
+  Keyshare as DklsKeyshare,
+  QcSession as DklsQcSession,
+  SignSession as DklsSignSession,
 } from '@vultisig/lib-dkls/vs_wasm'
-
 import initSchnorr, {
   KeygenSession as SchnorrKeygenSession,
-  SignSession as SchnorrSignSession,
-  Keyshare as SchnorrKeyshare,
-  QcSession as SchnorrQcSession,
   KeyImportInitiator as SchnorrKeyImportInitiator,
   KeyImportSession as SchnorrKeyImportSession,
+  Keyshare as SchnorrKeyshare,
+  QcSession as SchnorrQcSession,
+  SignSession as SchnorrSignSession,
 } from '@vultisig/lib-schnorr/vs_schnorr_wasm'
 
 // ---------------------------------------------------------------------------
@@ -51,7 +51,7 @@ function wrapKeyshare(ks: DklsKeyshare | SchnorrKeyshare): MpcKeyshare {
 // ---------------------------------------------------------------------------
 
 /** A WASM session object that follows the message-loop pattern. */
-interface WasmSessionLike {
+type WasmSessionLike = {
   outputMessage(): { body: Uint8Array; receivers: string[] } | undefined
   inputMessage(msg: Uint8Array): boolean
   free?(): void
@@ -285,6 +285,8 @@ class WasmSchnorrEngine implements SchnorrEngine {
 // ---------------------------------------------------------------------------
 
 export class WasmMpcEngine implements MpcEngine {
+  readonly _mpcEngineKind = WASM_MPC_ENGINE_KIND
+
   readonly dkls: DklsEngine = new WasmDklsEngine()
   readonly schnorr: SchnorrEngine = new WasmSchnorrEngine()
 

--- a/packages/sdk/tests/unit/configureMpc.duplicate.test.ts
+++ b/packages/sdk/tests/unit/configureMpc.duplicate.test.ts
@@ -1,11 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { MpcEngine } from '../../../mpc-types/src/index'
-import {
-  configureMpc,
-  getMpcEngine,
-  WASM_MPC_ENGINE_KIND,
-} from '../../../mpc-types/src/runtime'
+import { configureMpc, getMpcEngine, WASM_MPC_ENGINE_KIND } from '../../../mpc-types/src/runtime'
 import { __resetRuntimeStoreForTesting } from '../../../mpc-types/src/store'
 // Import configureMpc from mpc-types source so Vitest does not load two copies of runtime.ts.
 

--- a/packages/sdk/tests/unit/configureMpc.duplicate.test.ts
+++ b/packages/sdk/tests/unit/configureMpc.duplicate.test.ts
@@ -1,5 +1,13 @@
-import { __resetRuntimeStoreForTesting, configureMpc, getMpcEngine, type MpcEngine } from '@vultisig/mpc-types'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { MpcEngine } from '../../../mpc-types/src/index'
+import {
+  configureMpc,
+  getMpcEngine,
+  WASM_MPC_ENGINE_KIND,
+} from '../../../mpc-types/src/runtime'
+import { __resetRuntimeStoreForTesting } from '../../../mpc-types/src/store'
+// Import configureMpc from mpc-types source so Vitest does not load two copies of runtime.ts.
 
 function minimalEngine(id: string): MpcEngine {
   return {
@@ -15,6 +23,7 @@ describe('configureMpc duplicate engine detection', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
     process.env = { ...envSnapshot }
+    __resetRuntimeStoreForTesting()
   })
 
   afterEach(() => {
@@ -31,6 +40,47 @@ describe('configureMpc duplicate engine detection', () => {
     expect(getMpcEngine()).toBe(engine)
     expect(err).not.toHaveBeenCalled()
     expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('ignores a second distinct engine when both carry the WasmMPC brand', () => {
+    process.env.NODE_ENV = 'test'
+    Reflect.deleteProperty(process.env, 'VULTISIG_STRICT_SINGLETON')
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const branded = (id: string) => ({
+      _mpcEngineKind: WASM_MPC_ENGINE_KIND,
+      initialize: async () => {},
+      dkls: { _id: id } as unknown as MpcEngine['dkls'],
+      schnorr: { _id: id } as unknown as MpcEngine['schnorr'],
+    })
+
+    const a = branded('a')
+    const b = branded('b')
+    configureMpc(a as MpcEngine)
+    configureMpc(b as MpcEngine)
+    expect(getMpcEngine()).toBe(a)
+    expect(err).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it('still throws for two tagged Wasm engines when VULTISIG_STRICT_SINGLETON=1', () => {
+    process.env.NODE_ENV = 'production'
+    process.env.VULTISIG_STRICT_SINGLETON = '1'
+    Reflect.deleteProperty(process.env, 'EXPO_PUBLIC_VULTISIG_STRICT_SINGLETON')
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const branded = (id: string) => ({
+      _mpcEngineKind: WASM_MPC_ENGINE_KIND,
+      initialize: async () => {},
+      dkls: { _id: id } as unknown as MpcEngine['dkls'],
+      schnorr: { _id: id } as unknown as MpcEngine['schnorr'],
+    })
+    const a = branded('a')
+    const b = branded('b')
+    configureMpc(a as MpcEngine)
+    expect(() => configureMpc(b as MpcEngine)).toThrow(/configureMpc: duplicate MPC engine instance/)
+    expect(getMpcEngine()).toBe(a)
   })
 
   it('throws in non-production when a second distinct engine is registered', () => {

--- a/packages/sdk/tests/unit/vitest.config.ts
+++ b/packages/sdk/tests/unit/vitest.config.ts
@@ -43,7 +43,7 @@ export default defineConfig({
     },
     server: {
       deps: {
-        inline: [/@cosmjs/, /@scure/],
+        inline: [/@cosmjs/, /@scure/, /@vultisig\/mpc-types/],
       },
     },
     // Coverage configuration for Phase 1: 30% target

--- a/yarn.lock
+++ b/yarn.lock
@@ -6974,7 +6974,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@vultisig/mpc-types@workspace:packages/mpc-types"
   peerDependencies:
-    "@vultisig/mpc-wasm": ">=0.1.4"
+    "@vultisig/mpc-wasm": ">=0.1.5"
   peerDependenciesMeta:
     "@vultisig/mpc-wasm":
       optional: true


### PR DESCRIPTION
Closes #3831

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented signing failures when platform bundles load runtime across multiple chunks by treating duplicate Wasm MPC engine registrations as benign (or, in strict mode, emitting a clear error).
  * Avoided dev-time throws during redundant engine configuration; now warns and keeps the original engine by default.

* **Improvements**
  * Normalized WASM-emitted Schnorr signatures to improve signature reliability.

* **Tests**
  * Added tests validating branded Wasm engine singleton handling and strict-mode behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->