### PR TITLE
fix(solana): verify durable signature relay

### DIFF
--- a/.changeset/cosmos-native-denom-ticker.md
+++ b/.changeset/cosmos-native-denom-ticker.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/core-chain': patch
+---
+
+Preserve known THORChain single-segment denoms such as `tcy` during Cosmos coin discovery, let Solana standard RPC relay retry for its normal validity window, and keep Solana broadcast verification from treating unknown signatures as confirmed pending transactions.

--- a/packages/core/chain/coin/find/resolvers/cosmos.test.ts
+++ b/packages/core/chain/coin/find/resolvers/cosmos.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const getAllBalancesMock = vi.fn()
+
+vi.mock('@vultisig/core-chain/chains/cosmos/client', () => ({
+  getCosmosClient: () => ({
+    getAllBalances: getAllBalancesMock,
+  }),
+}))
+
+import { Chain } from '../../../Chain'
+import { findCosmosCoins } from './cosmos'
+
+describe('findCosmosCoins', () => {
+  it('keeps known single-segment THORChain denoms like TCY', async () => {
+    getAllBalancesMock.mockResolvedValue([
+      { denom: 'rune', amount: '1' },
+      { denom: 'tcy', amount: '2' },
+    ])
+
+    const coins = await findCosmosCoins({
+      address: 'thor1address',
+      chain: Chain.THORChain,
+    })
+
+    expect(coins).toEqual([
+      expect.objectContaining({
+        id: 'tcy',
+        ticker: 'TCY',
+        logo: 'tcy',
+      }),
+    ])
+  })
+})

--- a/packages/core/chain/coin/find/resolvers/cosmos.ts
+++ b/packages/core/chain/coin/find/resolvers/cosmos.ts
@@ -6,13 +6,8 @@ import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { FindCoinsResolver } from '@vultisig/core-chain/coin/find/resolver'
 import { getCosmosTokenMetadata } from '@vultisig/core-chain/coin/token/metadata/resolvers/cosmos'
 import { without } from '@vultisig/lib-utils/array/without'
-import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
-import { attempt } from '@vultisig/lib-utils/attempt'
 
-export const findCosmosCoins: FindCoinsResolver<CosmosChain> = async ({
-  address,
-  chain,
-}) => {
+export const findCosmosCoins: FindCoinsResolver<CosmosChain> = async ({ address, chain }) => {
   // While it should work for other cosmos chains, we only support THORChain for now
   if (chain !== CosmosChain.THORChain) return []
 
@@ -32,11 +27,9 @@ export const findCosmosCoins: FindCoinsResolver<CosmosChain> = async ({
 
   return without(
     coins.map(({ denom, ticker }) => {
-      const tickerAttempt = attempt(() =>
-        shouldBePresent(denom.split(/[-./]/)[1]?.toUpperCase())
-      )
+      const coinTicker = ticker || denom.split(/[-./]/)[1]?.toUpperCase()
 
-      if ('error' in tickerAttempt) {
+      if (!coinTicker) {
         console.error(`Failed to extract ticker from ${denom}`)
         return
       }
@@ -45,8 +38,8 @@ export const findCosmosCoins: FindCoinsResolver<CosmosChain> = async ({
         id: denom,
         chain,
         decimals: chainFeeCoin[chain].decimals,
-        ticker: ticker || tickerAttempt.data,
-        logo: tickerAttempt.data.toLowerCase(),
+        ticker: coinTicker,
+        logo: coinTicker.toLowerCase(),
         address,
       }
     }),

--- a/packages/core/chain/tx/broadcast/resolvers/solana.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/solana.test.ts
@@ -40,7 +40,6 @@ describe('broadcastSolanaTx', () => {
     expect(mocks.sendRawTransaction).toHaveBeenCalledWith(expect.any(Uint8Array), {
       skipPreflight: false,
       preflightCommitment: 'confirmed',
-      maxRetries: 3,
     })
   })
 

--- a/packages/core/chain/tx/broadcast/resolvers/solana.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/solana.ts
@@ -6,9 +6,7 @@ import base58 from 'bs58'
 import { BroadcastTxResolver } from '../resolver'
 import { verifyBroadcastByHash } from '../verifyBroadcastByHash'
 
-export const broadcastSolanaTx: BroadcastTxResolver<
-  OtherChain.Solana
-> = async ({ chain, tx }) => {
+export const broadcastSolanaTx: BroadcastTxResolver<OtherChain.Solana> = async ({ chain, tx }) => {
   const rawTransaction = base58.decode(tx.encoded)
 
   // Try JITO first for MEV protection, but still relay through standard RPC.
@@ -25,7 +23,6 @@ export const broadcastSolanaTx: BroadcastTxResolver<
     await client.sendRawTransaction(rawTransaction, {
       skipPreflight: false,
       preflightCommitment: 'confirmed',
-      maxRetries: 3,
     })
   } catch (error) {
     await verifyBroadcastByHash({ chain, tx, error })

--- a/packages/core/chain/tx/broadcast/verifyBroadcastByHash.test.ts
+++ b/packages/core/chain/tx/broadcast/verifyBroadcastByHash.test.ts
@@ -29,9 +29,7 @@ describe('verifyBroadcastByHash', () => {
     getTxHashMock.mockResolvedValue('0xdeadbeef')
     getTxStatusMock.mockResolvedValue({ status: 'pending' })
 
-    await expect(
-      verifyBroadcastByHash({ chain, tx, error: originalError }),
-    ).resolves.toBeUndefined()
+    await expect(verifyBroadcastByHash({ chain, tx, error: originalError })).resolves.toBeUndefined()
 
     expect(getTxHashMock).toHaveBeenCalledTimes(1)
     expect(getTxHashMock).toHaveBeenCalledWith({ chain, tx })
@@ -42,14 +40,20 @@ describe('verifyBroadcastByHash', () => {
     })
   })
 
+  it("rethrows original error when status is 'pending' but tx is unknown", async () => {
+    const originalError = new Error('broadcast boom')
+    getTxHashMock.mockResolvedValue('0xdeadbeef')
+    getTxStatusMock.mockResolvedValue({ status: 'pending', isKnown: false })
+
+    await expect(verifyBroadcastByHash({ chain, tx, error: originalError })).rejects.toBe(originalError)
+  })
+
   it("swallows error when status is 'success'", async () => {
     const originalError = new Error('duplicate tx')
     getTxHashMock.mockResolvedValue('0xabc')
     getTxStatusMock.mockResolvedValue({ status: 'success' })
 
-    await expect(
-      verifyBroadcastByHash({ chain, tx, error: originalError }),
-    ).resolves.toBeUndefined()
+    await expect(verifyBroadcastByHash({ chain, tx, error: originalError })).resolves.toBeUndefined()
   })
 
   it("rethrows original error when status is 'error'", async () => {
@@ -57,9 +61,7 @@ describe('verifyBroadcastByHash', () => {
     getTxHashMock.mockResolvedValue('0xabc')
     getTxStatusMock.mockResolvedValue({ status: 'error' })
 
-    await expect(
-      verifyBroadcastByHash({ chain, tx, error: originalError }),
-    ).rejects.toBe(originalError)
+    await expect(verifyBroadcastByHash({ chain, tx, error: originalError })).rejects.toBe(originalError)
   })
 
   it('rethrows original error when getTxStatus throws', async () => {
@@ -67,18 +69,14 @@ describe('verifyBroadcastByHash', () => {
     getTxHashMock.mockResolvedValue('0xabc')
     getTxStatusMock.mockRejectedValue(new Error('rpc down'))
 
-    await expect(
-      verifyBroadcastByHash({ chain, tx, error: originalError }),
-    ).rejects.toBe(originalError)
+    await expect(verifyBroadcastByHash({ chain, tx, error: originalError })).rejects.toBe(originalError)
   })
 
   it('rethrows original error when getTxHash throws', async () => {
     const originalError = new Error('original')
     getTxHashMock.mockRejectedValue(new Error('hash boom'))
 
-    await expect(
-      verifyBroadcastByHash({ chain, tx, error: originalError }),
-    ).rejects.toBe(originalError)
+    await expect(verifyBroadcastByHash({ chain, tx, error: originalError })).rejects.toBe(originalError)
 
     expect(getTxStatusMock).not.toHaveBeenCalled()
   })
@@ -87,8 +85,6 @@ describe('verifyBroadcastByHash', () => {
     getTxHashMock.mockResolvedValue('0xabc')
     getTxStatusMock.mockResolvedValue({ status: 'error' })
 
-    await expect(
-      verifyBroadcastByHash({ chain, tx, error: 'string-error' }),
-    ).rejects.toBe('string-error')
+    await expect(verifyBroadcastByHash({ chain, tx, error: 'string-error' })).rejects.toBe('string-error')
   })
 })

--- a/packages/core/chain/tx/broadcast/verifyBroadcastByHash.ts
+++ b/packages/core/chain/tx/broadcast/verifyBroadcastByHash.ts
@@ -28,15 +28,13 @@ type VerifyInput<T extends Chain> = {
  * yet, network error) falls through to re-throwing the original error —
  * verification is a safety net, never a new failure mode.
  */
-export const verifyBroadcastByHash = async <T extends Chain>({
-  chain,
-  tx,
-  error,
-}: VerifyInput<T>): Promise<void> => {
+export const verifyBroadcastByHash = async <T extends Chain>({ chain, tx, error }: VerifyInput<T>): Promise<void> => {
   try {
     const hash = await getTxHash({ chain, tx })
     const result = await getTxStatus({ chain, hash })
-    if (result.status === 'pending' || result.status === 'success') {
+    const isKnownPending = result.status === 'pending' && result.isKnown !== false
+
+    if (result.status === 'success' || isKnownPending) {
       return
     }
   } catch {

--- a/packages/core/chain/tx/status/resolver.ts
+++ b/packages/core/chain/tx/status/resolver.ts
@@ -12,6 +12,7 @@ export type TxReceiptInfo = {
 
 export type TxStatusResult = {
   status: TxStatus
+  isKnown?: boolean
   receipt?: TxReceiptInfo
 }
 

--- a/packages/core/chain/tx/status/resolvers/solana.test.ts
+++ b/packages/core/chain/tx/status/resolvers/solana.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getSignatureStatuses: vi.fn(),
+  getTransaction: vi.fn(),
+}))
+
+vi.mock('@vultisig/core-chain/chains/solana/client', () => ({
+  getSolanaClient: () => ({
+    getSignatureStatuses: mocks.getSignatureStatuses,
+    getTransaction: mocks.getTransaction,
+  }),
+}))
+
+import { Chain } from '../../../Chain'
+import { getSolanaTxStatus } from './solana'
+
+describe('getSolanaTxStatus', () => {
+  const hash = '2gB3ifNe2kSoJEYoVY7T4vw2z5ci9nL6WcQQuCC2ozCiURBwSfC9uGcCq9CS2pAzX7ed1xwyS4434BmSg2WhrZ7j'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('marks missing signatures as unknown pending', async () => {
+    mocks.getSignatureStatuses.mockResolvedValue({ value: [null] })
+
+    await expect(getSolanaTxStatus({ chain: Chain.Solana, hash })).resolves.toEqual({
+      status: 'pending',
+      isKnown: false,
+    })
+    expect(mocks.getTransaction).not.toHaveBeenCalled()
+  })
+
+  it('marks known signatures as known pending until transaction details are indexed', async () => {
+    mocks.getSignatureStatuses.mockResolvedValue({
+      value: [{ err: null, confirmationStatus: 'processed' }],
+    })
+    mocks.getTransaction.mockResolvedValue(null)
+
+    await expect(getSolanaTxStatus({ chain: Chain.Solana, hash })).resolves.toEqual({
+      status: 'pending',
+      isKnown: true,
+    })
+  })
+})

--- a/packages/core/chain/tx/status/resolvers/solana.ts
+++ b/packages/core/chain/tx/status/resolvers/solana.ts
@@ -5,10 +5,23 @@ import { attempt } from '@vultisig/lib-utils/attempt'
 
 import { TxStatusResolver } from '../resolver'
 
-export const getSolanaTxStatus: TxStatusResolver<OtherChain.Solana> = async ({
-  hash,
-}) => {
+export const getSolanaTxStatus: TxStatusResolver<OtherChain.Solana> = async ({ hash }) => {
   const client = getSolanaClient()
+
+  const { data: signatureStatuses, error: signatureStatusError } = await attempt(
+    client.getSignatureStatuses([hash], {
+      searchTransactionHistory: true,
+    })
+  )
+  const signatureStatus = signatureStatuses?.value[0]
+
+  if (signatureStatusError || !signatureStatus) {
+    return { status: 'pending', isKnown: false }
+  }
+
+  if (signatureStatus.err) {
+    return { status: 'error', isKnown: true }
+  }
 
   const { data: tx, error } = await attempt(
     client.getTransaction(hash, {
@@ -17,16 +30,16 @@ export const getSolanaTxStatus: TxStatusResolver<OtherChain.Solana> = async ({
   )
 
   if (error || !tx) {
-    return { status: 'pending' }
+    return { status: 'pending', isKnown: true }
   }
 
   const meta = tx.meta
   if (!meta) {
-    return { status: 'pending' }
+    return { status: 'pending', isKnown: true }
   }
 
   if (meta.err) {
-    return { status: 'error' }
+    return { status: 'error', isKnown: true }
   }
 
   const feeCoin = chainFeeCoin[Chain.Solana]


### PR DESCRIPTION
Summary
- Let Solana standard RPC relay use its normal retry window instead of capping retries at 3.
- Mark Solana signatures that are missing from getSignatureStatuses as unknown pending, so broadcast verification does not swallow real relay failures.
- Preserve known THORChain single-segment denoms such as TCY during Cosmos coin discovery.

Test Plan
- yarn test:core packages/core/chain/tx/status/resolvers/solana.test.ts packages/core/chain/tx/broadcast/verifyBroadcastByHash.test.ts packages/core/chain/tx/broadcast/resolvers/solana.test.ts packages/core/chain/coin/find/resolvers/cosmos.test.ts
- yarn build:all
- yarn check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Solana transaction broadcast behavior by adjusting standard RPC relay retry handling.
  * Enhanced Solana transaction status verification to correctly distinguish between known and unknown pending transactions, preventing incorrect confirmation of unverified broadcasts.
  * Fixed Cosmos coin discovery to properly preserve single-segment THORChain denominations like `tcy`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->