### PR TITLE
sdk-cli: drop legacy actions SSE channel consumption (Phase 1 of #385)

### DIFF
--- a/clients/cli/src/agent/client.ts
+++ b/clients/cli/src/agent/client.ts
@@ -6,7 +6,6 @@
  */
 import { AgentErrorCode, inferAgentErrorCodeFromMessage, isAgentErrorCode } from './agentErrors'
 import type {
-  Action,
   AuthTokenRequest,
   AuthTokenResponse,
   ConversationMessage,
@@ -147,7 +146,6 @@ export class AgentClient {
       // unhandled rejections.
       onClientSideToolCall?: (toolCallId: string, toolName: string, input: Record<string, unknown>) => void
       onTitle?: (title: string) => void
-      onActions?: (actions: Action[]) => void
       onSuggestions?: (suggestions: Suggestion[]) => void
       onTxReady?: (tx: TxReadyPayload) => void
       onMessage?: (msg: ConversationMessage) => void
@@ -177,7 +175,6 @@ export class AgentClient {
 
     const result: SSEStreamResult = {
       fullText: '',
-      actions: [],
       suggestions: [],
       transactions: [],
       message: null,
@@ -266,7 +263,6 @@ export class AgentClient {
       // unhandled rejections.
       onClientSideToolCall?: (toolCallId: string, toolName: string, input: Record<string, unknown>) => void
       onTitle?: (title: string) => void
-      onActions?: (actions: Action[]) => void
       onSuggestions?: (suggestions: Suggestion[]) => void
       onTxReady?: (tx: TxReadyPayload) => void
       onMessage?: (msg: ConversationMessage) => void
@@ -341,13 +337,6 @@ export class AgentClient {
           if (typeof title === 'string') callbacks.onTitle?.(title)
           break
         }
-        case 'actions': {
-          if (this.verbose) process.stderr.write(`[SSE:actions] raw: ${data.slice(0, 1000)}\n`)
-          const actions = v1Data?.actions ?? parsed.actions ?? []
-          result.actions.push(...actions)
-          callbacks.onActions?.(actions)
-          break
-        }
         case 'suggestions': {
           const suggestions = v1Data?.suggestions ?? parsed.suggestions ?? []
           result.suggestions.push(...suggestions)
@@ -406,8 +395,6 @@ export class AgentClient {
         return 'tool_progress'
       case 'data-title':
         return 'title'
-      case 'data-actions':
-        return 'actions'
       case 'data-suggestions':
         return 'suggestions'
       case 'data-tx_ready':
@@ -478,7 +465,6 @@ export class AgentClient {
 
 export type SSEStreamResult = {
   fullText: string
-  actions: Action[]
   suggestions: Suggestion[]
   transactions: TxReadyPayload[]
   message: ConversationMessage | null

--- a/clients/cli/src/agent/session.ts
+++ b/clients/cli/src/agent/session.ts
@@ -321,12 +321,6 @@ export class AgentSession {
       onTitle: (_title: string) => {
         // Title updates handled internally
       },
-      onActions: (_actions: Action[]) => {
-        // Legacy data-actions channel: backend no longer emits for
-        // client-side tools post-#119; any late-arriving legacy
-        // payloads are collected in streamResult for the fallback
-        // below.
-      },
       onSuggestions: (suggestions: any[]) => {
         ui.onSuggestions(suggestions)
       },
@@ -394,42 +388,6 @@ export class AgentSession {
     const displayText = stripLeakedToolCallTags(responseText)
     if (displayText) {
       ui.onAssistantMessage(displayText)
-    }
-
-    // data-actions fallback — still fires for schedule_task preview etc.
-    // sign_tx is excluded; it has its own synth path below.
-    const legacyActions = streamResult.actions.filter(a => a.type !== 'sign_tx')
-    if (legacyActions.length > 0) {
-      const results = await this.executeActions(legacyActions, ui)
-
-      // If a build_* action succeeded and produced a pending tx, auto-sign client-side
-      const hasBuildSuccess = results.some(r => r.success && r.action.startsWith('build_'))
-      if (hasBuildSuccess && this.executor.hasPendingTransaction()) {
-        if (this.config.verbose)
-          process.stderr.write(`[session] build_* action produced pending tx, auto-signing client-side\n`)
-        const signAction: Action = {
-          id: `tx_sign_${Date.now()}`,
-          type: 'sign_tx',
-          title: 'Sign transaction',
-          params: {},
-          auto_execute: true,
-        }
-        const signResults = await this.executeActions([signAction], ui)
-        const signResult = signResults[0]
-        if (signResult) {
-          this.pendingToolResults.push(actionResultToRecentAction(signResult))
-          await this.processMessageLoop(null, ui, depth + 1)
-          return
-        }
-      }
-
-      if (results.length > 0) {
-        for (const result of results) {
-          this.pendingToolResults.push(actionResultToRecentAction(result))
-        }
-        await this.processMessageLoop(null, ui, depth + 1)
-        return
-      }
     }
 
     // tx_ready → synth sign_tx → executeActions. Result threaded via recent_actions.


### PR DESCRIPTION
Phase 1 of #385. Drops consumption of the legacy `actions` SSE channel
without touching the `Action` / `ActionResult` types or
`executor.dispatch()` switch — those are still used by Path A
(`dispatchClientSideTool`) and Path C (`tx_ready` → synth `sign_tx`),
and a Phase 2 follow-up will refactor those callers off the wrapper so
the types can come out cleanly.

agent-backend has already migrated off the emitter side: `respond_to_user`
is no longer registered as a tool, the two `respond_to_user` branches in
`agent.go` are documented `// DEPRECATED`, and `processActions()` runs
on an empty slice every turn. The `actions` SSE channel exists but never
fires on real conversations — this PR just stops listening for it.

## Changes

- `client.ts`: drop `onActions` callback typedef from both `sendMessageStream` and `handleSSEEvent` signatures, drop the `case 'actions':` SSE switch arm, drop the `data-actions` → `actions` mapping in `mapV1EventType`, drop `actions: Action[]` field from `SSEStreamResult`.
- `session.ts`: drop the no-op `onActions` callback body, drop the entire `legacyActions` filter + auto-sign-from-build-action recursion block (was lines 399-432). The existing `tx_ready` → synth `sign_tx` path covers the same transaction-signing flow.

## Out of scope (Phase 2)

- `Action`, `ActionResult`, `SSEActions` types
- `executor.dispatch()` switch + `executeAction()` + `executeActions()`
- `actionResultToRecentAction()` adapter
- Top-level `action_result` field on outbound `SendMessageRequest`

These stay because `dispatchClientSideTool` and the `tx_ready` synth
flow currently route through `executeAction(Action)`. Refactoring those
callers to invoke per-tool methods directly is a follow-up.

## Verification

- ✅ `yarn workspace @vultisig/cli typecheck`
- ✅ `yarn test:cli` — all 131 tests green
- ✅ Grep for `onActions`, `streamResult.actions`, `case 'actions'`, `data-actions`, `legacyActions` returns zero hits in `clients/cli/src/`

## Test plan

- [ ] Manual verification against staging agent-backend: confirm `add_coin`, `remove_coin`, `add_chain`, `remove_chain`, `address_book_*`, `sign_typed_data`, `polymarket_sign_bet`, multi-leg tx sequences all still work (these all flow through `tool-input-available` SSE events, not the deleted channel).
- [ ] Confirm zero `onActions` callback firings in a normal session log

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified the agent streaming API by removing support for `onActions` callbacks during streaming operations.
  * Removed `actions` data from streaming results, streamlining the structure of returned data.
  * Updated message processing to eliminate legacy action handling paths and improve workflow for pending operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->