### PR TITLE
fix(lifi): bump default slippage to 1% — MPC ceremony breaks 0.5% on Solana

### DIFF
--- a/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
+++ b/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
@@ -23,6 +23,35 @@ const setupLifi = memoize(() => {
   })
 })
 
+// Slippage tolerance baked into the LiFi-prebuilt swap tx. The
+// returned `transactionRequest.data` is a fully-formed Solana / EVM
+// transaction that encodes a minAmountOut floor at quote time —
+// the underlying AMM (Raydium / Orca / Meteora on Solana; Uniswap /
+// 1inch on EVM) reverts if simulation-time output drops below the
+// floor. Default LiFi slippage is 0.005 (0.5%), which is far too
+// tight for MPC-signed flows where the keysign ceremony adds
+// 30-90s of clock drift between quote and broadcast and the price
+// routinely moves more than 0.5% on volatile pairs (SOL/USDC,
+// SOL/anything memecoin). Production repro (2026-05-22):
+// SOL→USDC simulation failed with `-32002: custom program error:
+// 0x32` (Raydium AMM error 50 = AmountExceedsMaximum / slippage
+// exceeded). Bump to 1% — covers the typical ceremony drift while
+// staying well inside the user's pre-sign card's risk surface
+// (typical realised slippage on these aggregators is <0.1%, so
+// the 1% is a ceiling, not the expected price hit).
+//
+// EVM is less time-sensitive (no MPC ceremony delay equivalent —
+// the model dispatches and the user signs in seconds) but the
+// same 1% bump still helps when the user pauses on the pre-sign
+// card for a moment.
+//
+// Hoisted to module scope so the planned per-pair / per-call
+// override (forwarding `execute_swap.slippage_tolerance_percent`
+// through the resolver, tracked as a follow-up) lands as a clean
+// diff rather than reshaping the function body. Codex Round 1b
+// review feedback (vultisig-sdk#513).
+const DEFAULT_LIFI_SLIPPAGE_TOLERANCE = 0.01
+
 export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: Input): Promise<GeneralSwapQuote> => {
   setupLifi()
 
@@ -30,29 +59,6 @@ export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: In
 
   const [fromToken, toToken] = [transfer.from, transfer.to].map(({ id, chain }) => id ?? chainFeeCoin[chain].ticker)
   const [fromAddress, toAddress] = [transfer.from, transfer.to].map(({ address }) => address)
-
-  // Slippage tolerance baked into the LiFi-prebuilt swap tx. The
-  // returned `transactionRequest.data` is a fully-formed Solana / EVM
-  // transaction that encodes a minAmountOut floor at quote time —
-  // the underlying AMM (Raydium / Orca / Meteora on Solana; Uniswap /
-  // 1inch on EVM) reverts if simulation-time output drops below the
-  // floor. Default LiFi slippage is 0.005 (0.5%), which is far too
-  // tight for MPC-signed flows where the keysign ceremony adds
-  // 30-90s of clock drift between quote and broadcast and the price
-  // routinely moves more than 0.5% on volatile pairs (SOL/USDC,
-  // SOL/anything memecoin). Production repro (2026-05-22):
-  // SOL→USDC simulation failed with `-32002: custom program error:
-  // 0x32` (Raydium AMM error 50 = AmountExceedsMaximum / slippage
-  // exceeded). Bump to 1% — covers the typical ceremony drift while
-  // staying well inside the user's pre-sign card's risk surface
-  // (typical realised slippage on these aggregators is <0.1%, so
-  // the 1% is a ceiling, not the expected price hit).
-  //
-  // EVM is less time-sensitive (no MPC ceremony delay equivalent —
-  // the model dispatches and the user signs in seconds) but the
-  // same 1% bump still helps when the user pauses on the pre-sign
-  // card for a moment.
-  const SLIPPAGE_TOLERANCE = 0.01
 
   const quote = await getQuote({
     fromChain,
@@ -63,7 +69,7 @@ export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: In
     fromAddress,
     toAddress,
     fee: affiliateBps ? affiliateBps / 10000 : undefined,
-    slippage: SLIPPAGE_TOLERANCE,
+    slippage: DEFAULT_LIFI_SLIPPAGE_TOLERANCE,
   })
 
   const { transactionRequest, estimate } = quote

--- a/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
+++ b/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
@@ -90,7 +90,6 @@ export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: In
   // on the user without anyone noticing. NeOMakinG #513 r1.
   const combinedCostBps = (affiliateBps ?? 0) + DEFAULT_LIFI_SLIPPAGE_TOLERANCE * 10000
   if (combinedCostBps > MAX_COMBINED_COST_BPS) {
-     
     console.warn(
       `[getLifiSwapQuote] affiliate + slippage combined cost exceeds ${MAX_COMBINED_COST_BPS}bps: ${combinedCostBps}bps`
     )

--- a/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
+++ b/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
@@ -31,6 +31,29 @@ export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: In
   const [fromToken, toToken] = [transfer.from, transfer.to].map(({ id, chain }) => id ?? chainFeeCoin[chain].ticker)
   const [fromAddress, toAddress] = [transfer.from, transfer.to].map(({ address }) => address)
 
+  // Slippage tolerance baked into the LiFi-prebuilt swap tx. The
+  // returned `transactionRequest.data` is a fully-formed Solana / EVM
+  // transaction that encodes a minAmountOut floor at quote time —
+  // the underlying AMM (Raydium / Orca / Meteora on Solana; Uniswap /
+  // 1inch on EVM) reverts if simulation-time output drops below the
+  // floor. Default LiFi slippage is 0.005 (0.5%), which is far too
+  // tight for MPC-signed flows where the keysign ceremony adds
+  // 30-90s of clock drift between quote and broadcast and the price
+  // routinely moves more than 0.5% on volatile pairs (SOL/USDC,
+  // SOL/anything memecoin). Production repro (2026-05-22):
+  // SOL→USDC simulation failed with `-32002: custom program error:
+  // 0x32` (Raydium AMM error 50 = AmountExceedsMaximum / slippage
+  // exceeded). Bump to 1% — covers the typical ceremony drift while
+  // staying well inside the user's pre-sign card's risk surface
+  // (typical realised slippage on these aggregators is <0.1%, so
+  // the 1% is a ceiling, not the expected price hit).
+  //
+  // EVM is less time-sensitive (no MPC ceremony delay equivalent —
+  // the model dispatches and the user signs in seconds) but the
+  // same 1% bump still helps when the user pauses on the pre-sign
+  // card for a moment.
+  const SLIPPAGE_TOLERANCE = 0.01
+
   const quote = await getQuote({
     fromChain,
     toChain,
@@ -40,6 +63,7 @@ export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: In
     fromAddress,
     toAddress,
     fee: affiliateBps ? affiliateBps / 10000 : undefined,
+    slippage: SLIPPAGE_TOLERANCE,
   })
 
   const { transactionRequest, estimate } = quote

--- a/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
+++ b/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
@@ -40,17 +40,40 @@ const setupLifi = memoize(() => {
 // (typical realised slippage on these aggregators is <0.1%, so
 // the 1% is a ceiling, not the expected price hit).
 //
-// EVM is less time-sensitive (no MPC ceremony delay equivalent —
-// the model dispatches and the user signs in seconds) but the
-// same 1% bump still helps when the user pauses on the pre-sign
-// card for a moment.
+// EVM is less time-sensitive — the model dispatches and the user
+// signs in seconds, but the same 1% bump still helps cover block
+// time variance during mempool pending (~12s on ETH, ~2s on L2s).
+// On WalletConnect / injected signers the dapp typically re-fetches
+// the quote at MetaMask/Rainbow signing time, so quote staleness from
+// user pause on the pre-sign card is NOT the failure mode — block-
+// time variance during pending is. (NeOMakinG #513 round 1 CR
+// `should-fix` 1 — comment was misleading pre-fix.)
+//
+// **Cross-chain bridge+swap caveat (NeOMakinG #513 round 1
+// `preferably-blocking`).** This 1% slippage applies to the FINAL
+// destination amount only. LiFi cross-chain routes (Stargate, Across,
+// Hop + destination AMM swap) have TWO slippage points: (1) bridge
+// liquidity pool exit on the source chain, (2) destination AMM swap.
+// Intermediate bridge slippage is managed by bridge protocols' own
+// limits and is NOT covered by this 1% floor — so total realised
+// slippage on a SOL→ETH→USDC route could be 2-3% even when this
+// constant says "1%". Document the bridge cost explicitly to users
+// when surfacing cross-chain quote previews; don't rely on this
+// constant as the single source of truth for cross-chain slippage.
 //
 // Hoisted to module scope so the planned per-pair / per-call
 // override (forwarding `execute_swap.slippage_tolerance_percent`
-// through the resolver, tracked as a follow-up) lands as a clean
-// diff rather than reshaping the function body. Codex Round 1b
-// review feedback (vultisig-sdk#513).
+// through the resolver, tracked at vultisig/vultisig-sdk#NEW — TODO
+// open) lands as a clean diff rather than reshaping the function
+// body. Codex Round 1b review feedback (vultisig-sdk#513 r1).
 const DEFAULT_LIFI_SLIPPAGE_TOLERANCE = 0.01
+
+// Combined affiliate + slippage ceiling. Defensive guard so a high
+// affiliateBps + the 1% slippage don't silently combine into a >3%
+// effective cost on the user without anyone noticing. Logged-only,
+// not a hard reject — getQuote will still dispatch. NeOMakinG #513
+// round 1 `suggestion` 1.
+const MAX_COMBINED_COST_BPS = 300
 
 export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: Input): Promise<GeneralSwapQuote> => {
   setupLifi()
@@ -59,6 +82,19 @@ export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: In
 
   const [fromToken, toToken] = [transfer.from, transfer.to].map(({ id, chain }) => id ?? chainFeeCoin[chain].ticker)
   const [fromAddress, toAddress] = [transfer.from, transfer.to].map(({ address }) => address)
+
+  // Defensive: log when affiliate + slippage combined cost crosses the
+  // 3% ceiling. Today affiliateBps is typically 0 and slippage is 1%,
+  // so 100bps total — well under the ceiling — but a future bump to
+  // affiliateBps shouldn't silently combine into a >3% effective cost
+  // on the user without anyone noticing. NeOMakinG #513 r1.
+  const combinedCostBps = (affiliateBps ?? 0) + DEFAULT_LIFI_SLIPPAGE_TOLERANCE * 10000
+  if (combinedCostBps > MAX_COMBINED_COST_BPS) {
+     
+    console.warn(
+      `[getLifiSwapQuote] affiliate + slippage combined cost exceeds ${MAX_COMBINED_COST_BPS}bps: ${combinedCostBps}bps`
+    )
+  }
 
   const quote = await getQuote({
     fromChain,


### PR DESCRIPTION
## Summary

Production repro (2026-05-22): SOL→USDC swap via Li.fi simulated as `-32002: custom program error: 0x32` from Raydium AMM (error index 50 = `AmountExceedsMaximum` / "slippage exceeded"). The LiFi-prebuilt Solana transaction encodes a `minAmountOut` floor at quote time; by broadcast time (30-90s later, dominated by MPC keysign ceremony + broadcaster roundtrips) SOL/USDC has routinely moved more than the 0.5% LiFi default slippage window, so the AMM rejects the swap during preflight simulation.

Bumping the LiFi `slippage` param to 1% (`0.01`) covers the typical ceremony drift while staying well inside the user's pre-sign risk surface — typical realised slippage on these aggregators is <0.1%, so the 1% is a ceiling, not the expected price hit.

## Test plan

- [x] runtime: local stack + iOS sim, `swap $.5 of SOL to USDC on Solana` → **BROADCAST + finalized**:
  - tx: `3iiHp82fX4ffta83TwWpybKVrL5gXUb3hLowEm1jsmA8i8CwFmYH4LaZkWTZBenrUjRfYcLgJ9YBuFtLwf4rcRb5`
  - https://scan.li.fi/tx/3iiHp82fX4ffta83TwWpybKVrL5gXUb3hLowEm1jsmA8i8CwFmYH4LaZkWTZBenrUjRfYcLgJ9YBuFtLwf4rcRb5
  - https://solscan.io/tx/3iiHp82fX4ffta83TwWpybKVrL5gXUb3hLowEm1jsmA8i8CwFmYH4LaZkWTZBenrUjRfYcLgJ9YBuFtLwf4rcRb5
  - Trade: 0.00573789 SOL → 0.496979 USDC via Titan (Li.fi)
  - Confirmation status: `finalized`, `err: null`
- [x] pre-fix the same swap surfaced `-32002: custom program error: 0x32` on every retry attempt (every retry produced a fresh stale-quote tx with the same 0.5% floor)

## Receipts

| Step | Screenshot |
| --- | --- |
| Pre-fix: `-32002 custom program error 0x32` (slippage exceeded) | _captured in paired-PR receipts; failure mode visible upstream of this fix_ |
| Post-fix: clean swap card prepared (Li.fi via Titan route) | https://files.catbox.moe/uxjm9q.png |
| Post-fix: **CONFIRMED on-chain** (tx hash visible) | https://files.catbox.moe/ybyh9g.png |
| Post-fix: LI.FI Scan showing tx Completed | https://files.catbox.moe/pzkwpx.png |

## Paired with

This fix is one of three lined-up patches that together close the SOL `$.5` swap defect chain:

- vultisig/mcp-ts#189 — `list_swap_routes` accepts fiat verbatim via SDK `fiatToAmount` (preserves user's literal `$X` shape, removes the prompt-space fiat→token conversion that drifted on SOL)
- vultisig/agent-backend#652 — wire-side `assertAmountShapePreserved` guard that catches LLM `$`-strip drift and routes the model back to retry with the fiat shape intact
- **this PR** — without 1% slippage, the broadcast itself still failed even with the correct amount, because LiFi-prebuilt Solana txs go stale before the MPC ceremony finishes

## Risk

Low. 1% is the de-facto default across mainstream DeFi UIs (Jupiter, Uniswap, 1inch, Phantom in-app swap) for the same reason — accounts for normal cross-block price drift. Realised slippage stays at the AMM's actual price-impact level (<0.1% for SOL/USDC at $0.50 size). For traders who want a tighter ceiling, a follow-up that threads `slippage_tolerance_percent` from `execute_swap` through to this resolver is the right shape — leaving that as a separate iteration since this PR is the unblock-first surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Applied a default slippage tolerance to swap quote calculations so transactions include minimum-amount protection against price movement.
  * Added a safeguard that flags unusually high combined fees for quotes; the system now warns when total estimated cost exceeds a configured ceiling (warning only, does not block quotes).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/513?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->