### PR TITLE
fix(cli): remove calldata_id resolution

### DIFF
--- a/clients/cli/src/agent/client.ts
+++ b/clients/cli/src/agent/client.ts
@@ -411,20 +411,6 @@ export class AgentClient {
   }
 
   // ============================================================================
-  // Calldata
-  // ============================================================================
-
-  async getCalldata(id: string): Promise<{ data: string; to?: string; chain?: string }> {
-    const res = await fetch(`${this.baseUrl}/agent/calldata/${id}`, {
-      headers: this.authToken ? { Authorization: `Bearer ${this.authToken}` } : {},
-    })
-    if (!res.ok) {
-      throw new Error(`Failed to resolve calldata_id ${id}: ${res.status} ${res.statusText}`)
-    }
-    return res.json() as Promise<{ data: string; to?: string; chain?: string }>
-  }
-
-  // ============================================================================
   // Private helpers
   // ============================================================================
 

--- a/clients/cli/src/agent/executor.ts
+++ b/clients/cli/src/agent/executor.ts
@@ -75,10 +75,6 @@ export class AgentExecutor {
   /** Held chain lock release functions, keyed by chain name */
   private chainLockReleases = new Map<string, () => Promise<void>>()
   private evmLastBroadcast = new Map<string, number>()
-  /** Backend client for resolving calldata_id references. */
-  private backendClient: {
-    getCalldata(id: string): Promise<{ data: string; to?: string; chain?: string }>
-  } | null = null
 
   constructor(vault: VaultBase, verbose = false, vaultId?: string, vultisig?: Vultisig) {
     this.vault = vault
@@ -91,10 +87,6 @@ export class AgentExecutor {
 
   setPassword(password: string): void {
     this.password = password
-  }
-
-  setBackendClient(client: { getCalldata(id: string): Promise<{ data: string; to?: string; chain?: string }> }): void {
-    this.backendClient = client
   }
 
   /**
@@ -775,18 +767,7 @@ export class AgentExecutor {
   }
 
   private async buildTx(params: Record<string, unknown>): Promise<Record<string, unknown>> {
-    // Resolve calldata_id → actual data before any other checks
-    if (params.calldata_id && !params.data && this.backendClient) {
-      const id = params.calldata_id as string
-      if (this.verbose) process.stderr.write(`[executor] resolving calldata_id ${id}\n`)
-      const entry = await this.backendClient.getCalldata(id)
-      params = { ...params, data: entry.data }
-      if (!params.to && entry.to) params = { ...params, to: entry.to }
-      delete (params as Record<string, unknown>).calldata_id
-      if (this.verbose) process.stderr.write(`[executor] calldata_id resolved, data len=${entry.data.length}\n`)
-    }
-
-    // EVM contract call with function_name + typed params (e.g. from build_custom_tx)
+    // EVM contract call with function_name + typed params
     if (params.function_name && params.contract_address) {
       return this.buildContractCallTx(params)
     }
@@ -825,7 +806,7 @@ export class AgentExecutor {
       }
     }
 
-    // If we got here with contract_address but no function_name or data,
+    // If we got here with contract_address but no function_name,
     // the params are incomplete for a contract call.
     if (params.contract_address && !params.function_name) {
       const provided = Object.keys(params).join(', ')
@@ -835,8 +816,12 @@ export class AgentExecutor {
       )
     }
 
-    // Fallback to simple send for native transfers
-    return this.buildSendTx(params)
+    throw new Error(
+      `build_custom_tx: unrecognized params shape. ` +
+        `Expected function_name + contract_address for ABI-encoding. ` +
+        `Server-built calldata should arrive via tx_ready, not via action params. ` +
+        `Got keys: ${Object.keys(params).join(', ')}`
+    )
   }
 
   /**

--- a/clients/cli/src/agent/session.ts
+++ b/clients/cli/src/agent/session.ts
@@ -114,9 +114,6 @@ export class AgentSession {
         this.client.setAuthToken(auth.token)
         saveCachedToken(this.publicKey, auth.token, auth.expiresAt)
       }
-
-      // Give the executor access to the authenticated client for calldata_id resolution
-      this.executor.setBackendClient(this.client)
     } catch (err: any) {
       throw new Error(`Authentication failed: ${err.message}`)
     }


### PR DESCRIPTION
## Summary

- Ports #247 (neavra) onto current main — original branch had merge conflicts from `evmLastBroadcast` addition in #402 and the improved hex-payload path
- Conflict resolution: kept `evmLastBroadcast` (EVM broadcast dedup tracking) and the improved `params.data || params.calldata || params.hex_payload` path with `stored` guard; removed `backendClient` + `calldata_id` resolution as intended by the original PR
- `tx_ready` SSE now delivers calldata directly — the client-side `calldata_id` resolution was a stale codepath

Supersedes #247 (conflicting).

🤖 Agent-generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the agent executor by removing support for client-side calldata resolution. Server-built calldata must now be provided directly via the `tx_ready` action rather than being resolved at the client level.
  * Enhanced validation and error handling for contract specifications with improved messaging when parameters are incomplete or unrecognized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->