### PR TITLE
fix(core-mpc/cardano): throw on memo until CIP-20 support lands (#432)

### DIFF
--- a/.changeset/cardano-memo-error.md
+++ b/.changeset/cardano-memo-error.md
@@ -1,0 +1,17 @@
+---
+"@vultisig/core-mpc": patch
+---
+
+fix(core-mpc/cardano): throw a clear error when a Cardano memo is provided
+
+Until CIP-20 auxiliary-data support lands (see vultisig/vultisig-sdk#432),
+`getCardanoSigningInputs` would silently drop `keysignPayload.memo` and
+produce a signed Cardano transaction with `auxiliary_data = null` — the
+memo never made it on-chain (e.g. tx
+`9c8549aea24106c699fffe74c7ded7186c25c390b33415853a83b0781efe4efe`).
+
+The resolver now fails fast with an explanatory error so callers (direct
+send, deposit, `VaultBase.send()`, `prepareSendTxFromKeys`, CLI/MCP) can
+surface the limitation to the user instead of issuing a tx that loses
+their memo. The CIP-30 path (`cardanoCip30.ts`) is unaffected — it signs
+the dApp-provided tx body hash and does not read `keysignPayload.memo`.

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cardano.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cardano.ts
@@ -16,6 +16,16 @@ const amountToBytes = (amount: bigint): Uint8Array => {
 }
 
 export const getCardanoSigningInputs: SigningInputsResolver<'cardano'> = ({ keysignPayload, walletCore }) => {
+  // Cardano memos require CIP-20 auxiliary data whose hash is committed to in the
+  // signed tx body — they cannot be attached after signing. Until that path is
+  // implemented (see vultisig/vultisig-sdk#432), fail loudly instead of silently
+  // dropping the memo and producing a tx with `auxiliary_data = null`.
+  if (keysignPayload.memo) {
+    throw new Error(
+      'Cardano memo is not supported yet: this SDK cannot attach CIP-20 metadata to direct sends, so the memo would be dropped and never land on-chain. Please retry without a memo, or wait for CIP-20 support (vultisig/vultisig-sdk#432).'
+    )
+  }
+
   const { sendMaxAmount, ttl, byteFee } = getBlockchainSpecificValue(keysignPayload.blockchainSpecific, 'cardano')
 
   const coin = shouldBePresent(keysignPayload.coin)


### PR DESCRIPTION
## Summary

- Cardano direct-send signing was silently dropping `keysignPayload.memo` and producing a signed transaction with `auxiliary_data = null`, so user memos never made it on-chain (e.g. cardanoscan tx `9c8549aea24106c699fffe74c7ded7186c25c390b33415853a83b0781efe4efe`).
- `getCardanoSigningInputs` now throws a clear, user-facing error when a memo is present, so callers can surface the limitation instead of issuing a tx that loses the memo.
- CIP-30 path (`cardanoCip30.ts`) is unaffected — it signs the dApp-provided tx body hash and does not read `keysignPayload.memo`.

## Why the error and not a proper fix?

Cardano memos require CIP-20 auxiliary data **whose hash is committed to in the signed tx body** — they can't be attached after signing. Implementing CIP-20 properly involves: encoding the metadata (label `674` with `msg` strings), including the aux-data hash in the tx body before MPC preimage signing, updating `buildSignedCardanoTx` to emit real auxiliary data instead of CBOR null, and adjusting fee/size planning. That work is tracked in #432. This PR is the safe interim: fail loudly so we don't silently lose user funds intent.

The chokepoint is `getCardanoSigningInputs`, which every Cardano signing path goes through (`VaultBase.send()`, `prepareSendTxFromKeys`, direct send, deposit, CLI/MCP). One gate covers them all.

## Companion PR

The Windows app added a UI-side gate that hides the memo field for Cardano: vultisig/vultisig-windows#3955 (fixes vultisig/vultisig-windows#3877). That PR prevents the memo from being entered in the first place. This PR is the SDK-level defense-in-depth: if a memo still reaches the SDK from any other client (CLI, MCP, dashboard, agent), it errors instead of being dropped.

## Test plan

- [x] `yarn typecheck` ✅
- [x] Lint clean on the changed file
- [ ] Manual: invoke a Cardano send with a non-empty memo via SDK → expect the new error message (and no broadcast).
- [ ] Manual: invoke a Cardano send with no memo / empty memo → expect existing behavior unchanged.
- [ ] Manual (CIP-30): sign a dApp-built Cardano tx via `cardanoCip30.ts` → expect existing behavior unchanged (path does not read `keysignPayload.memo`).

## Refs

- Fixes scope of #432 (the silent-drop bug)
- Companion to vultisig/vultisig-windows#3877, vultisig/vultisig-windows#3955

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cardano transactions that include memos now fail with a clear error message instead of silently dropping the memo, preventing unintended data loss and giving explicit feedback to users.

* **Documentation**
  * Added a release note entry documenting the memo-related fix for Cardano signing flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/508?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->