### PR TITLE
feat(qbtc): add broadcaster field to MsgClaimWithProof

### DIFF
--- a/.changeset/qbtc-claim-broadcaster.md
+++ b/.changeset/qbtc-claim-broadcaster.md
@@ -1,5 +1,7 @@
 ---
-'@vultisig/core-chain': minor
+'@vultisig/core-chain': major
 ---
 
-qbtc: add required `broadcaster` field to `BuildMsgClaimWithProofInput` (proto field 9). Mirrors the chain-side signer rework in btcq-org/qbtc#171 — `claimer` is now payload-only (mint destination), while `broadcaster` is the cosmos tx signer. Callers must populate `broadcaster` (typically equal to `claimer` for wallet flows where the user's own MLDSA key signs the tx).
+qbtc: add required `broadcaster` field to `BuildMsgClaimWithProofInput` (proto field 9). Mirrors the chain-side signer rework in btcq-org/qbtc#171 - `claimer` is now payload-only (mint destination), while `broadcaster` is the cosmos tx signer. Callers must populate `broadcaster` (typically equal to `claimer` for wallet flows where the user's own MLDSA key signs the tx).
+
+BREAKING CHANGE: `BuildMsgClaimWithProofInput` now requires a new `broadcaster: string` field. Existing callers will fail at TypeScript compile-time (or runtime if TS is bypassed) until updated. For wallet flows pass `broadcaster === claimer`.

--- a/.changeset/qbtc-claim-broadcaster.md
+++ b/.changeset/qbtc-claim-broadcaster.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/core-chain': minor
+---
+
+qbtc: add required `broadcaster` field to `BuildMsgClaimWithProofInput` (proto field 9). Mirrors the chain-side signer rework in btcq-org/qbtc#171 — `claimer` is now payload-only (mint destination), while `broadcaster` is the cosmos tx signer. Callers must populate `broadcaster` (typically equal to `claimer` for wallet flows where the user's own MLDSA key signs the tx).

--- a/packages/core/chain/chains/cosmos/qbtc/claim/buildClaimTx.test.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/buildClaimTx.test.ts
@@ -10,6 +10,7 @@ const validInput = {
   addressHash: 'cc'.repeat(20),
   qbtcAddressHash: 'dd'.repeat(32),
   pubKeyHashSha256: 'ee'.repeat(32),
+  broadcaster: 'qbtc1abc',
 }
 
 describe('validateClaimInput', () => {
@@ -99,6 +100,18 @@ describe('validateClaimInput', () => {
       validateClaimInput({ ...validInput, pubKeyHashSha256: 'aa'.repeat(16) })
     ).toThrow('pub_key_hash_sha256 must be 64 hex chars')
   })
+
+  it('rejects empty broadcaster', () => {
+    expect(() =>
+      validateClaimInput({ ...validInput, broadcaster: '' })
+    ).toThrow('broadcaster is required')
+  })
+
+  it('rejects empty claimer', () => {
+    expect(() => validateClaimInput({ ...validInput, claimer: '' })).toThrow(
+      'claimer is required'
+    )
+  })
 })
 
 describe('buildClaimTxBody', () => {
@@ -118,5 +131,14 @@ describe('buildClaimTxBody', () => {
     }
     const result = buildClaimTxBody(input)
     expect(result.length).toBeGreaterThan(0)
+  })
+
+  it('encodes broadcaster as proto field 9', () => {
+    const result = buildClaimTxBody({
+      ...validInput,
+      broadcaster: 'qbtc1broadcaster',
+    })
+    // Proto field 9 with wire type 2 (length-delimited) → tag byte 0x4a
+    expect(Array.from(result)).toContain(0x4a)
   })
 })

--- a/packages/core/chain/chains/cosmos/qbtc/claim/buildClaimTx.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/buildClaimTx.ts
@@ -13,7 +13,10 @@ type UtxoRef = {
 }
 
 type BuildMsgClaimWithProofInput = {
-  /** QBTC bech32 address of the claimer. */
+  /**
+   * QBTC bech32 address of the claimer (mint destination). Payload-only —
+   * no longer the cosmos signer since btcq-org/qbtc#171.
+   */
   claimer: string
   /** UTXOs to include in the claim (1-50, no duplicates). */
   utxos: UtxoRef[]
@@ -32,6 +35,13 @@ type BuildMsgClaimWithProofInput = {
    * Returned by the proof service as `pub_key_hash_sha256`.
    */
   pubKeyHashSha256: string
+  /**
+   * QBTC bech32 address of the cosmos tx signer (broadcaster). Required
+   * since btcq-org/qbtc#171 — the address derived from
+   * `signer_infos[0].pub_key` must equal this value. For wallet flows where
+   * the user signs the cosmos tx themselves, set `broadcaster === claimer`.
+   */
+  broadcaster: string
 }
 
 const isHex = (value: string) => /^[0-9a-f]+$/i.test(value)
@@ -47,13 +57,22 @@ const assertHex = (value: string, name: string, expectedLength: number) => {
 /** Validates the claim input against the chain's constraints (Section 5). */
 export const validateClaimInput = (input: BuildMsgClaimWithProofInput) => {
   const {
+    claimer,
     utxos,
     proof,
     messageHash,
     addressHash,
     qbtcAddressHash,
     pubKeyHashSha256,
+    broadcaster,
   } = input
+
+  if (claimer.length === 0) {
+    throw new Error('claimer is required')
+  }
+  if (broadcaster.length === 0) {
+    throw new Error('broadcaster is required')
+  }
 
   if (utxos.length === 0 || utxos.length > 50) {
     throw new Error(`UTXOs count must be 1-50, got ${utxos.length}`)
@@ -103,7 +122,8 @@ const buildMsgClaimWithProof = (
     protoString(4, input.messageHash),
     protoString(5, input.addressHash),
     protoString(6, input.qbtcAddressHash),
-    protoString(7, input.pubKeyHashSha256)
+    protoString(7, input.pubKeyHashSha256),
+    protoString(9, input.broadcaster)
   )
 }
 


### PR DESCRIPTION
## Summary

- Adds required `broadcaster: string` to `BuildMsgClaimWithProofInput` and encodes it as proto field 9 in the manual QBTC claim builder.
- Validates `broadcaster` and `claimer` are non-empty before encoding.
- Adds tests for the new field and a changeset (`@vultisig/core-chain` minor bump).

Mirrors the chain-side signer rework in [btcq-org/qbtc#171](https://github.com/btcq-org/qbtc/pull/171) (fix for [#170](https://github.com/btcq-org/qbtc/issues/170)). The cosmos signer for `MsgClaimWithProof` moved from `claimer` to a dedicated `broadcaster` field — `claimer` is now payload-only (mint destination). Without this change, every claim tx we build is rejected by the new `ValidateBasic`.

This is also a prerequisite for the first-time-claimer fix ([btcq-org/qbtc#147](https://github.com/btcq-org/qbtc/pull/147), [#142](https://github.com/btcq-org/qbtc/issues/142)): the `FreeClaimDecorator` ante handler pre-creates the signer account, but only if the tx is a single `MsgClaimWithProof` whose `broadcaster` matches the cosmos signer.

For wallet flows the caller will set `broadcaster === claimer` so the user's own MLDSA key signs the cosmos tx. The proof itself still binds BTC ownership to `claimer`, so no proof-service input change is needed.

Closes #477.

Downstream adoption (vultisig-windows): [vultisig/vultisig-windows#3939](https://github.com/vultisig/vultisig-windows/pull/3939) (windows issue [#3938](https://github.com/vultisig/vultisig-windows/issues/3938)).

## Test plan

- [x] `yarn test:core --run packages/core/chain/chains/cosmos/qbtc/claim/buildClaimTx.test.ts` — 18 passed
- [x] `yarn typecheck`
- [ ] Reviewer: confirm proto field number 9 matches `proto/qbtc/qbtc/v1/msg_claim_with_proof.proto` in btcq-org/qbtc
- [ ] Reviewer: confirm the `broadcaster` is omitted-friendly is NOT a concern (chain rejects missing/empty broadcaster, and we now throw client-side too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * The Qbtc claim protocol now requires a `broadcaster` field identifying the Cosmos transaction signer, typically equal to the claim destination in wallet flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->