### PR TITLE
docs(changelog): narrow rujira rpcEndpoint removal scope in changelog

### DIFF
--- a/packages/core/chain/CHANGELOG.md
+++ b/packages/core/chain/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - [#383](https://github.com/vultisig/vultisig-sdk/pull/383) [`745172f`](https://github.com/vultisig/vultisig-sdk/commit/745172f3ee511bc4e95914986bfbdb8acf794b1e) Thanks [@Ehsan-saradar](https://github.com/Ehsan-saradar)! - Migrate THORChain Midgard, THORNode REST, and Tendermint RPC endpoints from the legacy `*.thorchain.network` hosts to the Liquify gateway (`gateway.liquify.com/chain/thorchain_midgard`, `…/thorchain_api`, `…/thorchain_rpc`). Updated `cosmosRpcUrl.THORChain`, `tendermintRpcUrl.THORChain`, `thorchainMidgardBaseUrl`, and the rujira `MAINNET_CONFIG` endpoints accordingly.
 
-  In `RujiraDiscovery.discoverViaChain()`, replaced the brittle `rpc → thornode` string substitution with a direct read of `MAINNET_CONFIG.restEndpoint`. Under the new gateway routing the substitution silently produced an invalid host (`thorchain_thornode`) and the fallback branch was unreachable. Removed the now-unused `rpcEndpoint` option from `DiscoveryOptions` and the corresponding plumbing in `RujiraClient`.
+  In `RujiraDiscovery.discoverViaChain()`, replaced the brittle `rpc → thornode` string substitution with a direct read of `MAINNET_CONFIG.restEndpoint`. Under the new gateway routing the substitution silently produced an invalid host (`thorchain_thornode`) and the fallback branch was unreachable. Removed the now-unused `rpcEndpoint` option from `DiscoveryOptions` and the related discovery-specific plumbing in `RujiraClient`.
 
 ## 1.5.1
 


### PR DESCRIPTION
CR comment #r3192126365 on #408 flagged that the release note implied `RujiraClientOptions.rpcEndpoint` was removed from `RujiraClient`, but it's still present and used in `packages/rujira/src/client.ts`.

Narrowed the wording from "corresponding plumbing in RujiraClient" to "discovery-specific plumbing in RujiraClient" to avoid misleading upgrade notes.

## receipts

no runtime changes

🤖 Agent-generated — follow-up to #408 CR comment r3192126365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of endpoint discovery for blockchain operations.

* **Updates**
  * Updated quotes ranking logic.
  * Migrated gateway endpoints for enhanced service availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->