### PR TITLE
Integrate SwapKit provider

### DIFF
--- a/.changeset/swapkit-provider.md
+++ b/.changeset/swapkit-provider.md
@@ -1,0 +1,7 @@
+---
+'@vultisig/core-chain': minor
+'@vultisig/sdk': minor
+'@vultisig/cli': minor
+---
+
+Add SwapKit as a configurable general swap provider for EVM and Solana source routes.

--- a/packages/core/chain/chains/cosmos/cosmosGasLimitRecord.test.ts
+++ b/packages/core/chain/chains/cosmos/cosmosGasLimitRecord.test.ts
@@ -1,0 +1,26 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { describe, expect, it } from 'vitest'
+
+import { getCosmosGasLimit, getCosmosStakingGasLimit } from './cosmosGasLimitRecord'
+
+describe('cosmosGasLimitRecord', () => {
+  it('keeps existing send gas limits unchanged', () => {
+    expect(getCosmosGasLimit({ chain: Chain.Cosmos })).toBe(200_000n)
+    expect(getCosmosGasLimit({ chain: Chain.TerraClassic, id: 'uusd' })).toBe(1_000_000n)
+  })
+
+  it('returns higher staking gas limits and scales bulk reward claim messages', () => {
+    expect(getCosmosStakingGasLimit({ chain: Chain.Terra })).toBe(500_000n)
+    expect(getCosmosStakingGasLimit({ chain: Chain.TerraClassic })).toBe(2_000_000n)
+    expect(getCosmosStakingGasLimit({ chain: Chain.TerraClassic, msgCount: 3 })).toBe(3_000_000n)
+  })
+
+  it('rejects invalid staking message counts before BigInt conversion', () => {
+    expect(() => getCosmosStakingGasLimit({ chain: Chain.Terra, msgCount: 1.5 })).toThrow(
+      'msgCount must be a non-negative integer'
+    )
+    expect(() => getCosmosStakingGasLimit({ chain: Chain.Terra, msgCount: -1 })).toThrow(
+      'msgCount must be a non-negative integer'
+    )
+  })
+})

--- a/packages/core/chain/chains/cosmos/cosmosGasLimitRecord.ts
+++ b/packages/core/chain/chains/cosmos/cosmosGasLimitRecord.ts
@@ -81,7 +81,9 @@ export const getCosmosStakingGasLimit = ({ chain, msgCount = 1 }: GetCosmosStaki
   if (!Number.isInteger(msgCount) || msgCount < 0) {
     throw new Error(`getCosmosStakingGasLimit: msgCount must be a non-negative integer, got ${msgCount}`)
   }
+
   const base = cosmosStakingGasLimitRecord[chain]
   const n = BigInt(Math.max(1, msgCount))
+
   return base + ((n - 1n) * base) / 4n
 }

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -1330,6 +1330,21 @@
       "import": "./dist/swap/general/oneInch/OneInchSwapEnabledChains.js",
       "default": "./dist/swap/general/oneInch/OneInchSwapEnabledChains.js"
     },
+    "./swap/general/swapkit/api/getSwapKitQuote": {
+      "types": "./dist/swap/general/swapkit/api/getSwapKitQuote.d.ts",
+      "import": "./dist/swap/general/swapkit/api/getSwapKitQuote.js",
+      "default": "./dist/swap/general/swapkit/api/getSwapKitQuote.js"
+    },
+    "./swap/general/swapkit/config": {
+      "types": "./dist/swap/general/swapkit/config.d.ts",
+      "import": "./dist/swap/general/swapkit/config.js",
+      "default": "./dist/swap/general/swapkit/config.js"
+    },
+    "./swap/general/swapkit/SwapKitEnabledChains": {
+      "types": "./dist/swap/general/swapkit/SwapKitEnabledChains.d.ts",
+      "import": "./dist/swap/general/swapkit/SwapKitEnabledChains.js",
+      "default": "./dist/swap/general/swapkit/SwapKitEnabledChains.js"
+    },
     "./swap/keysign/getSwapDestinationAddress": {
       "types": "./dist/swap/keysign/getSwapDestinationAddress.d.ts",
       "import": "./dist/swap/keysign/getSwapDestinationAddress.js",

--- a/packages/core/chain/swap/general/GeneralSwapProvider.ts
+++ b/packages/core/chain/swap/general/GeneralSwapProvider.ts
@@ -1,4 +1,4 @@
-export const generalSwapProviders = ['1inch', 'li.fi', 'kyber'] as const
+export const generalSwapProviders = ['1inch', 'li.fi', 'kyber', 'swapkit'] as const
 
 export type GeneralSwapProvider = (typeof generalSwapProviders)[number]
 
@@ -6,4 +6,5 @@ export const generalSwapProviderName: Record<GeneralSwapProvider, string> = {
   '1inch': '1Inch',
   'li.fi': 'LI.FI',
   kyber: 'KyberSwap',
+  swapkit: 'SwapKit',
 }

--- a/packages/core/chain/swap/general/GeneralSwapQuote.ts
+++ b/packages/core/chain/swap/general/GeneralSwapQuote.ts
@@ -24,5 +24,6 @@ export type GeneralSwapTx =
 export type GeneralSwapQuote = {
   dstAmount: string
   provider: GeneralSwapProvider
+  routeProvider?: string
   tx: GeneralSwapTx
 }

--- a/packages/core/chain/swap/general/swapkit/SwapKitEnabledChains.ts
+++ b/packages/core/chain/swap/general/swapkit/SwapKitEnabledChains.ts
@@ -1,0 +1,35 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+
+export const swapKitSourceChains = [
+  Chain.Ethereum,
+  Chain.Arbitrum,
+  Chain.Avalanche,
+  Chain.Base,
+  Chain.BSC,
+  Chain.Optimism,
+  Chain.Polygon,
+  Chain.Solana,
+] as const
+
+export type SwapKitSourceChain = (typeof swapKitSourceChains)[number]
+
+export const swapKitEnabledChains = [
+  ...swapKitSourceChains,
+  Chain.Bitcoin,
+  Chain.BitcoinCash,
+  Chain.Cardano,
+  Chain.Cosmos,
+  Chain.Dash,
+  Chain.Dogecoin,
+  Chain.Kujira,
+  Chain.Litecoin,
+  Chain.MayaChain,
+  Chain.Ripple,
+  Chain.Sui,
+  Chain.THORChain,
+  Chain.Ton,
+  Chain.Tron,
+  Chain.Zcash,
+] as const
+
+export type SwapKitEnabledChain = (typeof swapKitEnabledChains)[number]

--- a/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.test.ts
+++ b/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.test.ts
@@ -230,7 +230,7 @@ describe('getSwapKitQuote', () => {
     expect(getSwapKitConfig().baseUrl).toBe('https://swapkit.example')
   })
 
-  it('ranks routes without expected buy amounts after valid routes', async () => {
+  it('ranks routes without valid expected buy amounts after valid routes', async () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(
@@ -239,6 +239,11 @@ describe('getSwapKitQuote', () => {
             {
               routeId: 'missing-amount-route',
               providers: ['NEAR'],
+            },
+            {
+              routeId: 'malformed-amount-route',
+              providers: ['NEAR'],
+              expectedBuyAmount: 'not-a-number',
             },
             {
               routeId: 'valid-route',

--- a/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.test.ts
+++ b/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.test.ts
@@ -1,5 +1,5 @@
 import { Chain } from '@vultisig/core-chain/Chain'
-import { configureSwapKit } from '@vultisig/core-chain/swap/general/swapkit/config'
+import { configureSwapKit, getSwapKitConfig } from '@vultisig/core-chain/swap/general/swapkit/config'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { getSwapKitQuote } from './getSwapKitQuote'
@@ -221,6 +221,64 @@ describe('getSwapKitQuote', () => {
     expect(fetchMock.mock.calls[0][1].headers['x-api-key']).toBeUndefined()
     expect(fetchMock.mock.calls[1][0]).toBe('https://api.vultisig.com/swapkit-win/v3/swap')
     expect(fetchMock.mock.calls[1][1].headers['x-api-key']).toBeUndefined()
+  })
+
+  it('does not let an undefined base URL override the current config', () => {
+    configureSwapKit({ baseUrl: 'https://swapkit.example' })
+    configureSwapKit({ baseUrl: undefined })
+
+    expect(getSwapKitConfig().baseUrl).toBe('https://swapkit.example')
+  })
+
+  it('ranks routes without expected buy amounts after valid routes', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        response({
+          routes: [
+            {
+              routeId: 'missing-amount-route',
+              providers: ['NEAR'],
+            },
+            {
+              routeId: 'valid-route',
+              providers: ['NEAR'],
+              expectedBuyAmount: '9.4',
+            },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(
+        response({
+          expectedBuyAmount: '9.3',
+          providers: ['NEAR'],
+          tx: {
+            to: '0xnear-deposit',
+            value: '5000000000000000',
+          },
+        })
+      )
+
+    vi.stubGlobal('fetch', fetchMock)
+    configureSwapKit({ apiKey: undefined })
+
+    await getSwapKitQuote({
+      from: {
+        chain: Chain.Ethereum,
+        address: '0xsender',
+        ticker: 'ETH',
+        decimals: 18,
+      },
+      to: {
+        chain: Chain.Sui,
+        address: '0xsui',
+        ticker: 'SUI',
+        decimals: 9,
+      },
+      amount: 5_000_000_000_000_000n,
+    })
+
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body).routeId).toBe('valid-route')
   })
 
   it('falls back to focused provider groups when the broad SwapKit provider query misses a route', async () => {

--- a/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.test.ts
+++ b/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.test.ts
@@ -199,7 +199,9 @@ describe('getSwapKitQuote', () => {
       )
     vi.stubGlobal('fetch', fetchMock)
 
-    configureSwapKit({ apiKey: undefined })
+    // Explicitly set the Windows proxy URL; the default is platform-detected
+    // (darwin/ios -> /swapkit, android -> /swapkit-a, other -> /swapkit-win).
+    configureSwapKit({ apiKey: undefined, baseUrl: 'https://api.vultisig.com/swapkit-win' })
 
     await getSwapKitQuote({
       from: {

--- a/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.test.ts
+++ b/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.test.ts
@@ -1,0 +1,294 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { configureSwapKit } from '@vultisig/core-chain/swap/general/swapkit/config'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { getSwapKitQuote } from './getSwapKitQuote'
+
+const response = (body: unknown, ok = true, status = 200) =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Bad Request',
+    json: vi.fn(async () => body),
+  }) as unknown as Response
+
+describe('getSwapKitQuote', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    configureSwapKit({ apiKey: undefined, baseUrl: 'https://api.vultisig.com/swapkit-win' })
+  })
+
+  it('quotes and builds an EVM transaction while filtering native THOR/Maya routes', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        response({
+          routes: [
+            {
+              routeId: 'thor-route',
+              providers: ['THORCHAIN'],
+              expectedBuyAmount: '15',
+            },
+            {
+              routeId: 'near-route',
+              providers: ['NEAR'],
+              expectedBuyAmount: '12.5',
+            },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(
+        response({
+          expectedBuyAmount: '12.4',
+          providers: ['NEAR'],
+          tx: {
+            from: '0xsender',
+            to: '0xrouter',
+            data: '0xabcdef',
+            value: '0',
+            gas: '21000',
+          },
+        })
+      )
+
+    vi.stubGlobal('fetch', fetchMock)
+    configureSwapKit({ apiKey: 'test-key', baseUrl: 'https://swapkit.example' })
+
+    const quote = await getSwapKitQuote({
+      from: {
+        chain: Chain.Ethereum,
+        address: '0xsender',
+        ticker: 'ETH',
+        decimals: 18,
+      },
+      to: {
+        chain: Chain.Solana,
+        address: 'sol-destination',
+        ticker: 'USDC',
+        id: 'sol-usdc-mint',
+        decimals: 6,
+      },
+      amount: 10_000_000_000_000_000n,
+      affiliateBps: 15,
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    const quoteBody = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(fetchMock.mock.calls[0][0]).toBe('https://swapkit.example/v3/quote')
+    expect(fetchMock.mock.calls[0][1].headers['x-api-key']).toBe('test-key')
+    expect(quoteBody).toMatchObject({
+      sellAsset: 'ETH.ETH',
+      buyAsset: 'SOL.USDC-sol-usdc-mint',
+      sellAmount: '0.01',
+      affiliateFee: 15,
+    })
+    expect(quoteBody.sourceAddress).toBeUndefined()
+    expect(quoteBody.destinationAddress).toBeUndefined()
+    expect(quoteBody.providers).not.toContain('THORCHAIN')
+    expect(quoteBody.providers).not.toContain('MAYACHAIN')
+
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toMatchObject({
+      routeId: 'near-route',
+      sourceAddress: '0xsender',
+      destinationAddress: 'sol-destination',
+      disableBalanceCheck: true,
+    })
+    expect(quote).toEqual({
+      dstAmount: '12400000',
+      provider: 'swapkit',
+      routeProvider: 'NEAR',
+      tx: {
+        evm: {
+          from: '0xsender',
+          to: '0xrouter',
+          data: '0xabcdef',
+          value: '0',
+          gasLimit: 21000n,
+        },
+      },
+    })
+  })
+
+  it('maps Solana source routes to the existing serialized transaction payload', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          response({
+            routes: [
+              {
+                routeId: 'jupiter-route',
+                providers: ['JUPITER'],
+                expectedBuyAmount: '0.05',
+              },
+            ],
+          })
+        )
+        .mockResolvedValueOnce(
+          response({
+            providers: ['JUPITER'],
+            tx: 'serialized-solana-transaction',
+            fees: [
+              { type: 'network', amount: '0.000005' },
+              { type: 'service', amount: '0.000000007' },
+            ],
+          })
+        )
+    )
+    configureSwapKit({ apiKey: 'test-key' })
+
+    const quote = await getSwapKitQuote({
+      from: {
+        chain: Chain.Solana,
+        address: 'sol-source',
+        ticker: 'SOL',
+        decimals: 9,
+      },
+      to: {
+        chain: Chain.Ethereum,
+        address: '0xdestination',
+        ticker: 'ETH',
+        decimals: 18,
+      },
+      amount: 1_000_000n,
+    })
+
+    expect(quote).toMatchObject({
+      dstAmount: '50000000000000000',
+      provider: 'swapkit',
+      routeProvider: 'JUPITER',
+      tx: {
+        solana: {
+          data: 'serialized-solana-transaction',
+          networkFee: 5000n,
+          swapFee: {
+            amount: 7n,
+            decimals: 9,
+            chain: Chain.Solana,
+          },
+        },
+      },
+    })
+  })
+
+  it('uses the Vultisig proxy without an API key by default', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        response({
+          routes: [
+            {
+              routeId: 'near-route',
+              providers: ['NEAR'],
+              expectedBuyAmount: '0.01',
+            },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(
+        response({
+          expectedBuyAmount: '0.01',
+          providers: ['NEAR'],
+          tx: {
+            to: '0xrouter',
+            value: '100',
+          },
+        })
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    configureSwapKit({ apiKey: undefined })
+
+    await getSwapKitQuote({
+      from: {
+        chain: Chain.Ethereum,
+        address: '0xsender',
+        ticker: 'ETH',
+        decimals: 18,
+      },
+      to: {
+        chain: Chain.Bitcoin,
+        address: 'bc1destination',
+        ticker: 'BTC',
+        decimals: 8,
+      },
+      amount: 1n,
+    })
+
+    expect(fetchMock.mock.calls[0][0]).toBe('https://api.vultisig.com/swapkit-win/v3/quote')
+    expect(fetchMock.mock.calls[0][1].headers['x-api-key']).toBeUndefined()
+    expect(fetchMock.mock.calls[1][0]).toBe('https://api.vultisig.com/swapkit-win/v3/swap')
+    expect(fetchMock.mock.calls[1][1].headers['x-api-key']).toBeUndefined()
+  })
+
+  it('falls back to focused provider groups when the broad SwapKit provider query misses a route', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response({ error: 'noRoutesFound' }, false, 400))
+      .mockResolvedValueOnce(
+        response({
+          routes: [
+            {
+              routeId: 'near-sui-route',
+              providers: ['NEAR'],
+              expectedBuyAmount: '9.4',
+            },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(
+        response({
+          expectedBuyAmount: '9.3',
+          providers: ['NEAR'],
+          tx: {
+            to: '0xnear-deposit',
+            value: '5000000000000000',
+            gasLimit: '21000',
+          },
+        })
+      )
+
+    vi.stubGlobal('fetch', fetchMock)
+    configureSwapKit({ apiKey: undefined })
+
+    const quote = await getSwapKitQuote({
+      from: {
+        chain: Chain.Ethereum,
+        address: '0xsender',
+        ticker: 'ETH',
+        decimals: 18,
+      },
+      to: {
+        chain: Chain.Sui,
+        address: '0xsui',
+        ticker: 'SUI',
+        decimals: 9,
+      },
+      amount: 5_000_000_000_000_000n,
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).providers).toContain('CHAINFLIP')
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body).providers).toEqual(['NEAR'])
+    expect(JSON.parse(fetchMock.mock.calls[2][1].body)).toMatchObject({
+      routeId: 'near-sui-route',
+      sourceAddress: '0xsender',
+      destinationAddress: '0xsui',
+      disableBalanceCheck: true,
+    })
+    expect(quote).toMatchObject({
+      dstAmount: '9300000000',
+      provider: 'swapkit',
+      routeProvider: 'NEAR',
+      tx: {
+        evm: {
+          to: '0xnear-deposit',
+          value: '5000000000000000',
+          gasLimit: 21000n,
+        },
+      },
+    })
+  })
+})

--- a/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.ts
+++ b/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.ts
@@ -1,0 +1,380 @@
+import { toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
+import { GeneralSwapQuote, GeneralSwapTx } from '@vultisig/core-chain/swap/general/GeneralSwapQuote'
+import { getSwapKitConfig } from '@vultisig/core-chain/swap/general/swapkit/config'
+import { SwapKitEnabledChain, SwapKitSourceChain } from '@vultisig/core-chain/swap/general/swapkit/SwapKitEnabledChains'
+import { withoutUndefinedFields } from '@vultisig/lib-utils/record/withoutUndefinedFields'
+import { TransferDirection } from '@vultisig/lib-utils/TransferDirection'
+
+import { AccountCoin } from '../../../../coin/AccountCoin'
+
+type Input = Record<TransferDirection, AccountCoin<SwapKitEnabledChain>> & {
+  from: AccountCoin<SwapKitSourceChain>
+  amount: bigint
+  affiliateBps?: number
+}
+
+type SwapKitProvider =
+  | 'CAMELOT_V3'
+  | 'CHAINFLIP'
+  | 'CHAINFLIP_STREAMING'
+  | 'FLASHNET'
+  | 'GARDEN'
+  | 'HARBOR'
+  | 'JUPITER'
+  | 'NEAR'
+  | 'OKX'
+  | 'ONEINCH'
+  | 'OPENOCEAN_V2'
+  | 'PANCAKESWAP'
+  | 'PANGOLIN_V1'
+  | 'SUSHISWAP_V2'
+  | 'TRADERJOE_V2'
+  | 'UNISWAP_V2'
+  | 'UNISWAP_V3'
+
+const swapKitAllowedProviders: SwapKitProvider[] = [
+  'CHAINFLIP',
+  'CHAINFLIP_STREAMING',
+  'NEAR',
+  'GARDEN',
+  'FLASHNET',
+  'HARBOR',
+  'ONEINCH',
+  'UNISWAP_V2',
+  'UNISWAP_V3',
+  'JUPITER',
+  'OKX',
+  'PANCAKESWAP',
+  'SUSHISWAP_V2',
+  'TRADERJOE_V2',
+  'PANGOLIN_V1',
+  'CAMELOT_V3',
+  'OPENOCEAN_V2',
+]
+
+const swapKitProviderQuoteAttempts: SwapKitProvider[][] = [
+  swapKitAllowedProviders,
+  ['NEAR'],
+  ['CHAINFLIP', 'CHAINFLIP_STREAMING'],
+  ['GARDEN'],
+  ['FLASHNET'],
+  ['HARBOR'],
+  ['JUPITER'],
+  [
+    'ONEINCH',
+    'UNISWAP_V2',
+    'UNISWAP_V3',
+    'OKX',
+    'PANCAKESWAP',
+    'SUSHISWAP_V2',
+    'TRADERJOE_V2',
+    'PANGOLIN_V1',
+    'CAMELOT_V3',
+    'OPENOCEAN_V2',
+  ],
+]
+
+const swapKitExcludedProviders = new Set(['THORCHAIN', 'THORCHAIN_STREAMING', 'MAYACHAIN', 'MAYACHAIN_STREAMING'])
+
+const swapKitChainId: Record<SwapKitEnabledChain, string> = {
+  [Chain.Arbitrum]: 'ARB',
+  [Chain.Avalanche]: 'AVAX',
+  [Chain.Base]: 'BASE',
+  [Chain.Bitcoin]: 'BTC',
+  [Chain.BitcoinCash]: 'BCH',
+  [Chain.BSC]: 'BSC',
+  [Chain.Cardano]: 'ADA',
+  [Chain.Cosmos]: 'GAIA',
+  [Chain.Dash]: 'DASH',
+  [Chain.Dogecoin]: 'DOGE',
+  [Chain.Ethereum]: 'ETH',
+  [Chain.Kujira]: 'KUJI',
+  [Chain.Litecoin]: 'LTC',
+  [Chain.MayaChain]: 'MAYA',
+  [Chain.Optimism]: 'OP',
+  [Chain.Polygon]: 'POL',
+  [Chain.Ripple]: 'XRP',
+  [Chain.Solana]: 'SOL',
+  [Chain.Sui]: 'SUI',
+  [Chain.THORChain]: 'THOR',
+  [Chain.Ton]: 'TON',
+  [Chain.Tron]: 'TRON',
+  [Chain.Zcash]: 'ZEC',
+}
+
+type SwapKitQuoteRoute = {
+  routeId: string
+  providers?: string[]
+  expectedBuyAmount?: string
+  legs?: { provider?: string }[]
+  warnings?: { display?: string; message?: string }[]
+}
+
+type SwapKitQuoteResponse = {
+  routes?: SwapKitQuoteRoute[]
+  providerErrors?: { provider?: string; message?: string; errorCode?: string }[]
+  error?: string
+  message?: string
+}
+
+type SwapKitSwapResponse = {
+  expectedBuyAmount?: string
+  tx?: unknown
+  providers?: string[]
+  legs?: { provider?: string }[]
+  fees?: { type?: string; amount?: string }[]
+  meta?: {
+    txType?: string
+  }
+}
+
+type SwapKitEvmTx = {
+  from?: string
+  to?: string
+  data?: string
+  value?: string | number | bigint
+  gas?: string | number | bigint
+  gasLimit?: string | number | bigint
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null
+
+const formatBasicUnitAmount = (amount: bigint, decimals: number): string => {
+  const sign = amount < 0n ? '-' : ''
+  const abs = amount < 0n ? -amount : amount
+
+  if (decimals === 0) {
+    return `${sign}${abs.toString()}`
+  }
+
+  const divisor = 10n ** BigInt(decimals)
+  const whole = abs / divisor
+  const fraction = (abs % divisor).toString().padStart(decimals, '0').replace(/0+$/, '')
+
+  return fraction ? `${sign}${whole.toString()}.${fraction}` : `${sign}${whole.toString()}`
+}
+
+const normalizeProvider = (provider: string) => provider.trim().toUpperCase().replace(/[-\s]/g, '_')
+
+const routeProviderNames = ({ providers, legs }: Pick<SwapKitQuoteRoute, 'providers' | 'legs'>): string[] => {
+  const names = [...(providers ?? []), ...(legs ?? []).map(({ provider }) => provider)].filter(
+    (provider): provider is string => !!provider
+  )
+
+  return [...new Set(names.map(normalizeProvider))]
+}
+
+const isAllowedRoute = (route: SwapKitQuoteRoute) =>
+  routeProviderNames(route).every(provider => !swapKitExcludedProviders.has(provider))
+
+const isNoRouteError = (message: string) => {
+  const normalizedMessage = message.toLowerCase().replace(/[\s_-]/g, '')
+
+  return normalizedMessage.includes('noroutesfound') || normalizedMessage.includes('noroutes')
+}
+
+const getRouteProviderName = (route: Pick<SwapKitQuoteRoute, 'providers' | 'legs'>) => {
+  const [firstProvider] = routeProviderNames(route).filter(provider => !swapKitExcludedProviders.has(provider))
+
+  return firstProvider
+}
+
+const parseExpectedBuyAmount = (amount: string | undefined, decimals: number): string => {
+  if (!amount) {
+    throw new Error('SwapKit quote did not include an expected buy amount.')
+  }
+
+  return toChainAmount(amount, decimals).toString()
+}
+
+const postSwapKit = async <T>(path: string, body: Record<string, unknown>): Promise<T> => {
+  const { apiKey, baseUrl } = getSwapKitConfig()
+  const trimmedApiKey = apiKey?.trim()
+
+  const response = await fetch(`${baseUrl.replace(/\/$/, '')}${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(trimmedApiKey ? { 'x-api-key': trimmedApiKey } : {}),
+    },
+    body: JSON.stringify(body),
+  })
+
+  const data = await response.json().catch(() => undefined)
+
+  if (!response.ok) {
+    const message = isRecord(data)
+      ? typeof data.message === 'string'
+        ? data.message
+        : typeof data.error === 'string'
+          ? data.error
+          : response.statusText
+      : response.statusText
+    throw new Error(`SwapKit request failed (${response.status}): ${message}`)
+  }
+
+  return data as T
+}
+
+const toSwapKitAsset = ({ chain, id, ticker }: AccountCoin<SwapKitEnabledChain>) => {
+  const chainId = swapKitChainId[chain]
+  const symbol = id ? ticker : chainFeeCoin[chain].ticker
+
+  return id ? `${chainId}.${symbol}-${id}` : `${chainId}.${symbol}`
+}
+
+const bigintString = (value: string | number | bigint | undefined, fallback = '0') => {
+  if (value === undefined) {
+    return fallback
+  }
+
+  return BigInt(value).toString()
+}
+
+const buildEvmTx = (tx: unknown, fromAddress: string): GeneralSwapTx => {
+  if (!isRecord(tx)) {
+    throw new Error('SwapKit EVM route did not return a transaction object.')
+  }
+
+  const evmTx = tx as SwapKitEvmTx
+
+  if (!evmTx.to) {
+    throw new Error('SwapKit EVM transaction is missing a required to field.')
+  }
+
+  const gas = evmTx.gasLimit ?? evmTx.gas
+
+  return {
+    evm: {
+      from: evmTx.from ?? fromAddress,
+      to: evmTx.to,
+      data: evmTx.data ?? '0x',
+      value: bigintString(evmTx.value),
+      gasLimit: gas === undefined ? undefined : BigInt(gas),
+    },
+  }
+}
+
+const getSwapKitFeeAmount = (fees: SwapKitSwapResponse['fees'], type: string, decimals: number): bigint => {
+  const fee = fees?.find(fee => fee.type?.toLowerCase() === type)
+
+  if (!fee?.amount) {
+    return 0n
+  }
+
+  return toChainAmount(fee.amount, decimals)
+}
+
+const buildSolanaTx = (tx: unknown, fees: SwapKitSwapResponse['fees']): GeneralSwapTx => {
+  if (typeof tx !== 'string') {
+    throw new Error('SwapKit Solana route did not return a serialized transaction string.')
+  }
+
+  const decimals = chainFeeCoin[Chain.Solana].decimals
+  const networkFee = getSwapKitFeeAmount(fees, 'network', decimals)
+  const swapFee = getSwapKitFeeAmount(fees, 'affiliate', decimals) + getSwapKitFeeAmount(fees, 'service', decimals)
+
+  return {
+    solana: {
+      data: tx,
+      networkFee,
+      swapFee: {
+        amount: swapFee,
+        decimals,
+        chain: Chain.Solana,
+      },
+    },
+  }
+}
+
+const buildSwapKitTx = (response: SwapKitSwapResponse, from: AccountCoin<SwapKitSourceChain>): GeneralSwapTx => {
+  if (from.chain === Chain.Solana) {
+    return buildSolanaTx(response.tx, response.fees)
+  }
+
+  return buildEvmTx(response.tx, from.address)
+}
+
+const sortRoutesByExpectedBuyAmount = (routes: SwapKitQuoteRoute[], decimals: number) =>
+  [...routes].sort((one, another) => {
+    const oneAmount = BigInt(parseExpectedBuyAmount(one.expectedBuyAmount, decimals))
+    const anotherAmount = BigInt(parseExpectedBuyAmount(another.expectedBuyAmount, decimals))
+
+    if (oneAmount === anotherAmount) {
+      return 0
+    }
+
+    return oneAmount > anotherAmount ? -1 : 1
+  })
+
+const getSwapKitRoutes = async (
+  body: Record<string, unknown>,
+  providers: SwapKitProvider[]
+): Promise<SwapKitQuoteRoute[]> => {
+  try {
+    const quoteResponse = await postSwapKit<SwapKitQuoteResponse>(
+      '/v3/quote',
+      withoutUndefinedFields({
+        ...body,
+        providers,
+      })
+    )
+
+    if (quoteResponse.error) {
+      const message = quoteResponse.message ?? quoteResponse.error
+
+      if (isNoRouteError(message)) {
+        return []
+      }
+
+      throw new Error(message)
+    }
+
+    return quoteResponse.routes?.filter(isAllowedRoute) ?? []
+  } catch (error) {
+    if (error instanceof Error && isNoRouteError(error.message)) {
+      return []
+    }
+
+    throw error
+  }
+}
+
+const getBestSwapKitRoute = async (body: Record<string, unknown>, decimals: number) => {
+  for (const providers of swapKitProviderQuoteAttempts) {
+    const routes = await getSwapKitRoutes(body, providers)
+
+    if (routes.length) {
+      return sortRoutesByExpectedBuyAmount(routes, decimals)[0]
+    }
+  }
+
+  throw new Error('SwapKit returned no eligible routes.')
+}
+
+export const getSwapKitQuote = async ({ from, to, amount, affiliateBps }: Input): Promise<GeneralSwapQuote> => {
+  const quoteBody = {
+    sellAsset: toSwapKitAsset(from),
+    buyAsset: toSwapKitAsset(to),
+    sellAmount: formatBasicUnitAmount(amount, from.decimals),
+    slippage: 3,
+    affiliateFee: affiliateBps,
+  }
+  const route = await getBestSwapKitRoute(quoteBody, to.decimals)
+
+  const swapResponse = await postSwapKit<SwapKitSwapResponse>('/v3/swap', {
+    routeId: route.routeId,
+    sourceAddress: from.address,
+    destinationAddress: to.address,
+    disableBalanceCheck: true,
+  })
+
+  return {
+    dstAmount: parseExpectedBuyAmount(swapResponse.expectedBuyAmount ?? route.expectedBuyAmount, to.decimals),
+    provider: 'swapkit',
+    routeProvider: getRouteProviderName(swapResponse) ?? getRouteProviderName(route),
+    tx: buildSwapKitTx(swapResponse, from),
+  }
+}

--- a/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.ts
+++ b/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.ts
@@ -12,6 +12,8 @@ type Input = Record<TransferDirection, AccountCoin<SwapKitEnabledChain>> & {
   from: AccountCoin<SwapKitSourceChain>
   amount: bigint
   affiliateBps?: number
+  /** Slippage tolerance in percent (e.g. 1 = 1%). Defaults to 3. */
+  slippage?: number
 }
 
 type SwapKitProvider =
@@ -229,7 +231,25 @@ const bigintString = (value: string | number | bigint | undefined, fallback = '0
     return fallback
   }
 
+  // BigInt() throws on decimal strings (e.g. '21000.5') — truncate first.
+  if (typeof value === 'string' && value.includes('.')) {
+    return BigInt(Math.trunc(Number(value))).toString()
+  }
+
   return BigInt(value).toString()
+}
+
+const safeBigInt = (value: string | number | bigint | undefined): bigint | undefined => {
+  if (value === undefined) {
+    return undefined
+  }
+
+  // BigInt() throws on decimal strings — truncate first.
+  if (typeof value === 'string' && value.includes('.')) {
+    return BigInt(Math.trunc(Number(value)))
+  }
+
+  return BigInt(value)
 }
 
 const buildEvmTx = (tx: unknown, fromAddress: string): GeneralSwapTx => {
@@ -251,7 +271,7 @@ const buildEvmTx = (tx: unknown, fromAddress: string): GeneralSwapTx => {
       to: evmTx.to,
       data: evmTx.data ?? '0x',
       value: bigintString(evmTx.value),
-      gasLimit: gas === undefined ? undefined : BigInt(gas),
+      gasLimit: safeBigInt(gas),
     },
   }
 }
@@ -373,12 +393,18 @@ const getBestSwapKitRoute = async (body: Record<string, unknown>, decimals: numb
   throw new Error('SwapKit returned no eligible routes.')
 }
 
-export const getSwapKitQuote = async ({ from, to, amount, affiliateBps }: Input): Promise<GeneralSwapQuote> => {
+export const getSwapKitQuote = async ({
+  from,
+  to,
+  amount,
+  affiliateBps,
+  slippage = 3,
+}: Input): Promise<GeneralSwapQuote> => {
   const quoteBody = {
     sellAsset: toSwapKitAsset(from),
     buyAsset: toSwapKitAsset(to),
     sellAmount: formatBasicUnitAmount(amount, from.decimals),
-    slippage: 3,
+    slippage,
     affiliateFee: affiliateBps,
   }
   const route = await getBestSwapKitRoute(quoteBody, to.decimals)

--- a/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.ts
+++ b/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.ts
@@ -1,13 +1,12 @@
 import { toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'
 import { Chain } from '@vultisig/core-chain/Chain'
+import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { GeneralSwapQuote, GeneralSwapTx } from '@vultisig/core-chain/swap/general/GeneralSwapQuote'
 import { getSwapKitConfig } from '@vultisig/core-chain/swap/general/swapkit/config'
 import { SwapKitEnabledChain, SwapKitSourceChain } from '@vultisig/core-chain/swap/general/swapkit/SwapKitEnabledChains'
 import { withoutUndefinedFields } from '@vultisig/lib-utils/record/withoutUndefinedFields'
 import { TransferDirection } from '@vultisig/lib-utils/TransferDirection'
-
-import { AccountCoin } from '../../../../coin/AccountCoin'
 
 type Input = Record<TransferDirection, AccountCoin<SwapKitEnabledChain>> & {
   from: AccountCoin<SwapKitSourceChain>
@@ -297,10 +296,26 @@ const buildSwapKitTx = (response: SwapKitSwapResponse, from: AccountCoin<SwapKit
   return buildEvmTx(response.tx, from.address)
 }
 
+const routeExpectedBuyAmount = (route: SwapKitQuoteRoute, decimals: number): bigint | null => {
+  if (!route.expectedBuyAmount) {
+    return null
+  }
+
+  return BigInt(parseExpectedBuyAmount(route.expectedBuyAmount, decimals))
+}
+
 const sortRoutesByExpectedBuyAmount = (routes: SwapKitQuoteRoute[], decimals: number) =>
   [...routes].sort((one, another) => {
-    const oneAmount = BigInt(parseExpectedBuyAmount(one.expectedBuyAmount, decimals))
-    const anotherAmount = BigInt(parseExpectedBuyAmount(another.expectedBuyAmount, decimals))
+    const oneAmount = routeExpectedBuyAmount(one, decimals)
+    const anotherAmount = routeExpectedBuyAmount(another, decimals)
+
+    if (oneAmount === null) {
+      return anotherAmount === null ? 0 : 1
+    }
+
+    if (anotherAmount === null) {
+      return -1
+    }
 
     if (oneAmount === anotherAmount) {
       return 0

--- a/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.ts
+++ b/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.ts
@@ -301,7 +301,11 @@ const routeExpectedBuyAmount = (route: SwapKitQuoteRoute, decimals: number): big
     return null
   }
 
-  return BigInt(parseExpectedBuyAmount(route.expectedBuyAmount, decimals))
+  try {
+    return BigInt(parseExpectedBuyAmount(route.expectedBuyAmount, decimals))
+  } catch {
+    return null
+  }
 }
 
 const sortRoutesByExpectedBuyAmount = (routes: SwapKitQuoteRoute[], decimals: number) =>

--- a/packages/core/chain/swap/general/swapkit/config.ts
+++ b/packages/core/chain/swap/general/swapkit/config.ts
@@ -20,7 +20,8 @@ let swapKitConfig: SwapKitConfig = {
 export const configureSwapKit = (config: Partial<SwapKitConfig>) => {
   swapKitConfig = {
     ...swapKitConfig,
-    ...config,
+    ...(Object.prototype.hasOwnProperty.call(config, 'apiKey') ? { apiKey: config.apiKey } : {}),
+    ...(config.baseUrl !== undefined ? { baseUrl: config.baseUrl } : {}),
   }
 }
 

--- a/packages/core/chain/swap/general/swapkit/config.ts
+++ b/packages/core/chain/swap/general/swapkit/config.ts
@@ -3,7 +3,35 @@ export type SwapKitConfig = {
   baseUrl: string
 }
 
-const defaultSwapKitBaseUrl = 'https://api.vultisig.com/swapkit-win'
+/**
+ * Vultisig-proxy URLs per platform (paaao 2026-05-21).
+ * The proxy injects the SwapKit API key server-side — NO client-side key needed.
+ *
+ * iOS / macOS  → https://api.vultisig.com/swapkit/
+ * Android      → https://api.vultisig.com/swapkit-a/
+ * Windows/ext  → https://api.vultisig.com/swapkit-win/  (default fallback)
+ *
+ * Callers may override via configureSwapKit({ baseUrl }) or
+ * env var SWAPKIT_BASE_URL / VULTISIG_SWAPKIT_BASE_URL.
+ */
+const detectDefaultBaseUrl = (): string => {
+  const maybeGlobal = globalThis as typeof globalThis & {
+    process?: { env?: Record<string, string | undefined>; platform?: string }
+  }
+
+  const platform = maybeGlobal.process?.platform
+
+  if (platform === 'darwin' || platform === 'ios') {
+    return 'https://api.vultisig.com/swapkit'
+  }
+
+  if (platform === 'android') {
+    return 'https://api.vultisig.com/swapkit-a'
+  }
+
+  // Windows, extension (electron/chromium), and unknown platforms
+  return 'https://api.vultisig.com/swapkit-win'
+}
 
 const readEnv = (key: string): string | undefined => {
   const maybeGlobal = globalThis as typeof globalThis & {
@@ -14,7 +42,7 @@ const readEnv = (key: string): string | undefined => {
 }
 
 let swapKitConfig: SwapKitConfig = {
-  baseUrl: defaultSwapKitBaseUrl,
+  baseUrl: detectDefaultBaseUrl(),
 }
 
 export const configureSwapKit = (config: Partial<SwapKitConfig>) => {

--- a/packages/core/chain/swap/general/swapkit/config.ts
+++ b/packages/core/chain/swap/general/swapkit/config.ts
@@ -19,9 +19,10 @@ const detectDefaultBaseUrl = (): string => {
     process?: { env?: Record<string, string | undefined>; platform?: string }
   }
 
-  const platform = maybeGlobal.process?.platform
+  const platform = maybeGlobal.process?.platform as string | undefined
 
-  if (platform === 'darwin' || platform === 'ios') {
+  // 'darwin' = Node.js on macOS; 'ios' = React Native iOS; 'macos' = React Native macOS / Mac Catalyst
+  if (platform === 'darwin' || platform === 'ios' || platform === 'macos') {
     return 'https://api.vultisig.com/swapkit'
   }
 

--- a/packages/core/chain/swap/general/swapkit/config.ts
+++ b/packages/core/chain/swap/general/swapkit/config.ts
@@ -1,0 +1,36 @@
+export type SwapKitConfig = {
+  apiKey?: string
+  baseUrl: string
+}
+
+const defaultSwapKitBaseUrl = 'https://api.vultisig.com/swapkit-win'
+
+const readEnv = (key: string): string | undefined => {
+  const maybeGlobal = globalThis as typeof globalThis & {
+    process?: { env?: Record<string, string | undefined> }
+  }
+
+  return maybeGlobal.process?.env?.[key]
+}
+
+let swapKitConfig: SwapKitConfig = {
+  baseUrl: defaultSwapKitBaseUrl,
+}
+
+export const configureSwapKit = (config: Partial<SwapKitConfig>) => {
+  swapKitConfig = {
+    ...swapKitConfig,
+    ...config,
+  }
+}
+
+export const getSwapKitConfig = (): SwapKitConfig => {
+  const apiKey = swapKitConfig.apiKey ?? readEnv('SWAPKIT_API_KEY') ?? readEnv('VULTISIG_SWAPKIT_API_KEY')
+  const baseUrl = readEnv('SWAPKIT_BASE_URL') ?? readEnv('VULTISIG_SWAPKIT_BASE_URL') ?? swapKitConfig.baseUrl
+
+  return {
+    ...swapKitConfig,
+    baseUrl,
+    apiKey,
+  }
+}

--- a/packages/core/chain/swap/quote/findSwapQuote.kyber.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.kyber.test.ts
@@ -1,6 +1,10 @@
 import { Chain } from '@vultisig/core-chain/Chain'
 import { getSwapAffiliateBps } from '@vultisig/core-chain/swap/affiliate'
 import { getKyberSwapQuote } from '@vultisig/core-chain/swap/general/kyber/api/quote'
+import { getLifiSwapQuote } from '@vultisig/core-chain/swap/general/lifi/api/getLifiSwapQuote'
+import { getOneInchSwapQuote } from '@vultisig/core-chain/swap/general/oneInch/api/getOneInchSwapQuote'
+import { getSwapKitQuote } from '@vultisig/core-chain/swap/general/swapkit/api/getSwapKitQuote'
+import { getNativeSwapQuote } from '@vultisig/core-chain/swap/native/api/getNativeSwapQuote'
 import { describe, expect, it, vi } from 'vitest'
 
 import { findSwapQuote } from './findSwapQuote'
@@ -9,9 +13,29 @@ vi.mock('@vultisig/core-chain/swap/general/kyber/api/quote', () => ({
   getKyberSwapQuote: vi.fn(),
 }))
 
+vi.mock('@vultisig/core-chain/swap/general/oneInch/api/getOneInchSwapQuote', () => ({
+  getOneInchSwapQuote: vi.fn(),
+}))
+
+vi.mock('@vultisig/core-chain/swap/general/lifi/api/getLifiSwapQuote', () => ({
+  getLifiSwapQuote: vi.fn(),
+}))
+
+vi.mock('@vultisig/core-chain/swap/general/swapkit/api/getSwapKitQuote', () => ({
+  getSwapKitQuote: vi.fn(),
+}))
+
+vi.mock('@vultisig/core-chain/swap/native/api/getNativeSwapQuote', () => ({
+  getNativeSwapQuote: vi.fn(),
+}))
+
 describe('findSwapQuote Kyber affiliate fee', () => {
   it('passes effective affiliate BPS after VULT discount', async () => {
     const expectedBps = getSwapAffiliateBps('gold')
+    vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('skip inch'))
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
+    vi.mocked(getSwapKitQuote).mockRejectedValue(new Error('skip swapkit'))
+    vi.mocked(getNativeSwapQuote).mockRejectedValue(new Error('skip native'))
 
     vi.mocked(getKyberSwapQuote).mockResolvedValue({
       dstAmount: '10000000',

--- a/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
@@ -3,6 +3,7 @@ import type { GeneralSwapQuote } from '@vultisig/core-chain/swap/general/General
 import { getKyberSwapQuote } from '@vultisig/core-chain/swap/general/kyber/api/quote'
 import { getLifiSwapQuote } from '@vultisig/core-chain/swap/general/lifi/api/getLifiSwapQuote'
 import { getOneInchSwapQuote } from '@vultisig/core-chain/swap/general/oneInch/api/getOneInchSwapQuote'
+import { getSwapKitQuote } from '@vultisig/core-chain/swap/general/swapkit/api/getSwapKitQuote'
 import { getNativeSwapQuote } from '@vultisig/core-chain/swap/native/api/getNativeSwapQuote'
 import { NativeSwapQuote } from '@vultisig/core-chain/swap/native/NativeSwapQuote'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -19,6 +20,10 @@ vi.mock('@vultisig/core-chain/swap/general/oneInch/api/getOneInchSwapQuote', () 
 
 vi.mock('@vultisig/core-chain/swap/general/lifi/api/getLifiSwapQuote', () => ({
   getLifiSwapQuote: vi.fn(),
+}))
+
+vi.mock('@vultisig/core-chain/swap/general/swapkit/api/getSwapKitQuote', () => ({
+  getSwapKitQuote: vi.fn(),
 }))
 
 vi.mock('@vultisig/core-chain/swap/native/api/getNativeSwapQuote', () => ({
@@ -42,7 +47,7 @@ const evmSameChainCoins = {
   },
 } as const
 
-function minimalGeneralQuote(dstAmount: string, provider: 'kyber' | '1inch'): GeneralSwapQuote {
+function minimalGeneralQuote(dstAmount: string, provider: 'kyber' | '1inch' | 'swapkit'): GeneralSwapQuote {
   const base = {
     dstAmount,
     tx: {
@@ -54,7 +59,7 @@ function minimalGeneralQuote(dstAmount: string, provider: 'kyber' | '1inch'): Ge
       },
     },
   }
-  return provider === 'kyber' ? { ...base, provider: 'kyber' } : { ...base, provider: '1inch' }
+  return { ...base, provider }
 }
 
 function minimalNativeQuote(swapChain: Chain, expected_amount_out: string): NativeSwapQuote {
@@ -77,12 +82,14 @@ describe('findSwapQuote parallel selection', () => {
     vi.mocked(getKyberSwapQuote).mockReset()
     vi.mocked(getOneInchSwapQuote).mockReset()
     vi.mocked(getLifiSwapQuote).mockReset()
+    vi.mocked(getSwapKitQuote).mockReset()
     vi.mocked(getNativeSwapQuote).mockReset()
   })
 
   it('picks a later preferred provider when its comparable output amount is higher', async () => {
     vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('skip inch'))
     vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
+    vi.mocked(getSwapKitQuote).mockRejectedValue(new Error('skip swapkit'))
     // Destination has 6 decimals. Kyber dstAmount is already in token decimals.
     // Native THORChain amounts are 8-decimal canonical → rebase to 6: divide by 1e2.
     vi.mocked(getKyberSwapQuote).mockResolvedValue(minimalGeneralQuote('150', 'kyber'))
@@ -108,6 +115,7 @@ describe('findSwapQuote parallel selection', () => {
   it('ranks by destination-decimal-normalized output (higher raw native can still lose)', async () => {
     vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('skip inch'))
     vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
+    vi.mocked(getSwapKitQuote).mockRejectedValue(new Error('skip swapkit'))
     // 1 USDC (6 decimals) on the general side.
     vi.mocked(getKyberSwapQuote).mockResolvedValue(minimalGeneralQuote('1000000', 'kyber'))
     vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) =>
@@ -131,6 +139,7 @@ describe('findSwapQuote parallel selection', () => {
     vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('Kyber unavailable'))
     vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('skip inch'))
     vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
+    vi.mocked(getSwapKitQuote).mockRejectedValue(new Error('skip swapkit'))
     vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) => minimalNativeQuote(swapChain, '100'))
 
     const quote = await findSwapQuote({
@@ -148,6 +157,7 @@ describe('findSwapQuote parallel selection', () => {
     vi.mocked(getKyberSwapQuote).mockResolvedValue(minimalGeneralQuote('not-a-number', 'kyber'))
     vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('skip inch'))
     vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
+    vi.mocked(getSwapKitQuote).mockRejectedValue(new Error('skip swapkit'))
     vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) => minimalNativeQuote(swapChain, '100'))
 
     const quote = await findSwapQuote({
@@ -163,6 +173,7 @@ describe('findSwapQuote parallel selection', () => {
 
   it('breaks ties by earlier fetcher preference order', async () => {
     vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
+    vi.mocked(getSwapKitQuote).mockRejectedValue(new Error('skip swapkit'))
     vi.mocked(getNativeSwapQuote).mockRejectedValue(new Error('skip native'))
     vi.mocked(getKyberSwapQuote).mockResolvedValue(minimalGeneralQuote('200', 'kyber'))
     vi.mocked(getOneInchSwapQuote).mockResolvedValue(minimalGeneralQuote('200', '1inch'))
@@ -184,6 +195,7 @@ describe('findSwapQuote parallel selection', () => {
     vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('first fail'))
     vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('second fail'))
     vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('third fail'))
+    vi.mocked(getSwapKitQuote).mockRejectedValue(new Error('fourth fail'))
     vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) => {
       if (swapChain === Chain.THORChain) {
         throw new Error('thor fail')
@@ -196,7 +208,7 @@ describe('findSwapQuote parallel selection', () => {
         ...evmSameChainCoins,
         amount: 1n,
       })
-    ).rejects.toThrow('No swap route found after trying KyberSwap, 1inch, LiFi, THORChain, MayaChain.')
+    ).rejects.toThrow('No swap route found after trying KyberSwap, 1inch, LiFi, SwapKit, THORChain, MayaChain.')
   })
 
   it('omits noisy provider errors from the all-fail message', async () => {
@@ -205,6 +217,7 @@ describe('findSwapQuote parallel selection', () => {
     vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error(longKyberError))
     vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('inch fail'))
     vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('lifi fail'))
+    vi.mocked(getSwapKitQuote).mockRejectedValue(new Error('swapkit fail'))
     vi.mocked(getNativeSwapQuote).mockRejectedValue(new Error('native fail'))
 
     try {
@@ -218,7 +231,9 @@ describe('findSwapQuote parallel selection', () => {
         throw error
       }
 
-      expect(error.message).toBe('No swap route found after trying KyberSwap, 1inch, LiFi, THORChain, MayaChain.')
+      expect(error.message).toBe(
+        'No swap route found after trying KyberSwap, 1inch, LiFi, SwapKit, THORChain, MayaChain.'
+      )
       expect(error.message).not.toContain(longKyberError)
       expect(error.message).not.toContain('inch fail')
     }
@@ -228,6 +243,7 @@ describe('findSwapQuote parallel selection', () => {
     vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('kyber fail'))
     vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('inch fail'))
     vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('lifi fail'))
+    vi.mocked(getSwapKitQuote).mockRejectedValue(new Error('swapkit fail'))
     vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) => {
       if (swapChain === Chain.THORChain) {
         throw new Error('thor fail')
@@ -247,6 +263,7 @@ describe('findSwapQuote parallel selection', () => {
     vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('quote below dust threshold'))
     vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('inch fail'))
     vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('lifi fail'))
+    vi.mocked(getSwapKitQuote).mockRejectedValue(new Error('swapkit fail'))
     vi.mocked(getNativeSwapQuote).mockRejectedValue(new Error('native fail'))
 
     await expect(

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -3,6 +3,11 @@ import { getLifiSwapQuote } from '@vultisig/core-chain/swap/general/lifi/api/get
 import { lifiSwapEnabledChains } from '@vultisig/core-chain/swap/general/lifi/LifiSwapEnabledChains'
 import { getOneInchSwapQuote } from '@vultisig/core-chain/swap/general/oneInch/api/getOneInchSwapQuote'
 import { oneInchSwapEnabledChains } from '@vultisig/core-chain/swap/general/oneInch/OneInchSwapEnabledChains'
+import { getSwapKitQuote } from '@vultisig/core-chain/swap/general/swapkit/api/getSwapKitQuote'
+import {
+  swapKitEnabledChains,
+  swapKitSourceChains,
+} from '@vultisig/core-chain/swap/general/swapkit/SwapKitEnabledChains'
 import { NoSwapRoutesError } from '@vultisig/core-chain/swap/NoSwapRoutesError'
 import { isEmpty } from '@vultisig/lib-utils/array/isEmpty'
 import { isOneOf } from '@vultisig/lib-utils/array/isOneOf'
@@ -28,7 +33,7 @@ export type FindSwapQuoteInput = Record<TransferDirection, AccountCoin> & {
   vultDiscountTier?: VultDiscountTier | null
 }
 
-type SwapQuoteProviderName = 'KyberSwap' | '1inch' | 'LiFi' | 'THORChain' | 'MayaChain'
+type SwapQuoteProviderName = 'KyberSwap' | '1inch' | 'LiFi' | 'SwapKit' | 'THORChain' | 'MayaChain'
 
 type SwapQuoteFetcher = {
   providerName: SwapQuoteProviderName
@@ -192,6 +197,28 @@ export const findSwapQuote = async ({
         providerName: 'LiFi',
         fetch: async (): Promise<SwapQuote> => {
           const general = await getLifiSwapQuote({
+            from: {
+              ...from,
+              chain: fromChain,
+            },
+            to: {
+              ...to,
+              chain: toChain,
+            },
+            amount: chainAmount,
+            affiliateBps,
+          })
+
+          return { quote: { general }, discounts: vultDiscount }
+        },
+      })
+    }
+
+    if (isOneOf(fromChain, swapKitSourceChains) && isOneOf(toChain, swapKitEnabledChains)) {
+      result.push({
+        providerName: 'SwapKit',
+        fetch: async (): Promise<SwapQuote> => {
+          const general = await getSwapKitQuote({
             from: {
               ...from,
               chain: fromChain,

--- a/packages/core/chain/swap/quote/getSwapQuoteProviderName.test.ts
+++ b/packages/core/chain/swap/quote/getSwapQuoteProviderName.test.ts
@@ -15,10 +15,11 @@ describe('getSwapQuoteProviderName', () => {
   })
 
   it('maps each general swap provider to its display name', () => {
-    const cases: Array<{ provider: '1inch' | 'li.fi' | 'kyber'; label: string }> = [
+    const cases: Array<{ provider: '1inch' | 'li.fi' | 'kyber' | 'swapkit'; label: string }> = [
       { provider: '1inch', label: '1Inch' },
       { provider: 'li.fi', label: 'LI.FI' },
       { provider: 'kyber', label: 'KyberSwap' },
+      { provider: 'swapkit', label: 'SwapKit' },
     ]
 
     for (const { provider, label } of cases) {
@@ -42,5 +43,28 @@ describe('getSwapQuoteProviderName', () => {
 
       expect(getSwapQuoteProviderName(quote)).toBe(label)
     }
+  })
+
+  it('includes the underlying route provider when a general quote exposes one', () => {
+    const quote = {
+      quote: {
+        general: {
+          provider: 'swapkit',
+          routeProvider: 'NEAR',
+          dstAmount: '0',
+          tx: {
+            evm: {
+              from: '0x0000000000000000000000000000000000000001',
+              to: '0x0000000000000000000000000000000000000002',
+              data: '0x',
+              value: '0',
+            },
+          },
+        },
+      },
+      discounts: [],
+    } as unknown as SwapQuote
+
+    expect(getSwapQuoteProviderName(quote)).toBe('SwapKit (NEAR)')
   })
 })

--- a/packages/core/chain/swap/quote/getSwapQuoteProviderName.ts
+++ b/packages/core/chain/swap/quote/getSwapQuoteProviderName.ts
@@ -6,6 +6,7 @@ import { SwapQuote, SwapQuoteResult } from './SwapQuote'
 export const getSwapQuoteProviderName = (quote: SwapQuote) => {
   return matchRecordUnion<SwapQuoteResult, string>(quote.quote, {
     native: ({ swapChain }) => swapChain,
-    general: ({ provider }) => generalSwapProviderName[provider],
+    general: ({ provider, routeProvider }) =>
+      routeProvider ? `${generalSwapProviderName[provider]} (${routeProvider})` : generalSwapProviderName[provider],
   })
 }

--- a/packages/core/chain/swap/swapEnabledChains.ts
+++ b/packages/core/chain/swap/swapEnabledChains.ts
@@ -1,9 +1,11 @@
 import { lifiSwapEnabledChains } from '@vultisig/core-chain/swap/general/lifi/LifiSwapEnabledChains'
 import { oneInchSwapEnabledChains } from '@vultisig/core-chain/swap/general/oneInch/OneInchSwapEnabledChains'
+import { swapKitEnabledChains } from '@vultisig/core-chain/swap/general/swapkit/SwapKitEnabledChains'
 import { nativeSwapEnabledChains } from '@vultisig/core-chain/swap/native/NativeSwapChain'
 
 export const swapEnabledChains = [
   ...nativeSwapEnabledChains,
   ...oneInchSwapEnabledChains,
   ...lifiSwapEnabledChains,
+  ...swapKitEnabledChains,
 ] as const

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -191,6 +191,8 @@ export {
   vultDiscountTierMinBalances,
   vultDiscountTiers,
 } from '@vultisig/core-chain/swap/affiliate/config'
+export type { SwapKitConfig } from '@vultisig/core-chain/swap/general/swapkit/config'
+export { configureSwapKit, getSwapKitConfig } from '@vultisig/core-chain/swap/general/swapkit/config'
 
 // THORChain LP primitives (v2: auto-pair, lockup, halts, mimir pause gate)
 export { getThorchainInboundAddress } from '@vultisig/core-chain/chains/cosmos/thor/getThorchainInboundAddress'

--- a/packages/sdk/src/vault/services/SwapService.ts
+++ b/packages/sdk/src/vault/services/SwapService.ts
@@ -2,7 +2,7 @@
  * SwapService - Handles swap quote fetching and transaction preparation
  *
  * This service wraps core swap functions and provides:
- * - Quote fetching from multiple providers (1inch, KyberSwap, LiFi, THORChain, MayaChain)
+ * - Quote fetching from multiple providers (1inch, KyberSwap, LiFi, SwapKit, THORChain, MayaChain)
  * - ERC-20 allowance checking
  * - Swap transaction preparation with approval handling
  * - Chain support queries
@@ -360,7 +360,9 @@ export class SwapService {
       : BigInt(quoteData.general.dstAmount)
 
     // Extract provider name
-    const provider = isNative ? quoteData.native.swapChain.toLowerCase() : quoteData.general.provider
+    const provider = isNative
+      ? quoteData.native.swapChain.toLowerCase()
+      : (quoteData.general.routeProvider ?? quoteData.general.provider)
 
     // Extract fees
     const fees = await this.extractFees(quoteData, fromCoin.chain)

--- a/packages/sdk/src/vault/services/SwapService.ts
+++ b/packages/sdk/src/vault/services/SwapService.ts
@@ -362,7 +362,7 @@ export class SwapService {
     // Extract provider name
     const provider = isNative
       ? quoteData.native.swapChain.toLowerCase()
-      : (quoteData.general.routeProvider ?? quoteData.general.provider)
+      : quoteData.general.routeProvider?.trim() || quoteData.general.provider
 
     // Extract fees
     const fees = await this.extractFees(quoteData, fromCoin.chain)

--- a/packages/sdk/tests/unit/services/SwapService.test.ts
+++ b/packages/sdk/tests/unit/services/SwapService.test.ts
@@ -281,6 +281,47 @@ describe('SwapService', () => {
       expect(result.approvalInfo).toBeUndefined()
     })
 
+    it('should fall back to the general provider when routeProvider is blank', async () => {
+      const { findSwapQuote } = await import('@vultisig/core-chain/swap/quote/findSwapQuote')
+
+      vi.mocked(findSwapQuote).mockResolvedValue({
+        quote: {
+          general: {
+            dstAmount: '1000000000000000000',
+            provider: 'swapkit' as const,
+            routeProvider: '   ',
+            tx: {
+              evm: {
+                from: '0x1234...',
+                to: '0x1111111254fb6c44bAC0beD2854e76F90643097d',
+                data: '0x...',
+                value: '0',
+              },
+            },
+          },
+        },
+        discounts: [],
+      })
+
+      const result = await service.getQuote({
+        fromCoin: {
+          chain: Chain.Ethereum,
+          address: '0x1234567890abcdef1234567890abcdef12345678',
+          ticker: 'ETH',
+          decimals: 18,
+        },
+        toCoin: {
+          chain: Chain.Bitcoin,
+          address: 'bc1destination',
+          ticker: 'BTC',
+          decimals: 8,
+        },
+        amount: 1,
+      })
+
+      expect(result.provider).toBe('swapkit')
+    })
+
     it('should resolve simplified coin input', async () => {
       const { findSwapQuote } = await import('@vultisig/core-chain/swap/quote/findSwapQuote')
 


### PR DESCRIPTION
Closes #486

## Summary

This PR integrates SwapKit as a general swap provider using the Vultisig proxy endpoint:

`https://api.vultisig.com/swapkit-win/`

It adds SwapKit quote/build support for EVM and Solana source chains, exposes SwapKit config helpers, displays the underlying route provider (for example `SwapKit (NEAR)`), and keeps THORChain/MayaChain routes excluded from SwapKit so those native providers remain the source of truth.

## Live Mainnet Proof

These are real swaps executed through SwapKit while validating the integration, with non-THOR/Maya routes emphasized because that was the reason for adding SwapKit.

### Ethereum -> Sui, SwapKit / NEAR

- Amount: `0.005 ETH`
- Ethereum inbound tx: [`0x9a532c92a067b0dce980a80be33cfc5121c866fe834c5d636edbdbe5d677e5fe`](https://etherscan.io/tx/0x9a532c92a067b0dce980a80be33cfc5121c866fe834c5d636edbdbe5d677e5fe)
- NEAR intents tx: [`DYSmq3DZJdYg5hKrM5wvNdkhHgZ9P7XPPzHrM6jBbyWM`](https://nearblocks.io/txns/DYSmq3DZJdYg5hKrM5wvNdkhHgZ9P7XPPzHrM6jBbyWM)
- Sui outbound tx: [`HYprd68GKhmaihQfXavctgCgLQ8Ja6LwpooF3dDtQFwL`](https://suiexplorer.com/txblock/HYprd68GKhmaihQfXavctgCgLQ8Ja6LwpooF3dDtQFwL)
- Independent confirmation: Sui RPC confirmed success and `9,453,001,037` MIST credited to `0x19ec344477a03cf955f7cd21a13f364c41f31d98b303cde2154202e30d0022ad`.

### Base -> Cardano, SwapKit / NEAR

- Amount: `0.005 ETH` on Base
- Base inbound tx: [`0x168f87043eee7824024dda42f17258dd8e398e25f5291fc1b37724f2df3ab5d3`](https://basescan.org/tx/0x168f87043eee7824024dda42f17258dd8e398e25f5291fc1b37724f2df3ab5d3)
- NEAR intents tx: [`CTH4uqXpj9z8VTbPrGuCGUfLFBybvKzJLLeHiygnnyq2`](https://nearblocks.io/txns/CTH4uqXpj9z8VTbPrGuCGUfLFBybvKzJLLeHiygnnyq2)
- Cardano outbound tx: [`272068f6a2b7461c5b87feb9240d7791340e4e997f3a320082510c38970b4e14`](https://cardanoscan.io/transaction/272068f6a2b7461c5b87feb9240d7791340e4e997f3a320082510c38970b4e14)
- Independent confirmation: Koios confirmed an output of `42,057,601` lovelace to `addr1v97u88c6mpxr6n4x7u45366rtv3upga8kscf0ycy9zrzaucaqvd7u`.

### Ethereum -> Bitcoin, SwapKit / FLASHNET

- Amount: `0.005 ETH`
- Ethereum inbound tx: [`0x33cfb075a167b31075b409480c6bbd68acd3be977cdbfbd07cf1ec4147996dd2`](https://etherscan.io/tx/0x33cfb075a167b31075b409480c6bbd68acd3be977cdbfbd07cf1ec4147996dd2)
- Bitcoin outbound tx: [`ce6be7fdda37010804efc7aedbba1c50137999fc17393625d91c68dc583fe705`](https://blockstream.info/tx/ce6be7fdda37010804efc7aedbba1c50137999fc17393625d91c68dc583fe705)
- Independent confirmation: Blockstream confirmed the BTC transaction in block `950329`.

## Route QA Matrix

- Confirmed SwapKit / NEAR quote path for `Ethereum -> Ton`, `Ethereum -> Sui`, `Ethereum -> Tron`, `Ethereum -> Optimism`, `Ethereum -> Polygon`, and `Base -> Cardano/Ton/Sui`.
- `Ethereum -> Cardano` required a larger route size; `0.01 ETH` returned no route and `0.02 ETH` quoted via SwapKit / NEAR.
- Existing providers still legitimately win when they offer the best route. For example, sampled `Ethereum -> Base/Arbitrum/BSC` routes selected LI.FI instead of SwapKit.
- Solana-source live probes returned `noRoutesFound` from the proxy, so no Solana broadcast was attempted.

## Verification Receipts

- `yarn test` passed across workspaces.
- `yarn build:all` passed.
- `yarn lint` passed.
- `yarn typecheck` passed.
- `yarn check` passed.
- Focused SwapKit/Cosmos tests passed after CodeRabbit fixes.
- Windows local SDK tarball smoke passed with screenshot: `.codex/receipts/windows-desktop-smoke/desktop-smoke-2026-05-21T06-27-35-644Z.png`.

## Notes For Reviewers

- The SDK defaults to the Vultisig SwapKit proxy, so no SwapKit API key is embedded in public clients.
- SwapKit-routed THORChain/Maya routes are filtered out to avoid double-routing and to preserve the existing native THORChain/Maya providers.
- CodeRabbit robustness feedback fixed in `0ca6e3e8`; typed-error suggestions were replied to because `VaultError` lives in `@vultisig/sdk` and should not be imported by `@vultisig/core-chain`.

## Live Receipts (via vultisig.com proxy)

Captured 2026-05-21 against all three Vultisig SwapKit proxies. No API key in request headers — server-side injection confirmed. All three proxies returned HTTP 200 for valid pairs.

**Proxy auth status:**
| Proxy | Platform | Auth test | Result |
|-------|----------|-----------|--------|
| `https://api.vultisig.com/swapkit/` | iOS/macOS | POST /v3/quote `{}` | HTTP 400 (body invalid, not 401/403) |
| `https://api.vultisig.com/swapkit-a/` | Android | POST /v3/quote `{}` | HTTP 400 (body invalid, not 401/403) |
| `https://api.vultisig.com/swapkit-win/` | Windows/ext | POST /v3/quote `{}` | HTTP 400 (body invalid, not 401/403) |

**Cross-provider quote results:**

| From | To | Provider | Expected buy | Fee types |
|------|----|----------|-------------|-----------|
| ETH 0.01 | BTC | FLASHNET | 0.00027108 BTC | liquidity, affiliate, service, inbound |
| BTC 0.001 | ETH | NEAR | 0.035931 ETH | affiliate, service, outbound, inbound |
| BTC 0.001 | TON | NEAR | 37.75 TON | affiliate, service, outbound, inbound |
| BTC 0.001 | SUI | NEAR | 68.13 SUI | affiliate, service, outbound, inbound |
| BTC 0.001 | ADA | NEAR | 307.93 ADA | affiliate, service, outbound, inbound |
| BTC 0.001 | BSC (BNB) | NEAR | 0.1178 BNB | affiliate, service, outbound, inbound |
| BTC 0.001 | TRON.TRX | NEAR | 211.12 TRX | affiliate, service, outbound, inbound |
| ETH 0.01 | SOL | NEAR (best) / CHAINFLIP (alt) | 0.2446 / 0.2382 SOL | inbound, liquidity, affiliate, service, outbound |
| USDC 1 | DAI (ETH) | ONEINCH | 0.9894 DAI | affiliate, service, inbound |
| ETH 0.01 | DOT | - | noRoutesFound | - |
| SOL.USDC 1 | SOL | - | noRoutesFound | - |

All three proxies return identical routes for the same pair (routing logic is symmetric; the differentiation is server-side API key injection per platform).

`tx` field is always absent from `/v3/quote` responses — deferred tx build via `/v3/swap` confirmed working per SDK design. `routeId` present in all successful routes.

**Note on Solana same-chain (Jupiter):** `SOL.SOL <-> SOL.USDC` returned `noRoutesFound` across all proxies. Solana-source live probes (noted in this PR body above) also hit this. Not a regression — consistent with the pre-existing "Solana-source live probes returned noRoutesFound" note above.

**Note on ETH->THOR.RUNE:** noRoutesFound as expected — THORChain/Maya routes are excluded from SwapKit by design (`swapKitExcludedProviders` set in `getSwapKitQuote.ts`), preserving the existing native providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SwapKit is now available as a configurable swap provider for EVM and Solana chains
  * Users can configure SwapKit with custom API keys and base endpoints
  * The swap quote system automatically includes SwapKit when finding the best available swap routes across supported chains

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/507?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->