### PR TITLE
fix(cli/agent/executor): recognize mcp-ts execute_* envelope (txArgs.tx)

### DIFF
--- a/.changeset/cli-mcp-ts-envelope-parity.md
+++ b/.changeset/cli-mcp-ts-envelope-parity.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/cli': patch
+---
+
+CLI agent executor now recognizes the mcp-ts `execute_*` tx_ready envelope shape (`txArgs.tx`) for `execute_send` and `execute_contract_call`. Previously the executor only handled mcp-go's older shapes (`swap_tx` / `send_tx` / `tx`) and silently skipped every mcp-ts payload, leaving local-dev parity broken against production. Multi-leg `execute_swap` envelopes (carrying `approvalTxArgs`) are explicitly rejected for now — multi-leg sequencing is a follow-up.

--- a/clients/cli/src/agent/__tests__/executor.envelope.test.ts
+++ b/clients/cli/src/agent/__tests__/executor.envelope.test.ts
@@ -174,4 +174,60 @@ describe('AgentExecutor.storeServerTransaction', () => {
       })
     ).toBe(false)
   })
+
+  // M1 — nested txArgs.tx error path. Locks parity with the top-level
+  // error-rejection above so a future change to extractNestedTx that
+  // accidentally returns the error tx object (instead of treating it as an
+  // error) doesn't regress silently.
+  it('rejects payloads with explicit error in nested txArgs.tx', () => {
+    const executor = makeExecutor()
+    expect(
+      executor.storeServerTransaction({
+        chain: 'Polygon',
+        txArgs: {
+          chain: 'Polygon',
+          chain_id: '137',
+          tx: { status: 'error', error: 'execution reverted' },
+        },
+      })
+    ).toBe(false)
+    expect(executor.hasPendingTransaction()).toBe(false)
+  })
+
+  // M2 — txArgs present but without a tx body. Real shape if mcp-ts adds a
+  // chain-rejection branch returning a stepperConfig + chain echo without
+  // building a tx. Should fall through extractNestedTx returning undefined
+  // and reject at the no-shape-found branch.
+  it('rejects payloads where txArgs is present but has no tx', () => {
+    const executor = makeExecutor()
+    expect(
+      executor.storeServerTransaction({
+        chain: 'Polygon',
+        txArgs: { chain: 'Polygon', chain_id: '137' },
+      })
+    ).toBe(false)
+    expect(executor.hasPendingTransaction()).toBe(false)
+  })
+
+  // M3 — chain context only inside txArgs (no top-level chain). This is
+  // the actual mcp-ts shape per buildEvmTxArgs in mcp-ts/_base.ts (chain
+  // always lives inside txArgs). Exercises resolveChainFromTxReady's new
+  // txArgs.chain / txArgs.chain_id branches, which are otherwise shadowed
+  // by the top-level chain fixtures above.
+  it('stores mcp-ts envelope with chain only inside txArgs (resolveChainFromTxReady fallback)', () => {
+    const executor = makeExecutor()
+    const env = {
+      // No top-level chain / from_chain / chain_id — chain context must
+      // come from txArgs for the executor to resolve correctly.
+      stepperConfig: { flow: 'send', steps: [] },
+      txArgs: {
+        chain: 'Polygon',
+        chain_id: '137',
+        from: '0xsender',
+        tx: SAMPLE_TX,
+      },
+    }
+    expect(executor.storeServerTransaction(env)).toBe(true)
+    expect(executor.hasPendingTransaction()).toBe(true)
+  })
 })

--- a/clients/cli/src/agent/__tests__/executor.envelope.test.ts
+++ b/clients/cli/src/agent/__tests__/executor.envelope.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Regression tests for tx_ready envelope shape compatibility.
+ *
+ * Two MCP servers emit different envelope shapes for signable
+ * transactions:
+ *   - mcp-go (build_*) — top-level `swap_tx` / `send_tx` / `tx`
+ *   - mcp-ts (execute_*) — nested `txArgs.tx`
+ *
+ * sdk-cli must accept all four shapes for single-tx flows
+ * (execute_send / execute_contract_call / build_evm_tx /
+ * build_swap_tx / build_*_send) and reject mcp-ts's multi-leg
+ * `execute_swap` envelope (carries `approvalTxArgs`) until the
+ * Phase B sequencing work lands.
+ *
+ * See task 070526-sdk-cli-mcp-ts-envelope-parity.md.
+ */
+import type { VaultBase } from '@vultisig/sdk'
+import { Chain } from '@vultisig/sdk'
+import { describe, expect, it, vi } from 'vitest'
+
+import { AgentExecutor, extractNestedTx } from '../executor'
+
+function createMockVault(): VaultBase {
+  return {
+    name: 'mock-vault',
+    id: 'vault-mock-1',
+    type: 'secure',
+    chains: [Chain.Ethereum, Chain.Polygon],
+    balances: vi.fn().mockResolvedValue({}),
+    address: vi.fn().mockResolvedValue('0xsender'),
+    balance: vi.fn().mockResolvedValue({ decimals: 18, symbol: 'ETH' }),
+  } as unknown as VaultBase
+}
+
+const SAMPLE_TX = {
+  to: '0x000000000000000000000000000000000000dEaD',
+  value: '50000000000000000',
+  data: '0x',
+  gas_limit: '21000',
+  max_fee_per_gas: '227524205642',
+  max_priority_fee_per_gas: '26700731074',
+  nonce: '60',
+}
+
+describe('extractNestedTx', () => {
+  it('finds top-level `tx` (mcp-go build_evm_tx)', () => {
+    expect(extractNestedTx({ chain: 'Ethereum', tx: SAMPLE_TX })).toBe(SAMPLE_TX)
+  })
+
+  it('finds top-level `send_tx` (mcp-go build_*_send)', () => {
+    expect(extractNestedTx({ chain: 'Bitcoin', send_tx: SAMPLE_TX })).toBe(SAMPLE_TX)
+  })
+
+  it('finds top-level `swap_tx` (mcp-go build_swap_tx)', () => {
+    expect(extractNestedTx({ chain: 'Ethereum', swap_tx: SAMPLE_TX })).toBe(SAMPLE_TX)
+  })
+
+  it('finds nested `txArgs.tx` (mcp-ts execute_send / execute_contract_call)', () => {
+    const env = {
+      chain: 'Polygon',
+      txArgs: { chain: 'Polygon', chain_id: '137', from: '0xabc', tx: SAMPLE_TX },
+    }
+    expect(extractNestedTx(env)).toBe(SAMPLE_TX)
+  })
+
+  it('returns undefined when no recognized shape is present', () => {
+    expect(extractNestedTx({ chain: 'Ethereum' })).toBeUndefined()
+    expect(extractNestedTx(null)).toBeUndefined()
+    expect(extractNestedTx(undefined)).toBeUndefined()
+  })
+
+  it('prefers top-level keys over nested when both are present', () => {
+    const topLevel = { ...SAMPLE_TX, to: '0xtop' }
+    const nested = { ...SAMPLE_TX, to: '0xnested' }
+    const env = { tx: topLevel, txArgs: { tx: nested } }
+    expect(extractNestedTx(env)).toBe(topLevel)
+  })
+})
+
+describe('AgentExecutor.storeServerTransaction', () => {
+  function makeExecutor(): AgentExecutor {
+    return new AgentExecutor(createMockVault())
+  }
+
+  it('stores mcp-go top-level `tx` envelope', () => {
+    const executor = makeExecutor()
+    const stored = executor.storeServerTransaction({
+      chain: 'Ethereum',
+      tx: SAMPLE_TX,
+    })
+    expect(stored).toBe(true)
+    expect(executor.hasPendingTransaction()).toBe(true)
+  })
+
+  it('stores mcp-go top-level `send_tx` envelope', () => {
+    const executor = makeExecutor()
+    expect(executor.storeServerTransaction({ chain: 'Bitcoin', send_tx: SAMPLE_TX })).toBe(true)
+  })
+
+  it('stores mcp-go top-level `swap_tx` envelope', () => {
+    const executor = makeExecutor()
+    expect(executor.storeServerTransaction({ chain: 'Ethereum', swap_tx: SAMPLE_TX })).toBe(true)
+  })
+
+  it('stores mcp-ts nested `txArgs.tx` envelope (execute_send)', () => {
+    const executor = makeExecutor()
+    const env = {
+      chain: 'Polygon',
+      from_chain: 'Polygon',
+      resolved: { labels: { resolved_amount: '0.05 POL' } },
+      stepperConfig: { flow: 'send', steps: [] },
+      txArgs: {
+        chain: 'Polygon',
+        chain_id: '137',
+        from: '0xsender',
+        tx: SAMPLE_TX,
+      },
+    }
+    expect(executor.storeServerTransaction(env)).toBe(true)
+    expect(executor.hasPendingTransaction()).toBe(true)
+  })
+
+  it('stores mcp-ts nested `txArgs.tx` envelope (execute_contract_call)', () => {
+    const executor = makeExecutor()
+    const env = {
+      chain: 'Polygon',
+      stepperConfig: { flow: 'contract_call', steps: [] },
+      txArgs: {
+        chain: 'Polygon',
+        chain_id: '137',
+        from: '0xsender',
+        tx: { ...SAMPLE_TX, value: '0', data: '0x095ea7b3' + '0'.repeat(120) },
+      },
+    }
+    expect(executor.storeServerTransaction(env)).toBe(true)
+  })
+
+  it('rejects mcp-ts execute_swap multi-leg envelope (approvalTxArgs present)', () => {
+    const executor = makeExecutor()
+    const env = {
+      chain: 'BSC',
+      from_chain: 'BSC',
+      stepperConfig: { flow: 'swap', steps: [] },
+      approvalTxArgs: {
+        chain: 'BSC',
+        chain_id: '56',
+        from: '0xsender',
+        tx: { ...SAMPLE_TX, to: '0xUSDC', value: '0', data: '0x095ea7b3' },
+      },
+      txArgs: {
+        chain: 'BSC',
+        chain_id: '56',
+        from: '0xsender',
+        tx: SAMPLE_TX,
+      },
+    }
+    expect(executor.storeServerTransaction(env)).toBe(false)
+    expect(executor.hasPendingTransaction()).toBe(false)
+  })
+
+  it('rejects empty / null payloads', () => {
+    const executor = makeExecutor()
+    expect(executor.storeServerTransaction({})).toBe(false)
+    expect(executor.storeServerTransaction(null as any)).toBe(false)
+    expect(executor.storeServerTransaction(undefined as any)).toBe(false)
+  })
+
+  it('rejects payloads with explicit error in nested tx', () => {
+    const executor = makeExecutor()
+    expect(
+      executor.storeServerTransaction({
+        chain: 'Ethereum',
+        tx: { status: 'error', error: 'no liquidity' },
+      })
+    ).toBe(false)
+  })
+})

--- a/clients/cli/src/agent/executor.ts
+++ b/clients/cli/src/agent/executor.ts
@@ -100,14 +100,27 @@ export class AgentExecutor {
       process.stderr.write(
         `[executor] storeServerTransaction called, keys: ${Object.keys(txReadyData || {}).join(',')}\n`
       )
-    const nestedTx = txReadyData?.swap_tx || txReadyData?.send_tx || txReadyData?.tx
+    // mcp-ts execute_swap emits two-leg flows (approvalTxArgs + txArgs).
+    // sdk-cli only handles single-tx envelopes today; reject loudly so we
+    // never half-broadcast the swap leg without the prerequisite approve.
+    // Multi-leg sequencing is tracked under task
+    // 070526-sdk-cli-mcp-ts-envelope-parity.md Phase B.
+    if (txReadyData?.approvalTxArgs) {
+      if (this.verbose)
+        process.stderr.write(
+          `[executor] skipping multi-leg execute_swap envelope (approvalTxArgs present): not yet supported in sdk-cli — Phase B\n`
+        )
+      return false
+    }
+    const nestedTx = extractNestedTx(txReadyData)
     if (nestedTx?.status === 'error' || nestedTx?.error) {
       if (this.verbose)
         process.stderr.write(`[executor] skipping error tx_ready: ${nestedTx.error || 'unknown error'}\n`)
       return false
     }
     if (!nestedTx) {
-      if (this.verbose) process.stderr.write(`[executor] storeServerTransaction: no swap_tx/send_tx/tx found in data\n`)
+      if (this.verbose)
+        process.stderr.write(`[executor] storeServerTransaction: no swap_tx/send_tx/tx/txArgs.tx found in data\n`)
       return false
     }
 
@@ -988,14 +1001,20 @@ export class AgentExecutor {
     defaultChain: Chain,
     params: Record<string, unknown>
   ): Promise<Record<string, unknown>> {
-    const swapTx = serverTxData.swap_tx || serverTxData.send_tx || serverTxData.tx
+    const swapTx = extractNestedTx(serverTxData)
     if (!swapTx?.to) {
       throw new Error('Server transaction missing required fields (to)')
     }
 
-    // Resolve chain from action params, tx data, or stored default
-    const chainName = (params.chain || serverTxData.chain || serverTxData.from_chain) as string | undefined
-    const chainId = (serverTxData.chain_id || swapTx.chainId) as string | number | undefined
+    // Resolve chain from action params, tx data, or stored default.
+    // mcp-ts nests chain / chain_id under txArgs; mcp-go puts them at top level.
+    const chainName = (params.chain || serverTxData.chain || serverTxData.from_chain || serverTxData.txArgs?.chain) as
+      | string
+      | undefined
+    const chainId = (serverTxData.chain_id || serverTxData.txArgs?.chain_id || swapTx.chainId) as
+      | string
+      | number
+      | undefined
     let chain = defaultChain
     if (chainName) {
       chain = resolveChain(chainName) || defaultChain
@@ -1786,12 +1805,40 @@ function resolveChainFromTxReady(txReadyData: any): Chain | null {
     const chain = resolveChainId(txReadyData.chain_id)
     if (chain) return chain
   }
-  const swapTx = txReadyData.swap_tx || txReadyData.send_tx || txReadyData.tx
+  // mcp-ts execute_* envelopes nest chain / chain_id under txArgs.
+  if (txReadyData.txArgs?.chain) {
+    const chain = resolveChain(txReadyData.txArgs.chain)
+    if (chain) return chain
+  }
+  if (txReadyData.txArgs?.chain_id) {
+    const chain = resolveChainId(txReadyData.txArgs.chain_id)
+    if (chain) return chain
+  }
+  const swapTx = extractNestedTx(txReadyData)
   if (swapTx?.chainId) {
     const chain = resolveChainId(swapTx.chainId)
     if (chain) return chain
   }
   return null
+}
+
+/**
+ * Extract the signable transaction object from a tx_ready envelope.
+ *
+ * mcp-go (build_*) emits the tx at top level under one of three keys:
+ *   - swap_tx   (build_swap_tx output)
+ *   - send_tx   (per-chain build_*_send output)
+ *   - tx        (build_evm_tx output)
+ *
+ * mcp-ts (execute_*) wraps the tx one level deeper:
+ *   - txArgs.tx (execute_send / execute_contract_call output)
+ *
+ * Multi-leg envelopes (mcp-ts execute_swap with approvalTxArgs) are NOT
+ * extracted here — see storeServerTransaction's approvalTxArgs guard
+ * and Phase B of 070526-sdk-cli-mcp-ts-envelope-parity.md.
+ */
+export function extractNestedTx(txReadyData: any): any {
+  return txReadyData?.swap_tx || txReadyData?.send_tx || txReadyData?.tx || txReadyData?.txArgs?.tx
 }
 
 /**


### PR DESCRIPTION
## Summary

sdk-cli's agent executor now recognizes the **mcp-ts `execute_*` tx_ready envelope shape** for single-tx flows (`execute_send`, `execute_contract_call`). Previously it only handled mcp-go's older shapes (`swap_tx` / `send_tx` / `tx`) and silently skipped every mcp-ts payload — leaving local-dev parity broken against production (which targets mcp-ts).

Multi-leg `execute_swap` envelopes (carrying `approvalTxArgs` + `txArgs`) are explicitly rejected for now with a clear stderr pointer; multi-leg sequencing is a deliberate follow-up (Phase B), not a regression.

## The bug

`vultisig-sdk/clients/cli/src/agent/executor.ts:103` extracted the signable tx via:

```ts
const nestedTx = txReadyData?.swap_tx || txReadyData?.send_tx || txReadyData?.tx
```

mcp-ts wraps the same tx one level deeper at `txReadyData.txArgs.tx`, alongside richer context (`resolved`, `stepperConfig`, `chain_id`). sdk-cli didn't reach into `txArgs`, so on every mcp-ts `tx_ready` event it logged `"no swap_tx/send_tx/tx found in data"` and dropped the payload.

This is why local-dev sdk-cli kept silently testing against mcp-go even when developers thought they were exercising the production stack. The prompt-strip experiment that uncovered this had `execute_send` correctly emitted by agent-backend but never broadcasted because sdk-cli's executor skipped the envelope.

## What changed

### `clients/cli/src/agent/executor.ts`

- **New module-scope helper** `extractNestedTx()` — returns the first present of `swap_tx`, `send_tx`, `tx`, `txArgs.tx`. DRYs the union across the three call sites (`storeServerTransaction`, `signServerTx`, `resolveChainFromTxReady`) that previously duplicated it.
- **`storeServerTransaction` guard** — when `approvalTxArgs` is present (mcp-ts execute_swap multi-leg), reject with stderr message and `return false`. This prevents half-broadcasting the swap leg without the prerequisite ERC-20 approve.
- **`signServerTx` chain resolution** — also reads `txArgs.chain` and `txArgs.chain_id` since mcp-ts nests them one level deeper.
- **`resolveChainFromTxReady`** — same; adds `txArgs.chain` / `txArgs.chain_id` lookups before the swapTx fallback.

### `clients/cli/src/agent/__tests__/executor.envelope.test.ts` (new, 14 tests)

| Fixture | Expectation |
|---|---|
| `extractNestedTx` for each of `tx`, `send_tx`, `swap_tx`, `txArgs.tx` | returns the nested tx |
| Top-level wins over nested when both present | preserves precedence |
| `storeServerTransaction` with each of the four shapes | stores the tx |
| `storeServerTransaction` with `approvalTxArgs` present | rejects with stderr |
| `storeServerTransaction` with empty/null/error payloads | rejects |

Locks the four recognized shapes plus the multi-leg rejection case so a future contributor can't accidentally re-introduce the silent skip.

## Compatibility matrix

| Tool family | Envelope shape | Before this PR | After this PR |
|---|---|---|---|
| mcp-go `build_evm_tx` | top-level `tx` | ✅ | ✅ |
| mcp-go `build_swap_tx` | top-level `swap_tx` | ✅ | ✅ |
| mcp-go `build_*_send` | top-level `send_tx` | ✅ | ✅ |
| mcp-ts `execute_send` | `txArgs.tx` | ❌ silently skipped | ✅ |
| mcp-ts `execute_contract_call` | `txArgs.tx` | ❌ silently skipped | ✅ |
| mcp-ts `execute_swap` | `txArgs` + `approvalTxArgs` | ❌ silently skipped | ❌ explicitly rejected with Phase B pointer |

## Test plan

- [x] `yarn workspace @vultisig/cli typecheck` — clean
- [x] `yarn test:cli` — 145/145 pass (10 test files)
- [x] `yarn format:check` — clean
- [x] On-chain E2E `execute_send`: 0.01 POL self-send on Polygon → confirmed [`0x186560ff...`](https://polygonscan.com/tx/0x186560ffe8eab6a62d602c94984779c5a7695d5d52608290cfb2f6eced01e5b1) (block 86512520, gas 21000)
- [x] On-chain E2E `execute_swap` (single-tx, native source): 0.05 POL → USDC on Polygon via Kyber → confirmed [`0x8fe809e6...`](https://polygonscan.com/tx/0x8fe809e65d2eceaebca13a58553b0e40954dc8f67dfe0f0da35a6dcae311c461) (block 86512540, gas 269489)

Both runs hit `[executor] storeServerTransaction called, keys: chain,from_chain,resolved,scan_request,stepperConfig,txArgs` followed by `[executor] Stored server tx for chain Polygon, pendingPayloads size=1` — i.e. the `txArgs.tx` extraction now resolves where the previous `swap_tx || send_tx || tx` union returned `undefined` and aborted with `"no swap_tx/send_tx/tx found in data"`.

Multi-leg rejection (`execute_swap` with `approvalTxArgs`) is locked by the new unit test `'rejects mcp-ts execute_swap multi-leg envelope (approvalTxArgs present)'`. A live `execute_swap` matrix that exercises the guard (e.g. USDC source on BSC) is left for the Phase B follow-up PR.

## Out of scope

- **Multi-leg sequencing for `execute_swap`** — needs a state machine mirroring `vultiagent-app/src/features/agent/hooks/useTransactionFlow.ts:307-378` (leg-1 broadcast → on-chain receipt wait → leg-2 broadcast, with the terminal-failed-on-receipt-unknown invariant). Days of work; separate PR.
- **Switching local-dev `MCP_SERVER_URL` default to `:9091`** — landed via env-file edit after this merges.
- **Stripping the agent-backend prompt of MCP-specific tool names** — separate task, depends on this for E2E receipts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI now recognizes newer transaction envelope shapes (previously ignored), restoring local/dev parity with production.
  * Improved extraction of chain/chainId from nested payloads so transactions resolve correctly.
  * Multi-leg swap envelopes with approval data are now rejected to prevent unsupported flows.

* **Tests**
  * Added regression tests covering envelope compatibility, chain resolution, and rejection of invalid/empty payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->