### PR TITLE
feat(address): accept optional chainPublicKeys to use pre-derived hardened pubkey

### DIFF
--- a/.changeset/derive-address-chain-public-keys.md
+++ b/.changeset/derive-address-chain-public-keys.md
@@ -1,0 +1,9 @@
+---
+"@vultisig/sdk": minor
+---
+
+feat(address): `deriveAddressFromKeys` accepts optional `chainPublicKeys` map
+
+Callers holding pre-derived hardened per-chain pubkeys (e.g. from KeyImport vaults or the agent-backend's `VaultInfo.ChainPublicKeys`) can now pass them through directly, bypassing the non-hardened BIP32 fallback path that produces a different address. Bidirectional Terra ↔ TerraClassic alias is built-in (both share coin_type 330). Existing callers passing no `chainPublicKeys` are unaffected — the non-hardened path remains the default.
+
+Unlocks the Luna boundary fix (mcp-ts get_address + agent-backend VaultInfo + vultiagent-app agentContext) so the agent chat path resolves the same Terra/TerraClassic address the in-process wallet derives.

--- a/packages/sdk/src/tools/address/deriveAddressFromKeys.ts
+++ b/packages/sdk/src/tools/address/deriveAddressFromKeys.ts
@@ -9,6 +9,18 @@ type DeriveAddressFromKeysInput = {
   ecdsaPublicKey?: string
   eddsaPublicKey?: string
   hexChainCode: string
+  /**
+   * Optional map of pre-derived hardened pubkeys keyed by chain name (e.g. `{ Terra: '03c7...' }`).
+   * When present for the requested chain, the derivation BIP32 re-walk is skipped and this pubkey
+   * is used directly — enabling correct addresses for hardened-only chains like Terra/TerraClassic
+   * in contexts where only the root pubkey + chain code are available (MCP / agent-backend).
+   *
+   * `Terra` is automatically aliased to `TerraClassic` (both share BIP44 coin_type 330).
+   *
+   * When absent or when the map does not contain an entry for the requested chain, the existing
+   * non-hardened BIP32 fallback is used unchanged — existing callers are unaffected.
+   */
+  chainPublicKeys?: Partial<Record<Chain, string>>
 }
 
 type DeriveAddressFromKeysResult = {
@@ -51,6 +63,17 @@ export const deriveAddressFromKeys = async (
     )
   }
 
+  // Terra and TerraClassic share BIP44 coin_type 330 and the same hardened-derived pubkey.
+  // Mirror the alias from addressDerivation.ts so callers only need to supply 'Terra'.
+  const resolvedChainPublicKeys: Partial<Record<Chain, string>> | undefined = (() => {
+    const keys = input.chainPublicKeys
+    if (!keys) return undefined
+    if (keys[Chain.Terra] && !keys[Chain.TerraClassic]) {
+      return { ...keys, [Chain.TerraClassic]: keys[Chain.Terra] }
+    }
+    return keys
+  })()
+
   let publicKey: ReturnType<typeof getPublicKey>
   try {
     publicKey = getPublicKey({
@@ -61,6 +84,7 @@ export const deriveAddressFromKeys = async (
         ecdsa: input.ecdsaPublicKey ?? '',
         eddsa: input.eddsaPublicKey ?? '',
       },
+      chainPublicKeys: resolvedChainPublicKeys,
     })
   } catch (err) {
     throw new Error(

--- a/packages/sdk/src/tools/address/deriveAddressFromKeys.ts
+++ b/packages/sdk/src/tools/address/deriveAddressFromKeys.ts
@@ -1,14 +1,14 @@
-import { Chain } from '@vultisig/core-chain/Chain'
-import { deriveAddress } from '@vultisig/core-chain/publicKey/address/deriveAddress'
-import { getPublicKey } from '@vultisig/core-chain/publicKey/getPublicKey'
+import { Chain } from "@vultisig/core-chain/Chain";
+import { deriveAddress } from "@vultisig/core-chain/publicKey/address/deriveAddress";
+import { getPublicKey } from "@vultisig/core-chain/publicKey/getPublicKey";
 
-import { getWalletCore } from '../../context/wasmRuntime'
+import { getWalletCore } from "../../context/wasmRuntime";
 
 type DeriveAddressFromKeysInput = {
-  chain: Chain
-  ecdsaPublicKey?: string
-  eddsaPublicKey?: string
-  hexChainCode: string
+  chain: Chain;
+  ecdsaPublicKey?: string;
+  eddsaPublicKey?: string;
+  hexChainCode: string;
   /**
    * Optional map of pre-derived hardened pubkeys keyed by chain name (e.g. `{ Terra: '03c7...' }`).
    * When present for the requested chain, the derivation BIP32 re-walk is skipped and this pubkey
@@ -20,13 +20,13 @@ type DeriveAddressFromKeysInput = {
    * When absent or when the map does not contain an entry for the requested chain, the existing
    * non-hardened BIP32 fallback is used unchanged — existing callers are unaffected.
    */
-  chainPublicKeys?: Partial<Record<Chain, string>>
-}
+  chainPublicKeys?: Partial<Record<Chain, string>>;
+};
 
 type DeriveAddressFromKeysResult = {
-  chain: Chain
-  address: string
-}
+  chain: Chain;
+  address: string;
+};
 
 /**
  * Derive a wallet address for a chain from raw ECDSA/EdDSA public keys and chain code.
@@ -45,22 +45,24 @@ type DeriveAddressFromKeysResult = {
  * ```
  */
 export const deriveAddressFromKeys = async (
-  input: DeriveAddressFromKeysInput
+  input: DeriveAddressFromKeysInput,
 ): Promise<DeriveAddressFromKeysResult> => {
   if (!input.ecdsaPublicKey && !input.eddsaPublicKey) {
-    throw new Error('At least one public key (ecdsaPublicKey or eddsaPublicKey) is required')
+    throw new Error(
+      "At least one public key (ecdsaPublicKey or eddsaPublicKey) is required",
+    );
   }
   if (!input.hexChainCode) {
-    throw new Error('hexChainCode is required for address derivation')
+    throw new Error("hexChainCode is required for address derivation");
   }
 
-  let walletCore: Awaited<ReturnType<typeof getWalletCore>>
+  let walletCore: Awaited<ReturnType<typeof getWalletCore>>;
   try {
-    walletCore = await getWalletCore()
+    walletCore = await getWalletCore();
   } catch (err) {
     throw new Error(
-      `Failed to initialize WalletCore for address derivation: ${err instanceof Error ? err.message : String(err)}`
-    )
+      `Failed to initialize WalletCore for address derivation: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 
   // Terra and TerraClassic share BIP44 coin_type 330 and the same hardened-derived pubkey.
@@ -68,47 +70,55 @@ export const deriveAddressFromKeys = async (
   // We also filter the map to only include the requested chain: getPublicKey treats any
   // non-empty map as authoritative and throws "Chain public key not found" when the chain
   // is absent, so we must not forward a partial map for an unrelated chain.
-  const resolvedChainPublicKeys: Partial<Record<Chain, string>> | undefined = (() => {
-    const keys = input.chainPublicKeys
-    if (!keys) return undefined
+  const resolvedChainPublicKeys: Partial<Record<Chain, string>> | undefined =
+    (() => {
+      const keys = input.chainPublicKeys;
+      if (!keys) return undefined;
 
-    // Apply bidirectional Terra ↔ TerraClassic alias (same coin_type 330).
-    const aliased: Partial<Record<Chain, string>> = { ...keys }
-    if (aliased[Chain.Terra] && !(Chain.TerraClassic in aliased)) {
-      aliased[Chain.TerraClassic] = aliased[Chain.Terra]
-    } else if (aliased[Chain.TerraClassic] && !(Chain.Terra in aliased)) {
-      aliased[Chain.Terra] = aliased[Chain.TerraClassic]
-    }
+      // Validate all present entries before any alias logic.
+      // An explicitly empty pubkey is a caller error — fail fast rather than silently
+      // falling back to non-hardened derivation, which would produce the wrong address.
+      // This must happen before alias expansion so that e.g. { Terra: "" } while
+      // requesting TerraClassic is caught here rather than silently bypassed.
+      for (const [chain, pubkey] of Object.entries(keys) as [Chain, string][]) {
+        if (pubkey !== undefined && !pubkey.trim()) {
+          throw new Error(
+            `Invalid chainPublicKeys entry for ${chain}: pubkey must be non-empty`,
+          );
+        }
+      }
 
-    // Only forward the map when the requested chain has an entry.
-    // When absent, let getPublicKey run its normal non-hardened BIP32 derivation.
-    if (!(input.chain in aliased)) return undefined
+      // Apply bidirectional Terra ↔ TerraClassic alias (same coin_type 330).
+      const aliased: Partial<Record<Chain, string>> = { ...keys };
+      if (aliased[Chain.Terra] && !(Chain.TerraClassic in aliased)) {
+        aliased[Chain.TerraClassic] = aliased[Chain.Terra];
+      } else if (aliased[Chain.TerraClassic] && !(Chain.Terra in aliased)) {
+        aliased[Chain.Terra] = aliased[Chain.TerraClassic];
+      }
 
-    // An explicitly empty pubkey is a caller error — fail fast rather than silently
-    // falling back to non-hardened derivation, which would produce the wrong address.
-    if (!aliased[input.chain]?.trim()) {
-      throw new Error(`Invalid chainPublicKeys entry for ${input.chain}: pubkey must be non-empty`)
-    }
+      // Only forward the map when the requested chain has an entry.
+      // When absent, let getPublicKey run its normal non-hardened BIP32 derivation.
+      if (!(input.chain in aliased)) return undefined;
 
-    return aliased
-  })()
+      return aliased;
+    })();
 
-  let publicKey: ReturnType<typeof getPublicKey>
+  let publicKey: ReturnType<typeof getPublicKey>;
   try {
     publicKey = getPublicKey({
       chain: input.chain,
       walletCore,
       hexChainCode: input.hexChainCode,
       publicKeys: {
-        ecdsa: input.ecdsaPublicKey ?? '',
-        eddsa: input.eddsaPublicKey ?? '',
+        ecdsa: input.ecdsaPublicKey ?? "",
+        eddsa: input.eddsaPublicKey ?? "",
       },
       chainPublicKeys: resolvedChainPublicKeys,
-    })
+    });
   } catch (err) {
     throw new Error(
-      `Failed to derive public key for ${input.chain}: ${err instanceof Error ? err.message : String(err)}`
-    )
+      `Failed to derive public key for ${input.chain}: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 
   try {
@@ -116,10 +126,12 @@ export const deriveAddressFromKeys = async (
       chain: input.chain,
       publicKey,
       walletCore,
-    })
+    });
 
-    return { chain: input.chain, address }
+    return { chain: input.chain, address };
   } catch (err) {
-    throw new Error(`Failed to derive address for ${input.chain}: ${err instanceof Error ? err.message : String(err)}`)
+    throw new Error(
+      `Failed to derive address for ${input.chain}: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
-}
+};

--- a/packages/sdk/src/tools/address/deriveAddressFromKeys.ts
+++ b/packages/sdk/src/tools/address/deriveAddressFromKeys.ts
@@ -1,14 +1,14 @@
-import { Chain } from "@vultisig/core-chain/Chain";
-import { deriveAddress } from "@vultisig/core-chain/publicKey/address/deriveAddress";
-import { getPublicKey } from "@vultisig/core-chain/publicKey/getPublicKey";
+import { Chain } from '@vultisig/core-chain/Chain'
+import { deriveAddress } from '@vultisig/core-chain/publicKey/address/deriveAddress'
+import { getPublicKey } from '@vultisig/core-chain/publicKey/getPublicKey'
 
-import { getWalletCore } from "../../context/wasmRuntime";
+import { getWalletCore } from '../../context/wasmRuntime'
 
 type DeriveAddressFromKeysInput = {
-  chain: Chain;
-  ecdsaPublicKey?: string;
-  eddsaPublicKey?: string;
-  hexChainCode: string;
+  chain: Chain
+  ecdsaPublicKey?: string
+  eddsaPublicKey?: string
+  hexChainCode: string
   /**
    * Optional map of pre-derived hardened pubkeys keyed by chain name (e.g. `{ Terra: '03c7...' }`).
    * When present for the requested chain, the derivation BIP32 re-walk is skipped and this pubkey
@@ -20,13 +20,13 @@ type DeriveAddressFromKeysInput = {
    * When absent or when the map does not contain an entry for the requested chain, the existing
    * non-hardened BIP32 fallback is used unchanged — existing callers are unaffected.
    */
-  chainPublicKeys?: Partial<Record<Chain, string>>;
-};
+  chainPublicKeys?: Partial<Record<Chain, string>>
+}
 
 type DeriveAddressFromKeysResult = {
-  chain: Chain;
-  address: string;
-};
+  chain: Chain
+  address: string
+}
 
 /**
  * Derive a wallet address for a chain from raw ECDSA/EdDSA public keys and chain code.
@@ -45,24 +45,22 @@ type DeriveAddressFromKeysResult = {
  * ```
  */
 export const deriveAddressFromKeys = async (
-  input: DeriveAddressFromKeysInput,
+  input: DeriveAddressFromKeysInput
 ): Promise<DeriveAddressFromKeysResult> => {
   if (!input.ecdsaPublicKey && !input.eddsaPublicKey) {
-    throw new Error(
-      "At least one public key (ecdsaPublicKey or eddsaPublicKey) is required",
-    );
+    throw new Error('At least one public key (ecdsaPublicKey or eddsaPublicKey) is required')
   }
   if (!input.hexChainCode) {
-    throw new Error("hexChainCode is required for address derivation");
+    throw new Error('hexChainCode is required for address derivation')
   }
 
-  let walletCore: Awaited<ReturnType<typeof getWalletCore>>;
+  let walletCore: Awaited<ReturnType<typeof getWalletCore>>
   try {
-    walletCore = await getWalletCore();
+    walletCore = await getWalletCore()
   } catch (err) {
     throw new Error(
-      `Failed to initialize WalletCore for address derivation: ${err instanceof Error ? err.message : String(err)}`,
-    );
+      `Failed to initialize WalletCore for address derivation: ${err instanceof Error ? err.message : String(err)}`
+    )
   }
 
   // Terra and TerraClassic share BIP44 coin_type 330 and the same hardened-derived pubkey.
@@ -70,55 +68,52 @@ export const deriveAddressFromKeys = async (
   // We also filter the map to only include the requested chain: getPublicKey treats any
   // non-empty map as authoritative and throws "Chain public key not found" when the chain
   // is absent, so we must not forward a partial map for an unrelated chain.
-  const resolvedChainPublicKeys: Partial<Record<Chain, string>> | undefined =
-    (() => {
-      const keys = input.chainPublicKeys;
-      if (!keys) return undefined;
+  const resolvedChainPublicKeys: Partial<Record<Chain, string>> | undefined = (() => {
+    const keys = input.chainPublicKeys
+    if (!keys) return undefined
 
-      // Validate all present entries before any alias logic.
-      // An explicitly empty pubkey is a caller error — fail fast rather than silently
-      // falling back to non-hardened derivation, which would produce the wrong address.
-      // This must happen before alias expansion so that e.g. { Terra: "" } while
-      // requesting TerraClassic is caught here rather than silently bypassed.
-      for (const [chain, pubkey] of Object.entries(keys) as [Chain, string][]) {
-        if (pubkey !== undefined && !pubkey.trim()) {
-          throw new Error(
-            `Invalid chainPublicKeys entry for ${chain}: pubkey must be non-empty`,
-          );
-        }
+    // Validate all present entries before any alias logic.
+    // An explicitly empty pubkey is a caller error — fail fast rather than silently
+    // falling back to non-hardened derivation, which would produce the wrong address.
+    // This must happen before alias expansion so that e.g. { Terra: "" } while
+    // requesting TerraClassic is caught here rather than silently bypassed.
+    for (const [chain, pubkey] of Object.entries(keys) as [Chain, string][]) {
+      if (pubkey !== undefined && !pubkey.trim()) {
+        throw new Error(`Invalid chainPublicKeys entry for ${chain}: pubkey must be non-empty`)
       }
+    }
 
-      // Apply bidirectional Terra ↔ TerraClassic alias (same coin_type 330).
-      const aliased: Partial<Record<Chain, string>> = { ...keys };
-      if (aliased[Chain.Terra] && !(Chain.TerraClassic in aliased)) {
-        aliased[Chain.TerraClassic] = aliased[Chain.Terra];
-      } else if (aliased[Chain.TerraClassic] && !(Chain.Terra in aliased)) {
-        aliased[Chain.Terra] = aliased[Chain.TerraClassic];
-      }
+    // Apply bidirectional Terra ↔ TerraClassic alias (same coin_type 330).
+    const aliased: Partial<Record<Chain, string>> = { ...keys }
+    if (aliased[Chain.Terra] && !(Chain.TerraClassic in aliased)) {
+      aliased[Chain.TerraClassic] = aliased[Chain.Terra]
+    } else if (aliased[Chain.TerraClassic] && !(Chain.Terra in aliased)) {
+      aliased[Chain.Terra] = aliased[Chain.TerraClassic]
+    }
 
-      // Only forward the map when the requested chain has an entry.
-      // When absent, let getPublicKey run its normal non-hardened BIP32 derivation.
-      if (!(input.chain in aliased)) return undefined;
+    // Only forward the map when the requested chain has an entry.
+    // When absent, let getPublicKey run its normal non-hardened BIP32 derivation.
+    if (!(input.chain in aliased)) return undefined
 
-      return aliased;
-    })();
+    return aliased
+  })()
 
-  let publicKey: ReturnType<typeof getPublicKey>;
+  let publicKey: ReturnType<typeof getPublicKey>
   try {
     publicKey = getPublicKey({
       chain: input.chain,
       walletCore,
       hexChainCode: input.hexChainCode,
       publicKeys: {
-        ecdsa: input.ecdsaPublicKey ?? "",
-        eddsa: input.eddsaPublicKey ?? "",
+        ecdsa: input.ecdsaPublicKey ?? '',
+        eddsa: input.eddsaPublicKey ?? '',
       },
       chainPublicKeys: resolvedChainPublicKeys,
-    });
+    })
   } catch (err) {
     throw new Error(
-      `Failed to derive public key for ${input.chain}: ${err instanceof Error ? err.message : String(err)}`,
-    );
+      `Failed to derive public key for ${input.chain}: ${err instanceof Error ? err.message : String(err)}`
+    )
   }
 
   try {
@@ -126,12 +121,10 @@ export const deriveAddressFromKeys = async (
       chain: input.chain,
       publicKey,
       walletCore,
-    });
+    })
 
-    return { chain: input.chain, address };
+    return { chain: input.chain, address }
   } catch (err) {
-    throw new Error(
-      `Failed to derive address for ${input.chain}: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    throw new Error(`Failed to derive address for ${input.chain}: ${err instanceof Error ? err.message : String(err)}`)
   }
-};
+}

--- a/packages/sdk/src/tools/address/deriveAddressFromKeys.ts
+++ b/packages/sdk/src/tools/address/deriveAddressFromKeys.ts
@@ -74,15 +74,21 @@ export const deriveAddressFromKeys = async (
 
     // Apply bidirectional Terra ↔ TerraClassic alias (same coin_type 330).
     const aliased: Partial<Record<Chain, string>> = { ...keys }
-    if (aliased[Chain.Terra] && !aliased[Chain.TerraClassic]) {
+    if (aliased[Chain.Terra] && !(Chain.TerraClassic in aliased)) {
       aliased[Chain.TerraClassic] = aliased[Chain.Terra]
-    } else if (aliased[Chain.TerraClassic] && !aliased[Chain.Terra]) {
+    } else if (aliased[Chain.TerraClassic] && !(Chain.Terra in aliased)) {
       aliased[Chain.Terra] = aliased[Chain.TerraClassic]
     }
 
     // Only forward the map when the requested chain has an entry.
     // When absent, let getPublicKey run its normal non-hardened BIP32 derivation.
-    if (!aliased[input.chain]) return undefined
+    if (!(input.chain in aliased)) return undefined
+
+    // An explicitly empty pubkey is a caller error — fail fast rather than silently
+    // falling back to non-hardened derivation, which would produce the wrong address.
+    if (!aliased[input.chain]?.trim()) {
+      throw new Error(`Invalid chainPublicKeys entry for ${input.chain}: pubkey must be non-empty`)
+    }
 
     return aliased
   })()

--- a/packages/sdk/src/tools/address/deriveAddressFromKeys.ts
+++ b/packages/sdk/src/tools/address/deriveAddressFromKeys.ts
@@ -64,14 +64,27 @@ export const deriveAddressFromKeys = async (
   }
 
   // Terra and TerraClassic share BIP44 coin_type 330 and the same hardened-derived pubkey.
-  // Mirror the alias from addressDerivation.ts so callers only need to supply 'Terra'.
+  // Mirror the alias from addressDerivation.ts so callers only need to supply one direction.
+  // We also filter the map to only include the requested chain: getPublicKey treats any
+  // non-empty map as authoritative and throws "Chain public key not found" when the chain
+  // is absent, so we must not forward a partial map for an unrelated chain.
   const resolvedChainPublicKeys: Partial<Record<Chain, string>> | undefined = (() => {
     const keys = input.chainPublicKeys
     if (!keys) return undefined
-    if (keys[Chain.Terra] && !keys[Chain.TerraClassic]) {
-      return { ...keys, [Chain.TerraClassic]: keys[Chain.Terra] }
+
+    // Apply bidirectional Terra ↔ TerraClassic alias (same coin_type 330).
+    const aliased: Partial<Record<Chain, string>> = { ...keys }
+    if (aliased[Chain.Terra] && !aliased[Chain.TerraClassic]) {
+      aliased[Chain.TerraClassic] = aliased[Chain.Terra]
+    } else if (aliased[Chain.TerraClassic] && !aliased[Chain.Terra]) {
+      aliased[Chain.Terra] = aliased[Chain.TerraClassic]
     }
-    return keys
+
+    // Only forward the map when the requested chain has an entry.
+    // When absent, let getPublicKey run its normal non-hardened BIP32 derivation.
+    if (!aliased[input.chain]) return undefined
+
+    return aliased
   })()
 
   let publicKey: ReturnType<typeof getPublicKey>

--- a/packages/sdk/tests/unit/tools/address/deriveAddressFromKeys.test.ts
+++ b/packages/sdk/tests/unit/tools/address/deriveAddressFromKeys.test.ts
@@ -1,163 +1,158 @@
-import { Chain } from "@vultisig/core-chain/Chain";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Chain } from '@vultisig/core-chain/Chain'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockGetWalletCore, mockGetPublicKey, mockDeriveAddress } = vi.hoisted(
-  () => ({
-    mockGetWalletCore: vi.fn(),
-    mockGetPublicKey: vi.fn(),
-    mockDeriveAddress: vi.fn(),
-  }),
-);
+const { mockGetWalletCore, mockGetPublicKey, mockDeriveAddress } = vi.hoisted(() => ({
+  mockGetWalletCore: vi.fn(),
+  mockGetPublicKey: vi.fn(),
+  mockDeriveAddress: vi.fn(),
+}))
 
-vi.mock("@/context/wasmRuntime", () => ({
+vi.mock('@/context/wasmRuntime', () => ({
   getWalletCore: mockGetWalletCore,
-}));
-vi.mock("@vultisig/core-chain/publicKey/getPublicKey", () => ({
+}))
+vi.mock('@vultisig/core-chain/publicKey/getPublicKey', () => ({
   getPublicKey: mockGetPublicKey,
-}));
-vi.mock("@vultisig/core-chain/publicKey/address/deriveAddress", () => ({
+}))
+vi.mock('@vultisig/core-chain/publicKey/address/deriveAddress', () => ({
   deriveAddress: mockDeriveAddress,
-}));
+}))
 
-import { deriveAddressFromKeys } from "@/tools/address/deriveAddressFromKeys";
+import { deriveAddressFromKeys } from '@/tools/address/deriveAddressFromKeys'
 
-const mockWalletCore = { __mock: "walletCore" };
-const mockPublicKey = { __mock: "publicKey" };
+const mockWalletCore = { __mock: 'walletCore' }
+const mockPublicKey = { __mock: 'publicKey' }
 
-describe("deriveAddressFromKeys", () => {
+describe('deriveAddressFromKeys', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    mockGetWalletCore.mockResolvedValue(mockWalletCore);
-    mockGetPublicKey.mockReturnValue(mockPublicKey);
-    mockDeriveAddress.mockReturnValue("0xabc123");
-  });
+    vi.clearAllMocks()
+    mockGetWalletCore.mockResolvedValue(mockWalletCore)
+    mockGetPublicKey.mockReturnValue(mockPublicKey)
+    mockDeriveAddress.mockReturnValue('0xabc123')
+  })
 
-  it("throws when neither ecdsa nor eddsa key", async () => {
+  it('throws when neither ecdsa nor eddsa key', async () => {
     await expect(
       deriveAddressFromKeys({
         chain: Chain.Ethereum,
-        hexChainCode: "00",
-      }),
-    ).rejects.toThrow(
-      "At least one public key (ecdsaPublicKey or eddsaPublicKey) is required",
-    );
-  });
+        hexChainCode: '00',
+      })
+    ).rejects.toThrow('At least one public key (ecdsaPublicKey or eddsaPublicKey) is required')
+  })
 
-  it("throws when hexChainCode empty", async () => {
+  it('throws when hexChainCode empty', async () => {
     await expect(
       deriveAddressFromKeys({
         chain: Chain.Ethereum,
-        ecdsaPublicKey: "02hex",
-        hexChainCode: "",
-      }),
-    ).rejects.toThrow("hexChainCode is required for address derivation");
-  });
+        ecdsaPublicKey: '02hex',
+        hexChainCode: '',
+      })
+    ).rejects.toThrow('hexChainCode is required for address derivation')
+  })
 
-  it("when getWalletCore rejects, error message mentions WalletCore init", async () => {
-    mockGetWalletCore.mockRejectedValueOnce(new Error("bootstrap failed"));
+  it('when getWalletCore rejects, error message mentions WalletCore init', async () => {
+    mockGetWalletCore.mockRejectedValueOnce(new Error('bootstrap failed'))
     await expect(
       deriveAddressFromKeys({
         chain: Chain.Ethereum,
-        ecdsaPublicKey: "02hex",
-        hexChainCode: "cafe",
-      }),
-    ).rejects.toThrow(/Failed to initialize WalletCore for address derivation/);
-  });
+        ecdsaPublicKey: '02hex',
+        hexChainCode: 'cafe',
+      })
+    ).rejects.toThrow(/Failed to initialize WalletCore for address derivation/)
+  })
 
-  it("when getPublicKey throws, error mentions chain name", async () => {
+  it('when getPublicKey throws, error mentions chain name', async () => {
     mockGetPublicKey.mockImplementationOnce(() => {
-      throw new Error("key derivation error");
-    });
+      throw new Error('key derivation error')
+    })
     await expect(
       deriveAddressFromKeys({
         chain: Chain.Solana,
-        ecdsaPublicKey: "02hex",
-        hexChainCode: "cafe",
-      }),
-    ).rejects.toThrow(/Failed to derive public key for Solana:/);
-  });
+        ecdsaPublicKey: '02hex',
+        hexChainCode: 'cafe',
+      })
+    ).rejects.toThrow(/Failed to derive public key for Solana:/)
+  })
 
-  it("when deriveAddress throws, error mentions chain", async () => {
+  it('when deriveAddress throws, error mentions chain', async () => {
     mockDeriveAddress.mockImplementationOnce(() => {
-      throw new Error("address derivation error");
-    });
+      throw new Error('address derivation error')
+    })
     await expect(
       deriveAddressFromKeys({
         chain: Chain.Bitcoin,
-        ecdsaPublicKey: "02hex",
-        hexChainCode: "cafe",
-      }),
-    ).rejects.toThrow(/Failed to derive address for Bitcoin:/);
-  });
+        ecdsaPublicKey: '02hex',
+        hexChainCode: 'cafe',
+      })
+    ).rejects.toThrow(/Failed to derive address for Bitcoin:/)
+  })
 
-  it("returns chain and address on success (no chainPublicKeys — fallback path unchanged)", async () => {
-    const address = "bc1qdummy";
-    mockDeriveAddress.mockReturnValueOnce(address);
+  it('returns chain and address on success (no chainPublicKeys — fallback path unchanged)', async () => {
+    const address = 'bc1qdummy'
+    mockDeriveAddress.mockReturnValueOnce(address)
     const result = await deriveAddressFromKeys({
       chain: Chain.Bitcoin,
-      ecdsaPublicKey: "02hex",
-      hexChainCode: "cafe",
-    });
-    expect(result).toEqual({ chain: Chain.Bitcoin, address });
-    expect(mockGetWalletCore).toHaveBeenCalledTimes(1);
+      ecdsaPublicKey: '02hex',
+      hexChainCode: 'cafe',
+    })
+    expect(result).toEqual({ chain: Chain.Bitcoin, address })
+    expect(mockGetWalletCore).toHaveBeenCalledTimes(1)
     expect(mockGetPublicKey).toHaveBeenCalledWith({
       chain: Chain.Bitcoin,
       walletCore: mockWalletCore,
-      hexChainCode: "cafe",
+      hexChainCode: 'cafe',
       publicKeys: {
-        ecdsa: "02hex",
-        eddsa: "",
+        ecdsa: '02hex',
+        eddsa: '',
       },
       chainPublicKeys: undefined,
-    });
+    })
     expect(mockDeriveAddress).toHaveBeenCalledWith({
       chain: Chain.Bitcoin,
       publicKey: mockPublicKey,
       walletCore: mockWalletCore,
-    });
-  });
+    })
+  })
 
-  describe("chainPublicKeys — pre-derived hardened pubkey path", () => {
+  describe('chainPublicKeys — pre-derived hardened pubkey path', () => {
     // Fixture: known Terra hardened-derived pubkey from test seed
     // seed: "quick assist swamp smoke unknown grit cattle choose fabric crawl announce charge"
     // path: m/44'/330'/0'/0/0
-    const terraHardenedPubkey =
-      "03c7721fa4760e081f7ae3b192084467528603ebdf84ebf3d86addc86d5bcdc31b";
-    const terraFundedAddress = "terra10mtp3kjs9jh05cp288alz35308jmr6arjfr43r";
+    const terraHardenedPubkey = '03c7721fa4760e081f7ae3b192084467528603ebdf84ebf3d86addc86d5bcdc31b'
+    const terraFundedAddress = 'terra10mtp3kjs9jh05cp288alz35308jmr6arjfr43r'
 
-    it("uses chainPublicKeys[Terra] directly and returns funded address", async () => {
-      mockDeriveAddress.mockReturnValueOnce(terraFundedAddress);
+    it('uses chainPublicKeys[Terra] directly and returns funded address', async () => {
+      mockDeriveAddress.mockReturnValueOnce(terraFundedAddress)
       const result = await deriveAddressFromKeys({
         chain: Chain.Terra,
-        ecdsaPublicKey: "root_pubkey_hex",
-        hexChainCode: "chain_code_hex",
+        ecdsaPublicKey: 'root_pubkey_hex',
+        hexChainCode: 'chain_code_hex',
         chainPublicKeys: { [Chain.Terra]: terraHardenedPubkey },
-      });
+      })
       expect(result).toEqual({
         chain: Chain.Terra,
         address: terraFundedAddress,
-      });
+      })
       // getPublicKey receives the chainPublicKeys map including the Terra alias
       expect(mockGetPublicKey).toHaveBeenCalledWith({
         chain: Chain.Terra,
         walletCore: mockWalletCore,
-        hexChainCode: "chain_code_hex",
-        publicKeys: { ecdsa: "root_pubkey_hex", eddsa: "" },
+        hexChainCode: 'chain_code_hex',
+        publicKeys: { ecdsa: 'root_pubkey_hex', eddsa: '' },
         chainPublicKeys: {
           [Chain.Terra]: terraHardenedPubkey,
           [Chain.TerraClassic]: terraHardenedPubkey,
         },
-      });
-    });
+      })
+    })
 
-    it("Terra key auto-aliases to TerraClassic", async () => {
-      mockDeriveAddress.mockReturnValueOnce(terraFundedAddress);
+    it('Terra key auto-aliases to TerraClassic', async () => {
+      mockDeriveAddress.mockReturnValueOnce(terraFundedAddress)
       await deriveAddressFromKeys({
         chain: Chain.TerraClassic,
-        ecdsaPublicKey: "root_pubkey_hex",
-        hexChainCode: "chain_code_hex",
+        ecdsaPublicKey: 'root_pubkey_hex',
+        hexChainCode: 'chain_code_hex',
         chainPublicKeys: { [Chain.Terra]: terraHardenedPubkey },
-      });
+      })
       // TerraClassic should be present in the forwarded map even though only Terra was supplied
       expect(mockGetPublicKey).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -165,116 +160,110 @@ describe("deriveAddressFromKeys", () => {
           chainPublicKeys: expect.objectContaining({
             [Chain.TerraClassic]: terraHardenedPubkey,
           }),
-        }),
-      );
-    });
+        })
+      )
+    })
 
-    it("when TerraClassic key already present, no overwrite", async () => {
-      const distinctClassicPubkey = "02aabbccdd";
-      mockDeriveAddress.mockReturnValueOnce("terra1classic");
+    it('when TerraClassic key already present, no overwrite', async () => {
+      const distinctClassicPubkey = '02aabbccdd'
+      mockDeriveAddress.mockReturnValueOnce('terra1classic')
       await deriveAddressFromKeys({
         chain: Chain.TerraClassic,
-        ecdsaPublicKey: "root_pubkey_hex",
-        hexChainCode: "chain_code_hex",
+        ecdsaPublicKey: 'root_pubkey_hex',
+        hexChainCode: 'chain_code_hex',
         chainPublicKeys: {
           [Chain.Terra]: terraHardenedPubkey,
           [Chain.TerraClassic]: distinctClassicPubkey,
         },
-      });
+      })
       // Pre-supplied TerraClassic key is preserved, not overwritten by alias
       expect(mockGetPublicKey).toHaveBeenCalledWith(
         expect.objectContaining({
           chainPublicKeys: expect.objectContaining({
             [Chain.TerraClassic]: distinctClassicPubkey,
           }),
-        }),
-      );
-    });
+        })
+      )
+    })
 
-    it("chainPublicKeys for unrelated chain: map is NOT forwarded so BIP32 fallback runs", async () => {
+    it('chainPublicKeys for unrelated chain: map is NOT forwarded so BIP32 fallback runs', async () => {
       // Ethereum pubkey is present but Terra is not — Terra should fall back to BIP32 derivation.
       // We must not forward the partial map to getPublicKey because it would throw
       // "Chain public key not found" (it treats any non-empty map as authoritative).
-      const ethOnlyKeys = { [Chain.Ethereum]: "02ethpubkey" };
-      mockDeriveAddress.mockReturnValueOnce("terra1nonhardened");
+      const ethOnlyKeys = { [Chain.Ethereum]: '02ethpubkey' }
+      mockDeriveAddress.mockReturnValueOnce('terra1nonhardened')
       await deriveAddressFromKeys({
         chain: Chain.Terra,
-        ecdsaPublicKey: "root_pubkey_hex",
-        hexChainCode: "chain_code_hex",
+        ecdsaPublicKey: 'root_pubkey_hex',
+        hexChainCode: 'chain_code_hex',
         chainPublicKeys: ethOnlyKeys,
-      });
+      })
       // chainPublicKeys must be undefined so the non-hardened BIP32 fallback runs
       expect(mockGetPublicKey).toHaveBeenCalledWith(
         expect.objectContaining({
           chain: Chain.Terra,
           chainPublicKeys: undefined,
-        }),
-      );
-    });
+        })
+      )
+    })
 
-    it("TerraClassic key reverse-aliases to Terra", async () => {
+    it('TerraClassic key reverse-aliases to Terra', async () => {
       // Caller supplies TerraClassic but queries Terra — reverse alias must kick in
-      mockDeriveAddress.mockReturnValueOnce(terraFundedAddress);
+      mockDeriveAddress.mockReturnValueOnce(terraFundedAddress)
       await deriveAddressFromKeys({
         chain: Chain.Terra,
-        ecdsaPublicKey: "root_pubkey_hex",
-        hexChainCode: "chain_code_hex",
+        ecdsaPublicKey: 'root_pubkey_hex',
+        hexChainCode: 'chain_code_hex',
         chainPublicKeys: { [Chain.TerraClassic]: terraHardenedPubkey },
-      });
+      })
       expect(mockGetPublicKey).toHaveBeenCalledWith(
         expect.objectContaining({
           chain: Chain.Terra,
           chainPublicKeys: expect.objectContaining({
             [Chain.Terra]: terraHardenedPubkey,
           }),
-        }),
-      );
-    });
+        })
+      )
+    })
 
-    it("omitting chainPublicKeys passes undefined to getPublicKey (no regression)", async () => {
+    it('omitting chainPublicKeys passes undefined to getPublicKey (no regression)', async () => {
       await deriveAddressFromKeys({
         chain: Chain.Ethereum,
-        ecdsaPublicKey: "02hex",
-        hexChainCode: "cafe",
-      });
-      expect(mockGetPublicKey).toHaveBeenCalledWith(
-        expect.objectContaining({ chainPublicKeys: undefined }),
-      );
-    });
+        ecdsaPublicKey: '02hex',
+        hexChainCode: 'cafe',
+      })
+      expect(mockGetPublicKey).toHaveBeenCalledWith(expect.objectContaining({ chainPublicKeys: undefined }))
+    })
 
-    it("explicit empty chainPublicKeys entry throws instead of silently falling back", async () => {
+    it('explicit empty chainPublicKeys entry throws instead of silently falling back', async () => {
       // Regression guard: an empty string is a caller error, not a "key absent" signal.
       // Before the fix, `if (!aliased[input.chain])` treated '' as falsy and fell back
       // to non-hardened BIP32 derivation, returning the wrong address silently.
       await expect(
         deriveAddressFromKeys({
           chain: Chain.Terra,
-          ecdsaPublicKey: "root_pubkey_hex",
-          hexChainCode: "chain_code_hex",
-          chainPublicKeys: { [Chain.Terra]: "" },
-        }),
-      ).rejects.toThrow(
-        /Invalid chainPublicKeys entry for Terra: pubkey must be non-empty/,
-      );
+          ecdsaPublicKey: 'root_pubkey_hex',
+          hexChainCode: 'chain_code_hex',
+          chainPublicKeys: { [Chain.Terra]: '' },
+        })
+      ).rejects.toThrow(/Invalid chainPublicKeys entry for Terra: pubkey must be non-empty/)
       // getPublicKey must NOT have been called — we should have thrown before reaching it
-      expect(mockGetPublicKey).not.toHaveBeenCalled();
-    });
+      expect(mockGetPublicKey).not.toHaveBeenCalled()
+    })
 
-    it("whitespace-only chainPublicKeys entry also throws", async () => {
+    it('whitespace-only chainPublicKeys entry also throws', async () => {
       await expect(
         deriveAddressFromKeys({
           chain: Chain.Terra,
-          ecdsaPublicKey: "root_pubkey_hex",
-          hexChainCode: "chain_code_hex",
-          chainPublicKeys: { [Chain.Terra]: "   " },
-        }),
-      ).rejects.toThrow(
-        /Invalid chainPublicKeys entry for Terra: pubkey must be non-empty/,
-      );
-      expect(mockGetPublicKey).not.toHaveBeenCalled();
-    });
+          ecdsaPublicKey: 'root_pubkey_hex',
+          hexChainCode: 'chain_code_hex',
+          chainPublicKeys: { [Chain.Terra]: '   ' },
+        })
+      ).rejects.toThrow(/Invalid chainPublicKeys entry for Terra: pubkey must be non-empty/)
+      expect(mockGetPublicKey).not.toHaveBeenCalled()
+    })
 
-    it("empty Terra key throws when deriving TerraClassic (alias-source presence check)", async () => {
+    it('empty Terra key throws when deriving TerraClassic (alias-source presence check)', async () => {
       // Regression: before the fix, { Terra: "" } while requesting TerraClassic
       // bypassed the empty-value guard because the truthy alias check skipped
       // alias expansion, leaving TerraClassic absent, so the code returned
@@ -282,28 +271,24 @@ describe("deriveAddressFromKeys", () => {
       await expect(
         deriveAddressFromKeys({
           chain: Chain.TerraClassic,
-          ecdsaPublicKey: "root_pubkey_hex",
-          hexChainCode: "chain_code_hex",
-          chainPublicKeys: { [Chain.Terra]: "" },
-        }),
-      ).rejects.toThrow(
-        /Invalid chainPublicKeys entry for Terra: pubkey must be non-empty/,
-      );
-      expect(mockGetPublicKey).not.toHaveBeenCalled();
-    });
+          ecdsaPublicKey: 'root_pubkey_hex',
+          hexChainCode: 'chain_code_hex',
+          chainPublicKeys: { [Chain.Terra]: '' },
+        })
+      ).rejects.toThrow(/Invalid chainPublicKeys entry for Terra: pubkey must be non-empty/)
+      expect(mockGetPublicKey).not.toHaveBeenCalled()
+    })
 
-    it("empty TerraClassic key throws when deriving Terra (reverse alias-source presence check)", async () => {
+    it('empty TerraClassic key throws when deriving Terra (reverse alias-source presence check)', async () => {
       await expect(
         deriveAddressFromKeys({
           chain: Chain.Terra,
-          ecdsaPublicKey: "root_pubkey_hex",
-          hexChainCode: "chain_code_hex",
-          chainPublicKeys: { [Chain.TerraClassic]: "" },
-        }),
-      ).rejects.toThrow(
-        /Invalid chainPublicKeys entry for TerraClassic: pubkey must be non-empty/,
-      );
-      expect(mockGetPublicKey).not.toHaveBeenCalled();
-    });
-  });
-});
+          ecdsaPublicKey: 'root_pubkey_hex',
+          hexChainCode: 'chain_code_hex',
+          chainPublicKeys: { [Chain.TerraClassic]: '' },
+        })
+      ).rejects.toThrow(/Invalid chainPublicKeys entry for TerraClassic: pubkey must be non-empty/)
+      expect(mockGetPublicKey).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/sdk/tests/unit/tools/address/deriveAddressFromKeys.test.ts
+++ b/packages/sdk/tests/unit/tools/address/deriveAddressFromKeys.test.ts
@@ -229,9 +229,7 @@ describe('deriveAddressFromKeys', () => {
         ecdsaPublicKey: '02hex',
         hexChainCode: 'cafe',
       })
-      expect(mockGetPublicKey).toHaveBeenCalledWith(
-        expect.objectContaining({ chainPublicKeys: undefined })
-      )
+      expect(mockGetPublicKey).toHaveBeenCalledWith(expect.objectContaining({ chainPublicKeys: undefined }))
     })
   })
 })

--- a/packages/sdk/tests/unit/tools/address/deriveAddressFromKeys.test.ts
+++ b/packages/sdk/tests/unit/tools/address/deriveAddressFromKeys.test.ts
@@ -231,5 +231,33 @@ describe('deriveAddressFromKeys', () => {
       })
       expect(mockGetPublicKey).toHaveBeenCalledWith(expect.objectContaining({ chainPublicKeys: undefined }))
     })
+
+    it('explicit empty chainPublicKeys entry throws instead of silently falling back', async () => {
+      // Regression guard: an empty string is a caller error, not a "key absent" signal.
+      // Before the fix, `if (!aliased[input.chain])` treated '' as falsy and fell back
+      // to non-hardened BIP32 derivation, returning the wrong address silently.
+      await expect(
+        deriveAddressFromKeys({
+          chain: Chain.Terra,
+          ecdsaPublicKey: 'root_pubkey_hex',
+          hexChainCode: 'chain_code_hex',
+          chainPublicKeys: { [Chain.Terra]: '' },
+        })
+      ).rejects.toThrow(/Invalid chainPublicKeys entry for Terra: pubkey must be non-empty/)
+      // getPublicKey must NOT have been called — we should have thrown before reaching it
+      expect(mockGetPublicKey).not.toHaveBeenCalled()
+    })
+
+    it('whitespace-only chainPublicKeys entry also throws', async () => {
+      await expect(
+        deriveAddressFromKeys({
+          chain: Chain.Terra,
+          ecdsaPublicKey: 'root_pubkey_hex',
+          hexChainCode: 'chain_code_hex',
+          chainPublicKeys: { [Chain.Terra]: '   ' },
+        })
+      ).rejects.toThrow(/Invalid chainPublicKeys entry for Terra: pubkey must be non-empty/)
+      expect(mockGetPublicKey).not.toHaveBeenCalled()
+    })
   })
 })

--- a/packages/sdk/tests/unit/tools/address/deriveAddressFromKeys.test.ts
+++ b/packages/sdk/tests/unit/tools/address/deriveAddressFromKeys.test.ts
@@ -183,8 +183,10 @@ describe('deriveAddressFromKeys', () => {
       )
     })
 
-    it('chainPublicKeys for unrelated chain does not affect Terra derivation (fallback)', async () => {
-      // Ethereum pubkey is present but Terra is not — Terra should fall back to BIP32
+    it('chainPublicKeys for unrelated chain: map is NOT forwarded so BIP32 fallback runs', async () => {
+      // Ethereum pubkey is present but Terra is not — Terra should fall back to BIP32 derivation.
+      // We must not forward the partial map to getPublicKey because it would throw
+      // "Chain public key not found" (it treats any non-empty map as authoritative).
       const ethOnlyKeys = { [Chain.Ethereum]: '02ethpubkey' }
       mockDeriveAddress.mockReturnValueOnce('terra1nonhardened')
       await deriveAddressFromKeys({
@@ -193,14 +195,30 @@ describe('deriveAddressFromKeys', () => {
         hexChainCode: 'chain_code_hex',
         chainPublicKeys: ethOnlyKeys,
       })
-      // The map is forwarded as-is (getPublicKey will throw "Chain public key not found"
-      // because chainPublicKeys is non-empty but has no Terra entry — that's intentional
-      // and matches getPublicKey's contract; callers must either supply the right chain
-      // or omit chainPublicKeys entirely)
+      // chainPublicKeys must be undefined so the non-hardened BIP32 fallback runs
       expect(mockGetPublicKey).toHaveBeenCalledWith(
         expect.objectContaining({
           chain: Chain.Terra,
-          chainPublicKeys: ethOnlyKeys,
+          chainPublicKeys: undefined,
+        })
+      )
+    })
+
+    it('TerraClassic key reverse-aliases to Terra', async () => {
+      // Caller supplies TerraClassic but queries Terra — reverse alias must kick in
+      mockDeriveAddress.mockReturnValueOnce(terraFundedAddress)
+      await deriveAddressFromKeys({
+        chain: Chain.Terra,
+        ecdsaPublicKey: 'root_pubkey_hex',
+        hexChainCode: 'chain_code_hex',
+        chainPublicKeys: { [Chain.TerraClassic]: terraHardenedPubkey },
+      })
+      expect(mockGetPublicKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chain: Chain.Terra,
+          chainPublicKeys: expect.objectContaining({
+            [Chain.Terra]: terraHardenedPubkey,
+          }),
         })
       )
     })

--- a/packages/sdk/tests/unit/tools/address/deriveAddressFromKeys.test.ts
+++ b/packages/sdk/tests/unit/tools/address/deriveAddressFromKeys.test.ts
@@ -86,7 +86,7 @@ describe('deriveAddressFromKeys', () => {
     ).rejects.toThrow(/Failed to derive address for Bitcoin:/)
   })
 
-  it('returns chain and address on success', async () => {
+  it('returns chain and address on success (no chainPublicKeys — fallback path unchanged)', async () => {
     const address = 'bc1qdummy'
     mockDeriveAddress.mockReturnValueOnce(address)
     const result = await deriveAddressFromKeys({
@@ -104,11 +104,116 @@ describe('deriveAddressFromKeys', () => {
         ecdsa: '02hex',
         eddsa: '',
       },
+      chainPublicKeys: undefined,
     })
     expect(mockDeriveAddress).toHaveBeenCalledWith({
       chain: Chain.Bitcoin,
       publicKey: mockPublicKey,
       walletCore: mockWalletCore,
+    })
+  })
+
+  describe('chainPublicKeys — pre-derived hardened pubkey path', () => {
+    // Fixture: known Terra hardened-derived pubkey from test seed
+    // seed: "quick assist swamp smoke unknown grit cattle choose fabric crawl announce charge"
+    // path: m/44'/330'/0'/0/0
+    const terraHardenedPubkey = '03c7721fa4760e081f7ae3b192084467528603ebdf84ebf3d86addc86d5bcdc31b'
+    const terraFundedAddress = 'terra10mtp3kjs9jh05cp288alz35308jmr6arjfr43r'
+
+    it('uses chainPublicKeys[Terra] directly and returns funded address', async () => {
+      mockDeriveAddress.mockReturnValueOnce(terraFundedAddress)
+      const result = await deriveAddressFromKeys({
+        chain: Chain.Terra,
+        ecdsaPublicKey: 'root_pubkey_hex',
+        hexChainCode: 'chain_code_hex',
+        chainPublicKeys: { [Chain.Terra]: terraHardenedPubkey },
+      })
+      expect(result).toEqual({ chain: Chain.Terra, address: terraFundedAddress })
+      // getPublicKey receives the chainPublicKeys map including the Terra alias
+      expect(mockGetPublicKey).toHaveBeenCalledWith({
+        chain: Chain.Terra,
+        walletCore: mockWalletCore,
+        hexChainCode: 'chain_code_hex',
+        publicKeys: { ecdsa: 'root_pubkey_hex', eddsa: '' },
+        chainPublicKeys: {
+          [Chain.Terra]: terraHardenedPubkey,
+          [Chain.TerraClassic]: terraHardenedPubkey,
+        },
+      })
+    })
+
+    it('Terra key auto-aliases to TerraClassic', async () => {
+      mockDeriveAddress.mockReturnValueOnce(terraFundedAddress)
+      await deriveAddressFromKeys({
+        chain: Chain.TerraClassic,
+        ecdsaPublicKey: 'root_pubkey_hex',
+        hexChainCode: 'chain_code_hex',
+        chainPublicKeys: { [Chain.Terra]: terraHardenedPubkey },
+      })
+      // TerraClassic should be present in the forwarded map even though only Terra was supplied
+      expect(mockGetPublicKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chain: Chain.TerraClassic,
+          chainPublicKeys: expect.objectContaining({
+            [Chain.TerraClassic]: terraHardenedPubkey,
+          }),
+        })
+      )
+    })
+
+    it('when TerraClassic key already present, no overwrite', async () => {
+      const distinctClassicPubkey = '02aabbccdd'
+      mockDeriveAddress.mockReturnValueOnce('terra1classic')
+      await deriveAddressFromKeys({
+        chain: Chain.TerraClassic,
+        ecdsaPublicKey: 'root_pubkey_hex',
+        hexChainCode: 'chain_code_hex',
+        chainPublicKeys: {
+          [Chain.Terra]: terraHardenedPubkey,
+          [Chain.TerraClassic]: distinctClassicPubkey,
+        },
+      })
+      // Pre-supplied TerraClassic key is preserved, not overwritten by alias
+      expect(mockGetPublicKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chainPublicKeys: expect.objectContaining({
+            [Chain.TerraClassic]: distinctClassicPubkey,
+          }),
+        })
+      )
+    })
+
+    it('chainPublicKeys for unrelated chain does not affect Terra derivation (fallback)', async () => {
+      // Ethereum pubkey is present but Terra is not — Terra should fall back to BIP32
+      const ethOnlyKeys = { [Chain.Ethereum]: '02ethpubkey' }
+      mockDeriveAddress.mockReturnValueOnce('terra1nonhardened')
+      await deriveAddressFromKeys({
+        chain: Chain.Terra,
+        ecdsaPublicKey: 'root_pubkey_hex',
+        hexChainCode: 'chain_code_hex',
+        chainPublicKeys: ethOnlyKeys,
+      })
+      // The map is forwarded as-is (getPublicKey will throw "Chain public key not found"
+      // because chainPublicKeys is non-empty but has no Terra entry — that's intentional
+      // and matches getPublicKey's contract; callers must either supply the right chain
+      // or omit chainPublicKeys entirely)
+      expect(mockGetPublicKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chain: Chain.Terra,
+          chainPublicKeys: ethOnlyKeys,
+        })
+      )
+    })
+
+    it('omitting chainPublicKeys passes undefined to getPublicKey (no regression)', async () => {
+      await deriveAddressFromKeys({
+        chain: Chain.Ethereum,
+        ecdsaPublicKey: '02hex',
+        hexChainCode: 'cafe',
+      })
+      expect(mockGetPublicKey).toHaveBeenCalledWith(
+        expect.objectContaining({ chainPublicKeys: undefined })
+      )
     })
   })
 })

--- a/packages/sdk/tests/unit/tools/address/deriveAddressFromKeys.test.ts
+++ b/packages/sdk/tests/unit/tools/address/deriveAddressFromKeys.test.ts
@@ -1,155 +1,163 @@
-import { Chain } from '@vultisig/core-chain/Chain'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Chain } from "@vultisig/core-chain/Chain";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockGetWalletCore, mockGetPublicKey, mockDeriveAddress } = vi.hoisted(() => ({
-  mockGetWalletCore: vi.fn(),
-  mockGetPublicKey: vi.fn(),
-  mockDeriveAddress: vi.fn(),
-}))
+const { mockGetWalletCore, mockGetPublicKey, mockDeriveAddress } = vi.hoisted(
+  () => ({
+    mockGetWalletCore: vi.fn(),
+    mockGetPublicKey: vi.fn(),
+    mockDeriveAddress: vi.fn(),
+  }),
+);
 
-vi.mock('@/context/wasmRuntime', () => ({
+vi.mock("@/context/wasmRuntime", () => ({
   getWalletCore: mockGetWalletCore,
-}))
-vi.mock('@vultisig/core-chain/publicKey/getPublicKey', () => ({
+}));
+vi.mock("@vultisig/core-chain/publicKey/getPublicKey", () => ({
   getPublicKey: mockGetPublicKey,
-}))
-vi.mock('@vultisig/core-chain/publicKey/address/deriveAddress', () => ({
+}));
+vi.mock("@vultisig/core-chain/publicKey/address/deriveAddress", () => ({
   deriveAddress: mockDeriveAddress,
-}))
+}));
 
-import { deriveAddressFromKeys } from '@/tools/address/deriveAddressFromKeys'
+import { deriveAddressFromKeys } from "@/tools/address/deriveAddressFromKeys";
 
-const mockWalletCore = { __mock: 'walletCore' }
-const mockPublicKey = { __mock: 'publicKey' }
+const mockWalletCore = { __mock: "walletCore" };
+const mockPublicKey = { __mock: "publicKey" };
 
-describe('deriveAddressFromKeys', () => {
+describe("deriveAddressFromKeys", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-    mockGetWalletCore.mockResolvedValue(mockWalletCore)
-    mockGetPublicKey.mockReturnValue(mockPublicKey)
-    mockDeriveAddress.mockReturnValue('0xabc123')
-  })
+    vi.clearAllMocks();
+    mockGetWalletCore.mockResolvedValue(mockWalletCore);
+    mockGetPublicKey.mockReturnValue(mockPublicKey);
+    mockDeriveAddress.mockReturnValue("0xabc123");
+  });
 
-  it('throws when neither ecdsa nor eddsa key', async () => {
+  it("throws when neither ecdsa nor eddsa key", async () => {
     await expect(
       deriveAddressFromKeys({
         chain: Chain.Ethereum,
-        hexChainCode: '00',
-      })
-    ).rejects.toThrow('At least one public key (ecdsaPublicKey or eddsaPublicKey) is required')
-  })
+        hexChainCode: "00",
+      }),
+    ).rejects.toThrow(
+      "At least one public key (ecdsaPublicKey or eddsaPublicKey) is required",
+    );
+  });
 
-  it('throws when hexChainCode empty', async () => {
+  it("throws when hexChainCode empty", async () => {
     await expect(
       deriveAddressFromKeys({
         chain: Chain.Ethereum,
-        ecdsaPublicKey: '02hex',
-        hexChainCode: '',
-      })
-    ).rejects.toThrow('hexChainCode is required for address derivation')
-  })
+        ecdsaPublicKey: "02hex",
+        hexChainCode: "",
+      }),
+    ).rejects.toThrow("hexChainCode is required for address derivation");
+  });
 
-  it('when getWalletCore rejects, error message mentions WalletCore init', async () => {
-    mockGetWalletCore.mockRejectedValueOnce(new Error('bootstrap failed'))
+  it("when getWalletCore rejects, error message mentions WalletCore init", async () => {
+    mockGetWalletCore.mockRejectedValueOnce(new Error("bootstrap failed"));
     await expect(
       deriveAddressFromKeys({
         chain: Chain.Ethereum,
-        ecdsaPublicKey: '02hex',
-        hexChainCode: 'cafe',
-      })
-    ).rejects.toThrow(/Failed to initialize WalletCore for address derivation/)
-  })
+        ecdsaPublicKey: "02hex",
+        hexChainCode: "cafe",
+      }),
+    ).rejects.toThrow(/Failed to initialize WalletCore for address derivation/);
+  });
 
-  it('when getPublicKey throws, error mentions chain name', async () => {
+  it("when getPublicKey throws, error mentions chain name", async () => {
     mockGetPublicKey.mockImplementationOnce(() => {
-      throw new Error('key derivation error')
-    })
+      throw new Error("key derivation error");
+    });
     await expect(
       deriveAddressFromKeys({
         chain: Chain.Solana,
-        ecdsaPublicKey: '02hex',
-        hexChainCode: 'cafe',
-      })
-    ).rejects.toThrow(/Failed to derive public key for Solana:/)
-  })
+        ecdsaPublicKey: "02hex",
+        hexChainCode: "cafe",
+      }),
+    ).rejects.toThrow(/Failed to derive public key for Solana:/);
+  });
 
-  it('when deriveAddress throws, error mentions chain', async () => {
+  it("when deriveAddress throws, error mentions chain", async () => {
     mockDeriveAddress.mockImplementationOnce(() => {
-      throw new Error('address derivation error')
-    })
+      throw new Error("address derivation error");
+    });
     await expect(
       deriveAddressFromKeys({
         chain: Chain.Bitcoin,
-        ecdsaPublicKey: '02hex',
-        hexChainCode: 'cafe',
-      })
-    ).rejects.toThrow(/Failed to derive address for Bitcoin:/)
-  })
+        ecdsaPublicKey: "02hex",
+        hexChainCode: "cafe",
+      }),
+    ).rejects.toThrow(/Failed to derive address for Bitcoin:/);
+  });
 
-  it('returns chain and address on success (no chainPublicKeys — fallback path unchanged)', async () => {
-    const address = 'bc1qdummy'
-    mockDeriveAddress.mockReturnValueOnce(address)
+  it("returns chain and address on success (no chainPublicKeys — fallback path unchanged)", async () => {
+    const address = "bc1qdummy";
+    mockDeriveAddress.mockReturnValueOnce(address);
     const result = await deriveAddressFromKeys({
       chain: Chain.Bitcoin,
-      ecdsaPublicKey: '02hex',
-      hexChainCode: 'cafe',
-    })
-    expect(result).toEqual({ chain: Chain.Bitcoin, address })
-    expect(mockGetWalletCore).toHaveBeenCalledTimes(1)
+      ecdsaPublicKey: "02hex",
+      hexChainCode: "cafe",
+    });
+    expect(result).toEqual({ chain: Chain.Bitcoin, address });
+    expect(mockGetWalletCore).toHaveBeenCalledTimes(1);
     expect(mockGetPublicKey).toHaveBeenCalledWith({
       chain: Chain.Bitcoin,
       walletCore: mockWalletCore,
-      hexChainCode: 'cafe',
+      hexChainCode: "cafe",
       publicKeys: {
-        ecdsa: '02hex',
-        eddsa: '',
+        ecdsa: "02hex",
+        eddsa: "",
       },
       chainPublicKeys: undefined,
-    })
+    });
     expect(mockDeriveAddress).toHaveBeenCalledWith({
       chain: Chain.Bitcoin,
       publicKey: mockPublicKey,
       walletCore: mockWalletCore,
-    })
-  })
+    });
+  });
 
-  describe('chainPublicKeys — pre-derived hardened pubkey path', () => {
+  describe("chainPublicKeys — pre-derived hardened pubkey path", () => {
     // Fixture: known Terra hardened-derived pubkey from test seed
     // seed: "quick assist swamp smoke unknown grit cattle choose fabric crawl announce charge"
     // path: m/44'/330'/0'/0/0
-    const terraHardenedPubkey = '03c7721fa4760e081f7ae3b192084467528603ebdf84ebf3d86addc86d5bcdc31b'
-    const terraFundedAddress = 'terra10mtp3kjs9jh05cp288alz35308jmr6arjfr43r'
+    const terraHardenedPubkey =
+      "03c7721fa4760e081f7ae3b192084467528603ebdf84ebf3d86addc86d5bcdc31b";
+    const terraFundedAddress = "terra10mtp3kjs9jh05cp288alz35308jmr6arjfr43r";
 
-    it('uses chainPublicKeys[Terra] directly and returns funded address', async () => {
-      mockDeriveAddress.mockReturnValueOnce(terraFundedAddress)
+    it("uses chainPublicKeys[Terra] directly and returns funded address", async () => {
+      mockDeriveAddress.mockReturnValueOnce(terraFundedAddress);
       const result = await deriveAddressFromKeys({
         chain: Chain.Terra,
-        ecdsaPublicKey: 'root_pubkey_hex',
-        hexChainCode: 'chain_code_hex',
+        ecdsaPublicKey: "root_pubkey_hex",
+        hexChainCode: "chain_code_hex",
         chainPublicKeys: { [Chain.Terra]: terraHardenedPubkey },
-      })
-      expect(result).toEqual({ chain: Chain.Terra, address: terraFundedAddress })
+      });
+      expect(result).toEqual({
+        chain: Chain.Terra,
+        address: terraFundedAddress,
+      });
       // getPublicKey receives the chainPublicKeys map including the Terra alias
       expect(mockGetPublicKey).toHaveBeenCalledWith({
         chain: Chain.Terra,
         walletCore: mockWalletCore,
-        hexChainCode: 'chain_code_hex',
-        publicKeys: { ecdsa: 'root_pubkey_hex', eddsa: '' },
+        hexChainCode: "chain_code_hex",
+        publicKeys: { ecdsa: "root_pubkey_hex", eddsa: "" },
         chainPublicKeys: {
           [Chain.Terra]: terraHardenedPubkey,
           [Chain.TerraClassic]: terraHardenedPubkey,
         },
-      })
-    })
+      });
+    });
 
-    it('Terra key auto-aliases to TerraClassic', async () => {
-      mockDeriveAddress.mockReturnValueOnce(terraFundedAddress)
+    it("Terra key auto-aliases to TerraClassic", async () => {
+      mockDeriveAddress.mockReturnValueOnce(terraFundedAddress);
       await deriveAddressFromKeys({
         chain: Chain.TerraClassic,
-        ecdsaPublicKey: 'root_pubkey_hex',
-        hexChainCode: 'chain_code_hex',
+        ecdsaPublicKey: "root_pubkey_hex",
+        hexChainCode: "chain_code_hex",
         chainPublicKeys: { [Chain.Terra]: terraHardenedPubkey },
-      })
+      });
       // TerraClassic should be present in the forwarded map even though only Terra was supplied
       expect(mockGetPublicKey).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -157,107 +165,145 @@ describe('deriveAddressFromKeys', () => {
           chainPublicKeys: expect.objectContaining({
             [Chain.TerraClassic]: terraHardenedPubkey,
           }),
-        })
-      )
-    })
+        }),
+      );
+    });
 
-    it('when TerraClassic key already present, no overwrite', async () => {
-      const distinctClassicPubkey = '02aabbccdd'
-      mockDeriveAddress.mockReturnValueOnce('terra1classic')
+    it("when TerraClassic key already present, no overwrite", async () => {
+      const distinctClassicPubkey = "02aabbccdd";
+      mockDeriveAddress.mockReturnValueOnce("terra1classic");
       await deriveAddressFromKeys({
         chain: Chain.TerraClassic,
-        ecdsaPublicKey: 'root_pubkey_hex',
-        hexChainCode: 'chain_code_hex',
+        ecdsaPublicKey: "root_pubkey_hex",
+        hexChainCode: "chain_code_hex",
         chainPublicKeys: {
           [Chain.Terra]: terraHardenedPubkey,
           [Chain.TerraClassic]: distinctClassicPubkey,
         },
-      })
+      });
       // Pre-supplied TerraClassic key is preserved, not overwritten by alias
       expect(mockGetPublicKey).toHaveBeenCalledWith(
         expect.objectContaining({
           chainPublicKeys: expect.objectContaining({
             [Chain.TerraClassic]: distinctClassicPubkey,
           }),
-        })
-      )
-    })
+        }),
+      );
+    });
 
-    it('chainPublicKeys for unrelated chain: map is NOT forwarded so BIP32 fallback runs', async () => {
+    it("chainPublicKeys for unrelated chain: map is NOT forwarded so BIP32 fallback runs", async () => {
       // Ethereum pubkey is present but Terra is not — Terra should fall back to BIP32 derivation.
       // We must not forward the partial map to getPublicKey because it would throw
       // "Chain public key not found" (it treats any non-empty map as authoritative).
-      const ethOnlyKeys = { [Chain.Ethereum]: '02ethpubkey' }
-      mockDeriveAddress.mockReturnValueOnce('terra1nonhardened')
+      const ethOnlyKeys = { [Chain.Ethereum]: "02ethpubkey" };
+      mockDeriveAddress.mockReturnValueOnce("terra1nonhardened");
       await deriveAddressFromKeys({
         chain: Chain.Terra,
-        ecdsaPublicKey: 'root_pubkey_hex',
-        hexChainCode: 'chain_code_hex',
+        ecdsaPublicKey: "root_pubkey_hex",
+        hexChainCode: "chain_code_hex",
         chainPublicKeys: ethOnlyKeys,
-      })
+      });
       // chainPublicKeys must be undefined so the non-hardened BIP32 fallback runs
       expect(mockGetPublicKey).toHaveBeenCalledWith(
         expect.objectContaining({
           chain: Chain.Terra,
           chainPublicKeys: undefined,
-        })
-      )
-    })
+        }),
+      );
+    });
 
-    it('TerraClassic key reverse-aliases to Terra', async () => {
+    it("TerraClassic key reverse-aliases to Terra", async () => {
       // Caller supplies TerraClassic but queries Terra — reverse alias must kick in
-      mockDeriveAddress.mockReturnValueOnce(terraFundedAddress)
+      mockDeriveAddress.mockReturnValueOnce(terraFundedAddress);
       await deriveAddressFromKeys({
         chain: Chain.Terra,
-        ecdsaPublicKey: 'root_pubkey_hex',
-        hexChainCode: 'chain_code_hex',
+        ecdsaPublicKey: "root_pubkey_hex",
+        hexChainCode: "chain_code_hex",
         chainPublicKeys: { [Chain.TerraClassic]: terraHardenedPubkey },
-      })
+      });
       expect(mockGetPublicKey).toHaveBeenCalledWith(
         expect.objectContaining({
           chain: Chain.Terra,
           chainPublicKeys: expect.objectContaining({
             [Chain.Terra]: terraHardenedPubkey,
           }),
-        })
-      )
-    })
+        }),
+      );
+    });
 
-    it('omitting chainPublicKeys passes undefined to getPublicKey (no regression)', async () => {
+    it("omitting chainPublicKeys passes undefined to getPublicKey (no regression)", async () => {
       await deriveAddressFromKeys({
         chain: Chain.Ethereum,
-        ecdsaPublicKey: '02hex',
-        hexChainCode: 'cafe',
-      })
-      expect(mockGetPublicKey).toHaveBeenCalledWith(expect.objectContaining({ chainPublicKeys: undefined }))
-    })
+        ecdsaPublicKey: "02hex",
+        hexChainCode: "cafe",
+      });
+      expect(mockGetPublicKey).toHaveBeenCalledWith(
+        expect.objectContaining({ chainPublicKeys: undefined }),
+      );
+    });
 
-    it('explicit empty chainPublicKeys entry throws instead of silently falling back', async () => {
+    it("explicit empty chainPublicKeys entry throws instead of silently falling back", async () => {
       // Regression guard: an empty string is a caller error, not a "key absent" signal.
       // Before the fix, `if (!aliased[input.chain])` treated '' as falsy and fell back
       // to non-hardened BIP32 derivation, returning the wrong address silently.
       await expect(
         deriveAddressFromKeys({
           chain: Chain.Terra,
-          ecdsaPublicKey: 'root_pubkey_hex',
-          hexChainCode: 'chain_code_hex',
-          chainPublicKeys: { [Chain.Terra]: '' },
-        })
-      ).rejects.toThrow(/Invalid chainPublicKeys entry for Terra: pubkey must be non-empty/)
+          ecdsaPublicKey: "root_pubkey_hex",
+          hexChainCode: "chain_code_hex",
+          chainPublicKeys: { [Chain.Terra]: "" },
+        }),
+      ).rejects.toThrow(
+        /Invalid chainPublicKeys entry for Terra: pubkey must be non-empty/,
+      );
       // getPublicKey must NOT have been called — we should have thrown before reaching it
-      expect(mockGetPublicKey).not.toHaveBeenCalled()
-    })
+      expect(mockGetPublicKey).not.toHaveBeenCalled();
+    });
 
-    it('whitespace-only chainPublicKeys entry also throws', async () => {
+    it("whitespace-only chainPublicKeys entry also throws", async () => {
       await expect(
         deriveAddressFromKeys({
           chain: Chain.Terra,
-          ecdsaPublicKey: 'root_pubkey_hex',
-          hexChainCode: 'chain_code_hex',
-          chainPublicKeys: { [Chain.Terra]: '   ' },
-        })
-      ).rejects.toThrow(/Invalid chainPublicKeys entry for Terra: pubkey must be non-empty/)
-      expect(mockGetPublicKey).not.toHaveBeenCalled()
-    })
-  })
-})
+          ecdsaPublicKey: "root_pubkey_hex",
+          hexChainCode: "chain_code_hex",
+          chainPublicKeys: { [Chain.Terra]: "   " },
+        }),
+      ).rejects.toThrow(
+        /Invalid chainPublicKeys entry for Terra: pubkey must be non-empty/,
+      );
+      expect(mockGetPublicKey).not.toHaveBeenCalled();
+    });
+
+    it("empty Terra key throws when deriving TerraClassic (alias-source presence check)", async () => {
+      // Regression: before the fix, { Terra: "" } while requesting TerraClassic
+      // bypassed the empty-value guard because the truthy alias check skipped
+      // alias expansion, leaving TerraClassic absent, so the code returned
+      // undefined and BIP32 fallback ran silently.
+      await expect(
+        deriveAddressFromKeys({
+          chain: Chain.TerraClassic,
+          ecdsaPublicKey: "root_pubkey_hex",
+          hexChainCode: "chain_code_hex",
+          chainPublicKeys: { [Chain.Terra]: "" },
+        }),
+      ).rejects.toThrow(
+        /Invalid chainPublicKeys entry for Terra: pubkey must be non-empty/,
+      );
+      expect(mockGetPublicKey).not.toHaveBeenCalled();
+    });
+
+    it("empty TerraClassic key throws when deriving Terra (reverse alias-source presence check)", async () => {
+      await expect(
+        deriveAddressFromKeys({
+          chain: Chain.Terra,
+          ecdsaPublicKey: "root_pubkey_hex",
+          hexChainCode: "chain_code_hex",
+          chainPublicKeys: { [Chain.TerraClassic]: "" },
+        }),
+      ).rejects.toThrow(
+        /Invalid chainPublicKeys entry for TerraClassic: pubkey must be non-empty/,
+      );
+      expect(mockGetPublicKey).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`deriveAddressFromKeys` now accepts an optional `chainPublicKeys` map. When a
chain entry is present, that pubkey is passed straight to `getPublicKey`,
bypassing the non-hardened BIP32 re-walk that produces the wrong terra1 address
for MPC/agent callers (root pubkey + chain code only → strips apostrophes → different
key).

- Bidirectional Terra ↔ TerraClassic alias applied automatically (both chains
  share BIP44 coin_type 330 and the same hardened-derived pubkey).
- When `chainPublicKeys` is absent, or when the map does not contain an entry
  for the requested chain, the existing non-hardened BIP32 fallback runs
  unchanged — no breaking change for existing callers.
- Partial maps (e.g. `{ Ethereum: '...' }` while deriving Terra) now correctly
  fall back to BIP32 instead of erroring.

Fixes Layer 1 of the Terra/LUNC derivation mismatch.
See spike: `.spikes/luna-derivation-mismatch-2026-05-12.md`

Closes vultisig/vultiagent-app#552

## What changed

`packages/sdk/src/tools/address/deriveAddressFromKeys.ts`
- Added `chainPublicKeys?: Partial<Record<Chain, string>>` to `DeriveAddressFromKeysInput`
- Terra ↔ TerraClassic bidirectional alias expansion before forwarding to `getPublicKey`
- Filter: only forward the map when the requested chain (after alias) is present; otherwise passes `undefined` so the non-hardened BIP32 fallback runs

`packages/sdk/tests/unit/tools/address/deriveAddressFromKeys.test.ts`
- 7 new test cases: Terra hardened pubkey passthrough, Terra→TerraClassic alias, TerraClassic→Terra reverse alias, partial-map BIP32 fallback, no-regression for existing callers

## Test transcript

```
Test Files  100 passed (100)
Tests       1365 passed (1365)
Duration    6.23s
```

All 12 address-specific tests pass including 6 new chainPublicKeys cases.

🤖 Agent-generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Address derivation accepts an optional map of pre-derived chain-specific public keys.
  * Terra ↔ TerraClassic auto-aliasing so one provided key can populate the other.

* **Bug Fixes**
  * Empty or whitespace public-key entries now raise an error instead of silently falling back.
  * Only relevant chain entries are forwarded; unrelated entries no longer alter fallback behavior.

* **Backward Compatibility**
  * Omitting the new parameter preserves prior derivation behavior.

* **Tests**
  * Unit tests expanded to cover aliasing, forwarding, and failure cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/463?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->