### PR TITLE
[sdk/swap] Report all quote provider failures

### DIFF
--- a/.changeset/short-swap-provider-errors.md
+++ b/.changeset/short-swap-provider-errors.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/core-chain': patch
+---
+
+Report all attempted swap quote provider failures with short provider-attributed messages.

--- a/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
@@ -190,7 +190,7 @@ describe('findSwapQuote parallel selection', () => {
     expect(quote.quote.general.provider).toBe('kyber')
   })
 
-  it('when all providers fail, propagates the first fetcher-order rejection', async () => {
+  it('when all providers fail, reports every attempted provider', async () => {
     const mayaError = 'maya last error'
     vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('first fail'))
     vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('second fail'))
@@ -207,7 +207,36 @@ describe('findSwapQuote parallel selection', () => {
         ...evmSameChainCoins,
         amount: 1n,
       })
-    ).rejects.toThrow('first fail')
+    ).rejects.toThrow(
+      'No swap route found after trying KyberSwap, 1inch, LiFi, THORChain, MayaChain.'
+    )
+  })
+
+  it('omits noisy provider errors from the all-fail message', async () => {
+    const longKyberError = `kyber ${'x'.repeat(220)}`
+
+    vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error(longKyberError))
+    vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('inch fail'))
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('lifi fail'))
+    vi.mocked(getNativeSwapQuote).mockRejectedValue(new Error('native fail'))
+
+    try {
+      await findSwapQuote({
+        ...evmSameChainCoins,
+        amount: 1n,
+      })
+      throw new Error('Expected findSwapQuote to fail')
+    } catch (error) {
+      if (!(error instanceof Error)) {
+        throw error
+      }
+
+      expect(error.message).toBe(
+        'No swap route found after trying KyberSwap, 1inch, LiFi, THORChain, MayaChain.'
+      )
+      expect(error.message).not.toContain(longKyberError)
+      expect(error.message).not.toContain('inch fail')
+    }
   })
 
   it('maps dust threshold on any provider to the user-facing message (Maya in this setup)', async () => {

--- a/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
@@ -42,10 +42,7 @@ const evmSameChainCoins = {
   },
 } as const
 
-function minimalGeneralQuote(
-  dstAmount: string,
-  provider: 'kyber' | '1inch'
-): GeneralSwapQuote {
+function minimalGeneralQuote(dstAmount: string, provider: 'kyber' | '1inch'): GeneralSwapQuote {
   const base = {
     dstAmount,
     tx: {
@@ -57,9 +54,7 @@ function minimalGeneralQuote(
       },
     },
   }
-  return provider === 'kyber'
-    ? { ...base, provider: 'kyber' }
-    : { ...base, provider: '1inch' }
+  return provider === 'kyber' ? { ...base, provider: 'kyber' } : { ...base, provider: '1inch' }
 }
 
 function minimalNativeQuote(swapChain: Chain, expected_amount_out: string): NativeSwapQuote {
@@ -136,9 +131,7 @@ describe('findSwapQuote parallel selection', () => {
     vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('Kyber unavailable'))
     vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('skip inch'))
     vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
-    vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) =>
-      minimalNativeQuote(swapChain, '100')
-    )
+    vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) => minimalNativeQuote(swapChain, '100'))
 
     const quote = await findSwapQuote({
       ...evmSameChainCoins,
@@ -152,14 +145,10 @@ describe('findSwapQuote parallel selection', () => {
   })
 
   it('does not let a malformed provider amount hide a succeeding one', async () => {
-    vi.mocked(getKyberSwapQuote).mockResolvedValue(
-      minimalGeneralQuote('not-a-number', 'kyber')
-    )
+    vi.mocked(getKyberSwapQuote).mockResolvedValue(minimalGeneralQuote('not-a-number', 'kyber'))
     vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('skip inch'))
     vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
-    vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) =>
-      minimalNativeQuote(swapChain, '100')
-    )
+    vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) => minimalNativeQuote(swapChain, '100'))
 
     const quote = await findSwapQuote({
       ...evmSameChainCoins,
@@ -207,9 +196,7 @@ describe('findSwapQuote parallel selection', () => {
         ...evmSameChainCoins,
         amount: 1n,
       })
-    ).rejects.toThrow(
-      'No swap route found after trying KyberSwap, 1inch, LiFi, THORChain, MayaChain.'
-    )
+    ).rejects.toThrow('No swap route found after trying KyberSwap, 1inch, LiFi, THORChain, MayaChain.')
   })
 
   it('omits noisy provider errors from the all-fail message', async () => {
@@ -231,9 +218,7 @@ describe('findSwapQuote parallel selection', () => {
         throw error
       }
 
-      expect(error.message).toBe(
-        'No swap route found after trying KyberSwap, 1inch, LiFi, THORChain, MayaChain.'
-      )
+      expect(error.message).toBe('No swap route found after trying KyberSwap, 1inch, LiFi, THORChain, MayaChain.')
       expect(error.message).not.toContain(longKyberError)
       expect(error.message).not.toContain('inch fail')
     }

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -19,10 +19,7 @@ import { getKyberSwapQuote } from '../general/kyber/api/quote'
 import { kyberSwapEnabledChains } from '../general/kyber/chains'
 import { getNativeSwapQuote } from '../native/api/getNativeSwapQuote'
 import { getNativeSwapDecimals } from '../native/utils/getNativeSwapDecimals'
-import {
-  nativeSwapChains,
-  nativeSwapEnabledChainsRecord,
-} from '../native/NativeSwapChain'
+import { nativeSwapChains, nativeSwapEnabledChainsRecord } from '../native/NativeSwapChain'
 import { SwapQuote } from './SwapQuote'
 
 export type FindSwapQuoteInput = Record<TransferDirection, AccountCoin> & {
@@ -31,12 +28,7 @@ export type FindSwapQuoteInput = Record<TransferDirection, AccountCoin> & {
   vultDiscountTier?: VultDiscountTier | null
 }
 
-type SwapQuoteProviderName =
-  | 'KyberSwap'
-  | '1inch'
-  | 'LiFi'
-  | 'THORChain'
-  | 'MayaChain'
+type SwapQuoteProviderName = 'KyberSwap' | '1inch' | 'LiFi' | 'THORChain' | 'MayaChain'
 
 type SwapQuoteFetcher = {
   providerName: SwapQuoteProviderName
@@ -49,11 +41,7 @@ type RankedSwapQuote = {
 }
 
 /** Re-base an integer amount from `fromDecimals` fixed-point to `toDecimals`. */
-function rebaseDecimals(
-  value: bigint,
-  fromDecimals: number,
-  toDecimals: number
-): bigint {
+function rebaseDecimals(value: bigint, fromDecimals: number, toDecimals: number): bigint {
   if (fromDecimals === toDecimals) {
     return value
   }
@@ -84,9 +72,7 @@ function getComparableOutputAmount(q: SwapQuote, to: AccountCoin): bigint {
   return BigInt(q.quote.general.dstAmount)
 }
 
-function selectBestEligibleQuote(
-  settled: PromiseSettledResult<RankedSwapQuote>[]
-): SwapQuote | null {
+function selectBestEligibleQuote(settled: PromiseSettledResult<RankedSwapQuote>[]): SwapQuote | null {
   let best: SwapQuote | null = null
   let bestAmount: bigint | null = null
   let bestIndex = Number.POSITIVE_INFINITY
@@ -99,11 +85,7 @@ function selectBestEligibleQuote(
     const { outputAmount, quote } = result.value
     // Tie-break: lower index wins. Fetchers are ordered by `shouldPreferGeneralSwap`
     // (general-first vs native-first), so this preserves that preference when amounts tie.
-    if (
-      bestAmount === null ||
-      outputAmount > bestAmount ||
-      (outputAmount === bestAmount && i < bestIndex)
-    ) {
+    if (bestAmount === null || outputAmount > bestAmount || (outputAmount === bestAmount && i < bestIndex)) {
       best = quote
       bestAmount = outputAmount
       bestIndex = i
@@ -122,18 +104,14 @@ export const findSwapQuote = async ({
 }: FindSwapQuoteInput): Promise<SwapQuote> => {
   const affiliateBps = getSwapAffiliateBps(vultDiscountTier ?? null)
 
-  const vultDiscount: SwapDiscount[] = vultDiscountTier
-    ? [{ vult: { tier: vultDiscountTier } }]
-    : []
+  const vultDiscount: SwapDiscount[] = vultDiscountTier ? [{ vult: { tier: vultDiscountTier } }] : []
 
   const referralDiscount: SwapDiscount[] = referral ? [{ referral: {} }] : []
 
   const involvedChains = [from.chain, to.chain]
 
   const matchingSwapChains = nativeSwapChains.filter(swapChain =>
-    involvedChains.every(chain =>
-      isOneOf(chain, nativeSwapEnabledChainsRecord[swapChain])
-    )
+    involvedChains.every(chain => isOneOf(chain, nativeSwapEnabledChainsRecord[swapChain]))
   )
 
   const getNativeFetchers = (): SwapQuoteFetcher[] =>
@@ -154,10 +132,7 @@ export const findSwapQuote = async ({
 
         return {
           quote: { native },
-          discounts:
-            swapChain === Chain.THORChain
-              ? [...vultDiscount, ...referralDiscount]
-              : vultDiscount,
+          discounts: swapChain === Chain.THORChain ? [...vultDiscount, ...referralDiscount] : vultDiscount,
         }
       },
     }))
@@ -195,10 +170,7 @@ export const findSwapQuote = async ({
       })
     }
 
-    if (
-      isOneOf(from.chain, oneInchSwapEnabledChains) &&
-      from.chain === to.chain
-    ) {
+    if (isOneOf(from.chain, oneInchSwapEnabledChains) && from.chain === to.chain) {
       result.push({
         providerName: '1inch',
         fetch: async (): Promise<SwapQuote> => {
@@ -215,10 +187,7 @@ export const findSwapQuote = async ({
       })
     }
 
-    if (
-      isOneOf(fromChain, lifiSwapEnabledChains) &&
-      isOneOf(toChain, lifiSwapEnabledChains)
-    ) {
+    if (isOneOf(fromChain, lifiSwapEnabledChains) && isOneOf(toChain, lifiSwapEnabledChains)) {
       result.push({
         providerName: 'LiFi',
         fetch: async (): Promise<SwapQuote> => {
@@ -244,8 +213,7 @@ export const findSwapQuote = async ({
   }
 
   const shouldPreferGeneralSwap =
-    [from.chain, to.chain].every(chain => isChainOfKind(chain, 'evm')) &&
-    [from.id, to.id].some(v => v)
+    [from.chain, to.chain].every(chain => isChainOfKind(chain, 'evm')) && [from.id, to.id].some(v => v)
 
   const fetchers = shouldPreferGeneralSwap
     ? [...getGeneralFetchers(), ...getNativeFetchers()]
@@ -272,9 +240,7 @@ export const findSwapQuote = async ({
 
   for (const result of settled) {
     if (result.status === 'rejected' && isInError(result.reason, 'dust threshold')) {
-      throw new Error(
-        'Swap amount too small. Please increase the amount to proceed.'
-      )
+      throw new Error('Swap amount too small. Please increase the amount to proceed.')
     }
   }
 
@@ -288,7 +254,5 @@ export const findSwapQuote = async ({
     })
     .filter((providerName): providerName is SwapQuoteProviderName => providerName !== null)
 
-  throw new Error(
-    `No swap route found after trying ${failedProviders.join(', ')}.`
-  )
+  throw new Error(`No swap route found after trying ${failedProviders.join(', ')}.`)
 }

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -31,7 +31,17 @@ export type FindSwapQuoteInput = Record<TransferDirection, AccountCoin> & {
   vultDiscountTier?: VultDiscountTier | null
 }
 
-type SwapQuoteFetcher = () => Promise<SwapQuote>
+type SwapQuoteProviderName =
+  | 'KyberSwap'
+  | '1inch'
+  | 'LiFi'
+  | 'THORChain'
+  | 'MayaChain'
+
+type SwapQuoteFetcher = {
+  providerName: SwapQuoteProviderName
+  fetch: () => Promise<SwapQuote>
+}
 
 type RankedSwapQuote = {
   quote: SwapQuote
@@ -127,27 +137,30 @@ export const findSwapQuote = async ({
   )
 
   const getNativeFetchers = (): SwapQuoteFetcher[] =>
-    matchingSwapChains.map(swapChain => async (): Promise<SwapQuote> => {
-      const fromDecimals = from.decimals
-      const amountNumber = bigIntToNumber(amount, fromDecimals)
-      const native = await getNativeSwapQuote({
-        swapChain,
-        destination: to.address,
-        from,
-        to,
-        amount: amountNumber,
-        referral,
-        affiliateBps,
-      })
+    matchingSwapChains.map(swapChain => ({
+      providerName: swapChain === Chain.THORChain ? 'THORChain' : 'MayaChain',
+      fetch: async (): Promise<SwapQuote> => {
+        const fromDecimals = from.decimals
+        const amountNumber = bigIntToNumber(amount, fromDecimals)
+        const native = await getNativeSwapQuote({
+          swapChain,
+          destination: to.address,
+          from,
+          to,
+          amount: amountNumber,
+          referral,
+          affiliateBps,
+        })
 
-      return {
-        quote: { native },
-        discounts:
-          swapChain === Chain.THORChain
-            ? [...vultDiscount, ...referralDiscount]
-            : vultDiscount,
-      }
-    })
+        return {
+          quote: { native },
+          discounts:
+            swapChain === Chain.THORChain
+              ? [...vultDiscount, ...referralDiscount]
+              : vultDiscount,
+        }
+      },
+    }))
 
   const getGeneralFetchers = (): SwapQuoteFetcher[] => {
     const result: SwapQuoteFetcher[] = []
@@ -161,21 +174,24 @@ export const findSwapQuote = async ({
       isOneOf(toChain, kyberSwapEnabledChains) &&
       fromChain === toChain
     ) {
-      result.push(async (): Promise<SwapQuote> => {
-        const general = await getKyberSwapQuote({
-          from: {
-            ...from,
-            chain: fromChain,
-          },
-          to: {
-            ...to,
-            chain: toChain,
-          },
-          amount: chainAmount,
-          affiliateBps,
-        })
+      result.push({
+        providerName: 'KyberSwap',
+        fetch: async (): Promise<SwapQuote> => {
+          const general = await getKyberSwapQuote({
+            from: {
+              ...from,
+              chain: fromChain,
+            },
+            to: {
+              ...to,
+              chain: toChain,
+            },
+            amount: chainAmount,
+            affiliateBps,
+          })
 
-        return { quote: { general }, discounts: vultDiscount }
+          return { quote: { general }, discounts: vultDiscount }
+        },
       })
     }
 
@@ -183,16 +199,19 @@ export const findSwapQuote = async ({
       isOneOf(from.chain, oneInchSwapEnabledChains) &&
       from.chain === to.chain
     ) {
-      result.push(async (): Promise<SwapQuote> => {
-        const general = await getOneInchSwapQuote({
-          account: pick(from, ['address', 'chain']),
-          fromCoinId: from.id ?? from.ticker,
-          toCoinId: to.id ?? to.ticker,
-          amount: chainAmount,
-          affiliateBps,
-        })
+      result.push({
+        providerName: '1inch',
+        fetch: async (): Promise<SwapQuote> => {
+          const general = await getOneInchSwapQuote({
+            account: pick(from, ['address', 'chain']),
+            fromCoinId: from.id ?? from.ticker,
+            toCoinId: to.id ?? to.ticker,
+            amount: chainAmount,
+            affiliateBps,
+          })
 
-        return { quote: { general }, discounts: vultDiscount }
+          return { quote: { general }, discounts: vultDiscount }
+        },
       })
     }
 
@@ -200,21 +219,24 @@ export const findSwapQuote = async ({
       isOneOf(fromChain, lifiSwapEnabledChains) &&
       isOneOf(toChain, lifiSwapEnabledChains)
     ) {
-      result.push(async (): Promise<SwapQuote> => {
-        const general = await getLifiSwapQuote({
-          from: {
-            ...from,
-            chain: fromChain,
-          },
-          to: {
-            ...to,
-            chain: toChain,
-          },
-          amount: chainAmount,
-          affiliateBps,
-        })
+      result.push({
+        providerName: 'LiFi',
+        fetch: async (): Promise<SwapQuote> => {
+          const general = await getLifiSwapQuote({
+            from: {
+              ...from,
+              chain: fromChain,
+            },
+            to: {
+              ...to,
+              chain: toChain,
+            },
+            amount: chainAmount,
+            affiliateBps,
+          })
 
-        return { quote: { general }, discounts: vultDiscount }
+          return { quote: { general }, discounts: vultDiscount }
+        },
       })
     }
 
@@ -235,7 +257,7 @@ export const findSwapQuote = async ({
 
   const settled = await Promise.allSettled(
     fetchers.map(async fetcher => {
-      const quote = await fetcher()
+      const quote = await fetcher.fetch()
       return {
         quote,
         outputAmount: getComparableOutputAmount(quote, to),
@@ -256,13 +278,17 @@ export const findSwapQuote = async ({
     }
   }
 
-  for (const result of settled) {
-    if (result.status === 'rejected') {
-      throw result.reason
-    }
-  }
+  const failedProviders = settled
+    .map((result, index) => {
+      if (result.status === 'fulfilled') {
+        return null
+      }
 
-  // Defensive: when fetchers are non-empty, `best` is null only if every
-  // fetcher rejected, and the loop above throws the first reason.
-  throw new Error('No quote')
+      return fetchers[index].providerName
+    })
+    .filter((providerName): providerName is SwapQuoteProviderName => providerName !== null)
+
+  throw new Error(
+    `No swap route found after trying ${failedProviders.join(', ')}.`
+  )
 }


### PR DESCRIPTION
## Summary
- add provider labels to swap quote fetchers so all-fail errors name every attempted provider
- report only the attempted provider names in the user-facing all-fail message
- keep best-successful-quote selection and the existing dust-threshold user-facing error unchanged

## Receipts
- Focused unit: `node node_modules/vitest/vitest.mjs run --config .config/vitest.core.config.ts packages/core/chain/swap/quote/findSwapQuote.selection.test.ts`
  - Result: PASS, 9 tests passed.
- Diff hygiene: `git diff --check`
  - Result: PASS.
- SDK node bundle for CLI smoke: `PATH="/home/sean/Repos/vultisig/vultisig-sdk/node_modules/.bin:/home/sean/.codex/tmp/arg0/codex-arg0958GRy:/home/sean/.local/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/sean/.bun/bin:/home/sean/.opencode/bin:/home/sean/.local/bin:/home/sean/go/bin:/home/sean/.cargo/bin:/home/sean/Android/Sdk/platform-tools:/home/sean/.claude/bin:/usr/lib64/ccache:/home/sean/.cargo/bin:/home/sean/.local/bin:/usr/local/bin:/usr/bin:/usr/sbin:/home/sean/.maestro/bin" yarn workspace @vultisig/sdk build:fast`
  - Result: PASS; Rollup emitted existing dependency warnings only.
- CLI smoke: `node clients/cli/dist/index.js swap-quote Polygon Polygon 1 --to-token BNB -o json`
  - Result: PASS, exercised the all-provider-failed CLI path.
  - Output excerpt:
    ```json
    {
      "success": false,
      "v": 1,
      "error": {
        "code": "USAGE_ERROR",
        "exitCode": 1,
        "message": "Swap failed: No swap route found after trying KyberSwap, 1inch, LiFi.",
        "retryable": false
      }
    }
    ```

## Notes
- `yarn test:core packages/core/chain/swap/quote/findSwapQuote.selection.test.ts` could not run in this checkout because Yarn did not resolve `vitest` (`command not found: vitest`); used the local Vitest binary directly.
- Full core suite was attempted and failed on unrelated environment/test issues: missing `@ton/core` in `ton/messageBody/decode.test.ts` and timeout in `packages/core/mpc/message/server.test.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap quote failure reporting: when all providers fail, the app now shows a single consolidated, sanitized message listing attempted providers (omitting verbose provider-specific error text) while preserving special-case dust-threshold handling.

* **Tests**
  * Updated tests to verify the consolidated, sanitized failure message and the all-providers-fail scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->