### PR TITLE
test(cli): fund-safety regression suite — silent-broadcast verifier (Phase 1: ETH + SOL)

### DIFF
--- a/clients/cli/package.json
+++ b/clients/cli/package.json
@@ -21,10 +21,11 @@
     "cli:interactive": "npx tsx src/index.ts --interactive",
     "repl": "npx tsx src/index.ts --interactive",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run --exclude 'tests/e2e/**'",
-    "test:watch": "vitest --exclude 'tests/e2e/**'",
+    "test": "vitest run --exclude 'tests/e2e/**' --exclude 'tests/fund-safety/**'",
+    "test:watch": "vitest --exclude 'tests/e2e/**' --exclude 'tests/fund-safety/**'",
     "test:e2e": "vitest run tests/e2e/",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "test:fund-safety": "FUND_SAFETY_E2E=1 vitest run tests/fund-safety/"
   },
   "keywords": [
     "vultisig",

--- a/clients/cli/tests/fund-safety/.gitignore
+++ b/clients/cli/tests/fund-safety/.gitignore
@@ -1,0 +1,1 @@
+last-run/

--- a/clients/cli/tests/fund-safety/README.md
+++ b/clients/cli/tests/fund-safety/README.md
@@ -1,0 +1,93 @@
+# Fund-safety regression suite
+
+Scripted, opt-in, real-mainnet broadcast verification for sdk-cli's
+sign + broadcast layer. Catches the **silent-broadcast bug class** —
+where the pipeline returns a "success" hash for a tx that never landed
+on-chain (canonical example: vultisig-sdk #458, Ripple `temREDUNDANT`).
+
+## Why sdk-cli
+
+It's the only client positioned for scripted broadcast-with-verification:
+vultiagent has emulator E2E (hard to script), agent-backend has unit
+tests (no signing), mcp has unit tests on tool emissions (no broadcast).
+sdk-cli has signing keys, can script broadcast, and can verify on-chain.
+The agent-backend validator pipeline (#527) runs at the tool-call
+boundary — it structurally cannot see sdk-cli's downstream
+sign+broadcast layer, which is exactly where #458 lived.
+
+## How it works
+
+For each `(chain, scenario)`:
+
+1. Drive `vsig agent ask "send X to <self>"` against a REAL funded vault.
+2. Capture the broadcast id sdk-cli reports (EVM tx hash / SOL signature).
+3. Independently verify via a **public RPC that is NOT sdk-cli's
+   broadcast downstream** — so a proxy that silently swallows a
+   malformed tx and reports success can't also fake the verification.
+4. Assert: the id exists on-chain AND from/to/value/chainId match intent.
+5. `hash returned but RPC says not-found` ⇒ **SILENT BROADCAST BUG**.
+
+## Safety
+
+- **Opt-in only.** Every test is gated on `FUND_SAFETY_E2E=1`. With it
+  unset, the suite performs **zero broadcasts** (`describe.skipIf`).
+  Defense-in-depth: the default `yarn test` also `--exclude`s
+  `tests/fund-safety/**` at collection time.
+- **Self-send only.** Tests send to the vault's own address. Never a
+  placeholder / burn address.
+- **Tiny amounts.** 0.0001 ETH (~$0.30 gas) / 0.0001 SOL (+fees).
+
+## Running
+
+```bash
+cd clients/cli
+yarn build               # dist/index.js must be current
+
+# Dry run — assertions only, zero broadcasts. Expect: N skipped.
+yarn vitest run tests/fund-safety/
+
+# Full run — REAL mainnet broadcasts, ~$0.50–$1 total across chains.
+yarn test:fund-safety
+```
+
+### Required setup before a full run
+
+The vault must be configured in the CLI keyring (`vsig auth setup`) and
+hold tiny mainnet balances:
+
+| env var | default | purpose |
+|---|---|---|
+| `FUND_SAFETY_E2E` | _(unset)_ | `1` to enable broadcasts. Without it: skip. |
+| `FUND_SAFETY_VAULT` | `Vultisig Cluster #1` | keyring vault name |
+| `FUND_SAFETY_PASSWORD` | `password` | vault password |
+| `FUND_SAFETY_ETH_ADDR` | `0x58C4…5C35` | ETH self-send recipient (vault's own) |
+| `FUND_SAFETY_SOL_ADDR` | _(unset — required for SOL)_ | vault's Solana address. SOL test fails fast without it (hardened derivation — no guessing). |
+| `FUND_SAFETY_BACKEND_URL` | _(prod abe.vultisig.com)_ | override agent-backend |
+
+### Cost per full run
+
+ETH ≈ $0.30 gas. SOL ≈ 0.0001 SOL + ~5000 lamports fee. Phase 1 total
+well under $1. (Actual measured numbers tracked in the task file.)
+
+### When to run
+
+- Before each sdk-cli release.
+- After any change to the sign / broadcast path
+  (`packages/sdk/src/tools/prep/`, chain broadcast helpers, the agent
+  executor's tx dispatch).
+
+## Verifiers
+
+Independent ground-truth endpoints (intentionally different from
+sdk-cli's broadcast path):
+
+| Chain | Endpoint | Method |
+|---|---|---|
+| Ethereum | `ethereum-rpc.publicnode.com` | `eth_getTransactionByHash` |
+| Solana | `api.mainnet-beta.solana.com` | `getTransaction` (finalized) |
+
+## Artifacts
+
+Each run writes a forensic JSON to `last-run/<test>.json` (broadcast
+capture, on-chain result, expected values). Inspect post-run when a
+test fails or surprises. Not committed (gitignored).

--- a/clients/cli/tests/fund-safety/lib/harness.ts
+++ b/clients/cli/tests/fund-safety/lib/harness.ts
@@ -1,0 +1,243 @@
+/**
+ * Fund-safety regression harness.
+ *
+ * Drives `vsig agent ask "send …"` end-to-end against a REAL funded
+ * vault on mainnet, captures the broadcast identifier sdk-cli reports,
+ * then independently verifies it landed on-chain via a public RPC that
+ * is NOT sdk-cli's broadcast downstream. The mismatch case
+ * (hash returned, chain has no record) is the silent-broadcast bug
+ * class — see vultisig-sdk #458 (Ripple `temREDUNDANT`).
+ *
+ * SAFETY: every test that calls `captureBroadcast` MUST first guard on
+ * `shouldRunE2E()`. With `FUND_SAFETY_E2E` unset the suite performs
+ * zero broadcasts (verified by the skip-gate test).
+ */
+import { execFile } from 'node:child_process'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { verifyEthereum } from './verifiers/ethereum'
+import { verifySolana } from './verifiers/solana'
+import type { OnChainResult, VerifyOptions } from './verifiers/types'
+
+export type Chain = 'ethereum' | 'solana'
+
+const CLI = resolve(__dirname, '../../../dist/index.js')
+const LAST_RUN_DIR = resolve(__dirname, '../last-run')
+
+/**
+ * The single safety gate. NOTHING in this suite may broadcast unless
+ * this returns true. Tests call it in a `describe.skipIf`/early-return.
+ */
+export function shouldRunE2E(): boolean {
+  return process.env.FUND_SAFETY_E2E === '1' || process.env.FUND_SAFETY_E2E === 'true'
+}
+
+/** Vault + password the harness drives. Canonical test wallet by default. */
+export function vaultConfig(): { vault: string; password: string; backendUrl?: string } {
+  return {
+    // `Vultisig Cluster #1` → 0x58C4a1F319297EC9c398A0F3a3b64AF5a18b5C35
+    vault: process.env.FUND_SAFETY_VAULT ?? 'Vultisig Cluster #1',
+    password: process.env.FUND_SAFETY_PASSWORD ?? 'password',
+    // Defaults to prod abe.vultisig.com inside the CLI when unset. The
+    // suite deliberately exercises the real signing+broadcast path.
+    backendUrl: process.env.FUND_SAFETY_BACKEND_URL,
+  }
+}
+
+type ExecResult = { stdout: string; stderr: string; code: number }
+
+function runVsig(args: string[], timeoutMs: number): Promise<ExecResult> {
+  return new Promise(res => {
+    execFile('node', [CLI, ...args], { timeout: timeoutMs, maxBuffer: 16 * 1024 * 1024 }, (err, stdout, stderr) => {
+      res({ stdout, stderr, code: (err as { code?: number } | null)?.code ?? 0 })
+    })
+  })
+}
+
+/**
+ * Extract the structured JSON object from CLI stdout. The signing flow
+ * may emit log lines before the JSON; the agent-ask JSON envelope is
+ * the last top-level `{ … }` block (mirrors tests/e2e/cli-commands).
+ */
+function parseAgentJson(result: ExecResult): {
+  session_id?: string
+  response?: string
+  tool_calls?: Array<{ action: string; success: boolean; data?: Record<string, unknown>; error?: string }>
+  transactions?: Array<{ hash: string; chain: string; explorerUrl?: string }>
+} | null {
+  const text = result.stdout.trim()
+  if (!text) return null
+  // outputJson wraps in { success, v, data }. Find the last balanced
+  // top-level object.
+  const lastBrace = text.lastIndexOf('\n{')
+  const candidate = lastBrace >= 0 ? text.slice(lastBrace + 1) : text
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(candidate)
+  } catch {
+    try {
+      parsed = JSON.parse(text)
+    } catch {
+      return null
+    }
+  }
+  const env = parsed as { success?: boolean; data?: unknown }
+  if (env && typeof env === 'object' && 'data' in env) {
+    return env.data as ReturnType<typeof parseAgentJson>
+  }
+  return parsed as ReturnType<typeof parseAgentJson>
+}
+
+export type BroadcastCapture = {
+  chain: Chain
+  /** sdk-cli-reported broadcast id: EVM tx hash / Solana signature. */
+  hash: string | null
+  /** Raw agent-ask response text (for forensics). */
+  response: string
+  /** All tool calls the agent emitted. */
+  toolCalls: Array<{ action: string; success: boolean; data?: Record<string, unknown>; error?: string }>
+  /** All transactions sdk-cli claims it broadcast. */
+  transactions: Array<{ hash: string; chain: string; explorerUrl?: string }>
+  /** stdout + stderr, kept for the artifact. */
+  rawStdout: string
+  rawStderr: string
+  exitCode: number
+}
+
+/**
+ * Drives one `vsig agent ask` send and captures what sdk-cli claims it
+ * broadcast. Does NOT verify on-chain — that's `verifyOnChain`.
+ *
+ * Throws only on harness misuse (e.g. called without the E2E gate).
+ * A failed/empty broadcast is returned as `hash: null` so the test can
+ * assert on it rather than crashing.
+ */
+export async function captureBroadcast(chain: Chain, prompt: string, timeoutMs = 180_000): Promise<BroadcastCapture> {
+  if (!shouldRunE2E()) {
+    throw new Error('captureBroadcast called without FUND_SAFETY_E2E — skip-gate breach')
+  }
+  const cfg = vaultConfig()
+  const args = [
+    '--output',
+    'json',
+    '--non-interactive',
+    'agent',
+    'ask',
+    prompt,
+    '--vault',
+    cfg.vault,
+    '--password',
+    cfg.password,
+  ]
+  if (cfg.backendUrl) args.push('--backend-url', cfg.backendUrl)
+
+  const result = await runVsig(args, timeoutMs)
+  const json = parseAgentJson(result)
+
+  const transactions = json?.transactions ?? []
+  const onChainTx = transactions.find(t => t.chain.toLowerCase().includes(chain === 'ethereum' ? 'eth' : 'sol'))
+
+  return {
+    chain,
+    hash: onChainTx?.hash ?? transactions[0]?.hash ?? null,
+    response: json?.response ?? '',
+    toolCalls: json?.tool_calls ?? [],
+    transactions,
+    rawStdout: result.stdout,
+    rawStderr: result.stderr,
+    exitCode: result.code,
+  }
+}
+
+export async function verifyOnChain(chain: Chain, hash: string, opts?: VerifyOptions): Promise<OnChainResult> {
+  switch (chain) {
+    case 'ethereum':
+      return verifyEthereum(hash, opts)
+    case 'solana':
+      return verifySolana(hash, opts)
+    default:
+      throw new Error(`no verifier for chain ${chain as string}`)
+  }
+}
+
+export type MatchExpectation = {
+  /** Lowercase expected sender. */
+  fromAddr?: string
+  /** Lowercase expected recipient. */
+  toAddr?: string
+  /** Exact native-unit value (wei / lamports) as a decimal string. */
+  value?: string
+  /** EVM chain id. */
+  chainId?: number
+}
+
+export class SilentBroadcastError extends Error {
+  constructor(
+    message: string,
+    readonly capture: BroadcastCapture,
+    readonly onChain: OnChainResult
+  ) {
+    super(message)
+    this.name = 'SilentBroadcastError'
+  }
+}
+
+/**
+ * The core assertion. Throws `SilentBroadcastError` when sdk-cli
+ * reported a hash but the independent RPC has no landed record of it —
+ * the exact failure mode of the Ripple #458 bug. Also throws on
+ * from/to/value/chainId mismatch (the cross-chain / wrong-amount
+ * classes).
+ */
+export function assertBroadcastMatches(
+  capture: BroadcastCapture,
+  onChain: OnChainResult,
+  expected: MatchExpectation
+): void {
+  if (!capture.hash) {
+    throw new SilentBroadcastError(
+      `sdk-cli returned no broadcast hash. response="${capture.response.slice(0, 200)}"`,
+      capture,
+      onChain
+    )
+  }
+  if (!onChain.exists) {
+    throw new SilentBroadcastError(
+      `SILENT BROADCAST: sdk-cli reported hash ${capture.hash} but the independent ` +
+        `RPC has no landed record of it. This is the #458 bug class.`,
+      capture,
+      onChain
+    )
+  }
+  const mismatches: string[] = []
+  if (expected.fromAddr && onChain.fromAddr && onChain.fromAddr !== expected.fromAddr) {
+    mismatches.push(`from: on-chain=${onChain.fromAddr} expected=${expected.fromAddr}`)
+  }
+  if (expected.toAddr && onChain.toAddr && onChain.toAddr !== expected.toAddr) {
+    mismatches.push(`to: on-chain=${onChain.toAddr} expected=${expected.toAddr}`)
+  }
+  if (expected.value && onChain.value && onChain.value !== expected.value) {
+    mismatches.push(`value: on-chain=${onChain.value} expected=${expected.value}`)
+  }
+  if (expected.chainId != null && onChain.chainId != null && onChain.chainId !== expected.chainId) {
+    mismatches.push(`chainId: on-chain=${onChain.chainId} expected=${expected.chainId}`)
+  }
+  if (mismatches.length > 0) {
+    throw new SilentBroadcastError(
+      `Broadcast landed but does NOT match intent:\n  ${mismatches.join('\n  ')}`,
+      capture,
+      onChain
+    )
+  }
+}
+
+/** Forensic artifact written under last-run/ for post-mortem inspection. */
+export function writeArtifact(name: string, data: unknown): void {
+  try {
+    mkdirSync(LAST_RUN_DIR, { recursive: true })
+    writeFileSync(resolve(LAST_RUN_DIR, `${name}.json`), JSON.stringify(data, null, 2))
+  } catch {
+    // Artifact writing is best-effort; never fail a test on it.
+  }
+}

--- a/clients/cli/tests/fund-safety/lib/verifiers/ethereum.ts
+++ b/clients/cli/tests/fund-safety/lib/verifiers/ethereum.ts
@@ -1,0 +1,90 @@
+/**
+ * Ethereum on-chain verifier.
+ *
+ * Ground truth = `eth_getTransactionByHash` on a public node that is NOT
+ * the endpoint sdk-cli broadcasts through. A hash present in sdk-cli's
+ * output but absent here (or present-but-never-mined) is the
+ * silent-broadcast signature (the Ripple #458 class, EVM analogue).
+ */
+import type { OnChainResult, VerifyOptions } from './types'
+
+const ETH_RPC = 'https://ethereum-rpc.publicnode.com'
+
+type RpcTx = {
+  from?: string
+  to?: string
+  value?: string
+  blockNumber?: string | null
+  chainId?: string
+}
+
+async function rpcCall(method: string, params: unknown[]): Promise<unknown> {
+  const res = await fetch(ETH_RPC, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+  })
+  if (!res.ok) {
+    throw new Error(`eth RPC ${method} HTTP ${res.status}`)
+  }
+  const body = (await res.json()) as { result?: unknown; error?: { message: string } }
+  if (body.error) {
+    throw new Error(`eth RPC ${method} error: ${body.error.message}`)
+  }
+  return body.result
+}
+
+const hexToDec = (hex?: string | null): string | undefined => {
+  if (hex == null) return undefined
+  try {
+    return BigInt(hex).toString(10)
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Polls the public node until the tx is found AND mined (blockNumber
+ * non-null), or the timeout elapses. Returns `exists:false` if the node
+ * never returns a tx for the hash — that is the silent-broadcast tell.
+ */
+export async function verifyEthereum(hash: string, opts: VerifyOptions = {}): Promise<OnChainResult> {
+  const timeoutSec = opts.timeoutSec ?? 60
+  const intervalMs = opts.intervalMs ?? 3000
+  const deadline = Date.now() + timeoutSec * 1000
+
+  let lastTx: RpcTx | null = null
+
+  while (Date.now() < deadline) {
+    const tx = (await rpcCall('eth_getTransactionByHash', [hash])) as RpcTx | null
+    if (tx) {
+      lastTx = tx
+      // Found in mempool — wait for it to be mined before asserting,
+      // so a stuck/replaced tx doesn't read as a clean success.
+      if (tx.blockNumber != null) {
+        return {
+          exists: true,
+          fromAddr: tx.from?.toLowerCase(),
+          toAddr: tx.to?.toLowerCase(),
+          value: hexToDec(tx.value),
+          blockNumber: tx.blockNumber ? Number(BigInt(tx.blockNumber)) : undefined,
+          chainId: tx.chainId ? Number(BigInt(tx.chainId)) : undefined,
+          raw: tx,
+        }
+      }
+    }
+    await new Promise(r => setTimeout(r, intervalMs))
+  }
+
+  // Timed out. If we never saw the tx at all, this is the silent-broadcast
+  // signature: sdk-cli handed us a hash the canonical chain has no record
+  // of. If we saw it in mempool but it never mined, surface that too —
+  // still a fund-safety concern (the user thinks it's done).
+  return {
+    exists: false,
+    fromAddr: lastTx?.from?.toLowerCase(),
+    toAddr: lastTx?.to?.toLowerCase(),
+    value: hexToDec(lastTx?.value),
+    raw: lastTx ?? { note: 'tx never returned by eth_getTransactionByHash within timeout' },
+  }
+}

--- a/clients/cli/tests/fund-safety/lib/verifiers/solana.ts
+++ b/clients/cli/tests/fund-safety/lib/verifiers/solana.ts
@@ -1,0 +1,113 @@
+/**
+ * Solana on-chain verifier.
+ *
+ * Ground truth = `getTransaction` on api.mainnet-beta.solana.com (a
+ * different endpoint than sdk-cli broadcasts through). Solana identifies
+ * txs by signature (base58), not by a content hash. A signature returned
+ * by sdk-cli that `getTransaction` reports `null` for after finalization
+ * is the silent-broadcast signature on Solana.
+ *
+ * The from/to/value are extracted from the first System Program
+ * `transfer` instruction. We read pre/post balances as a cross-check on
+ * the lamport delta (instruction parsing alone can be spoofed by a
+ * malformed-but-accepted tx; the balance delta is the chain's own
+ * accounting).
+ */
+import type { OnChainResult, VerifyOptions } from './types'
+
+const SOL_RPC = 'https://api.mainnet-beta.solana.com'
+const SYSTEM_PROGRAM = '11111111111111111111111111111111'
+
+type ParsedInstruction = {
+  program?: string
+  programId?: string
+  parsed?: {
+    type?: string
+    info?: { source?: string; destination?: string; lamports?: number }
+  }
+}
+
+type GetTxResult = {
+  slot?: number
+  transaction?: {
+    message?: {
+      accountKeys?: Array<string | { pubkey: string }>
+      instructions?: ParsedInstruction[]
+    }
+  }
+  meta?: {
+    err: unknown
+    preBalances?: number[]
+    postBalances?: number[]
+  } | null
+} | null
+
+async function rpcCall(method: string, params: unknown[]): Promise<unknown> {
+  const res = await fetch(SOL_RPC, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+  })
+  if (!res.ok) {
+    throw new Error(`sol RPC ${method} HTTP ${res.status}`)
+  }
+  const body = (await res.json()) as { result?: unknown; error?: { message: string } }
+  if (body.error) {
+    throw new Error(`sol RPC ${method} error: ${body.error.message}`)
+  }
+  return body.result
+}
+
+function extractTransfer(tx: NonNullable<GetTxResult>): {
+  from?: string
+  to?: string
+  lamports?: string
+} {
+  const instrs = tx.transaction?.message?.instructions ?? []
+  for (const ix of instrs) {
+    const isSystem = ix.program === 'system' || ix.programId === SYSTEM_PROGRAM
+    if (isSystem && ix.parsed?.type === 'transfer' && ix.parsed.info) {
+      const { source, destination, lamports } = ix.parsed.info
+      return {
+        from: source?.toLowerCase(),
+        to: destination?.toLowerCase(),
+        lamports: lamports != null ? String(lamports) : undefined,
+      }
+    }
+  }
+  return {}
+}
+
+export async function verifySolana(signature: string, opts: VerifyOptions = {}): Promise<OnChainResult> {
+  const timeoutSec = opts.timeoutSec ?? 60
+  const intervalMs = opts.intervalMs ?? 3000
+  const deadline = Date.now() + timeoutSec * 1000
+
+  while (Date.now() < deadline) {
+    const tx = (await rpcCall('getTransaction', [
+      signature,
+      { encoding: 'jsonParsed', commitment: 'finalized', maxSupportedTransactionVersion: 0 },
+    ])) as GetTxResult
+
+    if (tx) {
+      // A tx that landed but failed at the runtime level still has
+      // meta.err set — that is NOT a clean broadcast, surface it.
+      const transfer = extractTransfer(tx)
+      const failed = tx.meta?.err != null
+      return {
+        exists: !failed,
+        fromAddr: transfer.from,
+        toAddr: transfer.to,
+        value: transfer.lamports,
+        blockNumber: tx.slot,
+        raw: failed ? { meta_err: tx.meta?.err, ...tx } : tx,
+      }
+    }
+    await new Promise(r => setTimeout(r, intervalMs))
+  }
+
+  return {
+    exists: false,
+    raw: { note: 'signature never returned by getTransaction(finalized) within timeout' },
+  }
+}

--- a/clients/cli/tests/fund-safety/lib/verifiers/types.ts
+++ b/clients/cli/tests/fund-safety/lib/verifiers/types.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared verifier contract. Each chain verifier resolves a broadcast
+ * identifier (EVM tx hash, Solana signature, …) against an INDEPENDENT
+ * public RPC — intentionally a different endpoint than the one sdk-cli
+ * broadcasts through, so a proxy that silently swallows a malformed tx
+ * and reports success on its own downstream can't also fake the
+ * verification.
+ */
+
+export type OnChainResult = {
+  /** True only if the chain's canonical RPC has a record of the tx. */
+  exists: boolean
+  /** Normalized lowercase sender (chain-native format). */
+  fromAddr?: string
+  /** Normalized lowercase recipient. */
+  toAddr?: string
+  /** Native-unit value as a decimal string (wei for ETH, lamports for SOL). */
+  value?: string
+  /** Block / slot the tx landed in. Absence ⇒ not yet mined / not landed. */
+  blockNumber?: number
+  /** Chain id where applicable (EVM). */
+  chainId?: number
+  /** Raw RPC payload, kept for the forensic artifact. */
+  raw?: unknown
+}
+
+export type VerifyOptions = {
+  /** Max seconds to poll before giving up (default 60). */
+  timeoutSec?: number
+  /** Poll interval in ms (default 3000). */
+  intervalMs?: number
+}

--- a/clients/cli/tests/fund-safety/silent-broadcast/eth-self-send.test.ts
+++ b/clients/cli/tests/fund-safety/silent-broadcast/eth-self-send.test.ts
@@ -1,0 +1,79 @@
+/**
+ * ETH self-send — silent-broadcast verifier (canonical happy path).
+ *
+ * Drives a real 0.0001 ETH mainnet self-send through `vsig agent ask`,
+ * then independently verifies the tx landed via `eth_getTransactionByHash`
+ * on ethereum-rpc.publicnode.com (NOT sdk-cli's broadcast downstream).
+ *
+ * Expected: PASS. If this fails we have a regression in the canonical
+ * EVM broadcast path — investigate before trusting any other chain
+ * result.
+ *
+ * Gated on FUND_SAFETY_E2E. Cost ≈ $0.30 gas/run. Self-send only —
+ * never a placeholder/burn recipient.
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  assertBroadcastMatches,
+  captureBroadcast,
+  shouldRunE2E,
+  SilentBroadcastError,
+  verifyOnChain,
+  writeArtifact,
+} from '../lib/harness'
+
+// Canonical test wallet (Vultisig Cluster #1). Self-send: from === to.
+const VAULT_ETH_ADDR = (
+  process.env.FUND_SAFETY_ETH_ADDR ?? '0x58C4a1F319297EC9c398A0F3a3b64AF5a18b5C35'
+).toLowerCase()
+const SEND_ETH = '0.0001'
+const SEND_WEI = (BigInt(1) * 10n ** 14n).toString() // 0.0001 * 1e18
+
+describe.skipIf(!shouldRunE2E())('fund-safety: ETH self-send (silent-broadcast)', () => {
+  it(
+    'broadcasts 0.0001 ETH self-send and the tx is verifiable on an independent RPC',
+    async () => {
+      const prompt = `send ${SEND_ETH} ETH to ${VAULT_ETH_ADDR}`
+      const capture = await captureBroadcast('ethereum', prompt)
+
+      const onChain = capture.hash
+        ? await verifyOnChain('ethereum', capture.hash, { timeoutSec: 90 })
+        : { exists: false, raw: { note: 'no hash returned by sdk-cli' } }
+
+      writeArtifact('eth-self-send', {
+        ts: new Date().toISOString(),
+        prompt,
+        capture: { ...capture, rawStdout: undefined, rawStderr: undefined },
+        onChain,
+        expected: { from: VAULT_ETH_ADDR, to: VAULT_ETH_ADDR, valueWei: SEND_WEI, chainId: 1 },
+      })
+
+      try {
+        assertBroadcastMatches(capture, onChain, {
+          fromAddr: VAULT_ETH_ADDR,
+          toAddr: VAULT_ETH_ADDR,
+          value: SEND_WEI,
+          chainId: 1,
+        })
+      } catch (e) {
+        if (e instanceof SilentBroadcastError) {
+          // Surface the forensic context in the test failure so triage
+          // doesn't need to dig through last-run/.
+          throw new Error(
+            `${e.message}\n\n` +
+              `sdk-cli hash: ${capture.hash}\n` +
+              `on-chain exists: ${onChain.exists}\n` +
+              `agent response: ${capture.response.slice(0, 300)}\n` +
+              `tool calls: ${JSON.stringify(capture.toolCalls.map(t => ({ a: t.action, ok: t.success })))}`
+          )
+        }
+        throw e
+      }
+
+      expect(onChain.exists).toBe(true)
+      expect(onChain.blockNumber).toBeTypeOf('number')
+    },
+    300_000
+  )
+})

--- a/clients/cli/tests/fund-safety/silent-broadcast/sol-self-send.test.ts
+++ b/clients/cli/tests/fund-safety/silent-broadcast/sol-self-send.test.ts
@@ -1,0 +1,94 @@
+/**
+ * SOL self-send — silent-broadcast verifier (first scripted on-chain
+ * SOL run via sdk-cli).
+ *
+ * Drives a real 0.0001 SOL mainnet self-send through `vsig agent ask`,
+ * then independently verifies via `getTransaction` (finalized) on
+ * api.mainnet-beta.solana.com.
+ *
+ * Expected: PASS or FIND BUG. This is the first time the full SOL
+ * sign+broadcast path is exercised end-to-end with on-chain
+ * verification. Solana uses hardened ed25519 derivation, so this also
+ * implicitly checks that the address sdk-cli signs with matches the
+ * one agent-backend's envelope declares — related to the
+ * chain_public_keys forwarding gap (sibling task
+ * 180526-sdk-cli-chain-public-keys-parity.md). A wrong-address symptom
+ * here is a cross-task signal, not necessarily a silent-broadcast bug.
+ *
+ * Gated on FUND_SAFETY_E2E. Cost ≈ $0.0001 SOL + fees/run. Self-send.
+ *
+ * The SOL vault address is NOT hardcoded — it must be supplied via
+ * FUND_SAFETY_SOL_ADDR (derive it from the same vault and confirm it
+ * holds SOL before running; see task QUESTION protocol). Without it the
+ * test fails fast with a clear message rather than guessing an address.
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  assertBroadcastMatches,
+  captureBroadcast,
+  shouldRunE2E,
+  SilentBroadcastError,
+  verifyOnChain,
+  writeArtifact,
+} from '../lib/harness'
+
+const VAULT_SOL_ADDR = process.env.FUND_SAFETY_SOL_ADDR?.toLowerCase()
+const SEND_SOL = '0.0001'
+const SEND_LAMPORTS = (BigInt(1) * 10n ** 5n).toString() // 0.0001 * 1e9
+
+describe.skipIf(!shouldRunE2E())('fund-safety: SOL self-send (silent-broadcast)', () => {
+  it(
+    'broadcasts 0.0001 SOL self-send and the tx is verifiable on an independent RPC',
+    async () => {
+      if (!VAULT_SOL_ADDR) {
+        throw new Error(
+          'FUND_SAFETY_SOL_ADDR not set. Derive the Solana address from the test ' +
+            'vault, confirm it holds SOL, and pass it explicitly. The harness will ' +
+            'not guess a Solana address (hardened derivation — wrong address risks ' +
+            'a real loss).'
+        )
+      }
+      const prompt = `send ${SEND_SOL} SOL to ${VAULT_SOL_ADDR}`
+      const capture = await captureBroadcast('solana', prompt)
+
+      const onChain = capture.hash
+        ? await verifyOnChain('solana', capture.hash, { timeoutSec: 90 })
+        : { exists: false, raw: { note: 'no signature returned by sdk-cli' } }
+
+      writeArtifact('sol-self-send', {
+        ts: new Date().toISOString(),
+        prompt,
+        capture: { ...capture, rawStdout: undefined, rawStderr: undefined },
+        onChain,
+        expected: { from: VAULT_SOL_ADDR, to: VAULT_SOL_ADDR, valueLamports: SEND_LAMPORTS },
+      })
+
+      try {
+        assertBroadcastMatches(capture, onChain, {
+          fromAddr: VAULT_SOL_ADDR,
+          toAddr: VAULT_SOL_ADDR,
+          value: SEND_LAMPORTS,
+        })
+      } catch (e) {
+        if (e instanceof SilentBroadcastError) {
+          throw new Error(
+            `${e.message}\n\n` +
+              `sdk-cli signature: ${capture.hash}\n` +
+              `on-chain exists: ${onChain.exists}\n` +
+              `on-chain from: ${onChain.fromAddr} (expected ${VAULT_SOL_ADDR})\n` +
+              `agent response: ${capture.response.slice(0, 300)}\n` +
+              `tool calls: ${JSON.stringify(capture.toolCalls.map(t => ({ a: t.action, ok: t.success })))}\n` +
+              `NOTE: a from-address mismatch may indicate the chain_public_keys ` +
+              `forwarding gap (sibling task), not a silent-broadcast bug.`
+          )
+        }
+        throw e
+      }
+
+      expect(onChain.exists).toBe(true)
+      expect(onChain.blockNumber).toBeTypeOf('number')
+    },
+    300_000
+  )
+})


### PR DESCRIPTION
## Summary

Phase 1 of the sdk-cli fund-safety regression suite — scripted, opt-in,
real-mainnet broadcast verification that catches the **silent-broadcast
bug class** (vultisig-sdk #458, Ripple `temREDUNDANT`: pipeline returns
a "success" hash for a tx that never landed on-chain) plus the
structurally-adjacent cross-chain-mismatch / wrong-value classes.

sdk-cli is the only client positioned for scripted broadcast-with-
verification. The agent-backend validator pipeline (#527) runs at the
tool-call boundary and structurally cannot see sdk-cli's downstream
sign+broadcast layer — which is exactly where #458 lived.

## What's here (Phase 1)

- `tests/fund-safety/lib/harness.ts` — `captureBroadcast` / `verifyOnChain` / `assertBroadcastMatches` / `shouldRunE2E` gate / forensic artifacts
- `tests/fund-safety/lib/verifiers/{ethereum,solana,types}.ts` — independent public-RPC verifiers (intentionally NOT sdk-cli's broadcast downstream)
- `tests/fund-safety/silent-broadcast/{eth,sol}-self-send.test.ts`
- `README.md`; `last-run/` forensic artifacts (gitignored)
- `test:fund-safety` package script

## Safety (defense in depth)

- `describe.skipIf(!shouldRunE2E())` — **zero broadcasts** unless `FUND_SAFETY_E2E=1`. Verified: `vitest run tests/fund-safety/` without the env var → 2 skipped, 0 broadcasts.
- default `yarn test` also `--exclude`s `tests/fund-safety/**` at collection time.
- self-send only; tiny amounts (0.0001 ETH / SOL).
- SOL test fails fast without `FUND_SAFETY_SOL_ADDR` (hardened derivation — never guesses an address).

## Status

⚠️ **Draft.** Scaffolding + skip-gate verified. The real funded-vault
broadcast (ETH then SOL, cost-gated per the task plan) is **pending
operator confirmation of the funded test wallet** — see the task file
`QUESTION`. Findings will be appended under "Implementation Notes →
Bugs found" once the live run executes.

Phase 2-4 (cross-chain mismatch / decimals fail-closed / hallucination
detection) are scoped in the task file and out of scope for this PR.

## Test plan

- [x] Skip-gate: `vitest run tests/fund-safety/` with `FUND_SAFETY_E2E` unset → all skip, 0 broadcasts
- [x] Typecheck clean for all new files (pre-existing unrelated `executor.ts:839` error untouched)
- [ ] ETH self-send live (gated on funded-vault confirm)
- [ ] SOL self-send live (gated on funded-vault confirm + `FUND_SAFETY_SOL_ADDR`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)