### PR TITLE
chore(thorchain): use Liquify gateway for Midgard/THORNode/RPC

### DIFF
--- a/.changeset/thorchain-liquify-gateway.md
+++ b/.changeset/thorchain-liquify-gateway.md
@@ -1,0 +1,8 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/rujira': patch
+---
+
+Migrate THORChain Midgard, THORNode REST, and Tendermint RPC endpoints from the legacy `*.thorchain.network` hosts to the Liquify gateway (`gateway.liquify.com/chain/thorchain_midgard`, `…/thorchain_api`, `…/thorchain_rpc`). Updated `cosmosRpcUrl.THORChain`, `tendermintRpcUrl.THORChain`, `thorchainMidgardBaseUrl`, and the rujira `MAINNET_CONFIG` endpoints accordingly.
+
+In `RujiraDiscovery.discoverViaChain()`, replaced the brittle `rpc → thornode` string substitution with a direct read of `MAINNET_CONFIG.restEndpoint`. Under the new gateway routing the substitution silently produced an invalid host (`thorchain_thornode`) and the fallback branch was unreachable. Removed the now-unused `rpcEndpoint` option from `DiscoveryOptions` and the corresponding plumbing in `RujiraClient`.

--- a/packages/core/chain/chains/cosmos/cosmosRpcUrl.ts
+++ b/packages/core/chain/chains/cosmos/cosmosRpcUrl.ts
@@ -10,7 +10,7 @@ export const cosmosRpcUrl: Record<CosmosChain, string> = {
   Terra: 'https://terra-lcd.publicnode.com',
   TerraClassic: 'https://terra-classic-lcd.publicnode.com',
   Noble: 'https://noble-api.polkachu.com',
-  THORChain: 'https://thornode.thorchain.network',
+  THORChain: 'https://gateway.liquify.com/chain/thorchain_api',
   MayaChain: 'https://mayanode.mayachain.info',
   Akash: 'https://akash-rest.publicnode.com',
 }

--- a/packages/core/chain/chains/cosmos/tendermintRpcUrl.ts
+++ b/packages/core/chain/chains/cosmos/tendermintRpcUrl.ts
@@ -8,7 +8,7 @@ export const tendermintRpcUrl: Record<CosmosChain, string> = {
   Terra: 'https://terra-rpc.publicnode.com:443',
   TerraClassic: 'https://terra-classic-rpc.publicnode.com:443',
   Noble: 'https://noble-rpc.polkachu.com/',
-  THORChain: 'https://rpc.thorchain.network',
+  THORChain: 'https://gateway.liquify.com/chain/thorchain_rpc',
   MayaChain: 'https://tendermint.mayachain.info',
   Akash: 'https://akash-rpc.publicnode.com:443',
 }

--- a/packages/core/chain/chains/cosmos/thor/lp/pools.ts
+++ b/packages/core/chain/chains/cosmos/thor/lp/pools.ts
@@ -4,7 +4,7 @@ import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
  * Midgard base URL used by every helper in this module. Matches what
  * vultisig-ios and the rujira package use as the default mainnet endpoint.
  */
-export const thorchainMidgardBaseUrl = 'https://midgard.thorchain.network'
+export const thorchainMidgardBaseUrl = 'https://gateway.liquify.com/chain/thorchain_midgard'
 
 /**
  * Canonical THORChain pool-id format: `CHAIN.ASSET` for native assets

--- a/packages/rujira/src/client.ts
+++ b/packages/rujira/src/client.ts
@@ -82,7 +82,6 @@ export class RujiraClient {
     this.range = new RujiraRange(this)
 
     this.discovery = new RujiraDiscovery({
-      rpcEndpoint: this.config.rpcEndpoint,
       debug: this.debug,
     })
   }

--- a/packages/rujira/src/config.ts
+++ b/packages/rujira/src/config.ts
@@ -38,9 +38,9 @@ export type RujiraConfig = {
 export const MAINNET_CONFIG: RujiraConfig = {
   network: 'mainnet',
   chainId: 'thorchain-1',
-  rpcEndpoint: 'https://rpc.thorchain.network',
-  restEndpoint: 'https://thornode.thorchain.network',
-  midgardEndpoint: 'https://midgard.thorchain.network/v2',
+  rpcEndpoint: 'https://gateway.liquify.com/chain/thorchain_rpc',
+  restEndpoint: 'https://gateway.liquify.com/chain/thorchain_api',
+  midgardEndpoint: 'https://gateway.liquify.com/chain/thorchain_midgard/v2',
   graphqlWsEndpoint: 'wss://api.rujira.network/socket',
   gasPrice: DEFAULT_GAS_PRICE,
   gasLimit: 500000,

--- a/packages/rujira/src/discovery/discovery.ts
+++ b/packages/rujira/src/discovery/discovery.ts
@@ -6,14 +6,12 @@ import type { DiscoveredContracts, Market } from './types.js'
 
 export type DiscoveryOptions = {
   graphql?: GraphQLClientOptions
-  rpcEndpoint?: string
   cacheTtl?: number
   debug?: boolean
 }
 
 export class RujiraDiscovery {
   private graphql: GraphQLClient
-  private rpcEndpoint: string
   private cacheTtl: number
   private debug: boolean
   private finCodeId: number
@@ -23,7 +21,6 @@ export class RujiraDiscovery {
   constructor(options: DiscoveryOptions = {}) {
     const networkConfig = MAINNET_CONFIG
 
-    this.rpcEndpoint = options.rpcEndpoint || networkConfig.rpcEndpoint
     this.cacheTtl = options.cacheTtl ?? 5 * 60 * 1000
     this.debug = options.debug || false
     this.finCodeId = networkConfig.contracts.finCodeId
@@ -203,8 +200,15 @@ export class RujiraDiscovery {
   private async discoverViaChain(): Promise<DiscoveredContracts> {
     const fin: Record<string, string> = {}
 
-    const baseUrl = this.rpcEndpoint.replace(':26657', '').replace('rpc', 'thornode')
-    const restUrl = baseUrl.includes('thornode') ? baseUrl : 'https://thornode.thorchain.network'
+    // Read the THORNode REST URL straight from MAINNET_CONFIG instead of
+    // deriving it from rpcEndpoint via string substitution. The previous
+    // logic assumed RPC URLs contained the literal substring 'rpc' which
+    // could be swapped for 'thornode' (e.g. rpc.thorchain.network →
+    // thornode.thorchain.network). With the Liquify gateway the RPC and
+    // REST services live at distinct path segments (`thorchain_rpc` vs
+    // `thorchain_api`), so the substitution silently produced an invalid
+    // host (`thorchain_thornode`) and the fallback branch was unreachable.
+    const restUrl = MAINNET_CONFIG.restEndpoint
 
     try {
       // Paginate through all contracts for this code ID


### PR DESCRIPTION
## Summary
- Migrate THORChain Midgard, THORNode REST, and Tendermint RPC endpoints from `*.thorchain.network` to the Liquify gateway: `gateway.liquify.com/chain/thorchain_midgard`, `…/thorchain_api`, `…/thorchain_rpc`. Touches `cosmosRpcUrl.THORChain`, `tendermintRpcUrl.THORChain`, `thorchainMidgardBaseUrl`, and rujira `MAINNET_CONFIG`.
- Replace the brittle `rpc → thornode` string substitution in `RujiraDiscovery.discoverViaChain()` with a direct read of `MAINNET_CONFIG.restEndpoint`. Under the new gateway routing the old transform produced an invalid `thorchain_thornode` host and made the fallback branch unreachable.
- Drop the now-unused `rpcEndpoint` option from `DiscoveryOptions` and the corresponding plumbing in `RujiraClient`.

## Test plan
- [ ] `GET gateway.liquify.com/chain/thorchain_midgard/v2/pools` returns the expected pool list (wired via `getThorchainPools`).
- [ ] `GET gateway.liquify.com/chain/thorchain_api/cosmwasm/wasm/v1/code/{finCodeId}/contracts` paginates correctly through `RujiraDiscovery.discoverViaChain()`.
- [ ] Tendermint RPC operations against `gateway.liquify.com/chain/thorchain_rpc` succeed (status, abci_info, broadcast).
- [ ] `RujiraClient` connects on mainnet with the default config (no custom `rpcEndpoint` override required).
- [ ] Existing balance / send / swap flows on THORChain still work end-to-end through the SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated all THORChain service endpoints to the Liquify gateway infrastructure, including RPC, API, and Midgard services for improved reliability.
  * Simplified endpoint discovery configuration by removing the unused legacy RPC endpoint option and relying on centralized gateway configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->