### PR TITLE
feat(cli): --profile flag for agent + agent ask

### DIFF
--- a/clients/cli/src/agent/client.ts
+++ b/clients/cli/src/agent/client.ts
@@ -54,6 +54,7 @@ function sseErrorToMessage(value: unknown): string {
 export class AgentClient {
   private baseUrl: string
   private authToken: string | null = null
+  private profile: string = ''
   verbose = false
 
   constructor(baseUrl: string) {
@@ -64,6 +65,16 @@ export class AgentClient {
     this.authToken = token
   }
 
+  /** Set the billing-profile slug sent as X-Vultisig-Abe-Profile on every
+   *  request. Empty falls back to the backend's default profile. */
+  setProfile(profile: string): void {
+    this.profile = profile
+  }
+
+  private profileHeader(): Record<string, string> {
+    return this.profile ? { 'X-Vultisig-Abe-Profile': this.profile } : {}
+  }
+
   // ============================================================================
   // Authentication
   // ============================================================================
@@ -71,7 +82,7 @@ export class AgentClient {
   async authenticate(req: AuthTokenRequest): Promise<AuthTokenResponse> {
     const res = await fetch(`${this.baseUrl}/auth/token`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...this.profileHeader() },
       body: JSON.stringify(req),
     })
     if (!res.ok) {
@@ -159,6 +170,7 @@ export class AgentClient {
         'Content-Type': 'application/json',
         Accept: 'text/event-stream',
         ...(this.authToken ? { Authorization: `Bearer ${this.authToken}` } : {}),
+        ...this.profileHeader(),
       },
       body: JSON.stringify(req),
       signal,
@@ -420,6 +432,7 @@ export class AgentClient {
       headers: {
         'Content-Type': 'application/json',
         ...(this.authToken ? { Authorization: `Bearer ${this.authToken}` } : {}),
+        ...this.profileHeader(),
       },
       body: JSON.stringify(body),
     })
@@ -438,6 +451,7 @@ export class AgentClient {
       headers: {
         'Content-Type': 'application/json',
         ...(this.authToken ? { Authorization: `Bearer ${this.authToken}` } : {}),
+        ...this.profileHeader(),
       },
       body: JSON.stringify(body),
     })

--- a/clients/cli/src/agent/session.ts
+++ b/clients/cli/src/agent/session.ts
@@ -79,6 +79,9 @@ export class AgentSession {
     this.config = config
     this.client = new AgentClient(config.backendUrl)
     this.client.verbose = !!config.verbose
+    if (config.profile) {
+      this.client.setProfile(config.profile)
+    }
     this.executor = new AgentExecutor(vault, !!config.verbose, vault.publicKeys.ecdsa, config.vultisig)
     this.publicKey = vault.publicKeys.ecdsa
 

--- a/clients/cli/src/agent/types.ts
+++ b/clients/cli/src/agent/types.ts
@@ -28,6 +28,9 @@ export type AgentConfig = {
   verbose?: boolean
   /** Notification service URL for push notifications (empty = disabled) */
   notificationUrl?: string
+  /** Billing profile api_id slug — sent as X-Vultisig-Abe-Profile header.
+   *  Empty falls back to the backend's default profile. */
+  profile?: string
 }
 
 // ============================================================================

--- a/clients/cli/src/commands/agent.ts
+++ b/clients/cli/src/commands/agent.ts
@@ -43,7 +43,7 @@ export async function executeAgent(ctx: CommandContext, options: AgentCommandOpt
     sessionId: options.sessionId,
     verbose: options.verbose,
     notificationUrl: options.notificationUrl || process.env.VULTISIG_NOTIFICATION_URL || '',
-    profile: options.profile || process.env.VULTISIG_AGENT_PROFILE || '',
+    profile: options.profile ?? process.env.VULTISIG_AGENT_PROFILE ?? '',
   }
 
   const session = new AgentSession(vault, config)
@@ -126,7 +126,7 @@ export async function executeAgentAsk(ctx: CommandContext, message: string, opti
       sessionId: options.session,
       verbose: options.verbose,
       askMode: true,
-      profile: options.profile || process.env.VULTISIG_AGENT_PROFILE || '',
+      profile: options.profile ?? process.env.VULTISIG_AGENT_PROFILE ?? '',
     }
 
     const session = new AgentSession(vault, config)

--- a/clients/cli/src/commands/agent.ts
+++ b/clients/cli/src/commands/agent.ts
@@ -28,6 +28,7 @@ export type AgentCommandOptions = {
   sessionId?: string
   verbose?: boolean
   notificationUrl?: string
+  profile?: string
 }
 
 export async function executeAgent(ctx: CommandContext, options: AgentCommandOptions): Promise<void> {
@@ -42,6 +43,7 @@ export async function executeAgent(ctx: CommandContext, options: AgentCommandOpt
     sessionId: options.sessionId,
     verbose: options.verbose,
     notificationUrl: options.notificationUrl || process.env.VULTISIG_NOTIFICATION_URL || '',
+    profile: options.profile || process.env.VULTISIG_AGENT_PROFILE || '',
   }
 
   const session = new AgentSession(vault, config)
@@ -86,6 +88,7 @@ export type AgentAskOptions = {
   session?: string
   verbose?: boolean
   json?: boolean
+  profile?: string
 }
 
 /**
@@ -123,6 +126,7 @@ export async function executeAgentAsk(ctx: CommandContext, message: string, opti
       sessionId: options.session,
       verbose: options.verbose,
       askMode: true,
+      profile: options.profile || process.env.VULTISIG_AGENT_PROFILE || '',
     }
 
     const session = new AgentSession(vault, config)

--- a/clients/cli/src/index.ts
+++ b/clients/cli/src/index.ts
@@ -1317,6 +1317,7 @@ const agentCmd = program
   .option('--password-ttl <ms>', 'Password cache TTL in milliseconds (default: 300000, 86400000/24h for --via-agent)')
   .option('--session-id <id>', 'Resume an existing session')
   .option('--notification-url <url>', 'Notification service URL for push notifications')
+  .option('--profile <api_id>', 'Billing profile slug sent as X-Vultisig-Abe-Profile header')
   .action(
     async (options: {
       viaAgent?: boolean
@@ -1326,6 +1327,7 @@ const agentCmd = program
       passwordTtl?: string
       sessionId?: string
       notificationUrl?: string
+      profile?: string
     }) => {
       // Resolve password TTL: explicit flag > 24h for --via-agent > default 5min
       // Note: setTimeout uses 32-bit int, so Infinity gets clamped to 1ms. Use 24h instead.
@@ -1350,6 +1352,7 @@ const agentCmd = program
         password: options.password,
         sessionId: options.sessionId,
         notificationUrl: options.notificationUrl,
+        profile: options.profile,
       })
     }
   )
@@ -1363,12 +1366,14 @@ agentCmd
   .option('--password <password>', 'Vault password for signing operations')
   .option('--verbose', 'Show tool calls and debug info on stderr')
   .option('--json', 'Output structured JSON (deprecated: use --output json)')
+  .option('--profile <api_id>', 'Billing profile slug sent as X-Vultisig-Abe-Profile header')
   .addHelpText(
     'after',
     `
 Examples:
   vultisig agent ask "What is my ETH balance?" --output json
-  vultisig agent ask "Send 0.1 ETH to 0x..." --session abc123 --yes`
+  vultisig agent ask "Send 0.1 ETH to 0x..." --session abc123 --yes
+  vultisig agent ask "..." --profile station-wallet`
   )
   .action(
     async (
@@ -1379,6 +1384,7 @@ Examples:
         password?: string
         verbose?: boolean
         json?: boolean
+        profile?: string
       }
     ) => {
       const parentOpts = agentCmd.opts()
@@ -1388,6 +1394,7 @@ Examples:
         backendUrl: options.backendUrl || parentOpts.backendUrl,
         password: options.password || parentOpts.password,
         verbose: options.verbose || parentOpts.verbose,
+        profile: options.profile || parentOpts.profile,
       })
     }
   )

--- a/clients/cli/src/index.ts
+++ b/clients/cli/src/index.ts
@@ -1372,7 +1372,7 @@ agentCmd
     `
 Examples:
   vultisig agent ask "What is my ETH balance?" --output json
-  vultisig agent ask "Send 0.1 ETH to 0x..." --session abc123 --yes
+  vultisig agent ask "Send 0.1 ETH to 0x..." --session abc123
   vultisig agent ask "..." --profile station-wallet`
   )
   .action(
@@ -1394,7 +1394,7 @@ Examples:
         backendUrl: options.backendUrl || parentOpts.backendUrl,
         password: options.password || parentOpts.password,
         verbose: options.verbose || parentOpts.verbose,
-        profile: options.profile || parentOpts.profile,
+        profile: options.profile ?? parentOpts.profile,
       })
     }
   )


### PR DESCRIPTION
## Summary

Adds a `--profile <api_id>` flag (and `VULTISIG_AGENT_PROFILE` env) to `vultisig agent` and `vultisig agent ask`. The slug is sent on every backend request as `X-Vultisig-Abe-Profile` so the agent-backend's per-profile billing system (separate PR) can scope plans, tool costs, and model pricing to the right tenant.

Empty / missing profile silently falls back to the backend's default profile, preserving current behaviour for every existing client.

## Wiring

- `AgentClient` gains `setProfile` + `profileHeader()` helper
- Header injected on auth, conversations.messages (SSE), calldata, and the generic post/delete helpers
- `AgentConfig` / `AgentCommandOptions` / `AgentAskOptions` carry a `profile` field
- Help text + example added to `agent ask`

## Companion

Backend changes that consume this header: vultisig/agent-backend `feat/billing-profiles`.

## Test plan

- [ ] `vultisig agent ask "..."` (no flag) → default profile billing
- [ ] `vultisig agent ask "..." --profile default` → default profile billing
- [ ] `vultisig agent ask "..." --profile station-wallet` → custom profile billing
- [ ] `vultisig agent ask "..." --profile bogus-unknown` → silent fallback to default
- [ ] `VULTISIG_AGENT_PROFILE=station-wallet vultisig agent ask "..."` → env wiring works
- [ ] `vultisig agent --profile <slug>` → interactive TUI passes header

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a `--profile` CLI option for `agent` and `agent ask` to select a billing profile.
  * Profile can also be set via the VULTISIG_AGENT_PROFILE environment variable.
  * Selected profile is sent with agent requests to ensure correct billing attribution.
  * CLI help text updated to document profile usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->