### PR TITLE
fix(swap/swapkit): include utxo/cosmos/thor chains as swapkit source chains

### DIFF
--- a/packages/core/chain/swap/general/swapkit/SwapKitEnabledChains.ts
+++ b/packages/core/chain/swap/general/swapkit/SwapKitEnabledChains.ts
@@ -32,6 +32,35 @@ export const swapKitSourceChains = [
 
 export type SwapKitSourceChain = (typeof swapKitSourceChains)[number]
 
-export const swapKitEnabledChains = swapKitSourceChains
+// Chains that can be the DESTINATION of a SwapKit-routed swap.
+// Currently identical content to swapKitSourceChains but kept as a separate
+// const + type so consumers can narrow on source-only behavior in the future
+// without silently colliding with destination-only checks (per NeO CR
+// preferably-blocking 1 on sdk#514).
+export const swapKitEnabledChains = [
+  Chain.Ethereum,
+  Chain.Arbitrum,
+  Chain.Avalanche,
+  Chain.Base,
+  Chain.BSC,
+  Chain.Optimism,
+  Chain.Polygon,
+  Chain.Solana,
+  Chain.Bitcoin,
+  Chain.BitcoinCash,
+  Chain.Cardano,
+  Chain.Cosmos,
+  Chain.Dash,
+  Chain.Dogecoin,
+  Chain.Kujira,
+  Chain.Litecoin,
+  Chain.MayaChain,
+  Chain.Ripple,
+  Chain.Sui,
+  Chain.THORChain,
+  Chain.Ton,
+  Chain.Tron,
+  Chain.Zcash,
+] as const
 
 export type SwapKitEnabledChain = (typeof swapKitEnabledChains)[number]

--- a/packages/core/chain/swap/general/swapkit/SwapKitEnabledChains.ts
+++ b/packages/core/chain/swap/general/swapkit/SwapKitEnabledChains.ts
@@ -1,5 +1,9 @@
 import { Chain } from '@vultisig/core-chain/Chain'
 
+// Chains that can be the SOURCE of a SwapKit-routed swap.
+// Live curl matrix against the vultisig.com proxy confirms NEAR Intents +
+// THORChain via SwapKit accept these as source: BTC, ZEC, LTC, DOGE, BCH,
+// DASH, Cosmos, THORChain, MayaChain, Ton, Cardano, Sui, Tron, Ripple.
 export const swapKitSourceChains = [
   Chain.Ethereum,
   Chain.Arbitrum,
@@ -9,12 +13,6 @@ export const swapKitSourceChains = [
   Chain.Optimism,
   Chain.Polygon,
   Chain.Solana,
-] as const
-
-export type SwapKitSourceChain = (typeof swapKitSourceChains)[number]
-
-export const swapKitEnabledChains = [
-  ...swapKitSourceChains,
   Chain.Bitcoin,
   Chain.BitcoinCash,
   Chain.Cardano,
@@ -31,5 +29,9 @@ export const swapKitEnabledChains = [
   Chain.Tron,
   Chain.Zcash,
 ] as const
+
+export type SwapKitSourceChain = (typeof swapKitSourceChains)[number]
+
+export const swapKitEnabledChains = swapKitSourceChains
 
 export type SwapKitEnabledChain = (typeof swapKitEnabledChains)[number]


### PR DESCRIPTION
## what

Adds Bitcoin, BitcoinCash, Cardano, Cosmos, Dash, Dogecoin, Kujira, Litecoin, MayaChain, Ripple, Sui, THORChain, Ton, Tron, Zcash to `swapKitSourceChains`. Aligns it with the existing `swapKitEnabledChains` list, which had these chains for the destination side already.

## why

Found during a live SwapKit dogfood today on a vault holding 0.0085 ZEC.

`swap 0.008 ZEC to SOL` in agent chat returned `execute_swap: quote failed: No swap routes found.` Direct `curl POST https://api.vultisig.com/swapkit/v3/quote` with the same `sellAsset=ZEC.ZEC, buyAsset=SOL.SOL, sellAmount=0.008` returned a NEAR Intents route paying 0.058 SOL.

Root cause: `findSwapQuote.ts:217` only pushes the SwapKit fetcher when `isOneOf(fromChain, swapKitSourceChains)` and `swapKitSourceChains` was EVM-only + Solana. ZEC (and BTC, LTC, DOGE, BCH, DASH, Cosmos, THOR, Maya, TON, ADA, SUI, TRON, XRP) silently skipped the SwapKit branch in findSwapQuote, leaving only THORChain native + Maya as candidates - both of which lack ZEC pools.

## how

Lift the 14 chains that were already in `swapKitEnabledChains` (but not in `swapKitSourceChains`) into the source list. `swapKitEnabledChains` is now just a re-export of `swapKitSourceChains` since SwapKit accepts the same chain on either side via NEAR Intents / Chainflip / Garden / Flashnet / THORChain.

## risk

Low. The change only expands which fromChains are eligible for SwapKit attempts in `findSwapQuote.getGeneralFetchers`. SwapKit returns `noRoutesFound` for unsupported pairs and findSwapQuote already handles that gracefully (the fetcher just returns no routes alongside the other providers).

For overlap with direct providers (THORChain native + Maya), KEEP-BOTH-FALLBACK ranking still applies - direct typically wins on the same pair because it skips the +15bps SwapKit service fee.

## receipts

```
# Direct curl confirms ZEC source works on SwapKit proxy
$ curl -s -X POST https://api.vultisig.com/swapkit/v3/quote \
    -H Content-Type:application/json \
    -d {sellAsset:ZEC.ZEC,buyAsset:SOL.SOL,sellAmount:0.008,slippage:3,affiliateFee:0,providers:[NEAR]}
{
  "routes": [{
    "providers": ["NEAR"],
    "expectedBuyAmount": "0.058135374",
    ...
  }]
}

# Same call from SDK previously NEVER fired because findSwapQuote.ts:217 gated on EVM-only source list

# Test suite
$ yarn workspace @vultisig/sdk test
Test Files  101 passed (101)
     Tests  1380 passed (1380)
```

## related

- vp#727 (SwapKit provider label rendering)
- ab#646 (gas reserve floor fix on ETH/BSC, same pattern)
- ab#656 (gas reserve floor fix on Zcash, paired with this PR)
- closes the underlying bug behind today (~$5 worth of ZEC stuck unable to swap)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded and standardized SwapKit-supported source chains: Bitcoin, Cardano, Cosmos and other networks are now validated as proper sources for SwapKit-routed swaps via the vultisig proxy. This improves cross-chain swap compatibility and provides users more reliable routing options across supported networks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/514?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->