### PR TITLE
feat(tokens): vault-free Vultisig.discoverTokens({chain,address})

### DIFF
--- a/.changeset/vault-free-discover-tokens.md
+++ b/.changeset/vault-free-discover-tokens.md
@@ -1,0 +1,23 @@
+---
+"@vultisig/sdk": minor
+---
+
+feat(tokens): add vault-free `Vultisig.discoverTokens({ chain, address })`
+
+On-chain token discovery (1inch for EVM, Jupiter for Solana, LCD for
+Cosmos) was only reachable as the instance method
+`vault.discoverTokens(chain)`. Callers that hold a derived address but
+no SDK `Vault` — the agent, a portfolio/dashboard screen, the
+agent-backend — couldn't use it without constructing a full vault.
+
+Adds a static, vault-free `Vultisig.discoverTokens({ chain, address })`
+returning `DiscoveredToken[]`. It is a thin wrapper over the
+already-vault-free `findCoins({ address, chain })` from
+`@vultisig/core-chain/coin/find` — the exact same call + mapping
+`vault.discoverTokens()` already does internally, minus the
+`getAddress` step. No new discovery logic, no behavioural change to the
+instance method, zero regression surface.
+
+Lets vultiagent-app discover the long tail of held tokens (beyond
+native + manually-added) on its existing vault-free balance path so the
+dashboard + agent see the same token set as a wallet would.

--- a/packages/sdk/src/Vultisig.ts
+++ b/packages/sdk/src/Vultisig.ts
@@ -1,6 +1,7 @@
 import { banxaSupportedChains } from '@vultisig/core-chain/banxa'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
+import { findCoins as coreFindCoins } from '@vultisig/core-chain/coin/find'
 import { knownTokens, knownTokensIndex } from '@vultisig/core-chain/coin/knownTokens'
 import { getCoinPrices as coreCoinPrices } from '@vultisig/core-chain/coin/price/getCoinPrices'
 import { getCoinPricesWithChange as coreCoinPricesWithChange } from '@vultisig/core-chain/coin/price/getCoinPricesWithChange'
@@ -48,6 +49,7 @@ import type {
   CoinPricesParams,
   CoinPricesResult,
   CoinPricesWithChangeResult,
+  DiscoveredToken,
   FeeCoinInfo,
   TokenInfo,
 } from './types/tokens'
@@ -1116,6 +1118,35 @@ export class Vultisig extends UniversalEventEmitter<SdkEvents> {
   }
 
   // === STATIC TOKEN REGISTRY METHODS ===
+
+  /**
+   * Discover the tokens an address actually holds on a chain
+   * (1inch for EVM, Jupiter for Solana, LCD for Cosmos, …).
+   *
+   * Vault-FREE: takes a raw `{ chain, address }` and returns
+   * `DiscoveredToken[]`. The instance method `vault.discoverTokens()`
+   * is just `getAddress` + this same `findCoins` call — exposing it
+   * statically lets callers that only hold a derived address (the
+   * agent, a portfolio screen) discover tokens without constructing a
+   * full SDK Vault. No new logic; the mapping mirrors
+   * `TokenDiscoveryService.discoverTokens` exactly.
+   *
+   * @param params - `{ chain, address }`
+   * @returns Tokens with non-zero balance at that address
+   */
+  static async discoverTokens(params: { chain: Chain; address: string }): Promise<DiscoveredToken[]> {
+    const coins = await coreFindCoins({
+      address: params.address,
+      chain: params.chain,
+    })
+    return coins.map(coin => ({
+      chain: coin.chain,
+      contractAddress: coin.id ?? '',
+      ticker: coin.ticker,
+      decimals: coin.decimals,
+      logo: coin.logo,
+    }))
+  }
 
   /**
    * Get known tokens for a chain from the built-in registry.

--- a/packages/sdk/tests/unit/Vultisig.static-methods.test.ts
+++ b/packages/sdk/tests/unit/Vultisig.static-methods.test.ts
@@ -12,6 +12,11 @@ vi.mock('@vultisig/core-chain/security/blockaid/site', () => ({
   scanSiteWithBlockaid: vi.fn(),
 }))
 
+vi.mock('@vultisig/core-chain/coin/find', () => ({
+  findCoins: vi.fn(),
+}))
+
+import { findCoins } from '@vultisig/core-chain/coin/find'
 import { getCoinPrices } from '@vultisig/core-chain/coin/price/getCoinPrices'
 import { scanSiteWithBlockaid } from '@vultisig/core-chain/security/blockaid/site'
 
@@ -162,6 +167,72 @@ describe('Vultisig static methods', () => {
 
       expect(chains1).toEqual(chains2)
       expect(chains1).not.toBe(chains2)
+    })
+  })
+
+  describe('discoverTokens (vault-free)', () => {
+    it('maps findCoins AccountCoin[] to DiscoveredToken[]', async () => {
+      vi.mocked(findCoins).mockResolvedValue([
+        {
+          chain: Chain.Ethereum,
+          id: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+          ticker: 'USDC',
+          decimals: 6,
+          logo: 'usdc.png',
+        },
+        {
+          chain: Chain.Ethereum,
+          id: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+          ticker: 'USDT',
+          decimals: 6,
+        },
+      ] as never)
+
+      const result = await Vultisig.discoverTokens({
+        chain: Chain.Ethereum,
+        address: '0xabc',
+      })
+
+      expect(findCoins).toHaveBeenCalledWith({
+        address: '0xabc',
+        chain: Chain.Ethereum,
+      })
+      expect(result).toEqual([
+        {
+          chain: Chain.Ethereum,
+          contractAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+          ticker: 'USDC',
+          decimals: 6,
+          logo: 'usdc.png',
+        },
+        {
+          chain: Chain.Ethereum,
+          contractAddress: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+          ticker: 'USDT',
+          decimals: 6,
+          logo: undefined,
+        },
+      ])
+    })
+
+    it('coerces a missing coin id to an empty contractAddress', async () => {
+      vi.mocked(findCoins).mockResolvedValue([{ chain: Chain.Solana, ticker: 'SOL', decimals: 9 }] as never)
+
+      const result = await Vultisig.discoverTokens({
+        chain: Chain.Solana,
+        address: 'soL111',
+      })
+
+      expect(result[0]?.contractAddress).toBe('')
+    })
+
+    it('returns [] when the address holds nothing', async () => {
+      vi.mocked(findCoins).mockResolvedValue([] as never)
+      const result = await Vultisig.discoverTokens({
+        chain: Chain.Ethereum,
+        address: '0xempty',
+      })
+      expect(result).toEqual([])
     })
   })
 


### PR DESCRIPTION
## What
Static, vault-free `Vultisig.discoverTokens({ chain, address })` → `DiscoveredToken[]`.

## Why
On-chain token discovery (1inch EVM / Jupiter Solana / Cosmos LCD) was only reachable as the instance method `vault.discoverTokens(chain)`. Callers that hold a derived address but no SDK `Vault` — the agent, dashboard/portfolio screens, agent-backend — couldn't discover an address's held tokens without constructing a full vault. vultiagent-app's balance path is deliberately vault-free.

## Zero regression
Thin wrapper over the already-vault-free `findCoins({ address, chain })` from `@vultisig/core-chain/coin/find` — the exact call + `DiscoveredToken` mapping `vault.discoverTokens()` already does internally, minus the `getAddress` step. No new discovery logic; instance method untouched.

## Verification
+3 unit tests (mapping, missing-id coercion, empty). Full SDK unit suite **1379 pass**. Repo Prettier + ESLint clean (full static gate verified pre-push). Changeset: `@vultisig/sdk` minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Vultisig.discoverTokens({ chain, address }) — a vault-free way to discover held tokens and return token info (contract, ticker, decimals, logo).

* **Tests**
  * Added unit tests covering token mapping, missing contract IDs, and empty results to ensure reliable vault-free discovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/503?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->