### PR TITLE
feat(price): add getCoinPricesWithChange (24h % change)

### DIFF
--- a/.changeset/coin-prices-24h-change.md
+++ b/.changeset/coin-prices-24h-change.md
@@ -1,0 +1,30 @@
+---
+"@vultisig/sdk": minor
+---
+
+feat(price): add `Vultisig.getCoinPricesWithChange` returning 24h % change
+
+`getCoinPrices` returns only `Record<string, number>` (spot price), so
+consumers that need the 24h change — e.g. a price widget's −3.97%
+indicator — had to keep a side-channel CoinGecko call, duplicating the
+SDK and risking drift.
+
+Adds a parallel, additive path:
+
+- `Vultisig.getCoinPricesWithChange(params)` →
+  `Record<string, { price: number; change24h?: number }>`
+- core-chain `getCoinPricesWithChange` / `queryCoingeickoPricesWithChange`
+  (requests `include_24hr_change=true`; `change24h` is omitted when
+  CoinGecko has no datum for an id)
+- new public types `CoinPriceWithChange`, `CoinPricesWithChangeResult`
+
+Deliberately a **separate function**, not a flag on `getCoinPrices`:
+`getCoinPrices` / `CoinPricesResult` / `FiatValueService` /
+`fiatToAmount` / `getErc20Prices` are byte-for-byte unchanged — zero
+regression surface on the existing call sites. Price-only callers should
+keep using `getCoinPrices` (lighter payload, stable contract); reach for
+`getCoinPricesWithChange` only when the change is actually rendered.
+
+Lets vultiagent-app (and any other client) drop its hand-rolled
+`fetchPrices` 24h-change side-channel and source price+change from the
+SDK alone.

--- a/packages/core/chain/coin/price/getCoinPricesWithChange.tsx
+++ b/packages/core/chain/coin/price/getCoinPricesWithChange.tsx
@@ -1,0 +1,47 @@
+import { rootApiUrl } from '@vultisig/core-config'
+import { FiatCurrency } from '@vultisig/core-config/FiatCurrency'
+import { defaultFiatCurrency } from '@vultisig/core-config/FiatCurrency'
+import { addQueryParams } from '@vultisig/lib-utils/query/addQueryParams'
+
+import {
+  type CoinPriceWithChange,
+  queryCoingeickoPricesWithChange,
+} from './queryCoingeickoPricesWithChange'
+
+const baseUrl = `${rootApiUrl}/coingeicko/api/v3/simple/price`
+
+type GetCoinPricesWithChangeInput = {
+  ids: string[]
+  fiatCurrency?: FiatCurrency
+}
+
+/**
+ * Like `getCoinPrices`, but also returns each coin's 24h % change.
+ *
+ * Separate entry point (not a flag on `getCoinPrices`) so the existing
+ * function and its `Record<string, number>` contract — relied on by
+ * FiatValueService, fiatToAmount, getErc20Prices — stay byte-identical.
+ * Consumers that need the change (e.g. the dashboard price widget's
+ * −3.97% indicator) opt into this; everyone else is unaffected.
+ */
+export const getCoinPricesWithChange = async ({
+  ids,
+  fiatCurrency = defaultFiatCurrency,
+}: GetCoinPricesWithChangeInput): Promise<
+  Record<string, CoinPriceWithChange>
+> => {
+  const normalizedIds = Array.from(
+    new Set(ids.map(id => id.toLowerCase()).filter(Boolean))
+  )
+
+  const url = addQueryParams(baseUrl, {
+    ids: normalizedIds.join(','),
+    vs_currencies: fiatCurrency,
+    include_24hr_change: 'true',
+  })
+
+  return queryCoingeickoPricesWithChange({
+    url,
+    fiatCurrency,
+  })
+}

--- a/packages/core/chain/coin/price/queryCoingeickoPricesWithChange.test.ts
+++ b/packages/core/chain/coin/price/queryCoingeickoPricesWithChange.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockQueryUrl } = vi.hoisted(() => ({
+  mockQueryUrl: vi.fn(),
+}))
+
+vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
+  queryUrl: mockQueryUrl,
+}))
+
+import { queryCoingeickoPricesWithChange } from './queryCoingeickoPricesWithChange'
+
+describe('queryCoingeickoPricesWithChange', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('extracts both price and the <currency>_24h_change field', async () => {
+    mockQueryUrl.mockResolvedValue({
+      ethereum: { usd: 2067.1, usd_24h_change: -3.97 },
+      bitcoin: { usd: 76923, usd_24h_change: -5.24 },
+    })
+
+    const result = await queryCoingeickoPricesWithChange({
+      url: 'https://x/price',
+      fiatCurrency: 'usd' as never,
+    })
+
+    expect(result.ethereum).toEqual({ price: 2067.1, change24h: -3.97 })
+    expect(result.bitcoin).toEqual({ price: 76923, change24h: -5.24 })
+  })
+
+  it('omits change24h when CoinGecko has no datum for the id', async () => {
+    mockQueryUrl.mockResolvedValue({
+      'long-tail-token': { usd: 0.0001 },
+    })
+
+    const result = await queryCoingeickoPricesWithChange({
+      url: 'https://x/price',
+      fiatCurrency: 'usd' as never,
+    })
+
+    expect(result['long-tail-token']).toEqual({ price: 0.0001 })
+    expect(result['long-tail-token']).not.toHaveProperty('change24h')
+  })
+
+  it('defaults a missing price to 0 (defensive — never NaN/undefined)', async () => {
+    mockQueryUrl.mockResolvedValue({
+      weird: { usd_24h_change: 1.2 },
+    })
+
+    const result = await queryCoingeickoPricesWithChange({
+      url: 'https://x/price',
+      fiatCurrency: 'usd' as never,
+    })
+
+    expect(result.weird).toEqual({ price: 0, change24h: 1.2 })
+  })
+
+  it('honors a non-usd fiat currency for both price and change keys', async () => {
+    mockQueryUrl.mockResolvedValue({
+      ethereum: { eur: 1900, eur_24h_change: -2.1 },
+    })
+
+    const result = await queryCoingeickoPricesWithChange({
+      url: 'https://x/price',
+      fiatCurrency: 'eur' as never,
+    })
+
+    expect(result.ethereum).toEqual({ price: 1900, change24h: -2.1 })
+  })
+})

--- a/packages/core/chain/coin/price/queryCoingeickoPricesWithChange.ts
+++ b/packages/core/chain/coin/price/queryCoingeickoPricesWithChange.ts
@@ -1,0 +1,54 @@
+import { FiatCurrency } from '@vultisig/core-config/FiatCurrency'
+import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+import { recordMap } from '@vultisig/lib-utils/record/recordMap'
+
+/**
+ * One coin's spot price plus its 24h % change.
+ *
+ * `change24h` is optional: CoinGecko only returns it when
+ * `include_24hr_change=true` was requested AND the provider has the
+ * datum for that id (some long-tail ids omit it).
+ */
+export type CoinPriceWithChange = {
+  price: number
+  change24h?: number
+}
+
+/**
+ * Raw CoinGecko `simple/price` shape when `include_24hr_change=true`:
+ *   { ethereum: { usd: 2067.1, usd_24h_change: -3.97 }, ... }
+ * The change key is `<currency>_24h_change`.
+ */
+type CoinPricesWithChangeResponse = Record<
+  string,
+  Record<string, number | undefined>
+>
+
+type Input = {
+  url: string
+  fiatCurrency: FiatCurrency
+}
+
+/**
+ * Parallel to `queryCoingeickoPrices` but preserves the 24h change the
+ * plain query discards. Kept as a SEPARATE function (not a flag on the
+ * existing one) so `queryCoingeickoPrices` / `getCoinPrices` /
+ * `CoinPricesResult` / `FiatValueService` are 100% unaffected — no
+ * regression surface on the 5+ existing call sites.
+ */
+export const queryCoingeickoPricesWithChange = async ({
+  url,
+  fiatCurrency,
+}: Input): Promise<Record<string, CoinPriceWithChange>> => {
+  const result = await queryUrl<CoinPricesWithChangeResponse>(url)
+  const changeKey = `${fiatCurrency}_24h_change`
+
+  return recordMap(result, value => {
+    const price = value[fiatCurrency]
+    const change24h = value[changeKey]
+    return {
+      price: typeof price === 'number' ? price : 0,
+      ...(typeof change24h === 'number' ? { change24h } : {}),
+    }
+  })
+}

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -959,10 +959,20 @@
       "import": "./dist/coin/price/getCoinPrices.js",
       "default": "./dist/coin/price/getCoinPrices.js"
     },
+    "./coin/price/getCoinPricesWithChange": {
+      "types": "./dist/coin/price/getCoinPricesWithChange.d.ts",
+      "import": "./dist/coin/price/getCoinPricesWithChange.js",
+      "default": "./dist/coin/price/getCoinPricesWithChange.js"
+    },
     "./coin/price/queryCoingeickoPrices": {
       "types": "./dist/coin/price/queryCoingeickoPrices.d.ts",
       "import": "./dist/coin/price/queryCoingeickoPrices.js",
       "default": "./dist/coin/price/queryCoingeickoPrices.js"
+    },
+    "./coin/price/queryCoingeickoPricesWithChange": {
+      "types": "./dist/coin/price/queryCoingeickoPricesWithChange.d.ts",
+      "import": "./dist/coin/price/queryCoingeickoPricesWithChange.js",
+      "default": "./dist/coin/price/queryCoingeickoPricesWithChange.js"
     },
     "./coin/token/metadata": {
       "types": "./dist/coin/token/metadata/index.d.ts",

--- a/packages/sdk/src/Vultisig.ts
+++ b/packages/sdk/src/Vultisig.ts
@@ -3,6 +3,7 @@ import { Chain } from '@vultisig/core-chain/Chain'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { knownTokens, knownTokensIndex } from '@vultisig/core-chain/coin/knownTokens'
 import { getCoinPrices as coreCoinPrices } from '@vultisig/core-chain/coin/price/getCoinPrices'
+import { getCoinPricesWithChange as coreCoinPricesWithChange } from '@vultisig/core-chain/coin/price/getCoinPricesWithChange'
 import { scanSiteWithBlockaid } from '@vultisig/core-chain/security/blockaid/site'
 import { getBlockExplorerUrl } from '@vultisig/core-chain/utils/getBlockExplorerUrl'
 import { isValidAddress } from '@vultisig/core-chain/utils/isValidAddress'
@@ -43,7 +44,7 @@ import {
   VaultData,
 } from './types'
 import type { SiteScanResult } from './types/security'
-import type { CoinPricesParams, CoinPricesResult, FeeCoinInfo, TokenInfo } from './types/tokens'
+import type { CoinPricesParams, CoinPricesResult, CoinPricesWithChangeResult, FeeCoinInfo, TokenInfo } from './types/tokens'
 import { createVaultBackup } from './utils/export'
 import { parseKeygenQR } from './utils/parseKeygenQR'
 import { FastVault } from './vault/FastVault'
@@ -1170,6 +1171,27 @@ export class Vultisig extends UniversalEventEmitter<SdkEvents> {
    */
   static async getCoinPrices(params: CoinPricesParams): Promise<CoinPricesResult> {
     return coreCoinPrices({
+      ids: params.ids,
+      fiatCurrency: (params.fiatCurrency ?? 'usd') as any,
+    })
+  }
+
+  /**
+   * Fetch current prices AND 24h % change for tokens by CoinGecko IDs.
+   *
+   * Use this when you need the 24h change (e.g. a price widget's
+   * −3.97% indicator). For price-only lookups prefer `getCoinPrices`
+   * — it has a stable `Record<string, number>` contract and slightly
+   * lighter payload.
+   *
+   * @param params - Price lookup parameters
+   * @returns Map of token ID to `{ price, change24h? }` (change24h is
+   *          absent when CoinGecko has no datum for that id)
+   */
+  static async getCoinPricesWithChange(
+    params: CoinPricesParams
+  ): Promise<CoinPricesWithChangeResult> {
+    return coreCoinPricesWithChange({
       ids: params.ids,
       fiatCurrency: (params.fiatCurrency ?? 'usd') as any,
     })

--- a/packages/sdk/src/Vultisig.ts
+++ b/packages/sdk/src/Vultisig.ts
@@ -44,7 +44,13 @@ import {
   VaultData,
 } from './types'
 import type { SiteScanResult } from './types/security'
-import type { CoinPricesParams, CoinPricesResult, CoinPricesWithChangeResult, FeeCoinInfo, TokenInfo } from './types/tokens'
+import type {
+  CoinPricesParams,
+  CoinPricesResult,
+  CoinPricesWithChangeResult,
+  FeeCoinInfo,
+  TokenInfo,
+} from './types/tokens'
 import { createVaultBackup } from './utils/export'
 import { parseKeygenQR } from './utils/parseKeygenQR'
 import { FastVault } from './vault/FastVault'
@@ -1188,9 +1194,7 @@ export class Vultisig extends UniversalEventEmitter<SdkEvents> {
    * @returns Map of token ID to `{ price, change24h? }` (change24h is
    *          absent when CoinGecko has no datum for that id)
    */
-  static async getCoinPricesWithChange(
-    params: CoinPricesParams
-  ): Promise<CoinPricesWithChangeResult> {
+  static async getCoinPricesWithChange(params: CoinPricesParams): Promise<CoinPricesWithChangeResult> {
     return coreCoinPricesWithChange({
       ids: params.ids,
       fiatCurrency: (params.fiatCurrency ?? 'usd') as any,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -226,7 +226,7 @@ export {
 // PUBLIC API - Token Registry & Chain Data
 // ============================================================================
 
-export type { CoinPricesParams, CoinPricesResult, DiscoveredToken, FeeCoinInfo, TokenInfo } from './types'
+export type { CoinPriceWithChange, CoinPricesParams, CoinPricesResult, CoinPricesWithChangeResult, DiscoveredToken, FeeCoinInfo, TokenInfo } from './types'
 
 // ============================================================================
 // PUBLIC API - Security Scanning

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -226,7 +226,15 @@ export {
 // PUBLIC API - Token Registry & Chain Data
 // ============================================================================
 
-export type { CoinPricesParams, CoinPricesResult, CoinPricesWithChangeResult, CoinPriceWithChange, DiscoveredToken, FeeCoinInfo, TokenInfo } from './types'
+export type {
+  CoinPricesParams,
+  CoinPricesResult,
+  CoinPricesWithChangeResult,
+  CoinPriceWithChange,
+  DiscoveredToken,
+  FeeCoinInfo,
+  TokenInfo,
+} from './types'
 
 // ============================================================================
 // PUBLIC API - Security Scanning

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -226,7 +226,7 @@ export {
 // PUBLIC API - Token Registry & Chain Data
 // ============================================================================
 
-export type { CoinPriceWithChange, CoinPricesParams, CoinPricesResult, CoinPricesWithChangeResult, DiscoveredToken, FeeCoinInfo, TokenInfo } from './types'
+export type { CoinPricesParams, CoinPricesResult, CoinPricesWithChangeResult, CoinPriceWithChange, DiscoveredToken, FeeCoinInfo, TokenInfo } from './types'
 
 // ============================================================================
 // PUBLIC API - Security Scanning

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -655,7 +655,15 @@ export type {
 } from './cosmos'
 
 // Token registry & chain data types
-export type { CoinPricesParams, CoinPricesResult, CoinPricesWithChangeResult, CoinPriceWithChange, DiscoveredToken, FeeCoinInfo, TokenInfo } from './tokens'
+export type {
+  CoinPricesParams,
+  CoinPricesResult,
+  CoinPricesWithChangeResult,
+  CoinPriceWithChange,
+  DiscoveredToken,
+  FeeCoinInfo,
+  TokenInfo,
+} from './tokens'
 
 // Security scanning types
 export type { RiskLevel, SiteScanResult, TransactionSimulationResult, TransactionValidationResult } from './security'

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -655,7 +655,7 @@ export type {
 } from './cosmos'
 
 // Token registry & chain data types
-export type { CoinPricesParams, CoinPricesResult, DiscoveredToken, FeeCoinInfo, TokenInfo } from './tokens'
+export type { CoinPriceWithChange, CoinPricesParams, CoinPricesResult, CoinPricesWithChangeResult, DiscoveredToken, FeeCoinInfo, TokenInfo } from './tokens'
 
 // Security scanning types
 export type { RiskLevel, SiteScanResult, TransactionSimulationResult, TransactionValidationResult } from './security'

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -655,7 +655,7 @@ export type {
 } from './cosmos'
 
 // Token registry & chain data types
-export type { CoinPriceWithChange, CoinPricesParams, CoinPricesResult, CoinPricesWithChangeResult, DiscoveredToken, FeeCoinInfo, TokenInfo } from './tokens'
+export type { CoinPricesParams, CoinPricesResult, CoinPricesWithChangeResult, CoinPriceWithChange, DiscoveredToken, FeeCoinInfo, TokenInfo } from './tokens'
 
 // Security scanning types
 export type { RiskLevel, SiteScanResult, TransactionSimulationResult, TransactionValidationResult } from './security'

--- a/packages/sdk/src/types/tokens.ts
+++ b/packages/sdk/src/types/tokens.ts
@@ -39,3 +39,13 @@ export type CoinPricesParams = {
 
 /** Price lookup result: id -> price in fiat */
 export type CoinPricesResult = Record<string, number>
+
+/** One coin's spot price plus optional 24h % change. */
+export type CoinPriceWithChange = {
+  price: number
+  /** 24h % change; absent when CoinGecko has no datum for the id. */
+  change24h?: number
+}
+
+/** Price+change lookup result: id -> { price, change24h? } */
+export type CoinPricesWithChangeResult = Record<string, CoinPriceWithChange>


### PR DESCRIPTION
## What

Additive price API that also returns 24h % change:
- `Vultisig.getCoinPricesWithChange(params)` → `Record<string,{price:number;change24h?:number}>`
- core-chain `getCoinPricesWithChange` / `queryCoingeickoPricesWithChange` (`include_24hr_change=true`)
- new public types `CoinPriceWithChange`, `CoinPricesWithChangeResult`
- core-chain package.json exports for the 2 new modules; changeset: `@vultisig/sdk` minor

## Why
`getCoinPrices` returns only `Record<string,number>`. Clients needing 24h change (vultiagent-app dashboard price widget −3.97%) keep a hand-rolled side-channel call, duplicating the SDK. This sources price+change from the SDK alone.

## Zero regression
Separate function, NOT a flag on `getCoinPrices`. `getCoinPrices`/`CoinPricesResult`/`FiatValueService`/`fiatToAmount`/`getErc20Prices` byte-identical.

## Verification
+4 unit tests (all pass), existing price tests green, SDK typecheck + ESLint clean, build:shared emits both new modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SDK adds an API to fetch coin spot prices with optional 24‑hour percentage change; existing price-only APIs remain backward compatible.
  * New public types describing price-with-change results were added.

* **Tests**
  * Unit tests added to validate price and 24h-change extraction, handling of missing values/defaults, and correct fiat-key behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/502?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->