### PR TITLE
fix(qbtc): filter already-claimed UTXOs at list time

### DIFF
--- a/packages/core/chain/chains/cosmos/qbtc/claim/getClaimableUtxos.test.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/getClaimableUtxos.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { getClaimableUtxos } from './getClaimableUtxos'
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  vi.restoreAllMocks()
+})
+
+const btcAddress = 'bc1qrncuculen6deh35at408fv95ng9kx3ve70gjjx'
+
+const blockchairUtxoResponse = (utxos: Array<{ txid: string; index: number; value: number }>) => ({
+  data: {
+    [btcAddress]: {
+      utxo: utxos.map(({ txid, index, value }) => ({
+        block_id: 1,
+        transaction_hash: txid,
+        index,
+        value,
+      })),
+    },
+  },
+  context: {},
+})
+
+const utxoA = { txid: 'a'.repeat(64), index: 0, value: 681 }
+const utxoB = { txid: 'b'.repeat(64), index: 1, value: 1000 }
+
+const okResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+const errorResponse = (status: number, body = '') =>
+  new Response(body, { status })
+
+describe('getClaimableUtxos', () => {
+  it('keeps UTXOs the chain reports as claimable (200 OK)', async () => {
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('blockchair') || url.includes('utxo/dashboards')) {
+        return okResponse(blockchairUtxoResponse([utxoA, utxoB]))
+      }
+      // Both /qbtc/v1/utxo/.../... lookups succeed.
+      return okResponse({ utxo: { txid: 'irrelevant', vout: 0 } })
+    }) as typeof fetch
+
+    const result = await getClaimableUtxos({ btcAddress })
+
+    expect(result).toHaveLength(2)
+    expect(result.map(u => u.txid)).toEqual([utxoA.txid, utxoB.txid])
+  })
+
+  it('drops UTXOs the chain returns 404 for', async () => {
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('blockchair') || url.includes('utxo/dashboards')) {
+        return okResponse(blockchairUtxoResponse([utxoA, utxoB]))
+      }
+      // utxoA already claimed → 404; utxoB still claimable → 200.
+      if (url.endsWith(`/qbtc/v1/utxo/${utxoA.txid}/${utxoA.index}`)) {
+        return errorResponse(404, '{"code":2,"message":"UTXO not found"}')
+      }
+      return okResponse({ utxo: { txid: 'irrelevant', vout: 0 } })
+    }) as typeof fetch
+
+    const result = await getClaimableUtxos({ btcAddress })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].txid).toBe(utxoB.txid)
+  })
+
+  it('propagates non-404 errors from the chain (no silent drop)', async () => {
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('blockchair') || url.includes('utxo/dashboards')) {
+        return okResponse(blockchairUtxoResponse([utxoA]))
+      }
+      return errorResponse(503, 'Service Unavailable')
+    }) as typeof fetch
+
+    await expect(getClaimableUtxos({ btcAddress })).rejects.toThrow(
+      /Failed to verify UTXO/
+    )
+  })
+
+  it('returns an empty array when Blockchair has no UTXOs', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      okResponse(blockchairUtxoResponse([]))
+    ) as typeof fetch
+
+    const result = await getClaimableUtxos({ btcAddress })
+
+    expect(result).toEqual([])
+  })
+})

--- a/packages/core/chain/chains/cosmos/qbtc/claim/getClaimableUtxos.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/getClaimableUtxos.ts
@@ -1,4 +1,5 @@
 import { Chain } from '@vultisig/core-chain/Chain'
+import { qbtcRestUrl } from '@vultisig/core-chain/chains/cosmos/qbtc/tendermintRpcUrl'
 import { getUtxoAddressInfo } from '@vultisig/core-chain/chains/utxo/client/getUtxoAddressInfo'
 
 import { ClaimableUtxo } from './ClaimableUtxo'
@@ -8,11 +9,37 @@ type GetClaimableUtxosInput = {
 }
 
 /**
- * Fetches Bitcoin UTXOs for the given address via Blockchair and returns them
- * as claimable candidates on the QBTC chain.
+ * Asks the QBTC chain whether a given UTXO is still claimable
+ * (i.e. registered + unclaimed) via `GET /qbtc/v1/utxo/{txid}/{vout}`.
  *
- * Note: this does not cross-check with the QBTC chain to filter
- * already-claimed UTXOs — see btcq-org/qbtc#134.
+ * - 200 → claimable
+ * - 404 → already claimed or never registered
+ * - other → propagated as a hard error so transient network failures
+ *   don't silently drop UTXOs from the user's list.
+ */
+const isUtxoClaimableOnChain = async ({
+  txid,
+  vout,
+}: {
+  txid: string
+  vout: number
+}): Promise<boolean> => {
+  const response = await fetch(`${qbtcRestUrl}/qbtc/v1/utxo/${txid}/${vout}`)
+  if (response.ok) return true
+  if (response.status === 404) return false
+  throw new Error(
+    `Failed to verify UTXO ${txid}:${vout} on QBTC chain (${response.status} ${response.statusText})`
+  )
+}
+
+/**
+ * Fetches Bitcoin UTXOs for the given address via Blockchair and filters
+ * out any the QBTC chain has already paid out.
+ *
+ * Bitcoin doesn't know about QBTC claims, so a Blockchair UTXO can still
+ * appear "spendable" after the QBTC chain has consumed it. Cross-checking
+ * against the chain's UTXO endpoint (btcq-org/qbtc#141) prevents the user
+ * from selecting a stale entry and burning ~90s on a no-op claim.
  */
 export const getClaimableUtxos = async ({
   btcAddress,
@@ -22,11 +49,19 @@ export const getClaimableUtxos = async ({
     chain: Chain.Bitcoin,
   })
 
-  const utxos = response.data[btcAddress]?.utxo ?? []
+  const btcUtxos = response.data[btcAddress]?.utxo ?? []
 
-  return utxos.map(({ transaction_hash, index, value }) => ({
-    txid: transaction_hash,
-    vout: index,
-    amount: value,
-  }))
+  const candidates: ClaimableUtxo[] = btcUtxos.map(
+    ({ transaction_hash, index, value }) => ({
+      txid: transaction_hash,
+      vout: index,
+      amount: value,
+    })
+  )
+
+  const claimableFlags = await Promise.all(
+    candidates.map(({ txid, vout }) => isUtxoClaimableOnChain({ txid, vout }))
+  )
+
+  return candidates.filter((_, i) => claimableFlags[i])
 }


### PR DESCRIPTION
## Summary

Closes #381. Stops the QBTC claim picker from showing UTXOs the chain has already paid out.

Bitcoin doesn't know about QBTC claims, so a Blockchair UTXO can still appear "spendable" after the chain has consumed it. The claim flow then runs the full ~90s pipeline (BTC sign → proof service → MLDSA sign → broadcast) and the chain just shoves the UTXO into \`utxos_skipped\` with \`total_amount = 0\` — wasted time and a confusing 0-QBTC success screen.

## Fix

Cross-check each Blockchair UTXO against \`GET /qbtc/v1/utxo/{txid}/{vout}\` (added in [btcq-org/qbtc#141](https://github.com/btcq-org/qbtc/pull/141)):

- 200 → keep
- 404 → drop (already claimed / never registered)
- other → propagate as a hard error so transient network failures don't silently drop UTXOs the user expects to see

Lookups run in parallel via \`Promise.all\`. Typical address has a handful of UTXOs; if rate-limiting becomes a concern we can batch later.

## Test plan

- [x] \`yarn test:unit packages/core/chain/chains/cosmos/qbtc/claim/getClaimableUtxos.test.ts\` — covers all-claimable / mixed-with-404 / non-404-error / empty-list paths
- [x] \`yarn typecheck\` clean
- [ ] End-to-end claim from the extension ([vultisig/vultisig-windows#3747](https://github.com/vultisig/vultisig-windows/pull/3747)) — already-claimed UTXOs no longer appear in the picker

## Independence

Doesn't touch \`buildClaimTx.ts\` or \`proofService.ts\`, so it merges cleanly alongside the in-flight #378.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * UTXO verification now includes chain confirmation to ensure only valid UTXOs are identified as claimable, filtering out those not verified by the QBTC chain.

* **Tests**
  * Added comprehensive test coverage for UTXO verification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->