### PR TITLE
feat(qbtc): forward broadcast flag on /prove

### DIFF
--- a/.changeset/qbtc-claim-broadcast-route.md
+++ b/.changeset/qbtc-claim-broadcast-route.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/core-chain': minor
+---
+
+qbtc: `generateClaimProof` now accepts an optional `broadcast: boolean` input. When set, the proof service signs and broadcasts the resulting `MsgClaimWithProof` itself (via its pre-funded broadcaster account) and returns `tx_hash` in the response. Intended for first-time claimers whose own bech32 address doesn't exist on chain yet, so they can't produce a SignDoc the chain will accept. Server-side broadcasting is wired up in [btcq-org/qbtc#158](https://github.com/btcq-org/qbtc/pull/158).

--- a/.changeset/qbtc-claim-broadcast-route.md
+++ b/.changeset/qbtc-claim-broadcast-route.md
@@ -2,4 +2,4 @@
 '@vultisig/core-chain': minor
 ---
 
-qbtc: `generateClaimProof` now accepts an optional `broadcast: boolean` input. When set, the proof service signs and broadcasts the resulting `MsgClaimWithProof` itself (via its pre-funded broadcaster account) and returns `tx_hash` in the response. Intended for first-time claimers whose own bech32 address doesn't exist on chain yet, so they can't produce a SignDoc the chain will accept. Server-side broadcasting is wired up in [btcq-org/qbtc#158](https://github.com/btcq-org/qbtc/pull/158).
+qbtc: `generateClaimProof` now accepts an optional `broadcast: boolean` input. When set, the proof service signs and broadcasts the resulting `MsgClaimWithProof` itself (via its pre-funded broadcaster account) and returns `tx_hash` in the response. Intended for first-time claimers whose own bech32 address doesn't exist on-chain yet, so they can't produce a SignDoc the chain will accept. Server-side broadcasting is wired up in [btcq-org/qbtc#158](https://github.com/btcq-org/qbtc/pull/158).

--- a/packages/core/chain/chains/cosmos/qbtc/claim/broadcastClaimTx.test.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/broadcastClaimTx.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { broadcastClaimTx } from './broadcastClaimTx'
+import { broadcastClaimTx, waitForClaimTxResult } from './broadcastClaimTx'
 
 const originalFetch = globalThis.fetch
 
@@ -201,5 +201,49 @@ describe('broadcastClaimTx', () => {
     await expect(
       broadcastClaimTx({ txBytesBase64, txHash, ...fastPolling })
     ).rejects.toThrow('no valid claimable UTXOs found')
+  })
+})
+
+describe('waitForClaimTxResult', () => {
+  it('parses claim_with_proof event for an already-broadcast tx', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      includedSuccess({
+        total_amount: '12345',
+        utxos_claimed: '3',
+        utxos_skipped: '1',
+      })
+    ) as typeof fetch
+
+    const result = await waitForClaimTxResult({ txHash, ...fastPolling })
+
+    expect(result).toEqual({
+      totalAmountClaimed: 12345n,
+      utxosClaimed: 3,
+      utxosSkipped: 1,
+      txHash,
+    })
+  })
+
+  it('retries on 404 until included', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(errorResponse(404, 'tx not found'))
+      .mockResolvedValueOnce(includedSuccess({ total_amount: '7' }))
+    globalThis.fetch = fetchMock
+
+    const result = await waitForClaimTxResult({ txHash, ...fastPolling })
+
+    expect(result.totalAmountClaimed).toBe(7n)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws if the chain returned a non-zero code', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      okJson({ tx_response: { code: 5, raw_log: 'address mismatch' } })
+    ) as typeof fetch
+
+    await expect(
+      waitForClaimTxResult({ txHash, ...fastPolling })
+    ).rejects.toThrow(/QBTC claim tx error: address mismatch/)
   })
 })

--- a/packages/core/chain/chains/cosmos/qbtc/claim/broadcastClaimTx.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/broadcastClaimTx.ts
@@ -131,6 +131,48 @@ const waitForTxInclusion = async ({
   )
 }
 
+type WaitForClaimTxResultInput = {
+  /** Transaction hash (hex, upper-case) returned by the broadcaster. */
+  txHash: string
+  /** Max time to wait for inclusion. Defaults to 30 s. */
+  inclusionTimeoutMs?: number
+  /** Poll interval. Defaults to 1 s. */
+  inclusionPollIntervalMs?: number
+}
+
+/**
+ * Polls the chain for an already-broadcast claim tx (e.g. one submitted by
+ * the proof service via `generateClaimProof({ broadcast: true })`) and parses
+ * the `claim_with_proof` event into a {@link ClaimTxResponse}.
+ *
+ * Mirrors the wait-and-parse half of {@link broadcastClaimTx} so callers who
+ * didn't broadcast the tx themselves can still show real claim amounts.
+ */
+export const waitForClaimTxResult = async ({
+  txHash,
+  inclusionTimeoutMs = 30_000,
+  inclusionPollIntervalMs = 1_000,
+}: WaitForClaimTxResultInput): Promise<ClaimTxResponse> => {
+  const included = await waitForTxInclusion({
+    txHash,
+    timeoutMs: inclusionTimeoutMs,
+    intervalMs: inclusionPollIntervalMs,
+  })
+
+  if (typeof included.code !== 'number') {
+    throw new Error(
+      `QBTC claim tx ${txHash}: missing code on included tx_response`
+    )
+  }
+
+  if (included.code !== 0) {
+    const log = included.raw_log || included.log
+    throw new Error(`QBTC claim tx error: ${log}`)
+  }
+
+  return parseClaimResultFromEvents(included.events, txHash)
+}
+
 /**
  * Broadcasts a signed MsgClaimWithProof transaction to the QBTC chain
  * via the REST API (following the restOnlyChains pattern).

--- a/packages/core/chain/chains/cosmos/qbtc/claim/proofService.test.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/proofService.test.ts
@@ -170,13 +170,22 @@ describe('generateClaimProof', () => {
   })
 
   it('forwards broadcast=true and the returned tx_hash', async () => {
-    mockFetch({ ...validResponse, tx_hash: 'ABCDEF0123' })
+    const validTxHash = 'AB'.repeat(32)
+    mockFetch({ ...validResponse, tx_hash: validTxHash })
 
     const result = await generateClaimProof({ ...validInput, broadcast: true })
 
     const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>
     const body = JSON.parse(fetchMock.mock.calls[0][1].body)
     expect(body.broadcast).toBe(true)
-    expect(result.tx_hash).toBe('ABCDEF0123')
+    expect(result.tx_hash).toBe(validTxHash)
+  })
+
+  it('throws when tx_hash is present but not 64 hex chars', async () => {
+    mockFetch({ ...validResponse, tx_hash: 'too-short' })
+
+    await expect(
+      generateClaimProof({ ...validInput, broadcast: true })
+    ).rejects.toThrow('Invalid proof service response: invalid tx_hash')
   })
 })

--- a/packages/core/chain/chains/cosmos/qbtc/claim/proofService.test.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/proofService.test.ts
@@ -158,4 +158,25 @@ describe('generateClaimProof', () => {
       'Invalid proof service response: invalid message_hash'
     )
   })
+
+  it('omits broadcast from the request body when not requested', async () => {
+    mockFetch(validResponse)
+
+    await generateClaimProof(validInput)
+
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body).not.toHaveProperty('broadcast')
+  })
+
+  it('forwards broadcast=true and the returned tx_hash', async () => {
+    mockFetch({ ...validResponse, tx_hash: 'ABCDEF0123' })
+
+    const result = await generateClaimProof({ ...validInput, broadcast: true })
+
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.broadcast).toBe(true)
+    expect(result.tx_hash).toBe('ABCDEF0123')
+  })
 })

--- a/packages/core/chain/chains/cosmos/qbtc/claim/proofService.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/proofService.ts
@@ -113,6 +113,9 @@ const assertValidClaimProofResponse = (
       'Invalid proof service response: invalid pub_key_hash_sha256'
     )
   }
+  if (data.tx_hash !== undefined && !isHexWithLength(data.tx_hash, 64)) {
+    throw new Error('Invalid proof service response: invalid tx_hash')
+  }
 }
 
 /**

--- a/packages/core/chain/chains/cosmos/qbtc/claim/proofService.ts
+++ b/packages/core/chain/chains/cosmos/qbtc/claim/proofService.ts
@@ -42,6 +42,16 @@ type GenerateClaimProofInput = {
   chainId: string
   /** Proof service base URL. Defaults to {@link defaultProofServiceUrl}. */
   baseUrl?: string
+  /**
+   * If true, the proof service signs and broadcasts the resulting
+   * `MsgClaimWithProof` itself — using its own pre-funded broadcaster account.
+   * Intended for first-time claimers whose own bech32 address doesn't yet
+   * exist on chain (so they can't sign a SignDoc the chain will accept).
+   * When true, the response carries `tx_hash`.
+   *
+   * Wired up server-side by [btcq-org/qbtc#158](https://github.com/btcq-org/qbtc/pull/158).
+   */
+  broadcast?: boolean
 }
 
 type GenerateClaimProofResponse = {
@@ -64,6 +74,13 @@ type GenerateClaimProofResponse = {
   utxos: UtxoRef[]
   /** QBTC claimer address. */
   claimer_address: string
+  /**
+   * Set only when the request had `broadcast: true` and the proof service
+   * successfully submitted the claim tx on the caller's behalf. The hash
+   * matches what `cosmos.tx.v1beta1.BroadcastTxResponse.txhash` would have
+   * returned for a self-broadcast.
+   */
+  tx_hash?: string
 }
 
 export type { GenerateClaimProofResponse as ClaimProofResult }
@@ -113,6 +130,7 @@ export const generateClaimProof = async ({
   claimerAddress,
   chainId,
   baseUrl = defaultProofServiceUrl,
+  broadcast,
 }: GenerateClaimProofInput): Promise<GenerateClaimProofResponse> => {
   const controller = new AbortController()
   const timeout = setTimeout(
@@ -132,6 +150,7 @@ export const generateClaimProof = async ({
         utxos: utxos.map(({ txid, vout }) => ({ txid, vout })),
         claimer_address: claimerAddress,
         chain_id: chainId,
+        ...(broadcast ? { broadcast: true } : {}),
       }),
     })
 


### PR DESCRIPTION
## Summary

`generateClaimProof` now accepts an optional `broadcast: boolean` input. When set, it forwards `"broadcast": true` on the `/prove` request body and surfaces the returned `tx_hash` on the response.

This lets first-time claimers (whose own QBTC address doesn't exist on chain yet, so they can't sign a SignDoc the chain will accept) hand the cosmos broadcast off to the proof service's pre-funded broadcaster account. Existing-account claimers keep using the wallet-direct path that landed in #478.

Server-side broadcasting is wired up in [btcq-org/qbtc#158](https://github.com/btcq-org/qbtc/pull/158).

## Context

- We tried fixing this chain-side first ([btcq-org/qbtc#172](https://github.com/btcq-org/qbtc/issues/172), [btcq-org/qbtc#173](https://github.com/btcq-org/qbtc/pull/173)). The qbtc team preferred routing fresh-claimer txs through the proof service instead of changing the ante semantics, so those are closed.
- Downstream adoption in vultisig-windows will check whether `/cosmos/auth/v1beta1/accounts/{addr}` returns 404 and set `broadcast: true` only in that case.

## Test plan

- [x] `yarn test:core --run packages/core/chain/chains/cosmos/qbtc/claim/proofService.test.ts` — 12 passed (added two cases: `broadcast` is omitted when not requested, `broadcast: true` is forwarded and `tx_hash` is returned)
- [x] Added a changeset (`@vultisig/core-chain` minor — new optional field, fully backward compatible)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional broadcast when generating a claim proof: the service can sign & broadcast the claim and return the resulting transaction hash.
  * Ability to wait/poll for a broadcasted claim transaction until inclusion, with configurable timeout, polling and clear error reporting.

* **Tests**
  * Added tests for broadcast behavior, tx-hash validation/exposure, claim-result parsing, retry-on-404, and error propagation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/499?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->