### PR TITLE
chore(swap): add kyber-chains to swapEnabledChains flattened list

### DIFF
--- a/packages/core/chain/swap/swapEnabledChains.ts
+++ b/packages/core/chain/swap/swapEnabledChains.ts
@@ -1,3 +1,4 @@
+import { kyberSwapEnabledChains } from '@vultisig/core-chain/swap/general/kyber/chains'
 import { lifiSwapEnabledChains } from '@vultisig/core-chain/swap/general/lifi/LifiSwapEnabledChains'
 import { oneInchSwapEnabledChains } from '@vultisig/core-chain/swap/general/oneInch/OneInchSwapEnabledChains'
 import { swapKitEnabledChains } from '@vultisig/core-chain/swap/general/swapkit/SwapKitEnabledChains'
@@ -8,4 +9,5 @@ export const swapEnabledChains = [
   ...oneInchSwapEnabledChains,
   ...lifiSwapEnabledChains,
   ...swapKitEnabledChains,
+  ...kyberSwapEnabledChains,
 ] as const


### PR DESCRIPTION
Stacked on #507 (radzion's SwapKit integration).

`kyberSwapEnabledChains` was exported from `packages/core/chain/swap/general/kyber/chains.ts` but never included in the `swapEnabledChains` flattened array. This means Kyber-only chains (Blast, Zksync, and any future Kyber-specific chains) were silently missing from the global `swapEnabledChains` allowlist even though Kyber could quote them.

One-liner fix: add `...kyberSwapEnabledChains` to the spread.

Note: PR #507 added `...swapKitEnabledChains` but did not pick up the Kyber chains gap. This PR closes the remaining gap.

**Impact**: no behavior change for currently-configured chains (Kyber's chains are a subset of LiFi's EVM set + Blast/Zksync which are in LiFi too). Defensive correctness fix for future Kyber-specific additions.

🤖 Agent-generated

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>