### PR TITLE
feat(chain/evm): static known-contract label registry

### DIFF
--- a/.changeset/evm-known-contracts.md
+++ b/.changeset/evm-known-contracts.md
@@ -1,0 +1,7 @@
+---
+'@vultisig/core-chain': minor
+---
+
+feat(chain/evm): static known-contract label registry for offline transaction-intent display
+
+Adds `chains/evm/contract/knownContracts.ts` mapping well-known EVM contract addresses (Uniswap V2/V3 routers, 1inch V5/V6, Permit2, THORChain Router, Aave V3 Pool) to human-readable labels and categories. Complements `commonSelectors.ts`: that table labels what function is being called, this one labels who is being called (and lets UIs label spender-style address arguments). Lookup is offline, case-insensitive, and optionally chain-scoped.

--- a/packages/core/chain/chains/evm/contract/knownContracts.test.ts
+++ b/packages/core/chain/chains/evm/contract/knownContracts.test.ts
@@ -28,23 +28,25 @@ describe('knownEvmContracts', () => {
     }
   })
 
-  it('every declared category is used by at least one entry', () => {
-    const declared: KnownEvmContractCategory[] = [
-      'DEX Router',
-      'DEX Aggregator',
-      'Token Approval Helper',
-      'Cross-Chain Bridge',
-      'Lending Protocol',
-      'NFT Marketplace',
-    ]
+  it('every declared category is either used or explicitly reserved', () => {
+    // Record<UnionType, …> over a manual array so adding a category to
+    // KnownEvmContractCategory forces an explicit policy decision here at
+    // compile time instead of silently passing.
+    const categoryPolicy: Record<KnownEvmContractCategory, 'required' | 'reserved'> = {
+      'DEX Router': 'required',
+      'DEX Aggregator': 'required',
+      'Token Approval Helper': 'required',
+      'Cross-Chain Bridge': 'required',
+      'Lending Protocol': 'required',
+      // Reserved for future entries (OpenSea Seaport etc.) — not yet wired.
+      'NFT Marketplace': 'reserved',
+    }
     const used = new Set(Object.values(knownEvmContracts).map(e => e.category))
-    for (const category of declared) {
-      // Categories that no entry uses are dead enum members; remove them or
-      // add a representative entry.
-      if (category === 'NFT Marketplace') {
-        // Reserved for future entries (OpenSea Seaport etc.) — not yet wired.
-        continue
-      }
+    // Single localized cast at the iteration boundary — the policy object's
+    // keys are exactly KnownEvmContractCategory by construction.
+    const categories = Object.keys(categoryPolicy) as KnownEvmContractCategory[]
+    for (const category of categories) {
+      if (categoryPolicy[category] === 'reserved') continue
       expect(used.has(category)).toBe(true)
     }
   })

--- a/packages/core/chain/chains/evm/contract/knownContracts.test.ts
+++ b/packages/core/chain/chains/evm/contract/knownContracts.test.ts
@@ -96,4 +96,19 @@ describe('lookupKnownEvmContract', () => {
     expect(lookupKnownEvmContract(swapRouter02Base, { chain: EvmChain.Base })?.label).toBe('Uniswap V3 SwapRouter02')
     expect(lookupKnownEvmContract(swapRouter02Base, { chain: EvmChain.Ethereum })).toBeNull()
   })
+
+  it('routes BSC and Avalanche SwapRouter02 to their per-chain entries', () => {
+    // Each Uniswap V3 SwapRouter02 deployment is a separate entry — verify
+    // the BSC and Avalanche addresses don't leak across chains.
+    const swapRouter02Bsc = '0xb971ef87ede563556b2ed4b1c0b0019111dd85d2'
+    const swapRouter02Avalanche = '0xbb00ff08d01d300023c629e8ffffcb65a5a578ce'
+
+    expect(lookupKnownEvmContract(swapRouter02Bsc, { chain: EvmChain.BSC })?.label).toBe('Uniswap V3 SwapRouter02')
+    expect(lookupKnownEvmContract(swapRouter02Bsc, { chain: EvmChain.Ethereum })).toBeNull()
+
+    expect(lookupKnownEvmContract(swapRouter02Avalanche, { chain: EvmChain.Avalanche })?.label).toBe(
+      'Uniswap V3 SwapRouter02'
+    )
+    expect(lookupKnownEvmContract(swapRouter02Avalanche, { chain: EvmChain.BSC })).toBeNull()
+  })
 })

--- a/packages/core/chain/chains/evm/contract/knownContracts.test.ts
+++ b/packages/core/chain/chains/evm/contract/knownContracts.test.ts
@@ -1,0 +1,99 @@
+import { getAddress } from 'ethers'
+import { describe, expect, it } from 'vitest'
+
+import { EvmChain } from '../../../Chain'
+import { knownEvmContracts, type KnownEvmContractCategory, lookupKnownEvmContract } from './knownContracts'
+
+describe('knownEvmContracts', () => {
+  it('every key is a lowercase 0x-prefixed 40-hex-char string', () => {
+    for (const address of Object.keys(knownEvmContracts)) {
+      expect(address).toMatch(/^0x[0-9a-f]{40}$/)
+    }
+  })
+
+  it('every key is a checksum-valid EIP-55 address (sanity check)', () => {
+    // Catches typos like dropped/extra chars by re-parsing through ethers.
+    for (const address of Object.keys(knownEvmContracts)) {
+      expect(() => getAddress(address)).not.toThrow()
+    }
+  })
+
+  it('chain-scoped entries only reference real EvmChain members', () => {
+    const validChains = new Set<string>(Object.values(EvmChain))
+    for (const entry of Object.values(knownEvmContracts)) {
+      if (!entry.chains) continue
+      for (const chain of entry.chains) {
+        expect(validChains.has(chain)).toBe(true)
+      }
+    }
+  })
+
+  it('every declared category is used by at least one entry', () => {
+    const declared: KnownEvmContractCategory[] = [
+      'DEX Router',
+      'DEX Aggregator',
+      'Token Approval Helper',
+      'Cross-Chain Bridge',
+      'Lending Protocol',
+      'NFT Marketplace',
+    ]
+    const used = new Set(Object.values(knownEvmContracts).map(e => e.category))
+    for (const category of declared) {
+      // Categories that no entry uses are dead enum members; remove them or
+      // add a representative entry.
+      if (category === 'NFT Marketplace') {
+        // Reserved for future entries (OpenSea Seaport etc.) — not yet wired.
+        continue
+      }
+      expect(used.has(category)).toBe(true)
+    }
+  })
+})
+
+describe('lookupKnownEvmContract', () => {
+  const uniV2 = '0x7a250d5630b4cf539739df2c5dacb4c659f2488d'
+  const permit2 = '0x000000000022d473030f116ddee9f6b43ac78ba3'
+
+  it('finds known addresses', () => {
+    expect(lookupKnownEvmContract(uniV2)?.label).toBe('Uniswap V2 Router')
+    expect(lookupKnownEvmContract(permit2)?.label).toBe('Permit2')
+  })
+
+  it('is case-insensitive', () => {
+    expect(lookupKnownEvmContract(uniV2.toUpperCase())?.label).toBe('Uniswap V2 Router')
+    expect(lookupKnownEvmContract(getAddress(uniV2))?.label).toBe('Uniswap V2 Router')
+  })
+
+  it('returns null for unknown addresses', () => {
+    expect(lookupKnownEvmContract('0x000000000000000000000000000000000000dead')).toBeNull()
+  })
+
+  it('respects chain scoping when a chain is provided', () => {
+    expect(lookupKnownEvmContract(uniV2, { chain: EvmChain.Ethereum })?.label).toBe('Uniswap V2 Router')
+    // Same address, BSC isn't in the entry's chains list — should not match.
+    expect(lookupKnownEvmContract(uniV2, { chain: EvmChain.BSC })).toBeNull()
+  })
+
+  it('ignores chain scoping for entries without a chains filter', () => {
+    expect(lookupKnownEvmContract(permit2, { chain: EvmChain.Polygon })?.label).toBe('Permit2')
+    expect(lookupKnownEvmContract(permit2, { chain: EvmChain.BSC })?.label).toBe('Permit2')
+  })
+
+  it('best-effort matches chain-scoped entries when no chain is supplied', () => {
+    // Caller does not know which chain — return the label anyway. EVM
+    // contract addresses are statistically unique per deploy.
+    expect(lookupKnownEvmContract(uniV2)?.label).toBe('Uniswap V2 Router')
+  })
+
+  it('routes Base SwapRouter02 to the Base entry, not the multi-chain one', () => {
+    // Regression: Uniswap V3 SwapRouter02 lives at a different address on
+    // Base (0x2626…) than on Ethereum/Arbitrum/Optimism/Polygon (0x68b3…).
+    // Don't claim 0x68b3… is Uniswap on Base — it's some other contract.
+    const swapRouter02NonBase = '0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45'
+    const swapRouter02Base = '0x2626664c2603336e57b271c5c0b26f421741e481'
+
+    expect(lookupKnownEvmContract(swapRouter02NonBase, { chain: EvmChain.Base })).toBeNull()
+    expect(lookupKnownEvmContract(swapRouter02Base, { chain: EvmChain.Base })?.label).toBe('Uniswap V3 SwapRouter02')
+    expect(lookupKnownEvmContract(swapRouter02Base, { chain: EvmChain.Ethereum })).toBeNull()
+  })
+})

--- a/packages/core/chain/chains/evm/contract/knownContracts.ts
+++ b/packages/core/chain/chains/evm/contract/knownContracts.ts
@@ -81,6 +81,20 @@ export const knownEvmContracts: Readonly<Record<string, KnownEvmContract>> = {
     chains: ['Base'],
   },
 
+  // Uniswap V3 SwapRouter02 — BSC deployment.
+  '0xb971ef87ede563556b2ed4b1c0b0019111dd85d2': {
+    label: 'Uniswap V3 SwapRouter02',
+    category: 'DEX Router',
+    chains: ['BSC'],
+  },
+
+  // Uniswap V3 SwapRouter02 — Avalanche deployment.
+  '0xbb00ff08d01d300023c629e8ffffcb65a5a578ce': {
+    label: 'Uniswap V3 SwapRouter02',
+    category: 'DEX Router',
+    chains: ['Avalanche'],
+  },
+
   // 1inch Aggregation Router V5. Same address on most supported chains, but
   // not zkSync Era (different V5 router) — left unscoped because we don't
   // currently route on zkSync; tighten if that changes.

--- a/packages/core/chain/chains/evm/contract/knownContracts.ts
+++ b/packages/core/chain/chains/evm/contract/knownContracts.ts
@@ -1,0 +1,143 @@
+/**
+ * Static registry of well-known EVM contract addresses with human-readable
+ * labels. Used by transaction-intent display to label both the recipient
+ * (`tx.to`) of a contract call and address-typed arguments such as the
+ * `spender` in `approve(address,uint256)`.
+ *
+ * Layering for transaction-intent display:
+ *
+ *   1. Blockaid simulation may already attribute well-known contracts in its
+ *      `transaction_actions` / `address_validation` payloads — especially
+ *      malicious or sanctioned addresses. Run that first when available.
+ *
+ *   2. This static table — offline fast-path for the long tail of well-known
+ *      routers, aggregators, and protocol entry points the user is likely
+ *      interacting with on a healthy chain. Resolves instantly with no
+ *      network round-trip.
+ *
+ * Addresses are normalized to lowercase. Keys must be 0x-prefixed 40-hex-char
+ * strings (the canonical EIP-55 checksum form is lowercased here for stable
+ * lookup; callers may pass any casing).
+ *
+ * Chain scoping: many DEX/aggregator deployments use deterministic CREATE2
+ * addresses and live at the same address across every EVM chain. Such
+ * entries omit `chains`. Entries that are tied to a specific deployment
+ * include `chains` so the lookup helper can filter when the caller knows
+ * which chain the transaction is on.
+ */
+
+import type { EvmChain } from '../../../Chain'
+
+export type KnownEvmContractCategory =
+  | 'DEX Router'
+  | 'DEX Aggregator'
+  | 'Token Approval Helper'
+  | 'Cross-Chain Bridge'
+  | 'Lending Protocol'
+  | 'NFT Marketplace'
+
+export type KnownEvmContract = {
+  label: string
+  category: KnownEvmContractCategory
+  /**
+   * If present, the entry is only valid on these chains. Omit for entries
+   * whose canonical deployment uses the same address on every EVM chain
+   * (deterministic CREATE2 deploys).
+   */
+  chains?: ReadonlyArray<EvmChain>
+}
+
+export const knownEvmContracts: Readonly<Record<string, KnownEvmContract>> = {
+  // Uniswap V2 Router (UniswapV2Router02). Ethereum mainnet only — the V2
+  // contract was never re-deployed by Uniswap to other chains.
+  '0x7a250d5630b4cf539739df2c5dacb4c659f2488d': {
+    label: 'Uniswap V2 Router',
+    category: 'DEX Router',
+    chains: ['Ethereum'],
+  },
+
+  // Uniswap V3 SwapRouter (legacy, "Router1"). Valid for the deployments
+  // listed below; do NOT assume the same address across every EVM chain —
+  // Uniswap's deployment docs explicitly warn router addresses can differ.
+  '0xe592427a0aece92de3edee1f18e0157c05861564': {
+    label: 'Uniswap V3 Router',
+    category: 'DEX Router',
+    chains: ['Ethereum', 'Arbitrum', 'Optimism', 'Polygon'],
+  },
+
+  // Uniswap V3 SwapRouter02. Valid for these deployments. Base uses a
+  // different SwapRouter02 address — see the entry below.
+  '0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45': {
+    label: 'Uniswap V3 SwapRouter02',
+    category: 'DEX Router',
+    chains: ['Ethereum', 'Arbitrum', 'Optimism', 'Polygon'],
+  },
+
+  // Uniswap V3 SwapRouter02 — Base deployment (per Uniswap's Base contracts
+  // page).
+  '0x2626664c2603336e57b271c5c0b26f421741e481': {
+    label: 'Uniswap V3 SwapRouter02',
+    category: 'DEX Router',
+    chains: ['Base'],
+  },
+
+  // 1inch Aggregation Router V5. Same address on most supported chains, but
+  // not zkSync Era (different V5 router) — left unscoped because we don't
+  // currently route on zkSync; tighten if that changes.
+  '0x1111111254eeb25477b68fb85ed929f73a960582': {
+    label: '1inch V5 Router',
+    category: 'DEX Aggregator',
+  },
+
+  // 1inch Aggregation Router V6.
+  '0x111111125421ca6dc452d289314280a0f8842a65': {
+    label: '1inch V6 Router',
+    category: 'DEX Aggregator',
+  },
+
+  // Uniswap Permit2 — universal token-approval helper used by Universal
+  // Router and many other integrators. Deployed at the same address on every
+  // EVM chain Uniswap currently lists; left unscoped on that basis.
+  '0x000000000022d473030f116ddee9f6b43ac78ba3': {
+    label: 'Permit2',
+    category: 'Token Approval Helper',
+  },
+
+  // THORChain Router on Ethereum mainnet (deposit entry point for
+  // cross-chain swaps).
+  '0xd37bbe5744d730a1d98d8dc97c42f0ca46ad7146': {
+    label: 'THORChain Router',
+    category: 'Cross-Chain Bridge',
+    chains: ['Ethereum'],
+  },
+
+  // Aave V3 Pool on Ethereum mainnet.
+  '0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2': {
+    label: 'Aave V3 Pool',
+    category: 'Lending Protocol',
+    chains: ['Ethereum'],
+  },
+}
+
+export type LookupKnownEvmContractOptions = {
+  /**
+   * Chain the transaction is on. When omitted the lookup ignores any
+   * chain-scoping on entries (best-effort labeling). When supplied, entries
+   * with a `chains` filter only match if the chain is in that list.
+   */
+  chain?: EvmChain
+}
+
+export const lookupKnownEvmContract = (
+  address: string,
+  options?: LookupKnownEvmContractOptions
+): KnownEvmContract | null => {
+  const entry = knownEvmContracts[address.toLowerCase()]
+  if (!entry) {
+    return null
+  }
+  if (options?.chain && entry.chains && !entry.chains.includes(options.chain)) {
+    return null
+  }
+  return entry
+}

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -474,6 +474,11 @@
       "import": "./dist/chains/evm/contract/commonSelectors.js",
       "default": "./dist/chains/evm/contract/commonSelectors.js"
     },
+    "./chains/evm/contract/knownContracts": {
+      "types": "./dist/chains/evm/contract/knownContracts.d.ts",
+      "import": "./dist/chains/evm/contract/knownContracts.js",
+      "default": "./dist/chains/evm/contract/knownContracts.js"
+    },
     "./chains/evm/contract/universalRouter/decode": {
       "types": "./dist/chains/evm/contract/universalRouter/decode.d.ts",
       "import": "./dist/chains/evm/contract/universalRouter/decode.js",


### PR DESCRIPTION
## Description

Adds a static EVM known-contract registry under `chains/evm/contract/knownContracts.ts` so consumers can label `tx.to` and address-typed arguments (e.g. the `spender` in `approve(address,uint256)`) with human-readable names like "Uniswap V2 Router (0x7a25…488d)" without a network round-trip.

Companion to [Phase 1's `commonSelectors.ts`](https://github.com/vultisig/vultisig-sdk/pull/423): that table answers _what function is being called_, this one answers _who is being called_.

Refs vultisig/vultisig-windows#3738.

### What's in the registry

| Entry | Chains |
| --- | --- |
| Uniswap V2 Router (`0x7a25…488d`) | Ethereum |
| Uniswap V3 Router (`0xe592…1564`) | Ethereum, Arbitrum, Optimism, Polygon |
| Uniswap V3 SwapRouter02 (`0x68b3…fc45`) | Ethereum, Arbitrum, Optimism, Polygon |
| Uniswap V3 SwapRouter02 (`0x2626…1e481`) | Base (different address than the others) |
| 1inch Aggregation Router V5 / V6 | unscoped (deterministic deploy) |
| Permit2 (`0x0000…78ba3`) | unscoped (deterministic deploy) |
| THORChain Router (`0xd37b…7146`) | Ethereum |
| Aave V3 Pool (`0x8787…4fa4e2`) | Ethereum |

### Design notes

- **Lookup helper:** `lookupKnownEvmContract(address, { chain? })`. Case-insensitive on the address. When a `chain` is supplied, entries with a `chains` filter only match when the chain is in that list — prevents accidentally labeling an unrelated contract that happens to share the address on a chain where the canonical contract isn't deployed.
- **Chain scoping is intentional, not opportunistic.** Uniswap V3 SwapRouter02 is at a different address on Base — splitting it into two entries instead of widening one is the safer default. Comments call this out where it applies.
- **Layering:** Blockaid simulation runs first when available (it has runtime context — sanctioned addresses, etc.); this static table is the offline fast-path for the long tail.

## Which feature is affected?

- [ ] Create vault ( Secure / Fast)
- [ ] Sending
- [ ] Swap
- [x] New Chain / Chain related feature — pure SDK addition; no chain wiring changes

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Tests

11 new tests in `knownContracts.test.ts`, including:
- Every key is a lowercase 0x-prefixed 40-hex-char string
- Every key passes EIP-55 round-trip via ethers (catches address typos)
- Every chain in a `chains` filter is a real `EvmChain` member
- Every declared category is used (or explicitly reserved)
- Lookup is case-insensitive
- Chain scoping rejects matches on the wrong chain
- Unscoped entries match on any chain
- **Regression guard:** Base SwapRouter02 routes to the Base entry, not to the multi-chain `0x68b3…` one

## Screenshots

N/A — pure SDK module, no UI.

## Additional context

The first consumer is the windows extension (separate PR coming) which will use this in the dApp keysign verify and done screens to show "Spender: Uniswap V2 Router (0x7a25…488d)" instead of a bare address. iOS / Android can adopt the same data once the SDK release lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an offline known-contract registry for EVM networks that maps well-known contract addresses to human-readable labels and categories, improving transaction-intent clarity.

* **Tests**
  * Added tests covering address formatting, case-insensitive lookup, chain-scoped matching, best-effort matching when chain is omitted, and regressions for per-chain contract resolution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/441)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->