### PR TITLE
fix(qbtc): poll for inclusion and parse claim_with_proof event

### DIFF
--- a/packages/core/chain/chains/cosmos/qbtc/claim/broadcastClaimTx.test.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/broadcastClaimTx.test.ts
@@ -9,92 +9,197 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
+const txBytesBase64 = 'dHhieXRlcw=='
+const txHash = 'ABCDEF1234567890'
+
+const okJson = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+const errorResponse = (status: number, body = '') =>
+  new Response(body, { status })
+
+const claimEvent = (attrs: Record<string, string>) => ({
+  type: 'claim_with_proof',
+  attributes: Object.entries(attrs).map(([key, value]) => ({ key, value })),
+})
+
+const broadcastSuccess = () => okJson({ tx_response: { code: 0, txhash: txHash } })
+
+const includedSuccess = (attrs: Record<string, string> = {}) =>
+  okJson({ tx_response: { code: 0, events: [claimEvent(attrs)] } })
+
+const fastPolling = {
+  inclusionTimeoutMs: 5_000,
+  inclusionPollIntervalMs: 5,
+}
+
 describe('broadcastClaimTx', () => {
-  const validInput = {
-    txBytesBase64: 'dHhieXRlcw==',
-    txHash: 'ABCDEF1234567890',
-  }
-
   it('sends correctly formatted broadcast request', async () => {
-    globalThis.fetch = vi.fn(async () =>
-      new Response(JSON.stringify({ tx_response: { code: 0, txhash: 'abc' } }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    ) as typeof fetch
+    globalThis.fetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(broadcastSuccess())
+      .mockResolvedValueOnce(includedSuccess())
 
-    await broadcastClaimTx(validInput)
+    await broadcastClaimTx({ txBytesBase64, txHash, ...fastPolling })
 
-    expect(globalThis.fetch).toHaveBeenCalledWith(
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(
+      1,
       expect.stringContaining('/cosmos/tx/v1beta1/txs'),
       expect.objectContaining({
         method: 'POST',
         body: JSON.stringify({
-          tx_bytes: validInput.txBytesBase64,
+          tx_bytes: txBytesBase64,
           mode: 'BROADCAST_MODE_SYNC',
         }),
       })
     )
   })
 
-  it('returns claim result with tx hash', async () => {
-    globalThis.fetch = vi.fn(async () =>
-      new Response(JSON.stringify({ tx_response: { code: 0 } }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    ) as typeof fetch
+  it('returns real values parsed from the claim_with_proof event', async () => {
+    globalThis.fetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(broadcastSuccess())
+      .mockResolvedValueOnce(
+        includedSuccess({
+          total_amount: '681',
+          utxos_claimed: '1',
+          utxos_skipped: '0',
+        })
+      )
 
-    const result = await broadcastClaimTx(validInput)
+    const result = await broadcastClaimTx({
+      txBytesBase64,
+      txHash,
+      ...fastPolling,
+    })
 
-    expect(result.txHash).toBe(validInput.txHash)
+    expect(result).toEqual({
+      totalAmountClaimed: 681n,
+      utxosClaimed: 1,
+      utxosSkipped: 0,
+      txHash,
+    })
   })
 
-  it('throws on HTTP error', async () => {
+  it('retries on 404 until the tx is included', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(broadcastSuccess())
+      .mockResolvedValueOnce(errorResponse(404, 'tx not found'))
+      .mockResolvedValueOnce(errorResponse(404, 'tx not found'))
+      .mockResolvedValueOnce(
+        includedSuccess({
+          total_amount: '500',
+          utxos_claimed: '2',
+          utxos_skipped: '1',
+        })
+      )
+    globalThis.fetch = fetchMock
+
+    const result = await broadcastClaimTx({
+      txBytesBase64,
+      txHash,
+      ...fastPolling,
+    })
+
+    expect(result.totalAmountClaimed).toBe(500n)
+    expect(result.utxosClaimed).toBe(2)
+    expect(result.utxosSkipped).toBe(1)
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+  })
+
+  it('throws if DeliverTx code is non-zero after inclusion', async () => {
+    globalThis.fetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(broadcastSuccess())
+      .mockResolvedValueOnce(
+        okJson({ tx_response: { code: 5, raw_log: 'address mismatch' } })
+      )
+
+    await expect(
+      broadcastClaimTx({ txBytesBase64, txHash, ...fastPolling })
+    ).rejects.toThrow(/QBTC claim tx error: address mismatch/)
+  })
+
+  it('propagates non-404 infra errors from the inclusion query', async () => {
+    globalThis.fetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(broadcastSuccess())
+      .mockResolvedValueOnce(errorResponse(503, 'upstream down'))
+
+    await expect(
+      broadcastClaimTx({ txBytesBase64, txHash, ...fastPolling })
+    ).rejects.toThrow(/inclusion query failed \(503\)/)
+  })
+
+  it('throws if the tx never lands within the timeout', async () => {
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/cosmos/tx/v1beta1/txs')) return broadcastSuccess()
+      return errorResponse(404, 'tx not found')
+    }) as typeof fetch
+
+    await expect(
+      broadcastClaimTx({
+        txBytesBase64,
+        txHash,
+        inclusionTimeoutMs: 30,
+        inclusionPollIntervalMs: 5,
+      })
+    ).rejects.toThrow(/not included within 30ms/)
+  })
+
+  it('throws on broadcast HTTP error', async () => {
     globalThis.fetch = vi.fn(async () =>
-      new Response('internal error', { status: 500 })
+      errorResponse(500, 'internal error')
     ) as typeof fetch
 
-    await expect(broadcastClaimTx(validInput)).rejects.toThrow(
-      'QBTC claim broadcast failed (500)'
-    )
+    await expect(
+      broadcastClaimTx({ txBytesBase64, txHash, ...fastPolling })
+    ).rejects.toThrow('QBTC claim broadcast failed (500)')
   })
 
   it('treats "tx already exists in cache" HTTP error as idempotent success', async () => {
     globalThis.fetch = vi.fn(async () =>
-      new Response('tx already exists in cache', { status: 400 })
+      errorResponse(400, 'tx already exists in cache')
     ) as typeof fetch
 
-    const result = await broadcastClaimTx(validInput)
+    const result = await broadcastClaimTx({
+      txBytesBase64,
+      txHash,
+      ...fastPolling,
+    })
 
-    expect(result.txHash).toBe(validInput.txHash)
+    expect(result).toEqual({
+      totalAmountClaimed: 0n,
+      utxosClaimed: 0,
+      utxosSkipped: 0,
+      txHash,
+    })
   })
 
   it('throws on missing tx_response.code', async () => {
     globalThis.fetch = vi.fn(async () =>
-      new Response(JSON.stringify({ tx_response: {} }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
+      okJson({ tx_response: {} })
+    ) as typeof fetch
+
+    await expect(
+      broadcastClaimTx({ txBytesBase64, txHash, ...fastPolling })
+    ).rejects.toThrow('missing tx_response.code')
+  })
+
+  it('throws on non-zero CheckTx code', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      okJson({
+        tx_response: { code: 5, raw_log: 'no valid claimable UTXOs found' },
       })
     ) as typeof fetch
 
-    await expect(broadcastClaimTx(validInput)).rejects.toThrow(
-      'missing tx_response.code'
-    )
-  })
-
-  it('throws on non-zero tx response code', async () => {
-    globalThis.fetch = vi.fn(async () =>
-      new Response(
-        JSON.stringify({
-          tx_response: { code: 5, raw_log: 'no valid claimable UTXOs found' },
-        }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } }
-      )
-    ) as typeof fetch
-
-    await expect(broadcastClaimTx(validInput)).rejects.toThrow(
-      'no valid claimable UTXOs found'
-    )
+    await expect(
+      broadcastClaimTx({ txBytesBase64, txHash, ...fastPolling })
+    ).rejects.toThrow('no valid claimable UTXOs found')
   })
 })

--- a/packages/core/chain/chains/cosmos/qbtc/claim/broadcastClaimTx.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/broadcastClaimTx.ts
@@ -1,4 +1,5 @@
 import { qbtcRestUrl } from '@vultisig/core-chain/chains/cosmos/qbtc/tendermintRpcUrl'
+import { sleep } from '@vultisig/lib-utils/sleep'
 
 type ClaimTxResponse = {
   /** Total satoshis claimed. */
@@ -16,26 +17,137 @@ type BroadcastClaimTxInput = {
   txBytesBase64: string
   /** Transaction hash (SHA256 of TxRaw), hex-encoded. */
   txHash: string
+  /**
+   * Max time to wait for the tx to be included in a block after a
+   * successful broadcast. Defaults to 30 s — Cosmos block times are
+   * typically 5–7 s.
+   */
+  inclusionTimeoutMs?: number
+  /** Polling interval while waiting for inclusion. Defaults to 1 s. */
+  inclusionPollIntervalMs?: number
 }
 
-type BroadcastResponse = {
-  tx_response?: {
-    code?: number
-    txhash?: string
-    raw_log?: string
-    log?: string
+type EventAttribute = {
+  key: string
+  value?: string
+}
+
+type TxEvent = {
+  type: string
+  attributes?: EventAttribute[]
+}
+
+type TxResponse = {
+  code?: number
+  txhash?: string
+  raw_log?: string
+  log?: string
+  events?: TxEvent[]
+}
+
+type BroadcastResponseShape = {
+  tx_response?: TxResponse
+}
+
+type FetchTxResponseShape = {
+  tx_response?: TxResponse
+}
+
+const claimWithProofEventType = 'claim_with_proof'
+
+const findEventAttr = (
+  events: TxEvent[] | undefined,
+  type: string,
+  key: string
+): string | undefined =>
+  events
+    ?.find(e => e.type === type)
+    ?.attributes?.find(a => a.key === key)?.value
+
+const parseClaimResultFromEvents = (
+  events: TxEvent[] | undefined,
+  txHash: string
+): ClaimTxResponse => ({
+  totalAmountClaimed: BigInt(
+    findEventAttr(events, claimWithProofEventType, 'total_amount') ?? '0'
+  ),
+  utxosClaimed: Number(
+    findEventAttr(events, claimWithProofEventType, 'utxos_claimed') ?? '0'
+  ),
+  utxosSkipped: Number(
+    findEventAttr(events, claimWithProofEventType, 'utxos_skipped') ?? '0'
+  ),
+  txHash,
+})
+
+const idempotentResult = (txHash: string): ClaimTxResponse => ({
+  totalAmountClaimed: 0n,
+  utxosClaimed: 0,
+  utxosSkipped: 0,
+  txHash,
+})
+
+/**
+ * Polls `/cosmos/tx/v1beta1/txs/{txHash}` until the tx is included in a
+ * block (200 OK) or the timeout fires. 404 means "not yet included" and
+ * triggers a retry. Other non-2xx statuses propagate as errors so we
+ * don't mask infra failures as "still pending".
+ */
+const waitForTxInclusion = async ({
+  txHash,
+  timeoutMs,
+  intervalMs,
+}: {
+  txHash: string
+  timeoutMs: number
+  intervalMs: number
+}): Promise<TxResponse> => {
+  const url = `${qbtcRestUrl}/cosmos/tx/v1beta1/txs/${txHash}`
+  const deadline = Date.now() + timeoutMs
+
+  while (Date.now() <= deadline) {
+    const response = await fetch(url)
+
+    if (response.ok) {
+      const data: FetchTxResponseShape = await response.json()
+      if (data.tx_response) return data.tx_response
+      throw new Error(
+        `QBTC claim tx ${txHash}: missing tx_response on inclusion query`
+      )
+    }
+
+    if (response.status !== 404) {
+      const text = await response.text()
+      throw new Error(
+        `QBTC claim inclusion query failed (${response.status}): ${text}`
+      )
+    }
+
+    await sleep(intervalMs)
   }
+
+  throw new Error(
+    `QBTC claim tx ${txHash} not included within ${timeoutMs}ms`
+  )
 }
 
 /**
  * Broadcasts a signed MsgClaimWithProof transaction to the QBTC chain
  * via the REST API (following the restOnlyChains pattern).
  *
+ * BROADCAST_MODE_SYNC returns after Tendermint's CheckTx — the
+ * `claim_with_proof` event is emitted later in DeliverTx. We poll
+ * `/cosmos/tx/v1beta1/txs/{txHash}` until the tx lands and parse the
+ * event attributes (`total_amount`, `utxos_claimed`, `utxos_skipped`)
+ * so the success screen can show real numbers instead of zeros.
+ *
  * The claim transaction is gas-free — the chain does not charge gas.
  */
 export const broadcastClaimTx = async ({
   txBytesBase64,
   txHash,
+  inclusionTimeoutMs = 30_000,
+  inclusionPollIntervalMs = 1_000,
 }: BroadcastClaimTxInput): Promise<ClaimTxResponse> => {
   const response = await fetch(`${qbtcRestUrl}/cosmos/tx/v1beta1/txs`, {
     method: 'POST',
@@ -46,22 +158,15 @@ export const broadcastClaimTx = async ({
     }),
   })
 
-  const idempotentResult: ClaimTxResponse = {
-    totalAmountClaimed: 0n,
-    utxosClaimed: 0,
-    utxosSkipped: 0,
-    txHash,
-  }
-
   if (!response.ok) {
     const text = await response.text()
     if (text.includes('tx already exists in cache')) {
-      return idempotentResult
+      return idempotentResult(txHash)
     }
     throw new Error(`QBTC claim broadcast failed (${response.status}): ${text}`)
   }
 
-  const data: BroadcastResponse = await response.json()
+  const data: BroadcastResponseShape = await response.json()
 
   if (typeof data.tx_response?.code !== 'number') {
     throw new Error('QBTC claim broadcast failed: missing tx_response.code')
@@ -70,10 +175,28 @@ export const broadcastClaimTx = async ({
   if (data.tx_response.code !== 0) {
     const log = data.tx_response.raw_log || data.tx_response.log
     if (log?.includes('tx already exists in cache')) {
-      return idempotentResult
+      return idempotentResult(txHash)
     }
     throw new Error(`QBTC claim tx error: ${log}`)
   }
 
-  return idempotentResult
+  // CheckTx passed; wait for DeliverTx events.
+  const included = await waitForTxInclusion({
+    txHash,
+    timeoutMs: inclusionTimeoutMs,
+    intervalMs: inclusionPollIntervalMs,
+  })
+
+  if (typeof included.code !== 'number') {
+    throw new Error(
+      `QBTC claim tx ${txHash}: missing code on included tx_response`
+    )
+  }
+
+  if (included.code !== 0) {
+    const log = included.raw_log || included.log
+    throw new Error(`QBTC claim tx error: ${log}`)
+  }
+
+  return parseClaimResultFromEvents(included.events, txHash)
 }


### PR DESCRIPTION
## Summary

Closes #387. Stops `broadcastClaimTx` from reporting hard-coded zeros for every successful claim — the extension success screen now shows real amounts.

## Repro

Tx [`D5B9…0E0A`](https://api.vultisig.com/qbtc-rpc/cosmos/tx/v1beta1/txs/D5B920C8C4E3522B48068BCD7D01344281371C89191B0304836798DB4A0A0E0A) at height 125876 emitted:

```
claim_with_proof:
  total_amount:   681
  utxos_claimed:  1
  utxos_skipped:  0
```

Extension UI showed `0 QBTC / 0 / 0` because `broadcastClaimTx` always returned `{ totalAmountClaimed: 0n, utxosClaimed: 0, utxosSkipped: 0 }` — events were never read.

## Why broadcasting alone isn't enough

`BROADCAST_MODE_SYNC` returns after Tendermint's `CheckTx` (mempool admission), *before* the tx is included in a block. `claim_with_proof` is emitted in `DeliverTx`, so the broadcast response never carries it. Events only show up via `GET /cosmos/tx/v1beta1/txs/{hash}` once the block lands.

## Fix

After a successful `CheckTx` (`tx_response.code === 0`):

1. Poll `GET /cosmos/tx/v1beta1/txs/{txHash}` until inclusion. Cap at 30 s (configurable via `inclusionTimeoutMs`), 1 s interval (configurable via `inclusionPollIntervalMs`).
2. 404 → retry. Other non-2xx → propagate. 200 → parse.
3. Surface non-zero `code` from the included tx_response — previously a `DeliverTx` failure was reported as success.
4. Read `claim_with_proof` event attributes (`total_amount`, `utxos_claimed`, `utxos_skipped`) into `ClaimTxResponse`.

The "tx already exists in cache" idempotent branch is preserved (returns zeros without polling — that path is for retry-after-success and the caller already has the prior result).

## Test plan

- [x] `yarn test:unit packages/core/chain/chains/cosmos/qbtc/claim/broadcastClaimTx.test.ts` — 1357 passing. Covers:
  - Real values parsed from the event
  - Retry on 404 until inclusion
  - DeliverTx-time failure surfaces as error
  - Inclusion-query infra error (503) propagates
  - Inclusion timeout
  - Idempotent "already in cache" path
  - Existing CheckTx-error paths
- [x] `yarn typecheck` clean
- [ ] End-to-end claim from the extension ([vultisig/vultisig-windows#3747](https://github.com/vultisig/vultisig-windows/pull/3747)) — success screen shows real amount + UTXO counts

## Independence

Touches only `broadcastClaimTx.ts` + test. Doesn't depend on other in-flight QBTC PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claim transactions now wait for block inclusion and provide detailed claim information from on-chain events.
  * Added configurable inclusion timeout and polling interval parameters for better control over transaction monitoring.

* **Bug Fixes**
  * Enhanced error handling for edge cases including transaction cache conflicts and inclusion query failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->