### PR TITLE
fix(cli): wire CRUD action-discriminator tools (vault_coin/chain/address_book)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,9 +61,9 @@ When using `agent ask` or `--via-agent`, the agent backend proposes actions; the
 | `sign_typed_data` | EIP-712 typed data signing | local |
 | `read_evm_contract` | Read EVM contract state | local |
 | `scan_tx` | Security scan via Blockaid | backend |
-| `add_chain` / `remove_chain` | Enable/disable chains | local |
-| `add_coin` / `remove_coin` | Add/remove tokens | local |
-| `address_book_add` / `address_book_remove` | Manage saved addresses | backend |
+| `vault_chain` | Add/remove chains (`{action: "add"\|"remove", chains: [...]}`) | local |
+| `vault_coin` | Add/remove tokens (`{action: "add"\|"remove", coins: [...]}`) | local |
+| `address_book` | Manage saved addresses (`{action: "add"\|"remove", entry: {...}}`) | local |
 | `get_address_book` | List saved addresses (requires CLI `AgentConfig.vultisig`) | local |
 | `build_tx` | Build a generic transaction | local |
 | `list_vaults` | List available vaults | local |

--- a/clients/cli/src/agent/__tests__/clientSideDispatch.test.ts
+++ b/clients/cli/src/agent/__tests__/clientSideDispatch.test.ts
@@ -12,14 +12,14 @@ describe('actionResultToRecentAction', () => {
 
   it('converts successful ActionResult to RecentAction with data', () => {
     const actionResult: ActionResult = {
-      action: 'add_coin',
+      action: 'vault_coin',
       action_id: 'call-1',
       success: true,
       data: { chain: 'Base', ticker: 'USDC' },
     }
     const recent = convert(actionResult)
     expect(recent).toEqual({
-      tool: 'add_coin',
+      tool: 'vault_coin',
       success: true,
       data: { chain: 'Base', ticker: 'USDC' },
     })
@@ -60,7 +60,7 @@ describe('actionResultToRecentAction', () => {
 
   it('preserves existing data fields when folding error', () => {
     const actionResult: ActionResult = {
-      action: 'add_coin',
+      action: 'vault_coin',
       action_id: 'call-4',
       success: false,
       data: { requested: 'USDC' },
@@ -76,15 +76,9 @@ describe('actionResultToRecentAction', () => {
 
 describe('CLIENT_SIDE_TOOL_DISPATCH registry — capability drift guard', () => {
   // Locks the registry surface — drift is caught at test time, not runtime.
-  const EXPECTED_ENTRIES = [
-    'sign_typed_data',
-    'add_coin',
-    'remove_coin',
-    'add_chain',
-    'remove_chain',
-    'address_book_add',
-    'address_book_remove',
-  ]
+  // Backend collapsed the CRUD pairs (add_/remove_) into action-discriminator
+  // tools (vault_coin, vault_chain, address_book) in agent-backend#167.
+  const EXPECTED_ENTRIES = ['sign_typed_data', 'vault_coin', 'vault_chain', 'address_book']
 
   it('has exactly the expected tool names', () => {
     expect(Object.keys(registry).sort()).toEqual(EXPECTED_ENTRIES.slice().sort())
@@ -148,10 +142,10 @@ describe('processMessageLoop — depth cap', () => {
 
 // PB1 — session.ts:onClientSideToolCall must serialize dispatches in SSE
 // arrival order. Without this, two parallel dispatches race on (a) shared
-// vault state (add_chain → add_coin) and (b) the single-slot password
-// resolver (silent hang in pipe-UI mode). These tests pin the chain
-// pattern itself; the manual E2E in the PR description verifies it lands
-// inside session.ts.
+// vault state (vault_chain add → vault_coin add) and (b) the single-slot
+// password resolver (silent hang in pipe-UI mode). These tests pin the
+// chain pattern itself; the manual E2E in the PR description verifies it
+// lands inside session.ts.
 describe('PB1 — serialized dispatch chain pattern', () => {
   // Reproduce the exact chain shape from session.ts so the contract is
   // visible at the test level — any code change in session.ts that
@@ -358,15 +352,18 @@ describe('AgentClient SSE parser — clientExecuted routing', () => {
       JSON.stringify({
         type: 'tool-input-available',
         toolCallId: 'c1',
-        toolName: 'add_coin',
-        input: { tokens: [{ chain: 'Base', ticker: 'USDC' }] },
+        toolName: 'vault_coin',
+        input: { action: 'add', coins: [{ chain: 'Base', ticker: 'USDC' }] },
         clientExecuted: true,
       }),
       { onClientSideToolCall, onToolProgress }
     )
 
     expect(onClientSideToolCall).toHaveBeenCalledOnce()
-    expect(onClientSideToolCall).toHaveBeenCalledWith('c1', 'add_coin', { tokens: [{ chain: 'Base', ticker: 'USDC' }] })
+    expect(onClientSideToolCall).toHaveBeenCalledWith('c1', 'vault_coin', {
+      action: 'add',
+      coins: [{ chain: 'Base', ticker: 'USDC' }],
+    })
     expect(onToolProgress).toHaveBeenCalled()
   })
 
@@ -400,7 +397,7 @@ describe('AgentClient SSE parser — clientExecuted routing', () => {
         JSON.stringify({
           type: 'tool-input-available',
           toolCallId: 'c',
-          toolName: 'add_coin',
+          toolName: 'vault_coin',
           input: {},
           clientExecuted: v,
         }),
@@ -420,7 +417,7 @@ describe('AgentClient SSE parser — clientExecuted routing', () => {
       JSON.stringify({
         type: 'tool-input-start',
         toolCallId: 'c',
-        toolName: 'add_coin',
+        toolName: 'vault_coin',
         clientExecuted: true, // even if present, only tool-input-available should trigger dispatch
       }),
       { onClientSideToolCall }
@@ -438,13 +435,13 @@ describe('AgentClient SSE parser — clientExecuted routing', () => {
       JSON.stringify({
         type: 'tool-input-available',
         toolCallId: 'c',
-        toolName: 'add_coin',
+        toolName: 'vault_coin',
         input: null,
         clientExecuted: true,
       }),
       { onClientSideToolCall }
     )
 
-    expect(onClientSideToolCall).toHaveBeenCalledWith('c', 'add_coin', {})
+    expect(onClientSideToolCall).toHaveBeenCalledWith('c', 'vault_coin', {})
   })
 })

--- a/clients/cli/src/agent/__tests__/executor.test.ts
+++ b/clients/cli/src/agent/__tests__/executor.test.ts
@@ -33,10 +33,20 @@ function createMockVault(): VaultBase {
     address: vi.fn().mockResolvedValue('0xsender'),
     addChain: vi.fn().mockResolvedValue(undefined),
     removeChain: vi.fn().mockResolvedValue(undefined),
+    addToken: vi.fn().mockResolvedValue(undefined),
+    removeToken: vi.fn().mockResolvedValue(undefined),
     balance: vi.fn().mockResolvedValue({ decimals: 18, symbol: 'ETH' }),
     prepareSendTx: vi.fn().mockResolvedValue({ mockKeysignPayload: true }),
     extractMessageHashes: vi.fn().mockResolvedValue(['0xabc123']),
   } as unknown as VaultBase
+}
+
+function createMockVultisig(): ConstructorParameters<typeof AgentExecutor>[3] {
+  return {
+    addAddressBookEntry: vi.fn().mockResolvedValue(undefined),
+    removeAddressBookEntry: vi.fn().mockResolvedValue(undefined),
+    getAddressBook: vi.fn().mockResolvedValue({ saved: [], vaults: [] }),
+  } as unknown as ConstructorParameters<typeof AgentExecutor>[3]
 }
 
 function action(partial: Pick<Action, 'type'> & Partial<Action>): Action {
@@ -103,27 +113,17 @@ describe('AgentExecutor', () => {
     expect(vaults[0].chains).toEqual(['Ethereum', 'Bitcoin'])
   })
 
-  it('add_chain handles single chain', async () => {
-    const vault = createMockVault()
-    const executor = new AgentExecutor(vault)
-
-    const result = await executor.executeAction(action({ type: 'add_chain', params: { chain: 'Ethereum' } }))
-
-    expect(result.success).toBe(true)
-    expect(vault.addChain).toHaveBeenCalledWith(Chain.Ethereum)
-    expect(result.data?.chain).toBe('Ethereum')
-    expect(result.data?.added).toBe(true)
-    expect(vault.address).toHaveBeenCalled()
-  })
-
-  it('add_chain handles batch chains array', async () => {
+  // vault_chain — agent-backend wire shape: { action, chains: [{chain}] }.
+  // The executor also tolerates a single `chain` string for hand-rolled
+  // callers (CLI scripts, REPL).
+  it('vault_chain action=add with chains array adds each chain', async () => {
     const vault = createMockVault()
     const executor = new AgentExecutor(vault)
 
     const result = await executor.executeAction(
       action({
-        type: 'add_chain',
-        params: { chains: ['Bitcoin', { chain: 'Ethereum' }] },
+        type: 'vault_chain',
+        params: { action: 'add', chains: [{ chain: 'Bitcoin' }, { chain: 'Ethereum' }] },
       })
     )
 
@@ -132,6 +132,165 @@ describe('AgentExecutor', () => {
     const added = result.data?.added as Array<{ chain: string }>
     expect(added).toHaveLength(2)
     expect(added.map(a => a.chain).sort()).toEqual(['Bitcoin', 'Ethereum'])
+  })
+
+  it('vault_chain action=add tolerates single chain shape', async () => {
+    const vault = createMockVault()
+    const executor = new AgentExecutor(vault)
+
+    const result = await executor.executeAction(
+      action({ type: 'vault_chain', params: { action: 'add', chain: 'Ethereum' } })
+    )
+
+    expect(result.success).toBe(true)
+    expect(vault.addChain).toHaveBeenCalledWith(Chain.Ethereum)
+    expect(result.data?.added).toBe(true)
+    expect(result.data?.chain).toBe('Ethereum')
+  })
+
+  it('vault_chain action=remove removes each chain in batch', async () => {
+    const vault = createMockVault()
+    const executor = new AgentExecutor(vault)
+
+    const result = await executor.executeAction(
+      action({
+        type: 'vault_chain',
+        params: { action: 'remove', chains: [{ chain: 'Bitcoin' }, { chain: 'Ethereum' }] },
+      })
+    )
+
+    expect(result.success).toBe(true)
+    expect(vault.removeChain).toHaveBeenCalledTimes(2)
+    const removed = result.data?.removed as Array<{ chain: string }>
+    expect(removed.map(r => r.chain).sort()).toEqual(['Bitcoin', 'Ethereum'])
+  })
+
+  it('vault_chain rejects unknown action', async () => {
+    const vault = createMockVault()
+    const executor = new AgentExecutor(vault)
+
+    const result = await executor.executeAction(action({ type: 'vault_chain', params: { action: 'wat' } }))
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/vault_chain.*unknown action/)
+  })
+
+  // vault_coin — wire shape: { action, coins: [{chain, ticker, contract_address?, decimals?}] }
+  it('vault_coin action=add maps coins[] into vault.addToken calls', async () => {
+    const vault = createMockVault()
+    const executor = new AgentExecutor(vault)
+
+    const result = await executor.executeAction(
+      action({
+        type: 'vault_coin',
+        params: {
+          action: 'add',
+          coins: [
+            { chain: 'Ethereum', ticker: 'USDC', contract_address: '0xa0b8...eb48', decimals: 6 },
+            { chain: 'Bitcoin', ticker: 'BTC' },
+          ],
+        },
+      })
+    )
+
+    expect(result.success).toBe(true)
+    expect(vault.addToken).toHaveBeenCalledTimes(2)
+    const added = result.data?.added as Array<{ chain: string; symbol: string }>
+    expect(added.map(a => `${a.chain}:${a.symbol}`).sort()).toEqual(['Bitcoin:BTC', 'Ethereum:USDC'])
+  })
+
+  it('vault_coin action=remove uses contract_address as token id', async () => {
+    const vault = createMockVault()
+    const executor = new AgentExecutor(vault)
+
+    const result = await executor.executeAction(
+      action({
+        type: 'vault_coin',
+        params: {
+          action: 'remove',
+          coins: [{ chain: 'Ethereum', ticker: 'USDC', contract_address: '0xa0b8...eb48' }],
+        },
+      })
+    )
+
+    expect(result.success).toBe(true)
+    expect(vault.removeToken).toHaveBeenCalledWith(Chain.Ethereum, '0xa0b8...eb48')
+  })
+
+  it('vault_coin action=remove rejects coin missing contract_address', async () => {
+    const vault = createMockVault()
+    const executor = new AgentExecutor(vault)
+
+    const result = await executor.executeAction(
+      action({
+        type: 'vault_coin',
+        params: { action: 'remove', coins: [{ chain: 'Ethereum', ticker: 'USDC' }] },
+      })
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/missing contract_address/)
+    expect(vault.removeToken).not.toHaveBeenCalled()
+  })
+
+  // address_book — wire shape: { action, entry: { name, chain, address } }
+  it('address_book action=add forwards to Vultisig.addAddressBookEntry', async () => {
+    const vault = createMockVault()
+    const vultisig = createMockVultisig()
+    const executor = new AgentExecutor(vault, false, undefined, vultisig)
+
+    const result = await executor.executeAction(
+      action({
+        type: 'address_book',
+        params: { action: 'add', entry: { name: 'alice', chain: 'Ethereum', address: '0xalice' } },
+      })
+    )
+
+    expect(result.success).toBe(true)
+    const addFn = (vultisig as any).addAddressBookEntry
+    expect(addFn).toHaveBeenCalledOnce()
+    const [entries] = addFn.mock.calls[0]
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({
+      chain: Chain.Ethereum,
+      address: '0xalice',
+      name: 'alice',
+      source: 'saved',
+    })
+    expect(typeof entries[0].dateAdded).toBe('number')
+  })
+
+  it('address_book action=remove forwards to Vultisig.removeAddressBookEntry', async () => {
+    const vault = createMockVault()
+    const vultisig = createMockVultisig()
+    const executor = new AgentExecutor(vault, false, undefined, vultisig)
+
+    const result = await executor.executeAction(
+      action({
+        type: 'address_book',
+        params: { action: 'remove', entry: { chain: 'Ethereum', address: '0xalice' } },
+      })
+    )
+
+    expect(result.success).toBe(true)
+    expect((vultisig as any).removeAddressBookEntry).toHaveBeenCalledWith([
+      { chain: Chain.Ethereum, address: '0xalice' },
+    ])
+  })
+
+  it('address_book add fails when Vultisig instance is not configured', async () => {
+    const vault = createMockVault()
+    const executor = new AgentExecutor(vault) // no vultisig
+
+    const result = await executor.executeAction(
+      action({
+        type: 'address_book',
+        params: { action: 'add', entry: { name: 'alice', chain: 'Ethereum', address: '0xalice' } },
+      })
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/requires the CLI SDK instance/)
   })
 
   it('unknown action types return success: false', async () => {

--- a/clients/cli/src/agent/__tests__/executor.test.ts
+++ b/clients/cli/src/agent/__tests__/executor.test.ts
@@ -165,7 +165,7 @@ describe('AgentExecutor', () => {
     expect(removed.map(r => r.chain).sort()).toEqual(['Bitcoin', 'Ethereum'])
   })
 
-  it('vault_chain rejects unknown action', async () => {
+  it('vault_chain rejects unknown action without mutating state', async () => {
     const vault = createMockVault()
     const executor = new AgentExecutor(vault)
 
@@ -173,6 +173,20 @@ describe('AgentExecutor', () => {
 
     expect(result.success).toBe(false)
     expect(result.error).toMatch(/vault_chain.*unknown action/)
+    expect(vault.addChain).not.toHaveBeenCalled()
+    expect(vault.removeChain).not.toHaveBeenCalled()
+  })
+
+  it('vault_coin rejects unknown action without mutating state', async () => {
+    const vault = createMockVault()
+    const executor = new AgentExecutor(vault)
+
+    const result = await executor.executeAction(action({ type: 'vault_coin', params: { action: 'wat', coins: [] } }))
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/vault_coin.*unknown action/)
+    expect(vault.addToken).not.toHaveBeenCalled()
+    expect(vault.removeToken).not.toHaveBeenCalled()
   })
 
   // vault_coin — wire shape: { action, coins: [{chain, ticker, contract_address?, decimals?}] }
@@ -322,6 +336,56 @@ describe('AgentExecutor', () => {
 
     expect(result.success).toBe(false)
     expect(result.error).toMatch(/no saved entry named "alice"/)
+  })
+
+  // Two saved entries with the same name on the same chain are reachable
+  // because AddressBookManager dedupes by (chain, address) only. A naive
+  // `find()` would silently delete the first match — that's a real
+  // data-integrity bug since the user can't tell which entry was removed.
+  // Refuse ambiguity instead, listing candidate addresses so the agent
+  // can retry with explicit entry.address.
+  it('address_book action=remove refuses ambiguous name matches', async () => {
+    const vault = createMockVault()
+    const vultisig = createMockVultisig()
+    ;((vultisig as any).getAddressBook as ReturnType<typeof vi.fn>).mockResolvedValue({
+      saved: [
+        { chain: Chain.Ethereum, address: '0xalice1', name: 'alice', source: 'saved', dateAdded: 1 },
+        { chain: Chain.Ethereum, address: '0xalice2', name: 'Alice', source: 'saved', dateAdded: 2 },
+      ],
+      vaults: [],
+    })
+    const executor = new AgentExecutor(vault, false, undefined, vultisig)
+
+    const result = await executor.executeAction(
+      action({
+        type: 'address_book',
+        params: { action: 'remove', entry: { chain: 'Ethereum', name: 'alice' } },
+      })
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/ambiguous name "alice"/)
+    expect(result.error).toContain('0xalice1')
+    expect(result.error).toContain('0xalice2')
+    expect((vultisig as any).removeAddressBookEntry).not.toHaveBeenCalled()
+  })
+
+  it('address_book rejects unknown action without mutating state', async () => {
+    const vault = createMockVault()
+    const vultisig = createMockVultisig()
+    const executor = new AgentExecutor(vault, false, undefined, vultisig)
+
+    const result = await executor.executeAction(
+      action({
+        type: 'address_book',
+        params: { action: 'wat', entry: { name: 'alice', chain: 'Ethereum', address: '0xalice' } },
+      })
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/address_book.*unknown action/)
+    expect((vultisig as any).addAddressBookEntry).not.toHaveBeenCalled()
+    expect((vultisig as any).removeAddressBookEntry).not.toHaveBeenCalled()
   })
 
   it('address_book add fails when Vultisig instance is not configured', async () => {

--- a/clients/cli/src/agent/__tests__/executor.test.ts
+++ b/clients/cli/src/agent/__tests__/executor.test.ts
@@ -278,6 +278,52 @@ describe('AgentExecutor', () => {
     ])
   })
 
+  // The agent often emits `{chain, name}` without resolving the address.
+  // The executor falls back to Vultisig.getAddressBook to look up the
+  // address by name so name-based removal works end-to-end.
+  it('address_book action=remove resolves address by name when entry.address is missing', async () => {
+    const vault = createMockVault()
+    const vultisig = createMockVultisig()
+    ;((vultisig as any).getAddressBook as ReturnType<typeof vi.fn>).mockResolvedValue({
+      saved: [{ chain: Chain.Ethereum, address: '0xalice', name: 'alice', source: 'saved', dateAdded: 1 }],
+      vaults: [],
+    })
+    const executor = new AgentExecutor(vault, false, undefined, vultisig)
+
+    const result = await executor.executeAction(
+      action({
+        type: 'address_book',
+        params: { action: 'remove', entry: { chain: 'Ethereum', name: 'alice' } },
+      })
+    )
+
+    expect(result.success).toBe(true)
+    expect((vultisig as any).getAddressBook).toHaveBeenCalledWith(Chain.Ethereum)
+    expect((vultisig as any).removeAddressBookEntry).toHaveBeenCalledWith([
+      { chain: Chain.Ethereum, address: '0xalice' },
+    ])
+  })
+
+  it('address_book action=remove fails when name does not match any saved entry', async () => {
+    const vault = createMockVault()
+    const vultisig = createMockVultisig()
+    ;((vultisig as any).getAddressBook as ReturnType<typeof vi.fn>).mockResolvedValue({
+      saved: [],
+      vaults: [],
+    })
+    const executor = new AgentExecutor(vault, false, undefined, vultisig)
+
+    const result = await executor.executeAction(
+      action({
+        type: 'address_book',
+        params: { action: 'remove', entry: { chain: 'Ethereum', name: 'alice' } },
+      })
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/no saved entry named "alice"/)
+  })
+
   it('address_book add fails when Vultisig instance is not configured', async () => {
     const vault = createMockVault()
     const executor = new AgentExecutor(vault) // no vultisig

--- a/clients/cli/src/agent/executor.ts
+++ b/clients/cli/src/agent/executor.ts
@@ -247,20 +247,12 @@ export class AgentExecutor {
   // Chain & Token Management
   // ============================================================================
 
-  // Audit log for state-mutating CRUD tools. Always-on (regardless of
-  // --verbose) so the user sees what the agent persisted to vault state.
-  // Goes to stderr to keep stdout clean for JSON output.
-  private auditLog(tool: string, action: string | undefined, summary: string): void {
-    process.stderr.write(`[agent] ${tool} ${action ?? '?'}: ${summary}\n`)
-  }
-
   // vault_chain dispatcher — backend shape:
   //   { action: "add" | "remove", chains: [{ chain }] }
   // Single-chain (`chain` only) and legacy string arrays are tolerated for
   // forward compatibility / hand-rolled callers.
   private async vaultChain(params: Record<string, unknown>): Promise<Record<string, unknown>> {
     const action = params.action as string | undefined
-    this.auditLog('vault_chain', action, summarizeChains(params))
     switch (action) {
       case 'add':
         return this.addChainImpl(params)
@@ -275,7 +267,6 @@ export class AgentExecutor {
   //   { action: "add" | "remove", coins: [{ chain, ticker, contract_address?, decimals?, ... }] }
   private async vaultCoin(params: Record<string, unknown>): Promise<Record<string, unknown>> {
     const action = params.action as string | undefined
-    this.auditLog('vault_coin', action, summarizeCoins(params))
     switch (action) {
       case 'add':
         return this.addCoinImpl(params)
@@ -1623,7 +1614,6 @@ export class AgentExecutor {
   //   { action: "add" | "remove", entry: { name, chain, address } }
   private async addressBook(params: Record<string, unknown>): Promise<Record<string, unknown>> {
     const action = params.action as string | undefined
-    this.auditLog('address_book', action, summarizeAddressBookEntry(params))
     switch (action) {
       case 'add':
         return this.addAddressBookImpl(params)
@@ -1913,49 +1903,6 @@ function parseAmount(amountStr: string, decimals: number): bigint {
   const [whole, frac = ''] = amountStr.split('.')
   const paddedFrac = frac.slice(0, decimals).padEnd(decimals, '0')
   return BigInt(whole || '0') * 10n ** BigInt(decimals) + BigInt(paddedFrac || '0')
-}
-
-// Audit-log summarizers for state-mutating CRUD tools.
-// Short, scannable, mention what would help a user notice a wrong action.
-
-function shortenAddress(addr: string | undefined): string {
-  if (!addr || typeof addr !== 'string' || addr.length < 10) return addr ?? ''
-  return `${addr.slice(0, 6)}...${addr.slice(-4)}`
-}
-
-function summarizeChains(params: Record<string, unknown>): string {
-  const chains = params.chains as Array<unknown> | undefined
-  if (Array.isArray(chains) && chains.length > 0) {
-    const names = chains.map(c => (typeof c === 'string' ? c : (c as { chain?: unknown })?.chain)).filter(Boolean)
-    return names.length > 0 ? names.join(', ') : '(empty)'
-  }
-  return (params.chain as string) || '(unknown)'
-}
-
-function summarizeCoins(params: Record<string, unknown>): string {
-  const coins = (params.coins as Array<unknown> | undefined) ?? (params.tokens as Array<unknown> | undefined)
-  if (Array.isArray(coins) && coins.length > 0) {
-    return coins
-      .map(c => {
-        const t = c as { chain?: unknown; ticker?: unknown; symbol?: unknown; contract_address?: unknown; contractAddress?: unknown }
-        const sym = t.ticker || t.symbol || '?'
-        const ca = t.contract_address || t.contractAddress
-        const addrPart = ca ? ` (${shortenAddress(String(ca))})` : ''
-        return `${sym} on ${t.chain ?? '?'}${addrPart}`
-      })
-      .join(', ')
-  }
-  const sym = params.ticker || params.symbol || '?'
-  return `${sym} on ${params.chain ?? '?'}`
-}
-
-function summarizeAddressBookEntry(params: Record<string, unknown>): string {
-  const entry = params.entry as { name?: unknown; chain?: unknown; address?: unknown } | undefined
-  if (!entry) return '(missing entry)'
-  const name = entry.name || '(no name)'
-  const chain = entry.chain ?? '?'
-  const addr = entry.address ? shortenAddress(String(entry.address)) : null
-  return addr ? `${name} (${addr}) on ${chain}` : `${name} on ${chain}`
 }
 
 /**

--- a/clients/cli/src/agent/executor.ts
+++ b/clients/cli/src/agent/executor.ts
@@ -247,12 +247,20 @@ export class AgentExecutor {
   // Chain & Token Management
   // ============================================================================
 
+  // Audit log for state-mutating CRUD tools. Always-on (regardless of
+  // --verbose) so the user sees what the agent persisted to vault state.
+  // Goes to stderr to keep stdout clean for JSON output.
+  private auditLog(tool: string, action: string | undefined, summary: string): void {
+    process.stderr.write(`[agent] ${tool} ${action ?? '?'}: ${summary}\n`)
+  }
+
   // vault_chain dispatcher — backend shape:
   //   { action: "add" | "remove", chains: [{ chain }] }
   // Single-chain (`chain` only) and legacy string arrays are tolerated for
   // forward compatibility / hand-rolled callers.
   private async vaultChain(params: Record<string, unknown>): Promise<Record<string, unknown>> {
     const action = params.action as string | undefined
+    this.auditLog('vault_chain', action, summarizeChains(params))
     switch (action) {
       case 'add':
         return this.addChainImpl(params)
@@ -267,6 +275,7 @@ export class AgentExecutor {
   //   { action: "add" | "remove", coins: [{ chain, ticker, contract_address?, decimals?, ... }] }
   private async vaultCoin(params: Record<string, unknown>): Promise<Record<string, unknown>> {
     const action = params.action as string | undefined
+    this.auditLog('vault_coin', action, summarizeCoins(params))
     switch (action) {
       case 'add':
         return this.addCoinImpl(params)
@@ -383,7 +392,12 @@ export class AgentExecutor {
     const chain = resolveChain(chainName)
     if (!chain) throw new Error(`Unknown chain: ${chainName}`)
 
-    const tokenId = (params.contract_address || params.contractAddress || params.token_id || params.id) as string
+    const tokenId = (params.contract_address || params.contractAddress || params.token_id || params.id) as
+      | string
+      | undefined
+    if (!tokenId) {
+      throw new Error(`vault_coin remove: missing contract_address for coin on ${chainName}`)
+    }
     await this.vault.removeToken(chain, tokenId)
     return { chain: chain.toString(), removed: true }
   }
@@ -1609,6 +1623,7 @@ export class AgentExecutor {
   //   { action: "add" | "remove", entry: { name, chain, address } }
   private async addressBook(params: Record<string, unknown>): Promise<Record<string, unknown>> {
     const action = params.action as string | undefined
+    this.auditLog('address_book', action, summarizeAddressBookEntry(params))
     switch (action) {
       case 'add':
         return this.addAddressBookImpl(params)
@@ -1664,7 +1679,9 @@ export class AgentExecutor {
 
     // Agent often emits `{chain, name}` without resolving the address itself.
     // Look the entry up by name in the saved book so name-based removal works
-    // without forcing the model to call get_address_book first.
+    // without forcing the model to call get_address_book first. The SDK
+    // dedupes saved entries by (chain, address) only — name is not unique —
+    // so refuse ambiguous matches rather than silently deleting the first.
     let address = entry.address as string | undefined
     if (!address) {
       const name = entry.name as string | undefined
@@ -1673,11 +1690,17 @@ export class AgentExecutor {
       }
       const book = await this.vultisig.getAddressBook(chain)
       const lower = name.toLowerCase()
-      const match = book.saved.find(e => e.name.toLowerCase() === lower && e.chain === chain)
-      if (!match) {
+      const matches = book.saved.filter(e => e.name.toLowerCase() === lower && e.chain === chain)
+      if (matches.length === 0) {
         throw new Error(`address_book remove: no saved entry named "${name}" on ${chainName}`)
       }
-      address = match.address
+      if (matches.length > 1) {
+        const addrs = matches.map(m => m.address).join(', ')
+        throw new Error(
+          `address_book remove: ambiguous name "${name}" on ${chainName} — multiple addresses: ${addrs}. Specify entry.address explicitly.`
+        )
+      }
+      address = matches[0].address
     }
 
     await this.vultisig.removeAddressBookEntry([{ chain, address }])
@@ -1890,6 +1913,49 @@ function parseAmount(amountStr: string, decimals: number): bigint {
   const [whole, frac = ''] = amountStr.split('.')
   const paddedFrac = frac.slice(0, decimals).padEnd(decimals, '0')
   return BigInt(whole || '0') * 10n ** BigInt(decimals) + BigInt(paddedFrac || '0')
+}
+
+// Audit-log summarizers for state-mutating CRUD tools.
+// Short, scannable, mention what would help a user notice a wrong action.
+
+function shortenAddress(addr: string | undefined): string {
+  if (!addr || typeof addr !== 'string' || addr.length < 10) return addr ?? ''
+  return `${addr.slice(0, 6)}...${addr.slice(-4)}`
+}
+
+function summarizeChains(params: Record<string, unknown>): string {
+  const chains = params.chains as Array<unknown> | undefined
+  if (Array.isArray(chains) && chains.length > 0) {
+    const names = chains.map(c => (typeof c === 'string' ? c : (c as { chain?: unknown })?.chain)).filter(Boolean)
+    return names.length > 0 ? names.join(', ') : '(empty)'
+  }
+  return (params.chain as string) || '(unknown)'
+}
+
+function summarizeCoins(params: Record<string, unknown>): string {
+  const coins = (params.coins as Array<unknown> | undefined) ?? (params.tokens as Array<unknown> | undefined)
+  if (Array.isArray(coins) && coins.length > 0) {
+    return coins
+      .map(c => {
+        const t = c as { chain?: unknown; ticker?: unknown; symbol?: unknown; contract_address?: unknown; contractAddress?: unknown }
+        const sym = t.ticker || t.symbol || '?'
+        const ca = t.contract_address || t.contractAddress
+        const addrPart = ca ? ` (${shortenAddress(String(ca))})` : ''
+        return `${sym} on ${t.chain ?? '?'}${addrPart}`
+      })
+      .join(', ')
+  }
+  const sym = params.ticker || params.symbol || '?'
+  return `${sym} on ${params.chain ?? '?'}`
+}
+
+function summarizeAddressBookEntry(params: Record<string, unknown>): string {
+  const entry = params.entry as { name?: unknown; chain?: unknown; address?: unknown } | undefined
+  if (!entry) return '(missing entry)'
+  const name = entry.name || '(no name)'
+  const chain = entry.chain ?? '?'
+  const addr = entry.address ? shortenAddress(String(entry.address)) : null
+  return addr ? `${name} (${addr}) on ${chain}` : `${name} on ${chain}`
 }
 
 /**

--- a/clients/cli/src/agent/executor.ts
+++ b/clients/cli/src/agent/executor.ts
@@ -1654,15 +1654,31 @@ export class AgentExecutor {
         'address_book remove requires the CLI SDK instance. Ensure AgentConfig.vultisig is set when creating the session.'
       )
     }
-    const entry = params.entry as { chain?: unknown; address?: unknown } | undefined
+    const entry = params.entry as { chain?: unknown; address?: unknown; name?: unknown } | undefined
     if (!entry || typeof entry !== 'object') {
       throw new Error('address_book remove: missing entry')
     }
     const chainName = entry.chain as string | undefined
     const chain = chainName ? resolveChain(chainName) : undefined
     if (!chain) throw new Error(`address_book remove: unknown chain: ${chainName ?? '(missing)'}`)
-    const address = entry.address as string | undefined
-    if (!address) throw new Error('address_book remove: entry.address is required')
+
+    // Agent often emits `{chain, name}` without resolving the address itself.
+    // Look the entry up by name in the saved book so name-based removal works
+    // without forcing the model to call get_address_book first.
+    let address = entry.address as string | undefined
+    if (!address) {
+      const name = entry.name as string | undefined
+      if (!name) {
+        throw new Error('address_book remove: entry.address or entry.name is required')
+      }
+      const book = await this.vultisig.getAddressBook(chain)
+      const lower = name.toLowerCase()
+      const match = book.saved.find(e => e.name.toLowerCase() === lower && e.chain === chain)
+      if (!match) {
+        throw new Error(`address_book remove: no saved entry named "${name}" on ${chainName}`)
+      }
+      address = match.address
+    }
 
     await this.vultisig.removeAddressBookEntry([{ chain, address }])
     return { removed: { chain: chain.toString(), address } }

--- a/clients/cli/src/agent/executor.ts
+++ b/clients/cli/src/agent/executor.ts
@@ -172,14 +172,10 @@ export class AgentExecutor {
     switch (action.type) {
       case 'get_balances':
         return this.getBalances(params)
-      case 'add_chain':
-        return this.addChain(params)
-      case 'remove_chain':
-        return this.removeChain(params)
-      case 'add_coin':
-        return this.addCoin(params)
-      case 'remove_coin':
-        return this.removeCoin(params)
+      case 'vault_chain':
+        return this.vaultChain(params)
+      case 'vault_coin':
+        return this.vaultCoin(params)
       case 'build_send_tx':
         return this.buildSendTx(params)
       case 'build_swap_tx':
@@ -191,10 +187,8 @@ export class AgentExecutor {
         return this.signTx(params)
       case 'get_address_book':
         return this.getAddressBook(params)
-      case 'address_book_add':
-        return this.addAddressBookEntry(params)
-      case 'address_book_remove':
-        return this.removeAddressBookEntry(params)
+      case 'address_book':
+        return this.addressBook(params)
       case 'search_token':
         return this.searchToken(params)
       case 'list_vaults':
@@ -253,8 +247,37 @@ export class AgentExecutor {
   // Chain & Token Management
   // ============================================================================
 
-  private async addChain(params: Record<string, unknown>): Promise<Record<string, unknown>> {
-    // Backend may send a single chain or a batch via `chains` array
+  // vault_chain dispatcher — backend shape:
+  //   { action: "add" | "remove", chains: [{ chain }] }
+  // Single-chain (`chain` only) and legacy string arrays are tolerated for
+  // forward compatibility / hand-rolled callers.
+  private async vaultChain(params: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const action = params.action as string | undefined
+    switch (action) {
+      case 'add':
+        return this.addChainImpl(params)
+      case 'remove':
+        return this.removeChainImpl(params)
+      default:
+        throw new Error(`vault_chain: unknown action: ${action ?? '(missing)'}`)
+    }
+  }
+
+  // vault_coin dispatcher — backend shape:
+  //   { action: "add" | "remove", coins: [{ chain, ticker, contract_address?, decimals?, ... }] }
+  private async vaultCoin(params: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const action = params.action as string | undefined
+    switch (action) {
+      case 'add':
+        return this.addCoinImpl(params)
+      case 'remove':
+        return this.removeCoinImpl(params)
+      default:
+        throw new Error(`vault_coin: unknown action: ${action ?? '(missing)'}`)
+    }
+  }
+
+  private async addChainImpl(params: Record<string, unknown>): Promise<Record<string, unknown>> {
     const chains = params.chains as any[] | undefined
     if (chains && Array.isArray(chains)) {
       const results: { chain: string; address: string }[] = []
@@ -269,7 +292,6 @@ export class AgentExecutor {
       return { added: results }
     }
 
-    // Single chain format
     const chainName = params.chain as string
     const chain = resolveChain(chainName)
     if (!chain) throw new Error(`Unknown chain: ${chainName}`)
@@ -278,7 +300,20 @@ export class AgentExecutor {
     return { chain: chain.toString(), address, added: true }
   }
 
-  private async removeChain(params: Record<string, unknown>): Promise<Record<string, unknown>> {
+  private async removeChainImpl(params: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const chains = params.chains as any[] | undefined
+    if (chains && Array.isArray(chains)) {
+      const results: { chain: string }[] = []
+      for (const c of chains) {
+        const name = typeof c === 'string' ? c : c.chain
+        const chain = resolveChain(name)
+        if (!chain) throw new Error(`Unknown chain: ${name}`)
+        await this.vault.removeChain(chain)
+        results.push({ chain: chain.toString() })
+      }
+      return { removed: results }
+    }
+
     const chainName = params.chain as string
     const chain = resolveChain(chainName)
     if (!chain) throw new Error(`Unknown chain: ${chainName}`)
@@ -286,15 +321,15 @@ export class AgentExecutor {
     return { chain: chain.toString(), removed: true }
   }
 
-  private async addCoin(params: Record<string, unknown>): Promise<Record<string, unknown>> {
-    // Backend may send a single token or a batch via `tokens` array
-    const tokens = params.tokens as any[] | undefined
-    if (tokens && Array.isArray(tokens)) {
+  private async addCoinImpl(params: Record<string, unknown>): Promise<Record<string, unknown>> {
+    // Backend sends `coins` (vault_coin); legacy/hand-rolled callers may pass `tokens`.
+    const coins = (params.coins as any[] | undefined) ?? (params.tokens as any[] | undefined)
+    if (coins && Array.isArray(coins)) {
       const results: { chain: string; symbol: string }[] = []
-      for (const t of tokens) {
+      for (const t of coins) {
         const chain = resolveChain(t.chain)
         if (!chain) throw new Error(`Unknown chain: ${t.chain}`)
-        const symbol = t.symbol || t.ticker || ''
+        const symbol = t.ticker || t.symbol || ''
         await this.vault.addToken(chain, {
           id: (t.contract_address || t.contractAddress || '') as string,
           symbol,
@@ -313,7 +348,7 @@ export class AgentExecutor {
     const chain = resolveChain(chainName)
     if (!chain) throw new Error(`Unknown chain: ${chainName}`)
 
-    const symbol = (params.symbol || params.ticker) as string
+    const symbol = (params.ticker || params.symbol) as string
     await this.vault.addToken(chain, {
       id: (params.contract_address || params.contractAddress || '') as string,
       symbol,
@@ -325,12 +360,30 @@ export class AgentExecutor {
     return { chain: chain.toString(), symbol, added: true }
   }
 
-  private async removeCoin(params: Record<string, unknown>): Promise<Record<string, unknown>> {
+  private async removeCoinImpl(params: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const coins = (params.coins as any[] | undefined) ?? (params.tokens as any[] | undefined)
+    if (coins && Array.isArray(coins)) {
+      const results: { chain: string; tokenId: string }[] = []
+      for (const t of coins) {
+        const chain = resolveChain(t.chain)
+        if (!chain) throw new Error(`Unknown chain: ${t.chain}`)
+        const tokenId = (t.contract_address || t.contractAddress || t.token_id || t.id) as string
+        if (!tokenId) {
+          throw new Error(
+            `vault_coin remove: missing contract_address for ${t.ticker || t.symbol || 'coin'} on ${t.chain}`
+          )
+        }
+        await this.vault.removeToken(chain, tokenId)
+        results.push({ chain: chain.toString(), tokenId })
+      }
+      return { removed: results }
+    }
+
     const chainName = params.chain as string
     const chain = resolveChain(chainName)
     if (!chain) throw new Error(`Unknown chain: ${chainName}`)
 
-    const tokenId = (params.token_id || params.id || params.contract_address) as string
+    const tokenId = (params.contract_address || params.contractAddress || params.token_id || params.id) as string
     await this.vault.removeToken(chain, tokenId)
     return { chain: chain.toString(), removed: true }
   }
@@ -1552,14 +1605,67 @@ export class AgentExecutor {
     return (await this.vultisig.getAddressBook(chain)) as unknown as Record<string, unknown>
   }
 
-  private async addAddressBookEntry(_params: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error('address_book_add is not yet implemented locally. The backend may handle this action server-side.')
+  // address_book dispatcher — backend shape:
+  //   { action: "add" | "remove", entry: { name, chain, address } }
+  private async addressBook(params: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const action = params.action as string | undefined
+    switch (action) {
+      case 'add':
+        return this.addAddressBookImpl(params)
+      case 'remove':
+        return this.removeAddressBookImpl(params)
+      default:
+        throw new Error(`address_book: unknown action: ${action ?? '(missing)'}`)
+    }
   }
 
-  private async removeAddressBookEntry(_params: Record<string, unknown>): Promise<Record<string, unknown>> {
-    throw new Error(
-      'address_book_remove is not yet implemented locally. The backend may handle this action server-side.'
-    )
+  private async addAddressBookImpl(params: Record<string, unknown>): Promise<Record<string, unknown>> {
+    if (!this.vultisig) {
+      throw new Error(
+        'address_book add requires the CLI SDK instance. Ensure AgentConfig.vultisig is set when creating the session.'
+      )
+    }
+    const entry = params.entry as { name?: unknown; chain?: unknown; address?: unknown } | undefined
+    if (!entry || typeof entry !== 'object') {
+      throw new Error('address_book add: missing entry')
+    }
+    const chainName = entry.chain as string | undefined
+    const chain = chainName ? resolveChain(chainName) : undefined
+    if (!chain) throw new Error(`address_book add: unknown chain: ${chainName ?? '(missing)'}`)
+    const address = entry.address as string | undefined
+    if (!address) throw new Error('address_book add: entry.address is required')
+    const name = (entry.name as string | undefined) ?? ''
+
+    await this.vultisig.addAddressBookEntry([
+      {
+        chain,
+        address,
+        name,
+        source: 'saved',
+        dateAdded: Date.now(),
+      },
+    ])
+    return { added: { chain: chain.toString(), address, name } }
+  }
+
+  private async removeAddressBookImpl(params: Record<string, unknown>): Promise<Record<string, unknown>> {
+    if (!this.vultisig) {
+      throw new Error(
+        'address_book remove requires the CLI SDK instance. Ensure AgentConfig.vultisig is set when creating the session.'
+      )
+    }
+    const entry = params.entry as { chain?: unknown; address?: unknown } | undefined
+    if (!entry || typeof entry !== 'object') {
+      throw new Error('address_book remove: missing entry')
+    }
+    const chainName = entry.chain as string | undefined
+    const chain = chainName ? resolveChain(chainName) : undefined
+    if (!chain) throw new Error(`address_book remove: unknown chain: ${chainName ?? '(missing)'}`)
+    const address = entry.address as string | undefined
+    if (!address) throw new Error('address_book remove: entry.address is required')
+
+    await this.vultisig.removeAddressBookEntry([{ chain, address }])
+    return { removed: { chain: chain.toString(), address } }
   }
 
   // ============================================================================

--- a/clients/cli/src/agent/session.ts
+++ b/clients/cli/src/agent/session.ts
@@ -34,15 +34,14 @@ import { PASSWORD_REQUIRED_ACTIONS } from './types'
 // Must stay aligned with the backend's `clientSideToolNames`. Unknown tools
 // surface as `[cli] unimplemented client-side tool` (not silent).
 // `sign_tx` uses the tx_ready channel instead; create_vault / plugin_install /
-// create_policy / delete_policy are mobile-only.
+// create_policy / delete_policy are mobile-only. The CRUD trio
+// (vault_coin / vault_chain / address_book) carries an `action: 'add'|'remove'`
+// discriminator that the executor switches on internally.
 export const CLIENT_SIDE_TOOL_DISPATCH: Record<string, string> = {
   sign_typed_data: 'sign_typed_data',
-  add_coin: 'add_coin',
-  remove_coin: 'remove_coin',
-  add_chain: 'add_chain',
-  remove_chain: 'remove_chain',
-  address_book_add: 'address_book_add',
-  address_book_remove: 'address_book_remove',
+  vault_coin: 'vault_coin',
+  vault_chain: 'vault_chain',
+  address_book: 'address_book',
 }
 
 // 2x the backend's 8-iteration cap — belt-and-suspenders against runaway loops.
@@ -294,8 +293,9 @@ export class AgentSession {
     let serverTxStoredFromStream = 0
     const pendingDispatches: Promise<void>[] = []
     // Serialize client-side tool dispatches in SSE arrival order. Without
-    // this, ordering-sensitive flows (add_chain → add_coin) race and the
-    // single-slot password resolver hangs when two dispatches both prompt.
+    // this, ordering-sensitive flows (vault_chain add → vault_coin add) race
+    // and the single-slot password resolver hangs when two dispatches both
+    // prompt.
     let dispatchChain: Promise<void> = Promise.resolve()
 
     // Send via SSE stream. CR2: 401/403 retry happens at the request

--- a/clients/cli/src/agent/types.ts
+++ b/clients/cli/src/agent/types.ts
@@ -327,12 +327,9 @@ export type ActionResult = {
 
 /** Actions that auto-execute without user confirmation */
 export const AUTO_EXECUTE_ACTIONS = new Set([
-  'add_chain',
-  'add_coin',
-  'remove_coin',
-  'remove_chain',
-  'address_book_add',
-  'address_book_remove',
+  'vault_chain',
+  'vault_coin',
+  'address_book',
   'get_address_book',
   'get_balances',
   'search_token',


### PR DESCRIPTION
## Summary

Closes #414. Reconciles sdk-cli's `CLIENT_SIDE_TOOL_DISPATCH` with the action-discriminator tool shape that agent-backend has used since [vultisig/agent-backend#167](https://github.com/vultisig/agent-backend/pull/167) (merged 2026-04-28).

Before: agent calls `vault_coin` / `vault_chain` / `address_book` → CLI prints `[cli] unimplemented client-side tool: vault_coin` and the LLM narrates a fake success.

After: those tools route through real executor handlers that switch on `params.action` (`"add"` or `"remove"`).

## Tool registry sync

Verified against `agent-backend@8c11e37640852529e93801a67b56ff23fa560096` (origin/main as of 2026-05-07):

| Backend `clientSideActionTypes` | sdk-cli `CLIENT_SIDE_TOOL_DISPATCH` | Routing |
|---|---|---|
| `sign_typed_data` | ✅ | registry (pre-existing) |
| `vault_coin` | ✅ | registry (NEW in this PR) |
| `vault_chain` | ✅ | registry (NEW in this PR) |
| `address_book` | ✅ | registry (NEW in this PR) |
| `sign_tx` | — | `tx_ready` SSE channel, not the registry |
| `create_vault` / `verify_vault_email` / `import_vault` | — | Intentional miss — mobile-only flows; surface as `[cli] unimplemented` |

Tree sweep confirms zero remaining references to the legacy six tool names (`add_coin`/`remove_coin`/`add_chain`/`remove_chain`/`address_book_add`/`address_book_remove`) anywhere in the repo (including docs).

## Changes

**Commit 1 (`7578ccc3`) — main fix**

- **`session.ts`** — registry shrunk from 6 stale entries to 4 (`sign_typed_data` + the 3 new tools).
- **`executor.ts`** — three new dispatcher methods (`vaultCoin`, `vaultChain`, `addressBook`) switch on `params.action` and route to renamed `*Impl` helpers.
  - `vault_coin` reads `coins[]` (with `ticker`) — the new wire shape — in addition to legacy `tokens[]` (with `symbol`).
  - `removeChainImpl` and `removeCoinImpl` now handle batch `chains[]` / `coins[]` shapes (previously single-only).
  - `address_book` add/remove **were stubs that threw `not yet implemented locally`**. Now wired to `Vultisig.addAddressBookEntry(...)` / `removeAddressBookEntry(...)`.
- **`types.ts`** — `AUTO_EXECUTE_ACTIONS` updated to the 3 new action names.
- Tests: registry drift guard locked to the 4-entry shape; executor coverage for each tool's add/remove paths plus error edges.

**Commit 2 (`3bdb8cb5`) — E2E follow-up**

E2E surfaced that the agent often emits `{action: "remove", entry: {chain, name}}` without an address. Added a name-based lookup fallback in `removeAddressBookImpl` that calls `Vultisig.getAddressBook(chain)` and matches by name (case-insensitive).

**Commit 3 (`636e8ae3`) — team-review fixes**

- **H1 (blocker)** — `address_book` remove now refuses ambiguous name matches. Commit-2's `Array.find` was first-match-wins; `AddressBookManager` only dedupes by `(chain, address)`, so duplicate names are reachable. Now `filter`s, throws on ≥2 with candidate addresses listed so the agent retries with explicit `entry.address`.
- **M8/M9** — Unknown-action tests for all three dispatchers now also assert no state mutation. Two new tests for `vault_coin` and `address_book` close the coverage asymmetry.
- **LOW** — `removeCoinImpl` single-coin path throws on missing `contract_address` (was a silent no-op).

**Commit 4 (`e42a83fe`) — revert audit-log helpers + doc sync**

- Reverts the M3 stderr audit toast added in commit 3 (~50 LOC of helpers/summarizers). Doesn't justify its weight for the value provided.
- Syncs `AGENTS.md` client-side action table to the new tool names. Was the last holdout with legacy references.

## Verification

- `yarn workspace @vultisig/cli typecheck` ✓
- `yarn check` (typecheck + lint + knip + format) ✓
- `yarn test:cli` — 144 passed (was 141 before commits 3–4)
- `yarn test` — 2400+ passed across SDK / Rujira / Core / CLI / MCP

End-to-end against `agent-backend@8c11e376`:

- ✅ `Add the Base chain to my vault` → `vault_chain add` → added with address
- ✅ `Add USDC at 0x833... on Base to my vault` → `vault_coin add` → added
- ✅ `Add a contact named alice with 0x... to my address book` → `address_book add` → added
- ✅ `Remove USDC on Base from my vault` → `vault_coin remove` → removed
- ✅ `Remove alice from my address book` → `address_book remove` (with name-lookup) → removed
- ✅ `Remove the Base chain from my vault` → `vault_chain remove` → removed

## Deferred to follow-up PRs

The team review surfaced additional findings outside this PR's scope. Capturing them here for traceability:

- **Spoofed-token persistence** — agent-supplied `contract_address` writes to vault config with no `knownTokens` collision check; later `vault.send`/`swap` by symbol could route to it. Pre-existing trust pattern; belongs in a broader sanitization sweep.
- **`entry.name` input sanitization** — unbounded user-controlled string; ANSI escape injection vector when echoed in terminal output, prompt-injection vector when echoed in error strings round-tripped via `recent_actions`. Best fixed at the SDK boundary (`Vultisig.addAddressBookEntry` length cap + control-character strip) plus an executor-wide error-message audit.
- **Mock-vs-real test fidelity** — `createMockVault()` no-ops vault methods, `createMockVultisig()` bypasses `isValidAddress`. Belongs in a "CLI integration coverage" PR that exercises a real `VaultBase` against in-memory storage across the whole executor suite.
- **Batch partial-state reporting** — current behavior is "throw on first failure, leave 0..N-1 persisted." Mitigated by SDK idempotency. Structured `{succeeded, failedAt}` would need a coordinated backend prompt change.

The full team-review with severity ranking and source attribution is at `.claude/knowledge/reviews/070526-review-vultisig-sdk-pr420-vault-crud-tools.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)