### PR TITLE
Enable Terra Cosmos bank discovery

### DIFF
--- a/.changeset/quiet-terras-discover.md
+++ b/.changeset/quiet-terras-discover.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/sdk': patch
+---
+
+Enable Cosmos bank-balance token discovery for Terra and Terra Classic, including denom metadata decimals, IBC denom trace fallback, and hidden unknown denom metadata.

--- a/packages/core/chain/coin/Coin.ts
+++ b/packages/core/chain/coin/Coin.ts
@@ -17,6 +17,7 @@ export type CoinMetadata = {
   decimals: number
   ticker: string
   logo?: string
+  isHidden?: boolean
 }
 
 export type Coin<T extends Chain = Chain> = CoinKey<T> & CoinMetadata
@@ -31,6 +32,7 @@ export const coinMetadataFields: (keyof Coin)[] = [
   'decimals',
   'ticker',
   'logo',
+  'isHidden',
 ]
 
 export type CoinAmount = {

--- a/packages/core/chain/coin/find/resolvers/cosmos.test.ts
+++ b/packages/core/chain/coin/find/resolvers/cosmos.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const getAllBalancesMock = vi.fn()
 // #428 codex-adversarial M2: stub getCosmosTokenMetadata so the unit
@@ -22,6 +22,11 @@ import { Chain } from '../../../Chain'
 import { findCosmosCoins } from './cosmos'
 
 describe('findCosmosCoins', () => {
+  beforeEach(() => {
+    getAllBalancesMock.mockReset()
+    getCosmosTokenMetadataMock.mockReset()
+  })
+
   it('keeps known single-segment THORChain denoms like TCY', async () => {
     getAllBalancesMock.mockResolvedValue([
       { denom: 'rune', amount: '1' },
@@ -38,6 +43,7 @@ describe('findCosmosCoins', () => {
     expect(coins).toEqual([
       expect.objectContaining({
         id: 'tcy',
+        decimals: 8,
         ticker: 'TCY',
         logo: 'tcy',
       }),
@@ -210,9 +216,126 @@ describe('findCosmosCoins', () => {
     expect(coins).toEqual([
       expect.objectContaining({
         id: 'mysterytoken',
+        decimals: 8,
         ticker: 'MYSTERYTOKEN',
         logo: 'mysterytoken',
       }),
     ])
+  })
+
+  it('auto-discovers Terra Classic bank denoms with token metadata decimals', async () => {
+    getAllBalancesMock.mockResolvedValue([
+      { denom: 'uluna', amount: '1' },
+      { denom: 'uusd', amount: '2' },
+    ])
+    getCosmosTokenMetadataMock.mockResolvedValue({
+      ticker: 'USTC',
+      decimals: 6,
+      logo: 'ustc',
+      priceProviderId: 'terrausd',
+    })
+
+    const coins = await findCosmosCoins({
+      address: 'terra1address',
+      chain: Chain.TerraClassic,
+    })
+
+    expect(getCosmosTokenMetadataMock).toHaveBeenCalledWith({
+      chain: Chain.TerraClassic,
+      id: 'uusd',
+    })
+    expect(coins).toEqual([
+      expect.objectContaining({
+        id: 'uusd',
+        chain: Chain.TerraClassic,
+        decimals: 6,
+        ticker: 'USTC',
+        logo: 'ustc',
+        priceProviderId: 'terrausd',
+      }),
+    ])
+  })
+
+  it('uses metadata decimals for non-fee Terra denoms', async () => {
+    getAllBalancesMock.mockResolvedValue([
+      { denom: 'uluna', amount: '1' },
+      { denom: 'ibc/NON6DECIMALS', amount: '2' },
+    ])
+    getCosmosTokenMetadataMock.mockResolvedValue({
+      ticker: 'WETH',
+      decimals: 18,
+    })
+
+    const coins = await findCosmosCoins({
+      address: 'terra1address',
+      chain: Chain.Terra,
+    })
+
+    expect(coins).toEqual([
+      expect.objectContaining({
+        id: 'ibc/NON6DECIMALS',
+        decimals: 18,
+        ticker: 'WETH',
+      }),
+    ])
+  })
+
+  it('marks Terra denoms without metadata as hidden instead of dropping them', async () => {
+    getAllBalancesMock.mockResolvedValue([
+      { denom: 'uluna', amount: '1' },
+      { denom: 'factory/terra1creator/uspam', amount: '2' },
+    ])
+    getCosmosTokenMetadataMock.mockRejectedValue(new Error('no metadata'))
+
+    const coins = await findCosmosCoins({
+      address: 'terra1address',
+      chain: Chain.Terra,
+    })
+
+    expect(coins).toEqual([
+      expect.objectContaining({
+        id: 'factory/terra1creator/uspam',
+        decimals: 6,
+        ticker: 'USPAM',
+        isHidden: true,
+      }),
+    ])
+  })
+
+  it('propagates hidden metadata from IBC trace fallback', async () => {
+    getAllBalancesMock.mockResolvedValue([
+      { denom: 'uluna', amount: '1' },
+      { denom: 'ibc/OSMOHASH', amount: '2' },
+    ])
+    getCosmosTokenMetadataMock.mockResolvedValue({
+      ticker: 'osmo',
+      decimals: 6,
+      isHidden: true,
+    })
+
+    const coins = await findCosmosCoins({
+      address: 'terra1address',
+      chain: Chain.Terra,
+    })
+
+    expect(coins).toEqual([
+      expect.objectContaining({
+        id: 'ibc/OSMOHASH',
+        ticker: 'OSMO',
+        isHidden: true,
+      }),
+    ])
+  })
+
+  it('keeps non-allowlisted Cosmos chains disabled', async () => {
+    getAllBalancesMock.mockResolvedValue([{ denom: 'uatom', amount: '1' }])
+
+    await expect(
+      findCosmosCoins({
+        address: 'cosmos1address',
+        chain: Chain.Cosmos,
+      })
+    ).resolves.toEqual([])
+    expect(getAllBalancesMock).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/chain/coin/find/resolvers/cosmos.ts
+++ b/packages/core/chain/coin/find/resolvers/cosmos.ts
@@ -3,13 +3,61 @@ import { getCosmosClient } from '@vultisig/core-chain/chains/cosmos/client'
 import { cosmosFeeCoinDenom } from '@vultisig/core-chain/chains/cosmos/cosmosFeeCoinDenom'
 import { tcyAutoCompounderConfig } from '@vultisig/core-chain/chains/cosmos/thor/tcy-autocompound/config'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
+import { CoinMetadata } from '@vultisig/core-chain/coin/Coin'
 import { FindCoinsResolver } from '@vultisig/core-chain/coin/find/resolver'
 import { getCosmosTokenMetadata } from '@vultisig/core-chain/coin/token/metadata/resolvers/cosmos'
 import { without } from '@vultisig/lib-utils/array/without'
 
+const AUTO_DISCOVERY_CHAINS = new Set<CosmosChain>([CosmosChain.THORChain, CosmosChain.Terra, CosmosChain.TerraClassic])
+
+type DiscoveredDenom = {
+  denom: string
+  metadata?: CoinMetadata
+  isHidden?: boolean
+}
+
+const getFallbackTicker = (denom: string) => {
+  // #428: ticker fallback for denoms that lack metadata. Tiered by
+  // denom shape - they aren't all the same:
+  //
+  // 1. factory/{addr}/{subdenom} (THORChain factory tokens etc.) -
+  //    use slash-last. The legacy `split(/[-./]/)[1]` would resolve
+  //    to the creator address. Slash-last also preserves dotted
+  //    suffixes (`usdc.v2` -> `USDC.V2`) and hyphenated tails
+  //    (`yA-USDC` -> `YA-USDC`), mirroring the metadata resolver's
+  //    deriveTicker semantics
+  //    (packages/core/chain/coin/token/metadata/resolvers/cosmos.ts).
+  //
+  // 2. THORChain secured assets / dotted IBC (`btc-btc`,
+  //    `eth-usdc-0xa0b...`, `foo/bar`) - the legacy `[-./]` split is
+  //    correct, `[1]` resolves to the asset ticker (`btc`/`usdc`/
+  //    `bar`). Switching ALL denoms to slash-last would regress
+  //    these because `btc-btc` contains no `/` - `.at(-1)` would
+  //    surface the entire denom (`BTC-BTC`).
+  //
+  // 3. Single-token (no separator, e.g. `mysterytoken`) - the
+  //    `[-./]` split returns `[1] = undefined`, so we fall back to
+  //    the denom itself uppercased. Strictly better than silently
+  //    dropping the coin from the user's balance list.
+  const factoryTail = denom.startsWith('factory/') ? denom.split('/').at(-1) : undefined
+  const legacyMid = denom.split(/[-./]/)[1]
+
+  return (factoryTail || legacyMid || denom)?.toUpperCase()
+}
+
+const getDiscoveredDenom = async (chain: CosmosChain, denom: string): Promise<DiscoveredDenom> =>
+  getCosmosTokenMetadata({ chain, id: denom })
+    .then(metadata => ({
+      denom,
+      metadata,
+    }))
+    .catch(() => ({
+      denom,
+      isHidden: chain === CosmosChain.THORChain ? undefined : true,
+    }))
+
 export const findCosmosCoins: FindCoinsResolver<CosmosChain> = async ({ address, chain }) => {
-  // While it should work for other cosmos chains, we only support THORChain for now
-  if (chain !== CosmosChain.THORChain) return []
+  if (!AUTO_DISCOVERY_CHAINS.has(chain)) return []
 
   const client = await getCosmosClient(chain)
   const balances = await client.getAllBalances(address)
@@ -18,47 +66,13 @@ export const findCosmosCoins: FindCoinsResolver<CosmosChain> = async ({ address,
       balances.map(({ denom }) => denom),
       cosmosFeeCoinDenom[chain],
       tcyAutoCompounderConfig.shareDenom
-    ).map(denom =>
-      getCosmosTokenMetadata({ chain, id: denom })
-        .then(({ ticker }) => ({ denom, ticker }))
-        .catch(() => ({ denom, ticker: undefined }))
-    )
+    ).map(denom => getDiscoveredDenom(chain, denom))
   )
 
   return without(
-    coins.map(({ denom, ticker }) => {
-      // #428: ticker fallback for denoms that lack metadata. Tiered by
-      // denom shape - they aren't all the same:
-      //
-      // 1. factory/{addr}/{subdenom} (THORChain factory tokens etc.) -
-      //    use slash-last. The legacy `split(/[-./]/)[1]` would resolve
-      //    to the creator address. Slash-last also preserves dotted
-      //    suffixes (`usdc.v2` -> `USDC.V2`) and hyphenated tails
-      //    (`yA-USDC` -> `YA-USDC`), mirroring the metadata resolver's
-      //    deriveTicker semantics
-      //    (packages/core/chain/coin/token/metadata/resolvers/cosmos.ts).
-      //
-      // 2. THORChain secured assets / dotted IBC (`btc-btc`,
-      //    `eth-usdc-0xa0b...`, `foo/bar`) - the legacy `[-./]` split is
-      //    correct, `[1]` resolves to the asset ticker (`btc`/`usdc`/
-      //    `bar`). Switching ALL denoms to slash-last would regress
-      //    these because `btc-btc` contains no `/` - `.at(-1)` would
-      //    surface the entire denom (`BTC-BTC`).
-      //
-      // 3. Single-token (no separator, e.g. `mysterytoken`) - the
-      //    `[-./]` split returns `[1] = undefined`, so we fall back to
-      //    the denom itself uppercased. Strictly better than silently
-      //    dropping the coin from the user's balance list.
-      const factoryTail = denom.startsWith('factory/')
-        ? denom.split('/').at(-1)
-        : undefined
-      const legacyMid = denom.split(/[-./]/)[1]
-      const coinTicker = (
-        ticker ||
-        factoryTail ||
-        legacyMid ||
-        denom
-      )?.toUpperCase()
+    coins.map(({ denom, metadata, isHidden }) => {
+      const coinTicker = (metadata?.ticker || getFallbackTicker(denom))?.toUpperCase()
+      const coinIsHidden = isHidden ?? metadata?.isHidden
 
       if (!coinTicker) {
         console.error(`Failed to extract ticker from ${denom}`)
@@ -68,9 +82,11 @@ export const findCosmosCoins: FindCoinsResolver<CosmosChain> = async ({ address,
       return {
         id: denom,
         chain,
-        decimals: chainFeeCoin[chain].decimals,
+        decimals: metadata?.decimals ?? chainFeeCoin[chain].decimals,
         ticker: coinTicker,
-        logo: coinTicker.toLowerCase(),
+        logo: metadata?.logo ?? coinTicker.toLowerCase(),
+        ...(metadata?.priceProviderId === undefined ? {} : { priceProviderId: metadata.priceProviderId }),
+        ...(coinIsHidden === undefined ? {} : { isHidden: coinIsHidden }),
         address,
       }
     }),

--- a/packages/core/chain/coin/token/metadata/resolvers/cosmos.test.ts
+++ b/packages/core/chain/coin/token/metadata/resolvers/cosmos.test.ts
@@ -7,11 +7,12 @@ vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
 }))
 
 import { Chain } from '@vultisig/core-chain/Chain'
-import { getCosmosTokenMetadata } from './cosmos'
+import { clearCosmosTokenMetadataCacheForTests, getCosmosTokenMetadata } from './cosmos'
 
 describe('getCosmosTokenMetadata', () => {
   beforeEach(() => {
     queryUrlMock.mockReset()
+    clearCosmosTokenMetadataCacheForTests()
   })
 
   it('fetches Terra CW20 metadata from token_info', async () => {
@@ -90,6 +91,178 @@ describe('getCosmosTokenMetadata', () => {
     ).resolves.toEqual({
       ticker: 'nft',
       decimals: 0,
+    })
+  })
+
+  it('preserves known Cosmos token logo and price metadata', async () => {
+    await expect(
+      getCosmosTokenMetadata({
+        chain: Chain.TerraClassic,
+        id: 'uusd',
+      })
+    ).resolves.toEqual({
+      ticker: 'USTC',
+      decimals: 6,
+      logo: 'ustc.png',
+      priceProviderId: 'terrausd',
+    })
+
+    expect(queryUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('resolves IBC denom traces through base denom metadata', async () => {
+    queryUrlMock.mockImplementation((url: string) => {
+      if (url.includes('/denoms_metadata/ibc%2FTRACEHASH')) {
+        return Promise.resolve({ metadata: { base: 'ibc/TRACEHASH' } })
+      }
+      if (url.includes('/denoms_metadata?pagination.limit=1000')) {
+        return Promise.resolve({ metadatas: [] })
+      }
+      if (url.includes('/denom_traces/TRACEHASH')) {
+        return Promise.resolve({ denom_trace: { path: 'transfer/channel-1', base_denom: 'uatom' } })
+      }
+      if (url.includes('/denoms_metadata/uatom')) {
+        return Promise.resolve({
+          metadata: {
+            symbol: 'ATOM',
+            display: 'ATOM',
+            denom_units: [
+              {
+                denom: 'uatom',
+                exponent: 0,
+              },
+              {
+                denom: 'ATOM',
+                exponent: 6,
+              },
+            ],
+          },
+        })
+      }
+
+      throw new Error(`Unexpected URL ${url}`)
+    })
+
+    await expect(
+      getCosmosTokenMetadata({
+        chain: Chain.Terra,
+        id: 'ibc/TRACEHASH',
+      })
+    ).resolves.toEqual({
+      ticker: 'ATOM',
+      decimals: 6,
+    })
+  })
+
+  it('uses IBC trace ticker fallback as hidden when base metadata is unavailable', async () => {
+    queryUrlMock.mockImplementation((url: string) => {
+      if (url.includes('/denoms_metadata/ibc%2FOSMOHASH')) {
+        return Promise.resolve({ metadata: { base: 'ibc/OSMOHASH' } })
+      }
+      if (url.includes('/denom_traces/OSMOHASH')) {
+        return Promise.resolve({ denom_trace: { path: 'transfer/channel-1', base_denom: 'uosmo' } })
+      }
+      if (url.includes('/denoms_metadata/uosmo')) {
+        return Promise.resolve({ metadata: { base: 'uosmo' } })
+      }
+      if (url.includes('/denoms_metadata?pagination.limit=1000')) {
+        return Promise.resolve({ metadatas: [] })
+      }
+
+      throw new Error(`Unexpected URL ${url}`)
+    })
+
+    await expect(
+      getCosmosTokenMetadata({
+        chain: Chain.Terra,
+        id: 'ibc/OSMOHASH',
+      })
+    ).resolves.toEqual({
+      ticker: 'osmo',
+      decimals: 6,
+      isHidden: true,
+    })
+  })
+
+  it('caches bank denom metadata lookups for 24 hours', async () => {
+    queryUrlMock.mockResolvedValue({
+      metadata: {
+        symbol: 'CACHED',
+        display: 'CACHED',
+        denom_units: [
+          {
+            denom: 'ucached',
+            exponent: 0,
+          },
+          {
+            denom: 'CACHED',
+            exponent: 8,
+          },
+        ],
+      },
+    })
+
+    await getCosmosTokenMetadata({
+      chain: Chain.Cosmos,
+      id: 'ucached',
+    })
+    await getCosmosTokenMetadata({
+      chain: Chain.Cosmos,
+      id: 'ucached',
+    })
+
+    expect(queryUrlMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not cache missing bank denom metadata', async () => {
+    queryUrlMock.mockImplementation((url: string) => {
+      if (url.includes('/denoms_metadata/uappears')) {
+        if (
+          queryUrlMock.mock.calls.filter(([calledUrl]) => String(calledUrl).includes('/denoms_metadata/uappears'))
+            .length === 1
+        ) {
+          return Promise.resolve({})
+        }
+
+        return Promise.resolve({
+          metadata: {
+            symbol: 'APPEARS',
+            display: 'APPEARS',
+            denom_units: [
+              {
+                denom: 'uappears',
+                exponent: 0,
+              },
+              {
+                denom: 'APPEARS',
+                exponent: 9,
+              },
+            ],
+          },
+        })
+      }
+      if (url.includes('/denoms_metadata?pagination.limit=1000')) {
+        return Promise.resolve({ metadatas: [] })
+      }
+
+      throw new Error(`Unexpected URL ${url}`)
+    })
+
+    await expect(
+      getCosmosTokenMetadata({
+        chain: Chain.Terra,
+        id: 'uappears',
+      })
+    ).rejects.toThrow('No denom meta information available')
+
+    await expect(
+      getCosmosTokenMetadata({
+        chain: Chain.Terra,
+        id: 'uappears',
+      })
+    ).resolves.toEqual({
+      ticker: 'APPEARS',
+      decimals: 9,
     })
   })
 })

--- a/packages/core/chain/coin/token/metadata/resolvers/cosmos.ts
+++ b/packages/core/chain/coin/token/metadata/resolvers/cosmos.ts
@@ -4,6 +4,7 @@ import {
   getCosmosWasmTokenInfoUrl,
   isCosmosWasmTokenId,
 } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
+import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { CoinMetadata } from '@vultisig/core-chain/coin/Coin'
 import { knownCosmosTokens } from '@vultisig/core-chain/coin/knownTokens/cosmos'
 import { TokenMetadataResolver } from '@vultisig/core-chain/coin/token/metadata/resolver'
@@ -19,10 +20,58 @@ type DenomMetadata = {
   display?: string
   denom_units?: DenomUnits[]
 }
+type IbcDenomTrace = {
+  path?: string
+  base_denom?: string
+}
 type Cw20TokenInfo = {
   name?: string
   symbol?: string
   decimals?: number
+}
+
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000
+
+type CacheEntry<T> = {
+  expiresAt: number
+  value: Promise<T | null>
+}
+
+const denomMetadataCache = new Map<string, CacheEntry<DenomMetadata>>()
+const ibcDenomTraceCache = new Map<string, CacheEntry<IbcDenomTrace>>()
+
+const getCachedOptional = <T>(
+  cache: Map<string, CacheEntry<T>>,
+  key: string,
+  load: () => Promise<T | null>
+): Promise<T | null> => {
+  const now = Date.now()
+  const cached = cache.get(key)
+  if (cached && cached.expiresAt > now) return cached.value
+
+  const value = load()
+    .then(result => {
+      if (result === null) {
+        cache.delete(key)
+      }
+
+      return result
+    })
+    .catch(error => {
+      cache.delete(key)
+      throw error
+    })
+  cache.set(key, {
+    expiresAt: now + CACHE_TTL_MS,
+    value,
+  })
+
+  return value
+}
+
+export const clearCosmosTokenMetadataCacheForTests = () => {
+  denomMetadataCache.clear()
+  ibcDenomTraceCache.clear()
 }
 
 const decimalsFromMeta = (meta: DenomMetadata): number | null => {
@@ -54,7 +103,24 @@ const deriveTicker = (denom: string, meta: DenomMetadata): string => {
   return denom
 }
 
-const getDenomMetaFromLCD = async (lcdBase: string, denom: string): Promise<DenomMetadata | null> => {
+const getMetaResult = (denom: string, meta: DenomMetadata): CoinMetadata => {
+  const decimals = decimalsFromMeta(meta)
+  if (decimals === null) throw new Error(`Could not fetch decimal for ${denom}`)
+
+  return {
+    ticker: deriveTicker(denom, meta),
+    decimals,
+  }
+}
+
+const deriveIbcTraceTicker = (baseDenom: string): string => {
+  const ticker = deriveTicker(baseDenom, {})
+  if (ticker.startsWith('u') && ticker.length > 1) return ticker.slice(1)
+
+  return ticker
+}
+
+const fetchDenomMetaFromLCD = async (lcdBase: string, denom: string): Promise<DenomMetadata | null> => {
   return asyncFallbackChain(
     async () => {
       const byDenom = `${lcdBase}/cosmos/bank/v1beta1/denoms_metadata/${encodeURIComponent(denom)}`
@@ -68,6 +134,53 @@ const getDenomMetaFromLCD = async (lcdBase: string, denom: string): Promise<Deno
       return listRes.data?.metadatas?.find(data => data.base === denom) ?? null
     }
   )
+}
+
+const getDenomMetaFromLCD = async (lcdBase: string, denom: string): Promise<DenomMetadata | null> =>
+  getCachedOptional(denomMetadataCache, `${lcdBase}:${denom}`, () => fetchDenomMetaFromLCD(lcdBase, denom))
+
+const getIbcDenomTraceFromLCD = async (lcdBase: string, denom: string): Promise<IbcDenomTrace | null> => {
+  if (!denom.startsWith('ibc/')) return null
+
+  const hash = denom.replace(/^ibc\//, '')
+  return getCachedOptional(ibcDenomTraceCache, `${lcdBase}:${hash}`, async () => {
+    const url = `${lcdBase}/ibc/apps/transfer/v1/denom_traces/${encodeURIComponent(hash)}`
+    const res = await attempt(() => queryUrl<{ denom_trace?: IbcDenomTrace }>(url))
+
+    return res.data?.denom_trace ?? null
+  })
+}
+
+const getBankDenomMetadata = async (chain: CosmosChain, id: string): Promise<CoinMetadata> => {
+  const lcd = cosmosRpcUrl[chain]
+  const meta = await getDenomMetaFromLCD(lcd, id)
+  if (meta) {
+    try {
+      return getMetaResult(id, meta)
+    } catch (error) {
+      if (!id.startsWith('ibc/')) throw error
+    }
+  }
+
+  const trace = await getIbcDenomTraceFromLCD(lcd, id)
+  if (trace?.base_denom) {
+    const traceMeta = await getDenomMetaFromLCD(lcd, trace.base_denom)
+    if (traceMeta) {
+      try {
+        return getMetaResult(trace.base_denom, traceMeta)
+      } catch {
+        // Fall through to hidden trace fallback when trace metadata is incomplete.
+      }
+    }
+
+    return {
+      ticker: deriveIbcTraceTicker(trace.base_denom),
+      decimals: chainFeeCoin[chain].decimals,
+      isHidden: true,
+    }
+  }
+
+  throw new Error(`No denom meta information available for ${id}`)
 }
 
 const getCw20MetaFromLCD = async (chain: CosmosChain, id: string): Promise<CoinMetadata> => {
@@ -92,37 +205,17 @@ export const getCosmosTokenMetadata: TokenMetadataResolver<CosmosChain> = async 
     return {
       ticker: knownMeta.ticker,
       decimals: knownMeta.decimals,
+      logo: knownMeta.logo,
+      priceProviderId: knownMeta.priceProviderId,
     }
   }
 
   if (isCosmosWasmTokenId(id)) {
     return asyncFallbackChain(
       async () => getCw20MetaFromLCD(chain, id),
-      async () => {
-        const lcd = cosmosRpcUrl[chain]
-        const meta = await getDenomMetaFromLCD(lcd, id)
-        if (!meta) throw new Error(`No denom meta information available for ${id}`)
-        const decimals = decimalsFromMeta(meta)
-        if (decimals === null) throw new Error(`Could not fetch decimal for ${id}`)
-        const ticker = deriveTicker(id, meta)
-
-        return {
-          ticker,
-          decimals,
-        }
-      }
+      async () => getBankDenomMetadata(chain, id)
     )
   }
 
-  const lcd = cosmosRpcUrl[chain]
-  const meta = await getDenomMetaFromLCD(lcd, id)
-  if (!meta) throw new Error(`No denom meta information available for ${id}`)
-  const decimals = decimalsFromMeta(meta)
-  if (decimals === null) throw new Error(`Could not fetch decimal for ${id}`)
-  const ticker = deriveTicker(id, meta)
-
-  return {
-    ticker,
-    decimals,
-  }
+  return getBankDenomMetadata(chain, id)
 }

--- a/packages/sdk/src/types/tokens.ts
+++ b/packages/sdk/src/types/tokens.ts
@@ -27,6 +27,7 @@ export type DiscoveredToken = {
   decimals: number
   logo?: string
   balance?: string
+  isHidden?: boolean
 }
 
 /** Parameters for price lookup */

--- a/packages/sdk/src/vault/services/TokenDiscoveryService.ts
+++ b/packages/sdk/src/vault/services/TokenDiscoveryService.ts
@@ -20,6 +20,7 @@ export class TokenDiscoveryService {
         ticker: coin.ticker,
         decimals: coin.decimals,
         logo: coin.logo,
+        ...(coin.isHidden === undefined ? {} : { isHidden: coin.isHidden }),
       }))
     } catch (error) {
       throw new VaultError(


### PR DESCRIPTION
Closes #469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled Cosmos bank-balance token discovery for Terra and Terra Classic.
  * Tokens can now be marked as hidden/unknown in discovery results.
  * IBC denom trace fallback added to improve denom resolution.

* **Improvements**
  * Denom metadata now prefers on-chain decimals, logos and tickers; caching added for faster, more reliable lookups.
  * Discovery returns price/provider info when available.

* **Tests**
  * Expanded tests covering Terra/Terra Classic discovery, hidden-token handling, caching, and fallbacks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/498?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->