### PR TITLE
refactor(cosmos-fee): read fee from blockchainSpecific only

### DIFF
--- a/packages/core/mpc/keysign/fee/resolvers/cosmos.ts
+++ b/packages/core/mpc/keysign/fee/resolvers/cosmos.ts
@@ -1,9 +1,4 @@
-import { CosmosChain } from '@vultisig/core-chain/Chain'
-import { sumFeeAmountForCosmosChainFeeDenom } from '@vultisig/core-chain/chains/cosmos/sumFeeAmountForCosmosChainFeeDenom'
-import type { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
-import { fromBase64 } from '@cosmjs/encoding'
 import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
-import { AuthInfo } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
 
 import { getCosmosChainSpecific } from '../../signingInputs/resolvers/cosmos/chainSpecific'
 import { getKeysignChain } from '../../utils/getKeysignChain'
@@ -11,34 +6,13 @@ import { FeeAmountResolver } from '../resolver'
 
 const mayaGas = 2000000000n
 
-const getCosmosFeeFromSignData = (
-  keysignPayload: KeysignPayload,
-  chain: CosmosChain
-): bigint | null => {
-  const signData = keysignPayload.signData
-
-  if (signData.case === 'signDirect') {
-    const authInfoBytes = fromBase64(signData.value.authInfoBytes)
-    const authInfo = AuthInfo.decode(authInfoBytes)
-    if (!authInfo.fee?.amount) return null
-    return sumFeeAmountForCosmosChainFeeDenom({
-      amounts: authInfo.fee.amount,
-      chain,
-    })
-  }
-
-  if (signData.case === 'signAmino') {
-    const feeAmounts = signData.value.fee?.amount
-    if (!feeAmounts) return null
-    return sumFeeAmountForCosmosChainFeeDenom({
-      amounts: feeAmounts,
-      chain,
-    })
-  }
-
-  return null
-}
-
+/**
+ * Reads the cosmos fee from `blockchainSpecific`. Initiators are responsible
+ * for writing the canonical fee (e.g. the dapp-supplied value when signing
+ * via signAmino / signDirect) into `THORChainSpecific.fee` /
+ * `CosmosSpecific.gas` at keysign-payload build time, so every consumer —
+ * including this resolver — agrees on what the chain will charge.
+ */
 export const getCosmosFeeAmount: FeeAmountResolver = ({ keysignPayload }) => {
   const chain = getKeysignChain<'cosmos'>(keysignPayload)
 
@@ -49,17 +23,6 @@ export const getCosmosFeeAmount: FeeAmountResolver = ({ keysignPayload }) => {
 
   return matchRecordUnion(chainSpecific, {
     ibcEnabled: ({ gas }) => gas,
-    vaultBased: value => {
-      const feeFromSignData = getCosmosFeeFromSignData(keysignPayload, chain)
-      if (feeFromSignData !== null) {
-        return feeFromSignData
-      }
-
-      if ('fee' in value) {
-        return value.fee
-      }
-
-      return mayaGas
-    },
+    vaultBased: value => ('fee' in value ? value.fee : mayaGas),
   })
 }


### PR DESCRIPTION
## Summary
- Drops the in-resolver fallback that decoded the fee out of `signData` and made `blockchainSpecific` the single source of truth for cosmos fees. The resolver now reads `THORChainSpecific.fee` / `CosmosSpecific.gas` directly.
- Companion to vultisig/vultisig-windows#3843, which adds the build-time copy on the initiator side: when a dapp keysign payload is built with `signAmino` / `signDirect`, the fee is sumed into the matching `blockchainSpecific` field. With the windows change merged + released, this resolver agrees with the displayed JSON.

## Migration note
Other initiators (iOS / Android dapp browsers) need the same build-time copy for txs they originate. Until they do, cosigners on a new SDK version may display the network estimate instead of the dapp-supplied fee for cosmos txs initiated from those platforms — the broadcast tx itself is unaffected (still built from `signData`).

## Test plan
- [ ] `yarn check` succeeds in the SDK
- [ ] After cutting a release and bumping vultisig-windows, the windows companion PR's checks still pass against the new SDK
- [ ] On a THORChain Rujira tx with dapp-supplied `fee.amount = 0`, Network Fee row reads 0 RUNE on the windows extension popup
- [ ] On a Cosmos / IBC-enabled tx with a non-zero dapp fee, Network Fee row shows the exact value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified Cosmos fee resolution logic by leveraging canonical fee data from existing sources.

* **Documentation**
  * Added clarification on fee canonicalization requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->