### PR TITLE
fix(solana): relay after JITO acceptance

### DIFF
--- a/.changeset/solana-durable-rpc-relay.md
+++ b/.changeset/solana-durable-rpc-relay.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/core-chain": patch
+---
+
+Relay Solana transactions through standard RPC after JITO acceptance to avoid treating JITO-only acceptance as durable broadcast.

--- a/packages/core/chain/tx/broadcast/resolvers/solana.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/solana.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  sendJitoTransaction: vi.fn(),
+  sendRawTransaction: vi.fn(),
+  verifyBroadcastByHash: vi.fn(),
+}))
+
+vi.mock('@vultisig/core-chain/chains/solana/jito', () => ({
+  sendJitoTransaction: mocks.sendJitoTransaction,
+}))
+
+vi.mock('@vultisig/core-chain/chains/solana/client', () => ({
+  getSolanaClient: () => ({
+    sendRawTransaction: mocks.sendRawTransaction,
+  }),
+}))
+
+vi.mock('../verifyBroadcastByHash', () => ({
+  verifyBroadcastByHash: mocks.verifyBroadcastByHash,
+}))
+
+import { Chain } from '../../../Chain'
+import { broadcastSolanaTx } from './solana'
+
+describe('broadcastSolanaTx', () => {
+  const tx = { encoded: '1111' } as any
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.sendJitoTransaction.mockResolvedValue('jito-signature')
+    mocks.sendRawTransaction.mockResolvedValue('rpc-signature')
+  })
+
+  it('relays through standard RPC even when JITO accepts the transaction', async () => {
+    await broadcastSolanaTx({ chain: Chain.Solana, tx })
+
+    expect(mocks.sendJitoTransaction).toHaveBeenCalledTimes(1)
+    expect(mocks.sendRawTransaction).toHaveBeenCalledTimes(1)
+    expect(mocks.sendRawTransaction).toHaveBeenCalledWith(expect.any(Uint8Array), {
+      skipPreflight: false,
+      preflightCommitment: 'confirmed',
+      maxRetries: 3,
+    })
+  })
+
+  it('falls back to standard RPC when JITO rejects the transaction', async () => {
+    mocks.sendJitoTransaction.mockRejectedValue(new Error('jito unavailable'))
+
+    await broadcastSolanaTx({ chain: Chain.Solana, tx })
+
+    expect(mocks.sendJitoTransaction).toHaveBeenCalledTimes(1)
+    expect(mocks.sendRawTransaction).toHaveBeenCalledTimes(1)
+  })
+
+  it('verifies by hash when standard RPC rejects after JITO acceptance', async () => {
+    const rpcError = new Error('already processed')
+    mocks.sendRawTransaction.mockRejectedValue(rpcError)
+    mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+
+    await broadcastSolanaTx({ chain: Chain.Solana, tx })
+
+    expect(mocks.verifyBroadcastByHash).toHaveBeenCalledWith({
+      chain: Chain.Solana,
+      tx,
+      error: rpcError,
+    })
+  })
+})

--- a/packages/core/chain/tx/broadcast/resolvers/solana.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/solana.ts
@@ -11,12 +11,11 @@ export const broadcastSolanaTx: BroadcastTxResolver<
 > = async ({ chain, tx }) => {
   const rawTransaction = base58.decode(tx.encoded)
 
-  // Route all Solana transactions through JITO's sendTransaction endpoint
-  // for free MEV protection (private mempool). Falls back to standard RPC
-  // if JITO is unavailable.
+  // Try JITO first for MEV protection, but still relay through standard RPC.
+  // JITO can accept sendTransaction without the signature later appearing in
+  // public Solana history, so standard RPC propagation is the durable signal.
   try {
     await sendJitoTransaction(rawTransaction)
-    return
   } catch (err) {
     console.warn('[solana] JITO sendTransaction failed, falling back to standard RPC:', err)
   }


### PR DESCRIPTION
Summary
- Continue to submit Solana transactions through standard RPC after JITO accepts them.
- Keep JITO as the first relay attempt, but avoid treating JITO acceptance as durable broadcast.
- Add regression coverage for JITO success, JITO failure fallback, and RPC duplicate/already-processed verification.

Issue
- Extension users could receive a Solana signature from signAndSendTransaction even when JITO accepted but the transaction never appeared in public Solana history.

Test Plan
- yarn test:core packages/core/chain/tx/broadcast/resolvers/solana.test.ts packages/core/mpc/keysign/signingInputs/resolvers/solana/send.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Solana transaction broadcasting to relay through standard RPC after JITO acceptance, ensuring more reliable transaction confirmation and preventing incomplete broadcast scenarios.

* **Tests**
  * Added comprehensive tests for Solana broadcasting behavior to verify proper fallback to standard RPC, JITO failure handling, and transaction hash verification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->