### PR TITLE
feat(blockaid): parse all assets_diffs as net balance changes

### DIFF
--- a/packages/core/chain/security/blockaid/tx/simulation/api/core.test.ts
+++ b/packages/core/chain/security/blockaid/tx/simulation/api/core.test.ts
@@ -19,11 +19,12 @@ const asset = (overrides: Partial<Asset> = {}): Asset => ({
   ...overrides,
 })
 
-const side = (rawValue: string): Side => ({
-  usd_price: 1,
+const side = (rawValue: string, overrides: Partial<Side> = {}): Side => ({
+  usd_price: 0,
   summary: '',
-  value: 1,
+  value: 0,
   raw_value: rawValue,
+  ...overrides,
 })
 
 const diff = (parts: Partial<AssetDiff> & Pick<AssetDiff, 'asset'>): AssetDiff => ({
@@ -55,29 +56,30 @@ const TOKEN_B = asset({
 })
 
 describe('parseBlockaidEvmSimulation', () => {
-  it('returns a transfer for a single-diff simulation', async () => {
+  it('emits a single send change for a single-diff out simulation', async () => {
     const result = await parseBlockaidEvmSimulation(
       buildSimulation([diff({ asset: TOKEN_A, out: [side('1000')] })]),
       EvmChain.Ethereum
     )
 
     expect(result).toEqual({
-      transfer: {
-        fromCoin: {
-          decimals: TOKEN_A.decimals,
-          logo: TOKEN_A.logo_url,
-          ticker: TOKEN_A.symbol,
-          id: TOKEN_A.address,
-          chain: EvmChain.Ethereum,
+      changes: [
+        {
+          direction: 'send',
+          coin: {
+            decimals: TOKEN_A.decimals,
+            logo: TOKEN_A.logo_url,
+            ticker: TOKEN_A.symbol,
+            id: TOKEN_A.address,
+            chain: EvmChain.Ethereum,
+          },
+          amount: 1000n,
         },
-        fromAmount: 1000n,
-      },
+      ],
     })
   })
 
-  it('pairs swap diffs across a router-mediated permitAndCall flow (3 diffs)', async () => {
-    // Reproduces the issue: user sends Token A, receives Token B, with an
-    // empty intermediate router/permit leg between them.
+  it('returns net send + receive across a router-mediated permitAndCall flow (3 diffs)', async () => {
     const result = await parseBlockaidEvmSimulation(
       buildSimulation([
         diff({ asset: TOKEN_A, out: [side('5000')] }),
@@ -87,33 +89,47 @@ describe('parseBlockaidEvmSimulation', () => {
       EvmChain.Ethereum
     )
 
-    expect(result).toMatchObject({
-      swap: {
-        fromCoin: { id: TOKEN_A.address, ticker: 'A' },
-        toCoin: { id: TOKEN_B.address, ticker: 'B' },
-        fromAmount: 5000n,
-        toAmount: 42n,
-      },
+    expect(result).toEqual({
+      changes: [
+        expect.objectContaining({
+          direction: 'send',
+          coin: expect.objectContaining({ id: TOKEN_A.address, ticker: 'A' }),
+          amount: 5000n,
+        }),
+        expect.objectContaining({
+          direction: 'receive',
+          coin: expect.objectContaining({ id: TOKEN_B.address, ticker: 'B' }),
+          amount: 42n,
+        }),
+      ],
     })
   })
 
-  it('preserves the standard 2-diff swap shape', async () => {
+  it('emits two changes for the standard 2-diff swap shape', async () => {
     const result = await parseBlockaidEvmSimulation(
       buildSimulation([diff({ asset: TOKEN_A, out: [side('100')] }), diff({ asset: TOKEN_B, in: [side('200')] })]),
       EvmChain.Ethereum
     )
 
-    expect(result).toMatchObject({
-      swap: {
-        fromCoin: { id: TOKEN_A.address },
-        toCoin: { id: TOKEN_B.address },
-        fromAmount: 100n,
-        toAmount: 200n,
-      },
+    expect(result).toEqual({
+      changes: [
+        expect.objectContaining({
+          direction: 'send',
+          coin: expect.objectContaining({ id: TOKEN_A.address }),
+          amount: 100n,
+        }),
+        expect.objectContaining({
+          direction: 'receive',
+          coin: expect.objectContaining({ id: TOKEN_B.address }),
+          amount: 200n,
+        }),
+      ],
     })
   })
 
-  it('treats EIP-55 checksum casing as the same asset when picking the in-side', async () => {
+  it('groups EIP-55 checksum casing as the same asset and nets across legs', async () => {
+    // The checksum-case A leg cancels the original-case A leg (same address,
+    // different display casing), so the net effect is just the +B leg.
     const tokenAChecksum = asset({
       address: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
       symbol: 'A',
@@ -127,21 +143,38 @@ describe('parseBlockaidEvmSimulation', () => {
       EvmChain.Ethereum
     )
 
-    expect(result).toMatchObject({
-      swap: {
-        fromCoin: { id: TOKEN_A.address },
-        toCoin: { id: TOKEN_B.address },
-      },
+    expect(result).toEqual({
+      changes: [
+        expect.objectContaining({
+          direction: 'receive',
+          coin: expect.objectContaining({ id: TOKEN_B.address }),
+          amount: 2n,
+        }),
+      ],
     })
   })
 
-  it('returns null when there is no out-side diff', async () => {
+  it('returns null when there is no out-side diff and no in-side diff', async () => {
+    const result = await parseBlockaidEvmSimulation(
+      buildSimulation([diff({ asset: TOKEN_A }), diff({ asset: TOKEN_B })]),
+      EvmChain.Ethereum
+    )
+
+    expect(result).toBeNull()
+  })
+
+  it('emits two receives when only the in-side has values across two assets', async () => {
     const result = await parseBlockaidEvmSimulation(
       buildSimulation([diff({ asset: TOKEN_A, in: [side('1')] }), diff({ asset: TOKEN_B, in: [side('2')] })]),
       EvmChain.Ethereum
     )
 
-    expect(result).toBeNull()
+    expect(result).toEqual({
+      changes: [
+        expect.objectContaining({ direction: 'receive', amount: 1n }),
+        expect.objectContaining({ direction: 'receive', amount: 2n }),
+      ],
+    })
   })
 
   it('returns null when the only in-side diff is the same asset as the out-side (refund-shaped)', async () => {
@@ -172,5 +205,61 @@ describe('parseBlockaidEvmSimulation', () => {
     )
 
     expect(result).toBeNull()
+  })
+
+  it('emits net send when an asset has both out and in legs and out > in', async () => {
+    // User sends 10 A and receives 1 A as refund — net send of 9 A.
+    const result = await parseBlockaidEvmSimulation(
+      buildSimulation([
+        diff({ asset: TOKEN_A, out: [side('10')] }),
+        diff({ asset: TOKEN_A, in: [side('1')] }),
+      ]),
+      EvmChain.Ethereum
+    )
+
+    expect(result).toEqual({
+      changes: [
+        expect.objectContaining({
+          direction: 'send',
+          coin: expect.objectContaining({ id: TOKEN_A.address }),
+          amount: 9n,
+        }),
+      ],
+    })
+  })
+
+  it('emits multiple changes for a multicall-style simulation (4 diffs)', async () => {
+    const TOKEN_C = asset({
+      address: '0xcccccccccccccccccccccccccccccccccccccccc',
+      symbol: 'C',
+      decimals: 8,
+    })
+    const result = await parseBlockaidEvmSimulation(
+      buildSimulation([
+        diff({ asset: TOKEN_A, out: [side('100')] }),
+        diff({ asset: TOKEN_B, out: [side('200')] }),
+        diff({ asset: TOKEN_C, in: [side('300')] }),
+        diff({ asset: asset({ address: '0xdddd' }), in: [side('400')] }),
+      ]),
+      EvmChain.Ethereum
+    )
+
+    expect(result?.changes).toHaveLength(4)
+    expect(result?.changes.filter(c => c.direction === 'send')).toHaveLength(2)
+    expect(result?.changes.filter(c => c.direction === 'receive')).toHaveLength(2)
+  })
+
+  it('aggregates usdValue from in/out side prices when present', async () => {
+    const result = await parseBlockaidEvmSimulation(
+      buildSimulation([
+        diff({
+          asset: TOKEN_A,
+          out: [side('1000', { usd_price: 1.5, value: 2 })],
+        }),
+      ]),
+      EvmChain.Ethereum
+    )
+
+    expect(result?.changes[0].usdValue).toBe(3)
   })
 })

--- a/packages/core/chain/security/blockaid/tx/simulation/api/core.test.ts
+++ b/packages/core/chain/security/blockaid/tx/simulation/api/core.test.ts
@@ -262,4 +262,65 @@ describe('parseBlockaidEvmSimulation', () => {
 
     expect(result?.changes[0].usdValue).toBe(3)
   })
+
+  it('omits coin.id for native assets', async () => {
+    const nativeAsset = asset({
+      type: 'NATIVE',
+      address: undefined,
+      symbol: 'ETH',
+      decimals: 18,
+    })
+    const result = await parseBlockaidEvmSimulation(
+      buildSimulation([
+        diff({ asset_type: 'NATIVE', asset: nativeAsset, out: [side('1000')] }),
+      ]),
+      EvmChain.Ethereum
+    )
+
+    expect(result?.changes).toHaveLength(1)
+    expect(result?.changes[0].coin).not.toHaveProperty('id')
+    expect(result?.changes[0].coin).toMatchObject({
+      ticker: 'ETH',
+      chain: EvmChain.Ethereum,
+    })
+  })
+
+  it('lowercases ERC20 address in emitted coin.id regardless of input casing', async () => {
+    const tokenAChecksum = asset({
+      address: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      symbol: 'A',
+    })
+    const result = await parseBlockaidEvmSimulation(
+      buildSimulation([diff({ asset: tokenAChecksum, out: [side('1')] })]),
+      EvmChain.Ethereum
+    )
+
+    expect(result?.changes[0].coin.id).toBe(
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    )
+  })
+
+  it('skips malformed ERC20 entries without an address (does not group with native)', async () => {
+    const nativeAsset = asset({
+      type: 'NATIVE',
+      address: undefined,
+      symbol: 'ETH',
+      decimals: 18,
+    })
+    const malformedErc20 = asset({ address: undefined, symbol: 'BROKEN' })
+    const result = await parseBlockaidEvmSimulation(
+      buildSimulation([
+        diff({ asset_type: 'NATIVE', asset: nativeAsset, out: [side('100')] }),
+        diff({ asset: malformedErc20, in: [side('999')] }),
+      ]),
+      EvmChain.Ethereum
+    )
+
+    expect(result?.changes).toHaveLength(1)
+    expect(result?.changes[0]).toMatchObject({
+      direction: 'send',
+      amount: 100n,
+    })
+    expect(result?.changes[0].coin.ticker).toBe('ETH')
+  })
 })

--- a/packages/core/chain/security/blockaid/tx/simulation/api/core.ts
+++ b/packages/core/chain/security/blockaid/tx/simulation/api/core.ts
@@ -163,8 +163,13 @@ type EvmAssetSide = EvmAssetDiff['in'][number]
 
 const NATIVE_GROUP_KEY = 'native'
 
-const groupKeyForAsset = (asset: EvmAssetDiff['asset']): string =>
-  asset.address?.toLowerCase() ?? NATIVE_GROUP_KEY
+// Returns null for malformed ERC20 entries (missing address) so the caller
+// can skip them instead of silently merging into the native bucket.
+const groupKeyForAsset = (asset: EvmAssetDiff['asset']): string | null => {
+  if (asset.type === 'NATIVE') return NATIVE_GROUP_KEY
+  const address = asset.address?.toLowerCase()
+  return address ?? null
+}
 
 const sumRaw = (sides: EvmAssetSide[]): bigint =>
   sides.reduce((total, side) => total + BigInt(side.raw_value), 0n)
@@ -181,16 +186,24 @@ const usdValueForSides = (sides: EvmAssetSide[]): number => {
   return hasPrice ? total : 0
 }
 
+// `Coin.id` is token-only (see core/chain/coin/Coin.ts), and Blockaid sometimes
+// returns the same contract with mismatched casing across diffs; lowercase the
+// ERC20 address so downstream lookups don't depend on whichever case landed first.
 const buildCoinFromAsset = (
   asset: EvmAssetDiff['asset'],
   chain: EvmChain
-): Coin => ({
-  decimals: asset.decimals,
-  logo: asset.logo_url,
-  ticker: asset.symbol,
-  id: asset.address,
-  chain,
-})
+): Coin => {
+  const base: Coin = {
+    decimals: asset.decimals,
+    logo: asset.logo_url,
+    ticker: asset.symbol,
+    chain,
+  }
+  if (asset.type === 'ERC20' && asset.address) {
+    return { ...base, id: asset.address.toLowerCase() }
+  }
+  return base
+}
 
 /**
  * Parse a Blockaid EVM simulation into the user's net balance changes.
@@ -224,6 +237,7 @@ export const parseBlockaidEvmSimulation = async (
 
   for (const diff of simulation.account_summary.assets_diffs) {
     const key = groupKeyForAsset(diff.asset)
+    if (key === null) continue
     const sentRaw = sumRaw(diff.out)
     const receivedRaw = sumRaw(diff.in)
     const sentUsd = usdValueForSides(diff.out)

--- a/packages/core/chain/security/blockaid/tx/simulation/api/core.ts
+++ b/packages/core/chain/security/blockaid/tx/simulation/api/core.ts
@@ -2,7 +2,12 @@ import { EvmChain } from '@vultisig/core-chain/Chain'
 import { isChainOfKind } from '@vultisig/core-chain/ChainKind'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 
-import { BlockaidEvmSimulationInfo, BlockaidSolanaSimulationInfo } from '../core'
+import { Coin } from '../../../../../coin/Coin'
+import {
+  BlockaidEvmBalanceChange,
+  BlockaidEvmSimulationInfo,
+  BlockaidSolanaSimulationInfo,
+} from '../core'
 
 export type BlockaidSolanaSimulation = {
   account_summary: {
@@ -153,6 +158,54 @@ export const parseBlockaidSolanaSimulation = async (
   throw new Error('Invalid simulation data')
 }
 
+type EvmAssetDiff = BlockaidEVMSimulation['account_summary']['assets_diffs'][number]
+type EvmAssetSide = EvmAssetDiff['in'][number]
+
+const NATIVE_GROUP_KEY = 'native'
+
+const groupKeyForAsset = (asset: EvmAssetDiff['asset']): string =>
+  asset.address?.toLowerCase() ?? NATIVE_GROUP_KEY
+
+const sumRaw = (sides: EvmAssetSide[]): bigint =>
+  sides.reduce((total, side) => total + BigInt(side.raw_value), 0n)
+
+const usdValueForSides = (sides: EvmAssetSide[]): number => {
+  let total = 0
+  let hasPrice = false
+  for (const side of sides) {
+    if (typeof side.usd_price === 'number' && side.usd_price > 0) {
+      hasPrice = true
+    }
+    total += side.value * side.usd_price
+  }
+  return hasPrice ? total : 0
+}
+
+const buildCoinFromAsset = (
+  asset: EvmAssetDiff['asset'],
+  chain: EvmChain
+): Coin => ({
+  decimals: asset.decimals,
+  logo: asset.logo_url,
+  ticker: asset.symbol,
+  id: asset.address,
+  chain,
+})
+
+/**
+ * Parse a Blockaid EVM simulation into the user's net balance changes.
+ *
+ * Blockaid returns one entry per asset under `assets_diffs`, with separate
+ * `in` and `out` arrays that can each have multiple legs (router-mediated
+ * `permitAndCall` flows, multicalls, multi-hop swaps, etc.). We group all
+ * legs by canonical asset (lowercased address; native uses a sentinel key),
+ * sum each side, and emit one change per asset with the net direction.
+ *
+ * Refund-shaped pairs (same asset on both `in` and `out`) cancel out to a
+ * net of zero and are skipped — both casing-variant duplicates from
+ * Blockaid metadata noise and real same-asset refunds collapse to the
+ * accurate "no change" outcome.
+ */
 export const parseBlockaidEvmSimulation = async (
   simulation: BlockaidEVMSimulation,
   chain: EvmChain
@@ -161,83 +214,53 @@ export const parseBlockaidEvmSimulation = async (
     throw new Error(`parseBlockaidEvmSimulation only supports EVM chains, got: ${chain}`)
   }
 
-  const assetDiffs = simulation.account_summary.assets_diffs
+  type Group = {
+    asset: EvmAssetDiff['asset']
+    netRaw: bigint
+    netUsd: number
+  }
 
-  if (assetDiffs.length === 1) {
-    const [potentialOutAsset] = assetDiffs
+  const groups = new Map<string, Group>()
 
-    if (potentialOutAsset.out.length === 0) {
-      return null
-    }
+  for (const diff of simulation.account_summary.assets_diffs) {
+    const key = groupKeyForAsset(diff.asset)
+    const sentRaw = sumRaw(diff.out)
+    const receivedRaw = sumRaw(diff.in)
+    const sentUsd = usdValueForSides(diff.out)
+    const receivedUsd = usdValueForSides(diff.in)
 
-    return {
-      transfer: {
-        fromCoin: {
-          decimals: potentialOutAsset.asset.decimals,
-          logo: potentialOutAsset.asset.logo_url,
-          ticker: potentialOutAsset.asset.symbol,
-          id: potentialOutAsset.asset.address,
-          chain: chain,
-        },
-        fromAmount: shouldBePresent(BigInt(potentialOutAsset.out[0].raw_value)),
-      },
-    }
-  } else if (assetDiffs.length > 1) {
-    // Router-mediated flows (e.g. `permitAndCall`) often return three diffs
-    // with an intermediate permit/allowance leg between the user's `out` and
-    // `in` sides. Scan all diffs instead of using positional destructuring so
-    // the user-side pair is recovered regardless of order, and prefer an
-    // in-side asset that differs from the out-side asset (case-insensitive,
-    // since EIP-55 checksums vary by casing). Mirrors the iOS parser.
-    const outDiff = assetDiffs.find(diff => diff.out.length > 0)
-    if (!outDiff) {
-      return null
-    }
-
-    const outAddress = outDiff.asset.address?.toLowerCase()
-    const inDiff =
-      assetDiffs.find(diff => diff.in.length > 0 && diff.asset.address?.toLowerCase() !== outAddress) ??
-      assetDiffs.find(diff => diff.in.length > 0)
-
-    if (!inDiff) {
-      return null
-    }
-
-    // Address is the primary identity for a token; symbol is just metadata
-    // and Blockaid sometimes returns inconsistent casing (`USDC` vs `usdc`)
-    // for the same contract. Reject refund-shaped pairs by address alone so
-    // we don't render a nonsense `A → A` swap when the in-side fallback
-    // matches the out-side asset.
-    const inAddress = inDiff.asset.address?.toLowerCase()
-    if (outAddress === inAddress) {
-      return null
-    }
-
-    const outAsset = outDiff.asset
-    const outValue = outDiff.out
-    const inAsset = inDiff.asset
-    const inValue = inDiff.in
-
-    return {
-      swap: {
-        fromCoin: {
-          decimals: outAsset.decimals,
-          logo: outAsset.logo_url,
-          ticker: outAsset.symbol,
-          id: outAsset.address,
-          chain: chain,
-        },
-        toCoin: {
-          chain: chain,
-          decimals: inAsset.decimals,
-          logo: inAsset.logo_url,
-          ticker: inAsset.symbol,
-          id: inAsset.address,
-        },
-        fromAmount: shouldBePresent(BigInt(outValue[0].raw_value)),
-        toAmount: shouldBePresent(BigInt(inValue[0].raw_value)),
-      },
+    const existing = groups.get(key)
+    if (existing) {
+      existing.netRaw += receivedRaw - sentRaw
+      existing.netUsd += receivedUsd - sentUsd
+    } else {
+      groups.set(key, {
+        asset: diff.asset,
+        netRaw: receivedRaw - sentRaw,
+        netUsd: receivedUsd - sentUsd,
+      })
     }
   }
-  return null
+
+  const changes: BlockaidEvmBalanceChange[] = []
+  for (const { asset, netRaw, netUsd } of groups.values()) {
+    if (netRaw === 0n) continue
+    const direction: 'send' | 'receive' = netRaw > 0n ? 'receive' : 'send'
+    const amount = netRaw > 0n ? netRaw : -netRaw
+    const change: BlockaidEvmBalanceChange = {
+      direction,
+      coin: buildCoinFromAsset(asset, chain),
+      amount: shouldBePresent(amount),
+    }
+    if (netUsd !== 0) {
+      change.usdValue = Math.abs(netUsd)
+    }
+    changes.push(change)
+  }
+
+  if (changes.length === 0) {
+    return null
+  }
+
+  return { changes }
 }

--- a/packages/core/chain/security/blockaid/tx/simulation/core.ts
+++ b/packages/core/chain/security/blockaid/tx/simulation/core.ts
@@ -17,19 +17,13 @@ export type BlockaidSolanaSimulationInfo =
       }
     }
 
-export type BlockaidEvmSimulationInfo =
-  | {
-      swap: {
-        fromCoin: Coin
-        fromAmount: bigint
-        toCoin: Coin
-        toAmount: bigint
-      }
-    }
-  | {
-      transfer: {
-        fromCoin: Coin
-        fromAmount: bigint
-      }
-    }
-  | null
+export type BlockaidEvmBalanceChange = {
+  direction: 'send' | 'receive'
+  coin: Coin
+  amount: bigint
+  usdValue?: number
+}
+
+export type BlockaidEvmSimulationInfo = {
+  changes: BlockaidEvmBalanceChange[]
+} | null


### PR DESCRIPTION
## Summary
- Refactor `BlockaidEvmSimulationInfo` from `{ transfer | swap } | null` to `{ changes: BlockaidEvmBalanceChange[] } | null`
- Parser now groups every `assets_diffs[]` entry by canonical asset (lowercased address; native uses a sentinel key), nets `in` against `out` per asset, and emits one change per asset with the resulting direction
- Refund-shaped legs (same asset on both sides, including EIP-55 casing duplicates) cancel to net zero and drop out — both real refunds and Blockaid metadata noise collapse to the accurate "no change" outcome
- USD value aggregated per side from `value * usd_price` and exposed as optional `usdValue` on each change

## Why
Phase 1.1 of the dApp display work — see vultisig/vultisig-windows#3733. The previous parser only recognized 1- or 2-diff shapes (transfer / swap). Multicalls, staking deposits, and complex DeFi interactions returned `null` and fell through to the ABI fallback even though Blockaid had the data.

## Companion PR
- vultisig/vultisig-windows#3844 — UI consumer (new `BlockaidBalanceChanges` component, classification routing in `BlockaidSimulationContent`)

## Tests
11 cases in `packages/core/chain/security/blockaid/tx/simulation/api/core.test.ts`:
- Single-diff out → one send change
- 3-diff `permitAndCall` flow → send + receive (router leg drops out)
- Standard 2-diff swap → send + receive
- EIP-55 checksum casing variants → grouped and netted
- No-side diffs → null
- All-receive multi-asset → multiple receive changes
- Refund-shaped (same asset, equal in/out) → null
- Refund with mismatched symbol metadata → null (address-canonical)
- Same asset, out > in → net send of the difference
- 4-diff multicall → 4 distinct changes (2 send + 2 receive)
- USD aggregation from `value * usd_price`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Normalized transaction simulation output to a unified list of balance changes (send/receive) with consistent token IDs and aggregated net amounts and USD values.
  * Better handling of multicall/netting across legs, native vs token distinctions, and skipping malformed token entries.

* **Bug Fixes**
  * Avoids emitting zero-net changes and ensures ERC20 IDs are normalized.

* **Tests**
  * Expanded coverage for directional outputs, multicall scenarios, edge cases, and casing/format robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->