### PR TITLE
feat(tron): add buildTronTxFromRawData for prebuilt-tx signing

### DIFF
--- a/.changeset/tron-prebuilt-raw-data.md
+++ b/.changeset/tron-prebuilt-raw-data.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': minor
+---
+
+Add `buildTronTxFromRawData(rawDataHex)` to sign yield.xyz Tron actions whose `raw_data` is already encoded upstream (FreezeBalanceV2, UnfreezeBalanceV2, VoteWitnessContract, …). Hashes the raw_data bytes with SHA-256, takes the MPC signature, and wraps the final `Transaction { raw_data, signature }` envelope — same `{signingHashHex, unsignedRawHex, finalize(sig)}` contract as `buildTronSendTx`. Includes strict hex-character validation so malformed input fails fast instead of silently producing a wrong signing payload.

--- a/packages/sdk/src/chains/tron/index.ts
+++ b/packages/sdk/src/chains/tron/index.ts
@@ -1,6 +1,12 @@
 // Pure tx builders — no network I/O, no vault.
 export type { BuildTrc20TransferOptions, BuildTronSendOptions, TronTxBuilderResult } from './tx'
-export { buildTrc20CallData, buildTrc20TransferTx, buildTronSendTx, tronAddressToBytes } from './tx'
+export {
+  buildTrc20CallData,
+  buildTrc20TransferTx,
+  buildTronSendTx,
+  buildTronTxFromRawData,
+  tronAddressToBytes,
+} from './tx'
 
 // Protobuf primitives — exposed so downstream code can extend this surface
 // with `FreezeBalance` etc. without re-implementing varint / tag encoding.

--- a/packages/sdk/src/chains/tron/tx.ts
+++ b/packages/sdk/src/chains/tron/tx.ts
@@ -345,6 +345,16 @@ export function buildTronTxFromRawData(rawDataHex: string): TronTxBuilderResult 
   if (typeof rawDataHex !== 'string') {
     throw new Error('buildTronTxFromRawData: rawDataHex must be a hex string')
   }
+  // Reject non-hex characters explicitly. `hexToBytes` uses
+  // `parseInt(_, 16)` which silently returns NaN for invalid chars,
+  // producing garbage bytes that hash to a wrong signing payload and
+  // ultimately MPC-sign over nothing meaningful. The strict guard
+  // ensures malformed input from yield.xyz / app callers fails fast
+  // with a clear message rather than producing an unbroadcastable tx.
+  const stripped = rawDataHex.startsWith('0x') ? rawDataHex.slice(2) : rawDataHex
+  if (!/^[0-9a-fA-F]*$/.test(stripped)) {
+    throw new Error('buildTronTxFromRawData: rawDataHex contains non-hex characters')
+  }
   const rawData = hexToBytes(rawDataHex)
   if (rawData.length === 0) {
     throw new Error('buildTronTxFromRawData: rawDataHex decoded to zero bytes')

--- a/packages/sdk/src/chains/tron/tx.ts
+++ b/packages/sdk/src/chains/tron/tx.ts
@@ -337,9 +337,12 @@ export function buildTronSendTx(opts: BuildTronSendOptions): TronTxBuilderResult
  * @param rawDataHex  hex-encoded protobuf `Transaction.raw_data` bytes,
  *                    with or without `0x` prefix. Must NOT be the full
  *                    signed-tx envelope — only the inner raw_data.
- * @returns same shape as `buildTronSendTx`. `unsignedRawHex` round-trips
- *          the input verbatim so byte parity checks against the
- *          original payload still work.
+ * @returns same shape as `buildTronSendTx`. `unsignedRawHex` is the
+ *          *normalized* hex of the decoded raw_data bytes — equal to
+ *          the input after stripping any leading `0x`/`0X` prefix and
+ *          lowercasing. Byte-parity checks against the decoded bytes
+ *          hold; a naive string-level `===` against the original input
+ *          may differ on prefix or hex casing.
  */
 export function buildTronTxFromRawData(rawDataHex: string): TronTxBuilderResult {
   if (typeof rawDataHex !== 'string') {
@@ -351,11 +354,14 @@ export function buildTronTxFromRawData(rawDataHex: string): TronTxBuilderResult 
   // ultimately MPC-sign over nothing meaningful. The strict guard
   // ensures malformed input from yield.xyz / app callers fails fast
   // with a clear message rather than producing an unbroadcastable tx.
-  const stripped = rawDataHex.startsWith('0x') ? rawDataHex.slice(2) : rawDataHex
+  const stripped = rawDataHex.startsWith('0x') || rawDataHex.startsWith('0X') ? rawDataHex.slice(2) : rawDataHex
   if (!/^[0-9a-fA-F]*$/.test(stripped)) {
     throw new Error('buildTronTxFromRawData: rawDataHex contains non-hex characters')
   }
-  const rawData = hexToBytes(rawDataHex)
+  // Decode from the prefix-stripped form so `hexToBytes` doesn't have to
+  // re-do prefix handling (and so a `0X` prefix doesn't ride through to
+  // any future decoder that's `0x`-case-sensitive).
+  const rawData = hexToBytes(stripped)
   if (rawData.length === 0) {
     throw new Error('buildTronTxFromRawData: rawDataHex decoded to zero bytes')
   }

--- a/packages/sdk/src/chains/tron/tx.ts
+++ b/packages/sdk/src/chains/tron/tx.ts
@@ -304,6 +304,68 @@ export function buildTronSendTx(opts: BuildTronSendOptions): TronTxBuilderResult
   return { signingHashHex, unsignedRawHex, finalize }
 }
 
+/**
+ * Same signing-hash + finalize contract as `buildTronSendTx` /
+ * `buildTrc20TransferTx`, but takes a PRE-BUILT `raw_data` protobuf byte
+ * sequence instead of building it from a TransferContract or
+ * TriggerSmartContract. Use when an upstream service (e.g. yield.xyz,
+ * stakek.it, a delegation-service backend) hands you the encoded
+ * raw_data hex and you only need to:
+ *   1. compute the signing hash (sha256(raw_data)),
+ *   2. MPC-sign it,
+ *   3. wrap raw_data + signature into the outer Transaction protobuf
+ *      for broadcast.
+ *
+ * No validation of the protobuf contents — the caller has already
+ * decided the tx shape is correct. Validation lives one layer up
+ * (yield.xyz's preview, the user's review card, etc.).
+ *
+ * Why expose this:
+ *
+ *   - yield.xyz Tron actions (`tron-trx-native-staking`,
+ *     `tron-trx-strx-staking`) return a pre-encoded `raw_data` hex
+ *     covering FreezeBalanceV2 / UnfreezeBalanceV2 / VoteWitness etc.
+ *     contracts. Replicating those builders here would mean shipping
+ *     N more contract types just so the SDK can produce identical
+ *     bytes — wasteful when the upstream already did the work.
+ *
+ *   - Delegated-staking / dApp signing flows (e.g. wallet-connect
+ *     style) pre-build the tx on a remote node and expect the wallet
+ *     to sign without re-deriving the bytes. Same primitive serves
+ *     that use case too.
+ *
+ * @param rawDataHex  hex-encoded protobuf `Transaction.raw_data` bytes,
+ *                    with or without `0x` prefix. Must NOT be the full
+ *                    signed-tx envelope — only the inner raw_data.
+ * @returns same shape as `buildTronSendTx`. `unsignedRawHex` round-trips
+ *          the input verbatim so byte parity checks against the
+ *          original payload still work.
+ */
+export function buildTronTxFromRawData(rawDataHex: string): TronTxBuilderResult {
+  if (typeof rawDataHex !== 'string') {
+    throw new Error('buildTronTxFromRawData: rawDataHex must be a hex string')
+  }
+  const rawData = hexToBytes(rawDataHex)
+  if (rawData.length === 0) {
+    throw new Error('buildTronTxFromRawData: rawDataHex decoded to zero bytes')
+  }
+
+  const signingHashBytes = sha256(rawData)
+  const signingHashHex = bytesToHex(signingHashBytes)
+  // Normalise the round-trip representation so callers comparing the
+  // returned `unsignedRawHex` against the input string don't have to
+  // strip the optional `0x` prefix themselves.
+  const unsignedRawHex = bytesToHex(rawData)
+
+  const finalize = (sigHex: string): { signedTxHex: string; txId: string } => {
+    const sig = parseSignature(sigHex)
+    const signedTx = wrapTransaction(rawData, sig)
+    return { signedTxHex: bytesToHex(signedTx), txId: signingHashHex }
+  }
+
+  return { signingHashHex, unsignedRawHex, finalize }
+}
+
 export function buildTrc20TransferTx(opts: BuildTrc20TransferOptions): TronTxBuilderResult {
   validateRefs(opts.refBlockBytes, opts.refBlockHash)
   // feeLimit must be > 0 — buildRawData silently drops a zero feeLimit, and a

--- a/packages/sdk/src/platforms/react-native/chains/tron/index.ts
+++ b/packages/sdk/src/platforms/react-native/chains/tron/index.ts
@@ -10,6 +10,8 @@
  * Covered surface:
  *   - `buildTronSendTx`        — native TRX transfer
  *   - `buildTrc20TransferTx`   — TRC-20 token transfer (USDT etc.)
+ *   - `buildTronTxFromRawData` — sign a pre-built raw_data hex (e.g.
+ *                                yield.xyz staking actions, dApp signing)
  *   - `getTronBlockRefs`       — latest block hash + ref_block_* for building tx
  *   - `getTronAccount`         — balance + bandwidth/energy
  *   - `estimateTrc20Energy`    — contract-call energy prediction
@@ -29,6 +31,7 @@ export {
   buildTrc20CallData,
   buildTrc20TransferTx,
   buildTronSendTx,
+  buildTronTxFromRawData,
   encodeInt64Varint,
   encodeVarint,
   estimateTrc20Energy,

--- a/packages/sdk/tests/unit/chains/tron-tx.test.ts
+++ b/packages/sdk/tests/unit/chains/tron-tx.test.ts
@@ -226,6 +226,22 @@ describe('tron / buildTronTxFromRawData (prebuilt raw_data signing)', () => {
     expect(replay.signingHashHex).toBe(reference.signingHashHex)
   })
 
+  it('returns normalized (prefix-stripped, lowercased) `unsignedRawHex` — CodeRabbit #515 r3', () => {
+    // The JSDoc explicitly documents that `unsignedRawHex` is the
+    // normalized form of the decoded bytes. Pin both rules:
+    //   - leading `0x` / `0X` is stripped
+    //   - hex casing is lowercased
+    // so callers doing byte-level comparison (rather than string
+    // equality with the original input) get a stable round-trip.
+    const raw = '0A024010'
+    const out = buildTronTxFromRawData(raw)
+    expect(out.unsignedRawHex).toBe('0a024010')
+
+    const prefixedUpper = buildTronTxFromRawData('0X0A024010')
+    expect(prefixedUpper.unsignedRawHex).toBe('0a024010')
+    expect(prefixedUpper.signingHashHex).toBe(out.signingHashHex)
+  })
+
   it('round-trips arbitrary opaque raw_data bytes (the yield.xyz case)', () => {
     // yield.xyz Tron staking returns FreezeBalanceV2 / UnfreezeBalanceV2
     // / VoteWitness raw_data that we have NO local builder for. The

--- a/packages/sdk/tests/unit/chains/tron-tx.test.ts
+++ b/packages/sdk/tests/unit/chains/tron-tx.test.ts
@@ -239,9 +239,7 @@ describe('tron / buildTronTxFromRawData (prebuilt raw_data signing)', () => {
     // hash path (wrong algorithm, wrong input slice, extra prefix) fails
     // loudly rather than silently shifting the user's signing scope.
     // Computed independently via Node crypto, not via the function itself.
-    expect(out.signingHashHex).toBe(
-      'd3953dbc76634d62993fa4b0e619d03e75534fc366b33f9a2bf4c4ee319f9928'
-    )
+    expect(out.signingHashHex).toBe('d3953dbc76634d62993fa4b0e619d03e75534fc366b33f9a2bf4c4ee319f9928')
   })
 
   it('rejects empty hex', () => {

--- a/packages/sdk/tests/unit/chains/tron-tx.test.ts
+++ b/packages/sdk/tests/unit/chains/tron-tx.test.ts
@@ -235,17 +235,13 @@ describe('tron / buildTronTxFromRawData (prebuilt raw_data signing)', () => {
     const opaque = '0a024010'
     const out = buildTronTxFromRawData(opaque)
     expect(out.unsignedRawHex).toBe(opaque)
-    expect(out.signingHashHex).toMatch(/^[0-9a-f]{64}$/)
-
-    // sha256(0x0a024010) — deterministic; pin it so a regression in the
-    // hash path would fail this test rather than silently shift the
-    // user's signing scope.
-    // (Computed independently: sha256("0a024010" hex bytes)).
-    // Use a single-source dependency: compare to buildTronSendTx's hash
-    // is too circular here, so the regex match above is the canonical
-    // shape check; this assertion just confirms a stable, non-empty
-    // hex string.
-    expect(out.signingHashHex.length).toBe(64)
+    // sha256(0x0a 0x02 0x40 0x10) — pinned so any regression in the
+    // hash path (wrong algorithm, wrong input slice, extra prefix) fails
+    // loudly rather than silently shifting the user's signing scope.
+    // Computed independently via Node crypto, not via the function itself.
+    expect(out.signingHashHex).toBe(
+      'd3953dbc76634d62993fa4b0e619d03e75534fc366b33f9a2bf4c4ee319f9928'
+    )
   })
 
   it('rejects empty hex', () => {

--- a/packages/sdk/tests/unit/chains/tron-tx.test.ts
+++ b/packages/sdk/tests/unit/chains/tron-tx.test.ts
@@ -261,6 +261,15 @@ describe('tron / buildTronTxFromRawData (prebuilt raw_data signing)', () => {
     expect(() => buildTronTxFromRawData('0a02401')).toThrow()
   })
 
+  it('rejects hex strings containing non-hex characters (CodeRabbit r1)', () => {
+    // Even-length, decoded by parseInt(_,16) but with a non-hex char
+    // ('z') — under the unguarded path this would parseInt-to-NaN and
+    // produce garbage bytes, ultimately MPC-signing a wrong hash.
+    expect(() => buildTronTxFromRawData('0a0z4010')).toThrow(/non-hex/i)
+    // 0x-prefixed variant still triggers the guard.
+    expect(() => buildTronTxFromRawData('0x0a0z4010')).toThrow(/non-hex/i)
+  })
+
   it('finalize rejects a sig that is not 65 bytes', () => {
     const out = buildTronTxFromRawData('0a024010')
     expect(() => out.finalize('aa'.repeat(64))).toThrow(/65-byte/)

--- a/packages/sdk/tests/unit/chains/tron-tx.test.ts
+++ b/packages/sdk/tests/unit/chains/tron-tx.test.ts
@@ -8,7 +8,12 @@
 import { describe, expect, it } from 'vitest'
 
 import { encodeInt64Varint, encodeVarint } from '../../../src/chains/tron/proto'
-import { buildTrc20CallData, buildTrc20TransferTx, buildTronSendTx } from '../../../src/chains/tron/tx'
+import {
+  buildTrc20CallData,
+  buildTrc20TransferTx,
+  buildTronSendTx,
+  buildTronTxFromRawData,
+} from '../../../src/chains/tron/tx'
 
 // Valid Tron base58check addresses (0x41 || 20-byte payload, bs58check-encoded).
 const FROM = 'T9yED5xMV5ARV98BexN97aLZ1UUq7eKSxm'
@@ -174,5 +179,90 @@ describe('tron / buildTrc20TransferTx', () => {
         timestamp: 1_699_999_940_000n,
       })
     ).toThrow(/feeLimit must be > 0/)
+  })
+})
+
+describe('tron / buildTronTxFromRawData (prebuilt raw_data signing)', () => {
+  it('produces the same signingHash and signedTxHex as buildTronSendTx for an identical tx', () => {
+    // Round-trip: build a real native-send tx via buildTronSendTx, then
+    // feed its `unsignedRawHex` back through buildTronTxFromRawData. The
+    // signingHash MUST be byte-identical (same SHA-256 of the same
+    // raw_data) and `finalize()` MUST emit the same signed-tx hex when
+    // given the same signature.
+    const reference = buildTronSendTx({
+      from: FROM,
+      to: TO,
+      amount: 7_500_000n,
+      refBlockBytes: REF_BLOCK_BYTES,
+      refBlockHash: REF_BLOCK_HASH,
+      expiration: 1_700_000_000_000n,
+      timestamp: 1_699_999_940_000n,
+    })
+
+    const replay = buildTronTxFromRawData(reference.unsignedRawHex)
+    expect(replay.signingHashHex).toBe(reference.signingHashHex)
+    expect(replay.unsignedRawHex).toBe(reference.unsignedRawHex)
+
+    // Stub 65-byte signature (r || s || v) — content doesn't matter, only
+    // shape. Both finalize() calls must wrap it identically.
+    const sigHex = 'aa'.repeat(65)
+    const refSigned = reference.finalize(sigHex)
+    const replaySigned = replay.finalize(sigHex)
+    expect(replaySigned.signedTxHex).toBe(refSigned.signedTxHex)
+    expect(replaySigned.txId).toBe(refSigned.txId)
+  })
+
+  it('accepts `0x`-prefixed hex input', () => {
+    const reference = buildTronSendTx({
+      from: FROM,
+      to: TO,
+      amount: 100n,
+      refBlockBytes: REF_BLOCK_BYTES,
+      refBlockHash: REF_BLOCK_HASH,
+      expiration: 1_700_000_000_000n,
+      timestamp: 1_699_999_940_000n,
+    })
+    const replay = buildTronTxFromRawData('0x' + reference.unsignedRawHex)
+    expect(replay.signingHashHex).toBe(reference.signingHashHex)
+  })
+
+  it('round-trips arbitrary opaque raw_data bytes (the yield.xyz case)', () => {
+    // yield.xyz Tron staking returns FreezeBalanceV2 / UnfreezeBalanceV2
+    // / VoteWitness raw_data that we have NO local builder for. The
+    // primitive must work without parsing the protobuf — just hash and
+    // wrap. Use a synthetic-but-plausible raw_data: a single field
+    // ref_block_bytes (tag 0x0a, len 2, value 0x40df).
+    const opaque = '0a024010'
+    const out = buildTronTxFromRawData(opaque)
+    expect(out.unsignedRawHex).toBe(opaque)
+    expect(out.signingHashHex).toMatch(/^[0-9a-f]{64}$/)
+
+    // sha256(0x0a024010) — deterministic; pin it so a regression in the
+    // hash path would fail this test rather than silently shift the
+    // user's signing scope.
+    // (Computed independently: sha256("0a024010" hex bytes)).
+    // Use a single-source dependency: compare to buildTronSendTx's hash
+    // is too circular here, so the regex match above is the canonical
+    // shape check; this assertion just confirms a stable, non-empty
+    // hex string.
+    expect(out.signingHashHex.length).toBe(64)
+  })
+
+  it('rejects empty hex', () => {
+    expect(() => buildTronTxFromRawData('')).toThrow(/zero bytes/)
+  })
+
+  it('rejects non-string input', () => {
+    // @ts-expect-error — intentional shape violation for the runtime guard
+    expect(() => buildTronTxFromRawData(null)).toThrow(/hex string/)
+  })
+
+  it('rejects malformed hex (odd-length)', () => {
+    expect(() => buildTronTxFromRawData('0a02401')).toThrow()
+  })
+
+  it('finalize rejects a sig that is not 65 bytes', () => {
+    const out = buildTronTxFromRawData('0a024010')
+    expect(() => out.finalize('aa'.repeat(64))).toThrow(/65-byte/)
   })
 })

--- a/packages/sdk/tests/unit/chains/tron-tx.test.ts
+++ b/packages/sdk/tests/unit/chains/tron-tx.test.ts
@@ -224,6 +224,9 @@ describe('tron / buildTronTxFromRawData (prebuilt raw_data signing)', () => {
     })
     const replay = buildTronTxFromRawData('0x' + reference.unsignedRawHex)
     expect(replay.signingHashHex).toBe(reference.signingHashHex)
+    // unsignedRawHex must equal the normalized form (no 0x prefix, lowercase)
+    // CodeRabbit #515 r3 — locks the prefix-stripping/canonicalization contract
+    expect(replay.unsignedRawHex).toBe(reference.unsignedRawHex)
   })
 
   it('returns normalized (prefix-stripped, lowercased) `unsignedRawHex` — CodeRabbit #515 r3', () => {


### PR DESCRIPTION
## Goal

Sign Tron txs whose protobuf `raw_data` is built UPSTREAM (yield.xyz staking actions, dApp signing via WalletConnect, delegated-staking backends) — without shipping a builder for every contract type the SDK doesn't own.

## Contract

```ts
buildTronTxFromRawData(rawDataHex: string): TronTxBuilderResult
```

Returns the same shape as the existing chain-specific builders:
- `signingHashHex` — `sha256(raw_data)` for MPC sign
- `unsignedRawHex` — verbatim round-trip (0x-prefix stripped)
- `finalize(sigHex)` — wraps raw_data + signature into the outer Transaction protobuf

## Why this exists

yield.xyz Tron staking products (`tron-trx-native-staking`, `tron-trx-strx-staking`) return a pre-encoded `raw_data` hex per step. The contract types involved (FreezeBalanceV2, UnfreezeBalanceV2, VoteWitness, WithdrawBalance, …) aren't in the SDK's `tx.ts` today. Shipping a chain-specific builder for each just so we can produce identical bytes would mean duplicating every yield.xyz Tron contract surface here — wasteful when the upstream already did the work.

Same primitive serves dApp / WalletConnect Tron flows: the dApp builds the tx server-side, the wallet just signs.

## Why a NEW primitive vs. extending the existing ones

The existing `buildTronSendTx` / `buildTrc20TransferTx` take typed-input contract args (`from`, `to`, `amount`) and shape the protobuf themselves. They can't accept opaque raw_data without becoming a leaky abstraction that pretends to validate but doesn't.

A separate primitive keeps the validation story clean: the chain-specific builders validate inputs strictly; the prebuilt primitive trusts the caller (validation lives one layer up — yield.xyz preview, BuildTxCard, etc.).

## Testing

- **6 new tests** in `tron-tx.test.ts`:
  - Round-trip parity with `buildTronSendTx` (same signingHash + same signedTxHex for identical raw_data + sig — proves the new primitive is byte-equivalent to the existing one when fed equivalent input)
  - `0x`-prefix tolerance
  - Opaque raw_data round-trip (the yield.xyz case — we have no local FreezeBalance builder; just hash + wrap)
  - Empty hex rejection, non-string rejection, odd-length hex rejection
  - `finalize()` guards 65-byte sig length
- **86/86** across `packages/sdk/tests/unit/chains`
- `biome check` clean on all touched files

```bash
$ npx vitest run packages/sdk/tests/unit/chains/tron-tx.test.ts
 ✓ packages/sdk/tests/unit/chains/tron-tx.test.ts (22 tests) 6ms
 Test Files  1 passed (1)
      Tests  22 passed (22)
```

## Consumer integration

vultiagent-app companion PR (forthcoming) adds:
- `tron-prebuilt` to `ParsedServerTx` union
- `tron-prebuilt` case to `signAndBroadcast` (calls this new SDK primitive)
- `parseTronCanonical` extension to discriminate `{raw_data_hex: <hex>}` → `tron-prebuilt` vs the existing `{owner_address, to_address, amount}` → `generic`

mcp-ts companion PR (forthcoming): `parseActionDisplay` Tron branch — emits `{tx_encoding: 'tron-tx', chain: 'Tron', data: <hex>, action, description}` per step.

Tracking: vultiagent-poc-0tc.2 bead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Tron transaction builder that accepts hex-encoded raw transaction data (optional 0x), strictly validates input, computes a signing hash, and returns unsigned/signed transaction hex plus transaction ID; re-exported to React Native.

* **Tests**
  * Added unit tests for round-trip reconstruction, input validation (including 0x and non-hex), signature length checks, and opaque raw-data handling.

* **Chores**
  * Documentation and minor version bump documenting the new helper.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/515?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->