### PR TITLE
feat(ton): add buildTonTxFromSigningPayload for prebuilt-tx signing

### DIFF
--- a/.changeset/ton-prebuilt-signing-payload.md
+++ b/.changeset/ton-prebuilt-signing-payload.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': minor
+---
+
+Add `buildTonTxFromSigningPayload({publicKeyEd25519, signingPayloadBoc, includeStateInit, workchain})` to sign yield.xyz TON actions whose signing payload BoC is already constructed upstream. Parses the BoC, hashes the payload cell, takes the MPC signature, and wraps the final external message — same `{signingHashHex, unsignedBocHex, fromAddress, finalize(sig)}` contract as `buildTonSendTx`. Accepts either base64 or hex BoC input. Optional `includeStateInit` flag deploys the v4r2 wallet contract alongside the tx for first-send (seqno === 0) scenarios.

--- a/packages/sdk/src/chains/ton/index.ts
+++ b/packages/sdk/src/chains/ton/index.ts
@@ -1,7 +1,18 @@
 export { sha256 } from './crypto-rn'
 export type { TonWalletInfo, TonWalletStatus } from './rpc'
 export { broadcastTonTx, getTonBalance, getTonWalletInfo } from './rpc'
-export type { BuildTonJettonTransferOptions, BuildTonSendOptions, TonTxBuilderResult } from './tx'
-export { buildTonJettonTransferTx, buildTonSendTx, deriveTonAddress, validateTonMemo } from './tx'
+export type {
+  BuildTonJettonTransferOptions,
+  BuildTonSendOptions,
+  BuildTonTxFromSigningPayloadOptions,
+  TonTxBuilderResult,
+} from './tx'
+export {
+  buildTonJettonTransferTx,
+  buildTonSendTx,
+  buildTonTxFromSigningPayload,
+  deriveTonAddress,
+  validateTonMemo,
+} from './tx'
 export type { TonV4R2Wallet } from './walletV4R2'
 export { buildV4R2Wallet, TON_V4R2_SUB_WALLET_ID } from './walletV4R2'

--- a/packages/sdk/src/chains/ton/tx.ts
+++ b/packages/sdk/src/chains/ton/tx.ts
@@ -16,35 +16,46 @@
  * `./walletV4R2` / `./crypto-rn`. It never reaches `@ton/crypto-primitives`
  * so the RN bundle does not need the `crypto.subtle` polyfill.
  */
-import { Address, beginCell, Cell, internal, SendMode, storeMessageRelaxed } from '@ton/core'
+import {
+  Address,
+  beginCell,
+  Cell,
+  internal,
+  SendMode,
+  storeMessageRelaxed,
+} from "@ton/core";
 
-import { buildV4R2Wallet, storeStateInitCell, TON_V4R2_SUB_WALLET_ID } from './walletV4R2'
+import {
+  buildV4R2Wallet,
+  storeStateInitCell,
+  TON_V4R2_SUB_WALLET_ID,
+} from "./walletV4R2";
 
 // ---------------------------------------------------------------------------
 // Hex utils (RN-safe; no Buffer dependency in the hot path)
 // ---------------------------------------------------------------------------
 
 function hexToBytes(hex: string): Uint8Array {
-  const clean = hex.startsWith('0x') ? hex.slice(2) : hex
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
   if (clean.length % 2 !== 0) {
-    throw new Error(`TON hex input must have even length, got ${clean.length}`)
+    throw new Error(`TON hex input must have even length, got ${clean.length}`);
   }
   if (clean.length > 0 && !/^[0-9a-fA-F]+$/.test(clean)) {
-    throw new Error(`TON hex input contains non-hex characters: ${clean}`)
+    throw new Error(`TON hex input contains non-hex characters: ${clean}`);
   }
-  const bytes = new Uint8Array(clean.length / 2)
+  const bytes = new Uint8Array(clean.length / 2);
   for (let i = 0; i < bytes.length; i++) {
-    bytes[i] = parseInt(clean.substring(i * 2, i * 2 + 2), 16)
+    bytes[i] = parseInt(clean.substring(i * 2, i * 2 + 2), 16);
   }
-  return bytes
+  return bytes;
 }
 
 function bytesToHex(bytes: Uint8Array): string {
-  let out = ''
+  let out = "";
   for (let i = 0; i < bytes.length; i++) {
-    out += bytes[i].toString(16).padStart(2, '0')
+    out += bytes[i].toString(16).padStart(2, "0");
   }
-  return out
+  return out;
 }
 
 // ---------------------------------------------------------------------------
@@ -57,13 +68,16 @@ function bytesToHex(bytes: Uint8Array): string {
  */
 export function deriveTonAddress(
   publicKeyEd25519Hex: string,
-  opts: { workchain?: number; bounceable?: boolean; testOnly?: boolean } = {}
+  opts: { workchain?: number; bounceable?: boolean; testOnly?: boolean } = {},
 ): string {
   const wallet = buildV4R2Wallet({
     publicKeyEd25519: hexToBytes(publicKeyEd25519Hex),
     workchain: opts.workchain,
-  })
-  return wallet.addressString({ bounceable: opts.bounceable ?? false, testOnly: opts.testOnly })
+  });
+  return wallet.addressString({
+    bounceable: opts.bounceable ?? false,
+    testOnly: opts.testOnly,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -72,66 +86,66 @@ export function deriveTonAddress(
 
 export type BuildTonSendOptions = {
   /** Sender's Ed25519 public key, hex (no 0x prefix required). */
-  publicKeyEd25519: string
+  publicKeyEd25519: string;
   /** Destination in any TON address format (raw or user-friendly). */
-  to: string
+  to: string;
   /** Amount in nanotons (1 TON = 10^9 nanotons). */
-  amount: bigint
+  amount: bigint;
   /** Bounce flag on the inner transfer message. Caller should set this based on wallet-state of the recipient. */
-  bounceable: boolean
+  bounceable: boolean;
   /** Optional UTF-8 memo (≤ 123 bytes; longer memos are rejected per TON cell limit). */
-  memo?: string
+  memo?: string;
   /** Seqno from `getTonWalletInfo(from).seqno`. First tx = 0. */
-  seqno: number
+  seqno: number;
   /** Unix seconds after which the message is invalid. Default = now + 600. */
-  validUntil?: number
+  validUntil?: number;
   /**
    * Sub-wallet ID. Defaults to the V4R2 constant (698983191 for workchain 0).
    * Only override if you're targeting a non-default sub-wallet.
    */
-  subWalletId?: number
+  subWalletId?: number;
   /** Sender wallet workchain. Default 0. */
-  workchain?: number
-}
+  workchain?: number;
+};
 
 export type TonTxBuilderResult = {
   /**
    * Hex-encoded signing hash (32 bytes). This is what the EdDSA MPC engine
    * signs. Ed25519 sig over this hash is what goes back into `finalize`.
    */
-  signingHashHex: string
+  signingHashHex: string;
   /** Hex-encoded unsigned signing payload BOC, for debug/logging. */
-  unsignedBocHex: string
+  unsignedBocHex: string;
   /**
    * From address (non-bounceable user-friendly form) derived from the pubkey.
    * Handy for UIs that want to show the sender with bounceable=false.
    */
-  fromAddress: string
+  fromAddress: string;
   /**
    * Call once an Ed25519 signature (64 bytes, hex) is available to produce
    * the base64 BOC for `broadcastTonTx`.
    */
   finalize: (signatureHex: string) => {
-    signedBocBase64: string
+    signedBocBase64: string;
     /**
      * Hash of the external cell (not the signing hash). toncenter returns a
      * different hash on broadcast, so prefer that when available; this one
      * is a local fallback only.
      */
-    extMessageHashHex: string
-  }
-}
+    extMessageHashHex: string;
+  };
+};
 
 function buildSigningPayloadCell(args: {
-  subWalletId: number
-  validUntil: number
-  seqno: number
-  innerMsg: Cell
+  subWalletId: number;
+  validUntil: number;
+  seqno: number;
+  innerMsg: Cell;
 }): Cell {
   // V4R2 signing message layout:
   //   subWalletId(32) || validUntil(32) || seqno(32) || op(8) || sendMode(8) || ref(innerMsg)
   // op=0 for simple order; sendMode = PAY_GAS_SEPARATELY | IGNORE_ERRORS.
-  const sendMode = SendMode.PAY_GAS_SEPARATELY | SendMode.IGNORE_ERRORS
+  const sendMode = SendMode.PAY_GAS_SEPARATELY | SendMode.IGNORE_ERRORS;
   return beginCell()
     .storeUint(args.subWalletId, 32)
     .storeUint(args.validUntil, 32)
@@ -139,51 +153,55 @@ function buildSigningPayloadCell(args: {
     .storeUint(0, 8)
     .storeUint(sendMode, 8)
     .storeRef(args.innerMsg)
-    .endCell()
+    .endCell();
 }
 
 function buildCommentBody(memo: string | undefined): Cell | undefined {
-  if (!memo) return undefined
+  if (!memo) return undefined;
   // Max 123 UTF-8 bytes fit in a single cell slice (1023 bits - 32-bit opcode).
-  const encoded = new TextEncoder().encode(memo)
+  const encoded = new TextEncoder().encode(memo);
   if (encoded.length > 123) {
-    throw new Error(`TON memo exceeds 123 bytes (got ${encoded.length}); reject upstream`)
+    throw new Error(
+      `TON memo exceeds 123 bytes (got ${encoded.length}); reject upstream`,
+    );
   }
   // 0x00000000 opcode marks a text comment in the TON convention.
-  return beginCell().storeUint(0, 32).storeStringTail(memo).endCell()
+  return beginCell().storeUint(0, 32).storeStringTail(memo).endCell();
 }
 
 function buildExternalMessageCell(args: {
-  walletAddress: Address
-  signature: Uint8Array
-  signingPayload: Cell
-  includeStateInit: boolean
-  stateInitCell?: Cell
+  walletAddress: Address;
+  signature: Uint8Array;
+  signingPayload: Cell;
+  includeStateInit: boolean;
+  stateInitCell?: Cell;
 }): Cell {
   // ext_in_msg_info$10 src:MsgAddressNone dest:MsgAddressInt import_fee:Grams
   const ext = beginCell()
     .storeUint(0b10, 2)
     .storeUint(0, 2) // src = addr_none
     .storeAddress(args.walletAddress)
-    .storeCoins(0) // import_fee
+    .storeCoins(0); // import_fee
 
   if (args.includeStateInit) {
     if (!args.stateInitCell) {
-      throw new Error('TON external message: includeStateInit requested but no StateInit cell supplied')
+      throw new Error(
+        "TON external message: includeStateInit requested but no StateInit cell supplied",
+      );
     }
-    ext.storeBit(true).storeBit(true).storeRef(args.stateInitCell)
+    ext.storeBit(true).storeBit(true).storeRef(args.stateInitCell);
   } else {
-    ext.storeBit(false)
+    ext.storeBit(false);
   }
 
   // Body is the signed transfer cell (signature || signingPayload slice).
   const bodyCell = beginCell()
     .storeBuffer(Buffer.from(args.signature))
     .storeSlice(args.signingPayload.asSlice())
-    .endCell()
+    .endCell();
 
-  ext.storeBit(true).storeRef(bodyCell)
-  return ext.endCell()
+  ext.storeBit(true).storeRef(bodyCell);
+  return ext.endCell();
 }
 
 /**
@@ -196,10 +214,10 @@ function buildExternalMessageCell(args: {
  *   4. Broadcast `signedBocBase64` via `broadcastTonTx`.
  */
 export function buildTonSendTx(opts: BuildTonSendOptions): TonTxBuilderResult {
-  const pubKey = hexToBytes(opts.publicKeyEd25519)
-  const workchain = opts.workchain ?? 0
-  const wallet = buildV4R2Wallet({ publicKeyEd25519: pubKey, workchain })
-  const destination = Address.parse(opts.to)
+  const pubKey = hexToBytes(opts.publicKeyEd25519);
+  const workchain = opts.workchain ?? 0;
+  const wallet = buildV4R2Wallet({ publicKeyEd25519: pubKey, workchain });
+  const destination = Address.parse(opts.to);
 
   const innerMsg = beginCell()
     .store(
@@ -209,37 +227,40 @@ export function buildTonSendTx(opts: BuildTonSendOptions): TonTxBuilderResult {
           value: opts.amount,
           bounce: opts.bounceable,
           body: buildCommentBody(opts.memo),
-        })
-      )
+        }),
+      ),
     )
-    .endCell()
+    .endCell();
 
-  const validUntil = opts.validUntil ?? Math.floor(Date.now() / 1000) + 600
-  const subWalletId = opts.subWalletId ?? TON_V4R2_SUB_WALLET_ID + workchain
+  const validUntil = opts.validUntil ?? Math.floor(Date.now() / 1000) + 600;
+  const subWalletId = opts.subWalletId ?? TON_V4R2_SUB_WALLET_ID + workchain;
 
   const signingPayload = buildSigningPayloadCell({
     subWalletId,
     validUntil,
     seqno: opts.seqno,
     innerMsg,
-  })
+  });
 
-  const signingHashBytes = signingPayload.hash()
-  const signingHashHex = bytesToHex(signingHashBytes)
-  const unsignedBocBuf = signingPayload.toBoc({ idx: false })
-  const unsignedBocHex = bytesToHex(new Uint8Array(unsignedBocBuf))
+  const signingHashBytes = signingPayload.hash();
+  const signingHashHex = bytesToHex(signingHashBytes);
+  const unsignedBocBuf = signingPayload.toBoc({ idx: false });
+  const unsignedBocHex = bytesToHex(new Uint8Array(unsignedBocBuf));
 
-  const fromAddress = wallet.addressString({ bounceable: false })
-  const stateInitCell = opts.seqno === 0 ? storeStateInitCell(wallet.init) : undefined
+  const fromAddress = wallet.addressString({ bounceable: false });
+  const stateInitCell =
+    opts.seqno === 0 ? storeStateInitCell(wallet.init) : undefined;
 
   return {
     signingHashHex,
     unsignedBocHex,
     fromAddress,
     finalize: (signatureHex: string) => {
-      const signature = hexToBytes(signatureHex)
+      const signature = hexToBytes(signatureHex);
       if (signature.length !== 64) {
-        throw new Error(`TON signature must be 64 bytes (R||S), got ${signature.length}`)
+        throw new Error(
+          `TON signature must be 64 bytes (R||S), got ${signature.length}`,
+        );
       }
       const ext = buildExternalMessageCell({
         walletAddress: wallet.address,
@@ -247,46 +268,48 @@ export function buildTonSendTx(opts: BuildTonSendOptions): TonTxBuilderResult {
         signingPayload,
         includeStateInit: opts.seqno === 0,
         stateInitCell,
-      })
-      const signedBocBase64 = ext.toBoc().toString('base64')
-      const extMessageHashHex = bytesToHex(ext.hash())
-      return { signedBocBase64, extMessageHashHex }
+      });
+      const signedBocBase64 = ext.toBoc().toString("base64");
+      const extMessageHashHex = bytesToHex(ext.hash());
+      return { signedBocBase64, extMessageHashHex };
     },
-  }
+  };
 }
 
 // ---------------------------------------------------------------------------
 // Jetton transfer (TON's equivalent of ERC-20 / TRC-20)
 // ---------------------------------------------------------------------------
 
-const JETTON_TRANSFER_OPCODE = 0xf8a7ea5
+const JETTON_TRANSFER_OPCODE = 0xf8a7ea5;
 /** Standard 0.08 TON gas budget for a Jetton contract call. */
-const JETTON_GAS_AMOUNT_NANO = 80000000n
+const JETTON_GAS_AMOUNT_NANO = 80000000n;
 /** 1 nanoton forward amount — the minimum that triggers a transfer_notification. */
-const JETTON_FORWARD_AMOUNT_NANO = 1n
+const JETTON_FORWARD_AMOUNT_NANO = 1n;
 
 export type BuildTonJettonTransferOptions = {
-  publicKeyEd25519: string
+  publicKeyEd25519: string;
   /** Recipient's wallet address (where Jettons end up). */
-  to: string
+  to: string;
   /** Sender's *Jetton wallet* — not the TON wallet. toncenter `/getJettonWalletAddress` resolves this. */
-  jettonWalletAddress: string
+  jettonWalletAddress: string;
   /** Amount in Jetton minimal units (use the Jetton metadata's decimals). */
-  amount: bigint
-  memo?: string
-  seqno: number
-  validUntil?: number
-  subWalletId?: number
-  workchain?: number
-}
+  amount: bigint;
+  memo?: string;
+  seqno: number;
+  validUntil?: number;
+  subWalletId?: number;
+  workchain?: number;
+};
 
-export function buildTonJettonTransferTx(opts: BuildTonJettonTransferOptions): TonTxBuilderResult {
-  const pubKey = hexToBytes(opts.publicKeyEd25519)
-  const workchain = opts.workchain ?? 0
-  const wallet = buildV4R2Wallet({ publicKeyEd25519: pubKey, workchain })
+export function buildTonJettonTransferTx(
+  opts: BuildTonJettonTransferOptions,
+): TonTxBuilderResult {
+  const pubKey = hexToBytes(opts.publicKeyEd25519);
+  const workchain = opts.workchain ?? 0;
+  const wallet = buildV4R2Wallet({ publicKeyEd25519: pubKey, workchain });
 
-  const destinationAddr = Address.parse(opts.to)
-  const jettonWalletAddr = Address.parse(opts.jettonWalletAddress)
+  const destinationAddr = Address.parse(opts.to);
+  const jettonWalletAddr = Address.parse(opts.jettonWalletAddress);
 
   let jettonBody = beginCell()
     .storeUint(JETTON_TRANSFER_OPCODE, 32)
@@ -295,19 +318,21 @@ export function buildTonJettonTransferTx(opts: BuildTonJettonTransferOptions): T
     .storeAddress(destinationAddr)
     .storeAddress(wallet.address) // response_destination for excess TON
     .storeBit(false) // no custom_payload
-    .storeCoins(JETTON_FORWARD_AMOUNT_NANO)
+    .storeCoins(JETTON_FORWARD_AMOUNT_NANO);
 
   if (opts.memo) {
-    const commentCell = buildCommentBody(opts.memo)
+    const commentCell = buildCommentBody(opts.memo);
     if (!commentCell) {
-      throw new Error('TON jetton memo: buildCommentBody returned undefined unexpectedly')
+      throw new Error(
+        "TON jetton memo: buildCommentBody returned undefined unexpectedly",
+      );
     }
-    jettonBody = jettonBody.storeBit(true).storeRef(commentCell)
+    jettonBody = jettonBody.storeBit(true).storeRef(commentCell);
   } else {
-    jettonBody = jettonBody.storeBit(false)
+    jettonBody = jettonBody.storeBit(false);
   }
 
-  const bodyCell = jettonBody.endCell()
+  const bodyCell = jettonBody.endCell();
 
   const innerMsg = beginCell()
     .store(
@@ -317,34 +342,39 @@ export function buildTonJettonTransferTx(opts: BuildTonJettonTransferOptions): T
           value: JETTON_GAS_AMOUNT_NANO,
           bounce: true,
           body: bodyCell,
-        })
-      )
+        }),
+      ),
     )
-    .endCell()
+    .endCell();
 
-  const validUntil = opts.validUntil ?? Math.floor(Date.now() / 1000) + 600
-  const subWalletId = opts.subWalletId ?? TON_V4R2_SUB_WALLET_ID + workchain
+  const validUntil = opts.validUntil ?? Math.floor(Date.now() / 1000) + 600;
+  const subWalletId = opts.subWalletId ?? TON_V4R2_SUB_WALLET_ID + workchain;
 
   const signingPayload = buildSigningPayloadCell({
     subWalletId,
     validUntil,
     seqno: opts.seqno,
     innerMsg,
-  })
+  });
 
-  const signingHashHex = bytesToHex(signingPayload.hash())
-  const unsignedBocHex = bytesToHex(new Uint8Array(signingPayload.toBoc({ idx: false })))
-  const fromAddress = wallet.addressString({ bounceable: false })
-  const stateInitCell = opts.seqno === 0 ? storeStateInitCell(wallet.init) : undefined
+  const signingHashHex = bytesToHex(signingPayload.hash());
+  const unsignedBocHex = bytesToHex(
+    new Uint8Array(signingPayload.toBoc({ idx: false })),
+  );
+  const fromAddress = wallet.addressString({ bounceable: false });
+  const stateInitCell =
+    opts.seqno === 0 ? storeStateInitCell(wallet.init) : undefined;
 
   return {
     signingHashHex,
     unsignedBocHex,
     fromAddress,
     finalize: (signatureHex: string) => {
-      const signature = hexToBytes(signatureHex)
+      const signature = hexToBytes(signatureHex);
       if (signature.length !== 64) {
-        throw new Error(`TON signature must be 64 bytes (R||S), got ${signature.length}`)
+        throw new Error(
+          `TON signature must be 64 bytes (R||S), got ${signature.length}`,
+        );
       }
       const ext = buildExternalMessageCell({
         walletAddress: wallet.address,
@@ -352,13 +382,13 @@ export function buildTonJettonTransferTx(opts: BuildTonJettonTransferOptions): T
         signingPayload,
         includeStateInit: opts.seqno === 0,
         stateInitCell,
-      })
+      });
       return {
-        signedBocBase64: ext.toBoc().toString('base64'),
+        signedBocBase64: ext.toBoc().toString("base64"),
         extMessageHashHex: bytesToHex(ext.hash()),
-      }
+      };
     },
-  }
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -406,14 +436,14 @@ export type BuildTonTxFromSigningPayloadOptions = {
    * the hash of the payload BoC; the pubkey only affects the envelope
    * `dest:MsgAddressInt` field.
    */
-  publicKeyEd25519: string
+  publicKeyEd25519: string;
   /**
    * The pre-built signing-payload BoC, base64-encoded. yield.xyz returns
    * this verbatim in each step's `unsignedTransaction` field. Hex is
    * also accepted (auto-detect by prefix / character set) so a future
    * upstream that emits hex doesn't break this primitive.
    */
-  signingPayloadBoc: string
+  signingPayloadBoc: string;
   /**
    * When true, the external message wraps a StateInit cell (the wallet
    * deploys itself in the same tx). Required for the very first send
@@ -428,38 +458,38 @@ export type BuildTonTxFromSigningPayloadOptions = {
    * surfaces as a clear broadcast error; a stale StateInit on a later
    * send would pass an invalid contract redeploy).
    */
-  includeStateInit?: boolean
+  includeStateInit?: boolean;
   /**
    * Optional override for the wallet workchain. Defaults to 0 (the
    * masterchain). Pass `-1` for masterchain validators / system
    * contracts; almost no consumer needs this.
    */
-  workchain?: number
-}
+  workchain?: number;
+};
 
 function decodeSigningPayload(input: string): Cell {
   // Heuristic: strict hex if every char is a hex digit and length is
   // even, else assume base64. yield.xyz returns base64 in the
   // reference fixture; legacy / sandbox responses may emit hex.
-  const trimmed = input.trim()
+  const trimmed = input.trim();
   if (trimmed.length === 0) {
-    throw new Error('TON signing payload BoC is empty')
+    throw new Error("TON signing payload BoC is empty");
   }
   const looksLikeHex =
-    trimmed.length % 2 === 0 && /^[0-9a-fA-F]+$/.test(trimmed)
+    trimmed.length % 2 === 0 && /^[0-9a-fA-F]+$/.test(trimmed);
   const bocBytes = looksLikeHex
     ? hexToBytes(trimmed)
-    : new Uint8Array(Buffer.from(trimmed, 'base64'))
+    : new Uint8Array(Buffer.from(trimmed, "base64"));
 
-  const cells = Cell.fromBoc(Buffer.from(bocBytes))
+  const cells = Cell.fromBoc(Buffer.from(bocBytes));
   if (cells.length === 0) {
-    throw new Error('TON signing payload BoC contained zero cells')
+    throw new Error("TON signing payload BoC contained zero cells");
   }
-  const first = cells[0]
+  const first = cells[0];
   if (!first) {
-    throw new Error('TON signing payload BoC root cell missing')
+    throw new Error("TON signing payload BoC root cell missing");
   }
-  return first
+  return first;
 }
 
 /**
@@ -478,38 +508,38 @@ function decodeSigningPayload(input: string): Cell {
 export function buildTonTxFromSigningPayload(
   opts: BuildTonTxFromSigningPayloadOptions,
 ): TonTxBuilderResult {
-  const pubKey = hexToBytes(opts.publicKeyEd25519)
+  const pubKey = hexToBytes(opts.publicKeyEd25519);
   if (pubKey.length !== 32) {
     throw new Error(
       `TON publicKeyEd25519 must be 32 bytes, got ${pubKey.length}`,
-    )
+    );
   }
-  const workchain = opts.workchain ?? 0
-  const wallet = buildV4R2Wallet({ publicKeyEd25519: pubKey, workchain })
+  const workchain = opts.workchain ?? 0;
+  const wallet = buildV4R2Wallet({ publicKeyEd25519: pubKey, workchain });
 
-  const signingPayload = decodeSigningPayload(opts.signingPayloadBoc)
+  const signingPayload = decodeSigningPayload(opts.signingPayloadBoc);
 
-  const signingHashBytes = signingPayload.hash()
-  const signingHashHex = bytesToHex(signingHashBytes)
-  const unsignedBocBuf = signingPayload.toBoc({ idx: false })
-  const unsignedBocHex = bytesToHex(new Uint8Array(unsignedBocBuf))
+  const signingHashBytes = signingPayload.hash();
+  const signingHashHex = bytesToHex(signingHashBytes);
+  const unsignedBocBuf = signingPayload.toBoc({ idx: false });
+  const unsignedBocHex = bytesToHex(new Uint8Array(unsignedBocBuf));
 
-  const fromAddress = wallet.addressString({ bounceable: false })
-  const includeStateInit = opts.includeStateInit ?? false
+  const fromAddress = wallet.addressString({ bounceable: false });
+  const includeStateInit = opts.includeStateInit ?? false;
   const stateInitCell = includeStateInit
     ? storeStateInitCell(wallet.init)
-    : undefined
+    : undefined;
 
   return {
     signingHashHex,
     unsignedBocHex,
     fromAddress,
     finalize: (signatureHex: string) => {
-      const signature = hexToBytes(signatureHex)
+      const signature = hexToBytes(signatureHex);
       if (signature.length !== 64) {
         throw new Error(
           `TON signature must be 64 bytes (R||S), got ${signature.length}`,
-        )
+        );
       }
       const ext = buildExternalMessageCell({
         walletAddress: wallet.address,
@@ -517,13 +547,13 @@ export function buildTonTxFromSigningPayload(
         signingPayload,
         includeStateInit,
         stateInitCell,
-      })
+      });
       return {
-        signedBocBase64: ext.toBoc().toString('base64'),
+        signedBocBase64: ext.toBoc().toString("base64"),
         extMessageHashHex: bytesToHex(ext.hash()),
-      }
+      };
     },
-  }
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -533,8 +563,10 @@ export function buildTonTxFromSigningPayload(
 
 /** Throws if `memo` exceeds the 123-byte TON comment cell capacity. */
 export function validateTonMemo(memo: string): void {
-  const encoded = new TextEncoder().encode(memo)
+  const encoded = new TextEncoder().encode(memo);
   if (encoded.length > 123) {
-    throw new Error(`TON memo must be at most 123 bytes (got ${encoded.length})`)
+    throw new Error(
+      `TON memo must be at most 123 bytes (got ${encoded.length})`,
+    );
   }
 }

--- a/packages/sdk/src/chains/ton/tx.ts
+++ b/packages/sdk/src/chains/ton/tx.ts
@@ -16,8 +16,7 @@
  * `./walletV4R2` / `./crypto-rn`. It never reaches `@ton/crypto-primitives`
  * so the RN bundle does not need the `crypto.subtle` polyfill.
  */
-import type { Cell } from '@ton/core'
-import { Address, beginCell, internal, SendMode, storeMessageRelaxed } from '@ton/core'
+import { Address, beginCell, Cell, internal, SendMode, storeMessageRelaxed } from '@ton/core'
 
 import { buildV4R2Wallet, storeStateInitCell, TON_V4R2_SUB_WALLET_ID } from './walletV4R2'
 
@@ -439,28 +438,20 @@ export type BuildTonTxFromSigningPayloadOptions = {
 }
 
 function decodeSigningPayload(input: string): Cell {
-  // Wrap @ton/core's Cell.fromBoc — accepts base64 OR hex (heuristic:
-  // strict hex if every char is a hex digit and length is even, else
-  // assume base64). yield.xyz returns base64 in our reference fixture.
+  // Heuristic: strict hex if every char is a hex digit and length is
+  // even, else assume base64. yield.xyz returns base64 in the
+  // reference fixture; legacy / sandbox responses may emit hex.
   const trimmed = input.trim()
   if (trimmed.length === 0) {
     throw new Error('TON signing payload BoC is empty')
   }
   const looksLikeHex =
     trimmed.length % 2 === 0 && /^[0-9a-fA-F]+$/.test(trimmed)
-  let bocBytes: Uint8Array
-  if (looksLikeHex) {
-    bocBytes = hexToBytes(trimmed)
-  } else {
-    bocBytes = new Uint8Array(Buffer.from(trimmed, 'base64'))
-  }
-  // Late import (sync) of Cell to avoid a cyclic-import landmine —
-  // @ton/core is already loaded at the top of this file but the named
-  // `Cell.fromBoc` is only available off the module object, not from a
-  // named import (we already type-only-import the Cell type).
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const tonCore = require('@ton/core') as typeof import('@ton/core')
-  const cells = tonCore.Cell.fromBoc(Buffer.from(bocBytes))
+  const bocBytes = looksLikeHex
+    ? hexToBytes(trimmed)
+    : new Uint8Array(Buffer.from(trimmed, 'base64'))
+
+  const cells = Cell.fromBoc(Buffer.from(bocBytes))
   if (cells.length === 0) {
     throw new Error('TON signing payload BoC contained zero cells')
   }

--- a/packages/sdk/src/chains/ton/tx.ts
+++ b/packages/sdk/src/chains/ton/tx.ts
@@ -433,23 +433,57 @@ export type BuildTonTxFromSigningPayloadOptions = {
    */
   includeStateInit?: boolean
   /**
-   * Optional override for the wallet workchain. Defaults to 0 (the
-   * masterchain). Pass `-1` for masterchain validators / system
-   * contracts; almost no consumer needs this.
+   * Optional override for the wallet workchain. Defaults to `0` (the
+   * basechain — where all user wallets live). Pass `-1` for the
+   * masterchain (validators / system contracts); almost no consumer
+   * needs this.
    */
   workchain?: number
 }
 
 function decodeSigningPayload(input: string): Cell {
-  // Heuristic: strict hex if every char is a hex digit and length is
-  // even, else assume base64. yield.xyz returns base64 in the
-  // reference fixture; legacy / sandbox responses may emit hex.
+  // Encoding detection (CodeRabbit #516 R2). The serialized BoC arrives
+  // as either hex or base64, and yield.xyz uses both depending on the
+  // protocol family. Two refinements over the naive "any-even-hex →
+  // hex" check:
+  //
+  //   1. Accept an optional `0x`/`0X` prefix on hex input. Without
+  //      this, a callsite that prefixes (common in EVM-leaning
+  //      tooling) would silently fall through to the base64 branch
+  //      and produce wrong bytes.
+  //
+  //   2. Disambiguate hex vs base64 when both regexes would match.
+  //      A hex string like "abcdef0123456789" is *also* valid
+  //      base64. We prefer hex when EITHER:
+  //        - the input starts with `0x`/`0X`, OR
+  //        - the input is even-length, every char is in [0-9a-fA-F]
+  //          AND it cannot also be the start of a base64-encoded BoC.
+  //      A real BoC always begins with the magic byte 0xB5
+  //      (`B5EE9C72…` in hex). When we see that magic, treat it as
+  //      hex even if the rest could parse as base64.
+  //
+  // Anything else → base64. Buffer.from(_, 'base64') silently drops
+  // non-base64 characters, so we sanity-check by ensuring the
+  // produced byte stream re-parses as a valid BoC below; the
+  // Cell.fromBoc + zero-cells guards downstream catch corruption.
   const trimmed = input.trim()
   if (trimmed.length === 0) {
     throw new Error('TON signing payload BoC is empty')
   }
-  const looksLikeHex = trimmed.length % 2 === 0 && /^[0-9a-fA-F]+$/.test(trimmed)
-  const bocBytes = looksLikeHex ? hexToBytes(trimmed) : new Uint8Array(Buffer.from(trimmed, 'base64'))
+  const hadHexPrefix = trimmed.startsWith('0x') || trimmed.startsWith('0X')
+  const normalized = hadHexPrefix ? trimmed.slice(2) : trimmed
+  const isEvenHex = normalized.length % 2 === 0 && /^[0-9a-fA-F]+$/.test(normalized)
+  // BoC magic 0xB5EE9C72 (4 bytes = 8 hex chars). If the input is hex
+  // AND begins with that prefix, it's unambiguously hex.
+  const startsWithBocMagic = isEvenHex && /^b5ee9c72/i.test(normalized)
+  // Prefer hex when:
+  //  - caller explicitly prefixed with 0x, OR
+  //  - input matches the BoC magic in hex, OR
+  //  - input is even-length hex AND cannot also be parsed as base64
+  //    (length not multiple of 4 → base64 padding can't fit).
+  const couldBeBase64 = /^[A-Za-z0-9+/]+={0,2}$/.test(normalized) && normalized.length % 4 === 0
+  const looksLikeHex = hadHexPrefix || startsWithBocMagic || (isEvenHex && !couldBeBase64)
+  const bocBytes = looksLikeHex ? hexToBytes(normalized) : new Uint8Array(Buffer.from(normalized, 'base64'))
 
   const cells = Cell.fromBoc(Buffer.from(bocBytes))
   if (cells.length === 0) {

--- a/packages/sdk/src/chains/ton/tx.ts
+++ b/packages/sdk/src/chains/ton/tx.ts
@@ -16,46 +16,35 @@
  * `./walletV4R2` / `./crypto-rn`. It never reaches `@ton/crypto-primitives`
  * so the RN bundle does not need the `crypto.subtle` polyfill.
  */
-import {
-  Address,
-  beginCell,
-  Cell,
-  internal,
-  SendMode,
-  storeMessageRelaxed,
-} from "@ton/core";
+import { Address, beginCell, Cell, internal, SendMode, storeMessageRelaxed } from '@ton/core'
 
-import {
-  buildV4R2Wallet,
-  storeStateInitCell,
-  TON_V4R2_SUB_WALLET_ID,
-} from "./walletV4R2";
+import { buildV4R2Wallet, storeStateInitCell, TON_V4R2_SUB_WALLET_ID } from './walletV4R2'
 
 // ---------------------------------------------------------------------------
 // Hex utils (RN-safe; no Buffer dependency in the hot path)
 // ---------------------------------------------------------------------------
 
 function hexToBytes(hex: string): Uint8Array {
-  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  const clean = hex.startsWith('0x') ? hex.slice(2) : hex
   if (clean.length % 2 !== 0) {
-    throw new Error(`TON hex input must have even length, got ${clean.length}`);
+    throw new Error(`TON hex input must have even length, got ${clean.length}`)
   }
   if (clean.length > 0 && !/^[0-9a-fA-F]+$/.test(clean)) {
-    throw new Error(`TON hex input contains non-hex characters: ${clean}`);
+    throw new Error(`TON hex input contains non-hex characters: ${clean}`)
   }
-  const bytes = new Uint8Array(clean.length / 2);
+  const bytes = new Uint8Array(clean.length / 2)
   for (let i = 0; i < bytes.length; i++) {
-    bytes[i] = parseInt(clean.substring(i * 2, i * 2 + 2), 16);
+    bytes[i] = parseInt(clean.substring(i * 2, i * 2 + 2), 16)
   }
-  return bytes;
+  return bytes
 }
 
 function bytesToHex(bytes: Uint8Array): string {
-  let out = "";
+  let out = ''
   for (let i = 0; i < bytes.length; i++) {
-    out += bytes[i].toString(16).padStart(2, "0");
+    out += bytes[i].toString(16).padStart(2, '0')
   }
-  return out;
+  return out
 }
 
 // ---------------------------------------------------------------------------
@@ -68,16 +57,16 @@ function bytesToHex(bytes: Uint8Array): string {
  */
 export function deriveTonAddress(
   publicKeyEd25519Hex: string,
-  opts: { workchain?: number; bounceable?: boolean; testOnly?: boolean } = {},
+  opts: { workchain?: number; bounceable?: boolean; testOnly?: boolean } = {}
 ): string {
   const wallet = buildV4R2Wallet({
     publicKeyEd25519: hexToBytes(publicKeyEd25519Hex),
     workchain: opts.workchain,
-  });
+  })
   return wallet.addressString({
     bounceable: opts.bounceable ?? false,
     testOnly: opts.testOnly,
-  });
+  })
 }
 
 // ---------------------------------------------------------------------------
@@ -86,66 +75,66 @@ export function deriveTonAddress(
 
 export type BuildTonSendOptions = {
   /** Sender's Ed25519 public key, hex (no 0x prefix required). */
-  publicKeyEd25519: string;
+  publicKeyEd25519: string
   /** Destination in any TON address format (raw or user-friendly). */
-  to: string;
+  to: string
   /** Amount in nanotons (1 TON = 10^9 nanotons). */
-  amount: bigint;
+  amount: bigint
   /** Bounce flag on the inner transfer message. Caller should set this based on wallet-state of the recipient. */
-  bounceable: boolean;
+  bounceable: boolean
   /** Optional UTF-8 memo (≤ 123 bytes; longer memos are rejected per TON cell limit). */
-  memo?: string;
+  memo?: string
   /** Seqno from `getTonWalletInfo(from).seqno`. First tx = 0. */
-  seqno: number;
+  seqno: number
   /** Unix seconds after which the message is invalid. Default = now + 600. */
-  validUntil?: number;
+  validUntil?: number
   /**
    * Sub-wallet ID. Defaults to the V4R2 constant (698983191 for workchain 0).
    * Only override if you're targeting a non-default sub-wallet.
    */
-  subWalletId?: number;
+  subWalletId?: number
   /** Sender wallet workchain. Default 0. */
-  workchain?: number;
-};
+  workchain?: number
+}
 
 export type TonTxBuilderResult = {
   /**
    * Hex-encoded signing hash (32 bytes). This is what the EdDSA MPC engine
    * signs. Ed25519 sig over this hash is what goes back into `finalize`.
    */
-  signingHashHex: string;
+  signingHashHex: string
   /** Hex-encoded unsigned signing payload BOC, for debug/logging. */
-  unsignedBocHex: string;
+  unsignedBocHex: string
   /**
    * From address (non-bounceable user-friendly form) derived from the pubkey.
    * Handy for UIs that want to show the sender with bounceable=false.
    */
-  fromAddress: string;
+  fromAddress: string
   /**
    * Call once an Ed25519 signature (64 bytes, hex) is available to produce
    * the base64 BOC for `broadcastTonTx`.
    */
   finalize: (signatureHex: string) => {
-    signedBocBase64: string;
+    signedBocBase64: string
     /**
      * Hash of the external cell (not the signing hash). toncenter returns a
      * different hash on broadcast, so prefer that when available; this one
      * is a local fallback only.
      */
-    extMessageHashHex: string;
-  };
-};
+    extMessageHashHex: string
+  }
+}
 
 function buildSigningPayloadCell(args: {
-  subWalletId: number;
-  validUntil: number;
-  seqno: number;
-  innerMsg: Cell;
+  subWalletId: number
+  validUntil: number
+  seqno: number
+  innerMsg: Cell
 }): Cell {
   // V4R2 signing message layout:
   //   subWalletId(32) || validUntil(32) || seqno(32) || op(8) || sendMode(8) || ref(innerMsg)
   // op=0 for simple order; sendMode = PAY_GAS_SEPARATELY | IGNORE_ERRORS.
-  const sendMode = SendMode.PAY_GAS_SEPARATELY | SendMode.IGNORE_ERRORS;
+  const sendMode = SendMode.PAY_GAS_SEPARATELY | SendMode.IGNORE_ERRORS
   return beginCell()
     .storeUint(args.subWalletId, 32)
     .storeUint(args.validUntil, 32)
@@ -153,55 +142,51 @@ function buildSigningPayloadCell(args: {
     .storeUint(0, 8)
     .storeUint(sendMode, 8)
     .storeRef(args.innerMsg)
-    .endCell();
+    .endCell()
 }
 
 function buildCommentBody(memo: string | undefined): Cell | undefined {
-  if (!memo) return undefined;
+  if (!memo) return undefined
   // Max 123 UTF-8 bytes fit in a single cell slice (1023 bits - 32-bit opcode).
-  const encoded = new TextEncoder().encode(memo);
+  const encoded = new TextEncoder().encode(memo)
   if (encoded.length > 123) {
-    throw new Error(
-      `TON memo exceeds 123 bytes (got ${encoded.length}); reject upstream`,
-    );
+    throw new Error(`TON memo exceeds 123 bytes (got ${encoded.length}); reject upstream`)
   }
   // 0x00000000 opcode marks a text comment in the TON convention.
-  return beginCell().storeUint(0, 32).storeStringTail(memo).endCell();
+  return beginCell().storeUint(0, 32).storeStringTail(memo).endCell()
 }
 
 function buildExternalMessageCell(args: {
-  walletAddress: Address;
-  signature: Uint8Array;
-  signingPayload: Cell;
-  includeStateInit: boolean;
-  stateInitCell?: Cell;
+  walletAddress: Address
+  signature: Uint8Array
+  signingPayload: Cell
+  includeStateInit: boolean
+  stateInitCell?: Cell
 }): Cell {
   // ext_in_msg_info$10 src:MsgAddressNone dest:MsgAddressInt import_fee:Grams
   const ext = beginCell()
     .storeUint(0b10, 2)
     .storeUint(0, 2) // src = addr_none
     .storeAddress(args.walletAddress)
-    .storeCoins(0); // import_fee
+    .storeCoins(0) // import_fee
 
   if (args.includeStateInit) {
     if (!args.stateInitCell) {
-      throw new Error(
-        "TON external message: includeStateInit requested but no StateInit cell supplied",
-      );
+      throw new Error('TON external message: includeStateInit requested but no StateInit cell supplied')
     }
-    ext.storeBit(true).storeBit(true).storeRef(args.stateInitCell);
+    ext.storeBit(true).storeBit(true).storeRef(args.stateInitCell)
   } else {
-    ext.storeBit(false);
+    ext.storeBit(false)
   }
 
   // Body is the signed transfer cell (signature || signingPayload slice).
   const bodyCell = beginCell()
     .storeBuffer(Buffer.from(args.signature))
     .storeSlice(args.signingPayload.asSlice())
-    .endCell();
+    .endCell()
 
-  ext.storeBit(true).storeRef(bodyCell);
-  return ext.endCell();
+  ext.storeBit(true).storeRef(bodyCell)
+  return ext.endCell()
 }
 
 /**
@@ -214,10 +199,10 @@ function buildExternalMessageCell(args: {
  *   4. Broadcast `signedBocBase64` via `broadcastTonTx`.
  */
 export function buildTonSendTx(opts: BuildTonSendOptions): TonTxBuilderResult {
-  const pubKey = hexToBytes(opts.publicKeyEd25519);
-  const workchain = opts.workchain ?? 0;
-  const wallet = buildV4R2Wallet({ publicKeyEd25519: pubKey, workchain });
-  const destination = Address.parse(opts.to);
+  const pubKey = hexToBytes(opts.publicKeyEd25519)
+  const workchain = opts.workchain ?? 0
+  const wallet = buildV4R2Wallet({ publicKeyEd25519: pubKey, workchain })
+  const destination = Address.parse(opts.to)
 
   const innerMsg = beginCell()
     .store(
@@ -227,40 +212,37 @@ export function buildTonSendTx(opts: BuildTonSendOptions): TonTxBuilderResult {
           value: opts.amount,
           bounce: opts.bounceable,
           body: buildCommentBody(opts.memo),
-        }),
-      ),
+        })
+      )
     )
-    .endCell();
+    .endCell()
 
-  const validUntil = opts.validUntil ?? Math.floor(Date.now() / 1000) + 600;
-  const subWalletId = opts.subWalletId ?? TON_V4R2_SUB_WALLET_ID + workchain;
+  const validUntil = opts.validUntil ?? Math.floor(Date.now() / 1000) + 600
+  const subWalletId = opts.subWalletId ?? TON_V4R2_SUB_WALLET_ID + workchain
 
   const signingPayload = buildSigningPayloadCell({
     subWalletId,
     validUntil,
     seqno: opts.seqno,
     innerMsg,
-  });
+  })
 
-  const signingHashBytes = signingPayload.hash();
-  const signingHashHex = bytesToHex(signingHashBytes);
-  const unsignedBocBuf = signingPayload.toBoc({ idx: false });
-  const unsignedBocHex = bytesToHex(new Uint8Array(unsignedBocBuf));
+  const signingHashBytes = signingPayload.hash()
+  const signingHashHex = bytesToHex(signingHashBytes)
+  const unsignedBocBuf = signingPayload.toBoc({ idx: false })
+  const unsignedBocHex = bytesToHex(new Uint8Array(unsignedBocBuf))
 
-  const fromAddress = wallet.addressString({ bounceable: false });
-  const stateInitCell =
-    opts.seqno === 0 ? storeStateInitCell(wallet.init) : undefined;
+  const fromAddress = wallet.addressString({ bounceable: false })
+  const stateInitCell = opts.seqno === 0 ? storeStateInitCell(wallet.init) : undefined
 
   return {
     signingHashHex,
     unsignedBocHex,
     fromAddress,
     finalize: (signatureHex: string) => {
-      const signature = hexToBytes(signatureHex);
+      const signature = hexToBytes(signatureHex)
       if (signature.length !== 64) {
-        throw new Error(
-          `TON signature must be 64 bytes (R||S), got ${signature.length}`,
-        );
+        throw new Error(`TON signature must be 64 bytes (R||S), got ${signature.length}`)
       }
       const ext = buildExternalMessageCell({
         walletAddress: wallet.address,
@@ -268,48 +250,46 @@ export function buildTonSendTx(opts: BuildTonSendOptions): TonTxBuilderResult {
         signingPayload,
         includeStateInit: opts.seqno === 0,
         stateInitCell,
-      });
-      const signedBocBase64 = ext.toBoc().toString("base64");
-      const extMessageHashHex = bytesToHex(ext.hash());
-      return { signedBocBase64, extMessageHashHex };
+      })
+      const signedBocBase64 = ext.toBoc().toString('base64')
+      const extMessageHashHex = bytesToHex(ext.hash())
+      return { signedBocBase64, extMessageHashHex }
     },
-  };
+  }
 }
 
 // ---------------------------------------------------------------------------
 // Jetton transfer (TON's equivalent of ERC-20 / TRC-20)
 // ---------------------------------------------------------------------------
 
-const JETTON_TRANSFER_OPCODE = 0xf8a7ea5;
+const JETTON_TRANSFER_OPCODE = 0xf8a7ea5
 /** Standard 0.08 TON gas budget for a Jetton contract call. */
-const JETTON_GAS_AMOUNT_NANO = 80000000n;
+const JETTON_GAS_AMOUNT_NANO = 80000000n
 /** 1 nanoton forward amount — the minimum that triggers a transfer_notification. */
-const JETTON_FORWARD_AMOUNT_NANO = 1n;
+const JETTON_FORWARD_AMOUNT_NANO = 1n
 
 export type BuildTonJettonTransferOptions = {
-  publicKeyEd25519: string;
+  publicKeyEd25519: string
   /** Recipient's wallet address (where Jettons end up). */
-  to: string;
+  to: string
   /** Sender's *Jetton wallet* — not the TON wallet. toncenter `/getJettonWalletAddress` resolves this. */
-  jettonWalletAddress: string;
+  jettonWalletAddress: string
   /** Amount in Jetton minimal units (use the Jetton metadata's decimals). */
-  amount: bigint;
-  memo?: string;
-  seqno: number;
-  validUntil?: number;
-  subWalletId?: number;
-  workchain?: number;
-};
+  amount: bigint
+  memo?: string
+  seqno: number
+  validUntil?: number
+  subWalletId?: number
+  workchain?: number
+}
 
-export function buildTonJettonTransferTx(
-  opts: BuildTonJettonTransferOptions,
-): TonTxBuilderResult {
-  const pubKey = hexToBytes(opts.publicKeyEd25519);
-  const workchain = opts.workchain ?? 0;
-  const wallet = buildV4R2Wallet({ publicKeyEd25519: pubKey, workchain });
+export function buildTonJettonTransferTx(opts: BuildTonJettonTransferOptions): TonTxBuilderResult {
+  const pubKey = hexToBytes(opts.publicKeyEd25519)
+  const workchain = opts.workchain ?? 0
+  const wallet = buildV4R2Wallet({ publicKeyEd25519: pubKey, workchain })
 
-  const destinationAddr = Address.parse(opts.to);
-  const jettonWalletAddr = Address.parse(opts.jettonWalletAddress);
+  const destinationAddr = Address.parse(opts.to)
+  const jettonWalletAddr = Address.parse(opts.jettonWalletAddress)
 
   let jettonBody = beginCell()
     .storeUint(JETTON_TRANSFER_OPCODE, 32)
@@ -318,21 +298,19 @@ export function buildTonJettonTransferTx(
     .storeAddress(destinationAddr)
     .storeAddress(wallet.address) // response_destination for excess TON
     .storeBit(false) // no custom_payload
-    .storeCoins(JETTON_FORWARD_AMOUNT_NANO);
+    .storeCoins(JETTON_FORWARD_AMOUNT_NANO)
 
   if (opts.memo) {
-    const commentCell = buildCommentBody(opts.memo);
+    const commentCell = buildCommentBody(opts.memo)
     if (!commentCell) {
-      throw new Error(
-        "TON jetton memo: buildCommentBody returned undefined unexpectedly",
-      );
+      throw new Error('TON jetton memo: buildCommentBody returned undefined unexpectedly')
     }
-    jettonBody = jettonBody.storeBit(true).storeRef(commentCell);
+    jettonBody = jettonBody.storeBit(true).storeRef(commentCell)
   } else {
-    jettonBody = jettonBody.storeBit(false);
+    jettonBody = jettonBody.storeBit(false)
   }
 
-  const bodyCell = jettonBody.endCell();
+  const bodyCell = jettonBody.endCell()
 
   const innerMsg = beginCell()
     .store(
@@ -342,39 +320,34 @@ export function buildTonJettonTransferTx(
           value: JETTON_GAS_AMOUNT_NANO,
           bounce: true,
           body: bodyCell,
-        }),
-      ),
+        })
+      )
     )
-    .endCell();
+    .endCell()
 
-  const validUntil = opts.validUntil ?? Math.floor(Date.now() / 1000) + 600;
-  const subWalletId = opts.subWalletId ?? TON_V4R2_SUB_WALLET_ID + workchain;
+  const validUntil = opts.validUntil ?? Math.floor(Date.now() / 1000) + 600
+  const subWalletId = opts.subWalletId ?? TON_V4R2_SUB_WALLET_ID + workchain
 
   const signingPayload = buildSigningPayloadCell({
     subWalletId,
     validUntil,
     seqno: opts.seqno,
     innerMsg,
-  });
+  })
 
-  const signingHashHex = bytesToHex(signingPayload.hash());
-  const unsignedBocHex = bytesToHex(
-    new Uint8Array(signingPayload.toBoc({ idx: false })),
-  );
-  const fromAddress = wallet.addressString({ bounceable: false });
-  const stateInitCell =
-    opts.seqno === 0 ? storeStateInitCell(wallet.init) : undefined;
+  const signingHashHex = bytesToHex(signingPayload.hash())
+  const unsignedBocHex = bytesToHex(new Uint8Array(signingPayload.toBoc({ idx: false })))
+  const fromAddress = wallet.addressString({ bounceable: false })
+  const stateInitCell = opts.seqno === 0 ? storeStateInitCell(wallet.init) : undefined
 
   return {
     signingHashHex,
     unsignedBocHex,
     fromAddress,
     finalize: (signatureHex: string) => {
-      const signature = hexToBytes(signatureHex);
+      const signature = hexToBytes(signatureHex)
       if (signature.length !== 64) {
-        throw new Error(
-          `TON signature must be 64 bytes (R||S), got ${signature.length}`,
-        );
+        throw new Error(`TON signature must be 64 bytes (R||S), got ${signature.length}`)
       }
       const ext = buildExternalMessageCell({
         walletAddress: wallet.address,
@@ -382,13 +355,13 @@ export function buildTonJettonTransferTx(
         signingPayload,
         includeStateInit: opts.seqno === 0,
         stateInitCell,
-      });
+      })
       return {
-        signedBocBase64: ext.toBoc().toString("base64"),
+        signedBocBase64: ext.toBoc().toString('base64'),
         extMessageHashHex: bytesToHex(ext.hash()),
-      };
+      }
     },
-  };
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -436,14 +409,14 @@ export type BuildTonTxFromSigningPayloadOptions = {
    * the hash of the payload BoC; the pubkey only affects the envelope
    * `dest:MsgAddressInt` field.
    */
-  publicKeyEd25519: string;
+  publicKeyEd25519: string
   /**
    * The pre-built signing-payload BoC, base64-encoded. yield.xyz returns
    * this verbatim in each step's `unsignedTransaction` field. Hex is
    * also accepted (auto-detect by prefix / character set) so a future
    * upstream that emits hex doesn't break this primitive.
    */
-  signingPayloadBoc: string;
+  signingPayloadBoc: string
   /**
    * When true, the external message wraps a StateInit cell (the wallet
    * deploys itself in the same tx). Required for the very first send
@@ -458,38 +431,35 @@ export type BuildTonTxFromSigningPayloadOptions = {
    * surfaces as a clear broadcast error; a stale StateInit on a later
    * send would pass an invalid contract redeploy).
    */
-  includeStateInit?: boolean;
+  includeStateInit?: boolean
   /**
    * Optional override for the wallet workchain. Defaults to 0 (the
    * masterchain). Pass `-1` for masterchain validators / system
    * contracts; almost no consumer needs this.
    */
-  workchain?: number;
-};
+  workchain?: number
+}
 
 function decodeSigningPayload(input: string): Cell {
   // Heuristic: strict hex if every char is a hex digit and length is
   // even, else assume base64. yield.xyz returns base64 in the
   // reference fixture; legacy / sandbox responses may emit hex.
-  const trimmed = input.trim();
+  const trimmed = input.trim()
   if (trimmed.length === 0) {
-    throw new Error("TON signing payload BoC is empty");
+    throw new Error('TON signing payload BoC is empty')
   }
-  const looksLikeHex =
-    trimmed.length % 2 === 0 && /^[0-9a-fA-F]+$/.test(trimmed);
-  const bocBytes = looksLikeHex
-    ? hexToBytes(trimmed)
-    : new Uint8Array(Buffer.from(trimmed, "base64"));
+  const looksLikeHex = trimmed.length % 2 === 0 && /^[0-9a-fA-F]+$/.test(trimmed)
+  const bocBytes = looksLikeHex ? hexToBytes(trimmed) : new Uint8Array(Buffer.from(trimmed, 'base64'))
 
-  const cells = Cell.fromBoc(Buffer.from(bocBytes));
+  const cells = Cell.fromBoc(Buffer.from(bocBytes))
   if (cells.length === 0) {
-    throw new Error("TON signing payload BoC contained zero cells");
+    throw new Error('TON signing payload BoC contained zero cells')
   }
-  const first = cells[0];
+  const first = cells[0]
   if (!first) {
-    throw new Error("TON signing payload BoC root cell missing");
+    throw new Error('TON signing payload BoC root cell missing')
   }
-  return first;
+  return first
 }
 
 /**
@@ -505,41 +475,33 @@ function decodeSigningPayload(input: string): Cell {
  *          string verbatim — equality holds at the byte level after
  *          BoC re-serialization).
  */
-export function buildTonTxFromSigningPayload(
-  opts: BuildTonTxFromSigningPayloadOptions,
-): TonTxBuilderResult {
-  const pubKey = hexToBytes(opts.publicKeyEd25519);
+export function buildTonTxFromSigningPayload(opts: BuildTonTxFromSigningPayloadOptions): TonTxBuilderResult {
+  const pubKey = hexToBytes(opts.publicKeyEd25519)
   if (pubKey.length !== 32) {
-    throw new Error(
-      `TON publicKeyEd25519 must be 32 bytes, got ${pubKey.length}`,
-    );
+    throw new Error(`TON publicKeyEd25519 must be 32 bytes, got ${pubKey.length}`)
   }
-  const workchain = opts.workchain ?? 0;
-  const wallet = buildV4R2Wallet({ publicKeyEd25519: pubKey, workchain });
+  const workchain = opts.workchain ?? 0
+  const wallet = buildV4R2Wallet({ publicKeyEd25519: pubKey, workchain })
 
-  const signingPayload = decodeSigningPayload(opts.signingPayloadBoc);
+  const signingPayload = decodeSigningPayload(opts.signingPayloadBoc)
 
-  const signingHashBytes = signingPayload.hash();
-  const signingHashHex = bytesToHex(signingHashBytes);
-  const unsignedBocBuf = signingPayload.toBoc({ idx: false });
-  const unsignedBocHex = bytesToHex(new Uint8Array(unsignedBocBuf));
+  const signingHashBytes = signingPayload.hash()
+  const signingHashHex = bytesToHex(signingHashBytes)
+  const unsignedBocBuf = signingPayload.toBoc({ idx: false })
+  const unsignedBocHex = bytesToHex(new Uint8Array(unsignedBocBuf))
 
-  const fromAddress = wallet.addressString({ bounceable: false });
-  const includeStateInit = opts.includeStateInit ?? false;
-  const stateInitCell = includeStateInit
-    ? storeStateInitCell(wallet.init)
-    : undefined;
+  const fromAddress = wallet.addressString({ bounceable: false })
+  const includeStateInit = opts.includeStateInit ?? false
+  const stateInitCell = includeStateInit ? storeStateInitCell(wallet.init) : undefined
 
   return {
     signingHashHex,
     unsignedBocHex,
     fromAddress,
     finalize: (signatureHex: string) => {
-      const signature = hexToBytes(signatureHex);
+      const signature = hexToBytes(signatureHex)
       if (signature.length !== 64) {
-        throw new Error(
-          `TON signature must be 64 bytes (R||S), got ${signature.length}`,
-        );
+        throw new Error(`TON signature must be 64 bytes (R||S), got ${signature.length}`)
       }
       const ext = buildExternalMessageCell({
         walletAddress: wallet.address,
@@ -547,13 +509,13 @@ export function buildTonTxFromSigningPayload(
         signingPayload,
         includeStateInit,
         stateInitCell,
-      });
+      })
       return {
-        signedBocBase64: ext.toBoc().toString("base64"),
+        signedBocBase64: ext.toBoc().toString('base64'),
         extMessageHashHex: bytesToHex(ext.hash()),
-      };
+      }
     },
-  };
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -563,10 +525,8 @@ export function buildTonTxFromSigningPayload(
 
 /** Throws if `memo` exceeds the 123-byte TON comment cell capacity. */
 export function validateTonMemo(memo: string): void {
-  const encoded = new TextEncoder().encode(memo);
+  const encoded = new TextEncoder().encode(memo)
   if (encoded.length > 123) {
-    throw new Error(
-      `TON memo must be at most 123 bytes (got ${encoded.length})`,
-    );
+    throw new Error(`TON memo must be at most 123 bytes (got ${encoded.length})`)
   }
 }

--- a/packages/sdk/src/chains/ton/tx.ts
+++ b/packages/sdk/src/chains/ton/tx.ts
@@ -363,6 +363,179 @@ export function buildTonJettonTransferTx(opts: BuildTonJettonTransferOptions): T
 }
 
 // ---------------------------------------------------------------------------
+// Prebuilt-signing-payload primitive
+//
+// `buildTonTxFromSigningPayload` accepts a pre-built signing-payload BoC
+// (the inner Cell that gets hashed for signing) plus the user's pubkey,
+// returns the same {signingHashHex, finalize} contract as the
+// chain-specific builders. Used by:
+//
+//   - yield.xyz TON staking actions (tston-staking, nomination-staking,
+//     chorus-one-pools-staking) which return the signing-payload BoC
+//     pre-encoded — we'd otherwise need to ship a builder per pool
+//     contract variant.
+//
+//   - WalletConnect / dApp signing flows where the dApp constructs the
+//     payload server-side.
+//
+// ## Seqno freshness — critical
+//
+// TON wallets reject any external message whose embedded seqno doesn't
+// match the wallet contract's CURRENT seqno (the wallet's nonce). yield.xyz
+// pins the seqno at action-create time; if the user takes >30s to sign,
+// the seqno is stale and the broadcast fails with `external message was
+// not accepted`.
+//
+// This primitive does NOT re-pin the seqno — it signs whatever payload
+// it's given, deterministically. The consumer (app's signing flow) is
+// responsible for either:
+//   (a) regenerating the payload with a fresh seqno right before signing
+//       (recommended for yield.xyz-style integrations), OR
+//   (b) accepting the risk of seqno-stale failures with a clear user
+//       message when broadcast 4xxs.
+//
+// Surfacing both options keeps the primitive pure — re-pinning would
+// mean parsing the BoC, mutating the seqno cell, and re-hashing, which
+// is a different abstraction.
+// ---------------------------------------------------------------------------
+
+export type BuildTonTxFromSigningPayloadOptions = {
+  /**
+   * Ed25519 pubkey of the signer (32 bytes, hex). Used to derive the
+   * V4R2 wallet address for the outer external-message envelope —
+   * NOT included in the signed payload itself. The signing hash is
+   * the hash of the payload BoC; the pubkey only affects the envelope
+   * `dest:MsgAddressInt` field.
+   */
+  publicKeyEd25519: string
+  /**
+   * The pre-built signing-payload BoC, base64-encoded. yield.xyz returns
+   * this verbatim in each step's `unsignedTransaction` field. Hex is
+   * also accepted (auto-detect by prefix / character set) so a future
+   * upstream that emits hex doesn't break this primitive.
+   */
+  signingPayloadBoc: string
+  /**
+   * When true, the external message wraps a StateInit cell (the wallet
+   * deploys itself in the same tx). Required for the very first send
+   * from a wallet — the contract isn't on-chain yet so the message
+   * must include code+data.
+   *
+   * For TON V4R2 the rule is: include StateInit iff seqno === 0. Callers
+   * that derive the BoC from yield.xyz typically know this from their
+   * own seqno lookup; pass true on first-ever send, false otherwise.
+   *
+   * Default false to fail-closed (a missing StateInit on first send
+   * surfaces as a clear broadcast error; a stale StateInit on a later
+   * send would pass an invalid contract redeploy).
+   */
+  includeStateInit?: boolean
+  /**
+   * Optional override for the wallet workchain. Defaults to 0 (the
+   * masterchain). Pass `-1` for masterchain validators / system
+   * contracts; almost no consumer needs this.
+   */
+  workchain?: number
+}
+
+function decodeSigningPayload(input: string): Cell {
+  // Wrap @ton/core's Cell.fromBoc — accepts base64 OR hex (heuristic:
+  // strict hex if every char is a hex digit and length is even, else
+  // assume base64). yield.xyz returns base64 in our reference fixture.
+  const trimmed = input.trim()
+  if (trimmed.length === 0) {
+    throw new Error('TON signing payload BoC is empty')
+  }
+  const looksLikeHex =
+    trimmed.length % 2 === 0 && /^[0-9a-fA-F]+$/.test(trimmed)
+  let bocBytes: Uint8Array
+  if (looksLikeHex) {
+    bocBytes = hexToBytes(trimmed)
+  } else {
+    bocBytes = new Uint8Array(Buffer.from(trimmed, 'base64'))
+  }
+  // Late import (sync) of Cell to avoid a cyclic-import landmine —
+  // @ton/core is already loaded at the top of this file but the named
+  // `Cell.fromBoc` is only available off the module object, not from a
+  // named import (we already type-only-import the Cell type).
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const tonCore = require('@ton/core') as typeof import('@ton/core')
+  const cells = tonCore.Cell.fromBoc(Buffer.from(bocBytes))
+  if (cells.length === 0) {
+    throw new Error('TON signing payload BoC contained zero cells')
+  }
+  const first = cells[0]
+  if (!first) {
+    throw new Error('TON signing payload BoC root cell missing')
+  }
+  return first
+}
+
+/**
+ * Sign a pre-built TON signing payload (the inner Cell that gets hashed
+ * for the wallet's external-message body). See the section header
+ * comment above for the full design rationale and seqno-freshness
+ * warnings.
+ *
+ * @returns {signingHashHex, unsignedBocHex, fromAddress, finalize(sig)}
+ *          — identical contract to `buildTonSendTx` so call-sites can
+ *          treat both paths uniformly. `unsignedBocHex` round-trips
+ *          the decoded payload's serialized form (NOT the input
+ *          string verbatim — equality holds at the byte level after
+ *          BoC re-serialization).
+ */
+export function buildTonTxFromSigningPayload(
+  opts: BuildTonTxFromSigningPayloadOptions,
+): TonTxBuilderResult {
+  const pubKey = hexToBytes(opts.publicKeyEd25519)
+  if (pubKey.length !== 32) {
+    throw new Error(
+      `TON publicKeyEd25519 must be 32 bytes, got ${pubKey.length}`,
+    )
+  }
+  const workchain = opts.workchain ?? 0
+  const wallet = buildV4R2Wallet({ publicKeyEd25519: pubKey, workchain })
+
+  const signingPayload = decodeSigningPayload(opts.signingPayloadBoc)
+
+  const signingHashBytes = signingPayload.hash()
+  const signingHashHex = bytesToHex(signingHashBytes)
+  const unsignedBocBuf = signingPayload.toBoc({ idx: false })
+  const unsignedBocHex = bytesToHex(new Uint8Array(unsignedBocBuf))
+
+  const fromAddress = wallet.addressString({ bounceable: false })
+  const includeStateInit = opts.includeStateInit ?? false
+  const stateInitCell = includeStateInit
+    ? storeStateInitCell(wallet.init)
+    : undefined
+
+  return {
+    signingHashHex,
+    unsignedBocHex,
+    fromAddress,
+    finalize: (signatureHex: string) => {
+      const signature = hexToBytes(signatureHex)
+      if (signature.length !== 64) {
+        throw new Error(
+          `TON signature must be 64 bytes (R||S), got ${signature.length}`,
+        )
+      }
+      const ext = buildExternalMessageCell({
+        walletAddress: wallet.address,
+        signature,
+        signingPayload,
+        includeStateInit,
+        stateInitCell,
+      })
+      return {
+        signedBocBase64: ext.toBoc().toString('base64'),
+        extMessageHashHex: bytesToHex(ext.hash()),
+      }
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Memo validation helper — useful to surface user errors upstream before
 // the tx builder throws mid-encoding.
 // ---------------------------------------------------------------------------

--- a/packages/sdk/src/platforms/react-native/chains/ton/index.ts
+++ b/packages/sdk/src/platforms/react-native/chains/ton/index.ts
@@ -12,6 +12,7 @@
 export type {
   BuildTonJettonTransferOptions,
   BuildTonSendOptions,
+  BuildTonTxFromSigningPayloadOptions,
   TonTxBuilderResult,
   TonV4R2Wallet,
   TonWalletInfo,
@@ -21,6 +22,7 @@ export {
   broadcastTonTx,
   buildTonJettonTransferTx,
   buildTonSendTx,
+  buildTonTxFromSigningPayload,
   buildV4R2Wallet,
   deriveTonAddress,
   getTonBalance,

--- a/packages/sdk/tests/unit/chains/ton.test.ts
+++ b/packages/sdk/tests/unit/chains/ton.test.ts
@@ -189,6 +189,49 @@ describe('chains/ton / buildTonTxFromSigningPayload (prebuilt-payload signing)',
     expect(replay.signingHashHex).toBe(reference.signingHashHex)
   })
 
+  it('accepts a 0x-prefixed hex signing payload (CodeRabbit #516 r2)', () => {
+    // The decoder must strip an optional 0x prefix before deciding
+    // hex-vs-base64. Without that, an EVM-leaning callsite that
+    // prepends "0x" silently fell through to the base64 branch and
+    // produced garbage bytes (wrong signing hash → wrong MPC sig).
+    const reference = buildTonSendTx({
+      publicKeyEd25519: PUBKEY_HEX,
+      to: RECIPIENT,
+      amount: 100n,
+      bounceable: false,
+      seqno: 7,
+      validUntil: 1_700_000_000,
+    })
+    const replay = buildTonTxFromSigningPayload({
+      publicKeyEd25519: PUBKEY_HEX,
+      signingPayloadBoc: '0x' + reference.unsignedBocHex,
+    })
+    expect(replay.signingHashHex).toBe(reference.signingHashHex)
+  })
+
+  it('disambiguates hex from base64 via BoC magic 0xB5EE9C72 (CodeRabbit #516 r2)', () => {
+    // A real BoC starts with the magic 0xB5EE9C72. The decoder must
+    // recognise that prefix as hex even when the byte stream could
+    // also be a syntactically-valid base64 string. Without the magic
+    // disambiguation, even-length hex that happens to match base64
+    // alphabet rules could be misclassified.
+    const reference = buildTonSendTx({
+      publicKeyEd25519: PUBKEY_HEX,
+      to: RECIPIENT,
+      amount: 100n,
+      bounceable: false,
+      seqno: 9,
+      validUntil: 1_700_000_000,
+    })
+    // BoC's serialized form always begins with the magic bytes.
+    expect(/^b5ee9c72/i.test(reference.unsignedBocHex)).toBe(true)
+    const replay = buildTonTxFromSigningPayload({
+      publicKeyEd25519: PUBKEY_HEX,
+      signingPayloadBoc: reference.unsignedBocHex,
+    })
+    expect(replay.signingHashHex).toBe(reference.signingHashHex)
+  })
+
   it('emits a larger BoC when includeStateInit=true (first-send deployment envelope)', () => {
     // The wallet address derives from the pubkey; we only test the BoC
     // size grows because adding StateInit appends a code+data ref.

--- a/packages/sdk/tests/unit/chains/ton.test.ts
+++ b/packages/sdk/tests/unit/chains/ton.test.ts
@@ -13,8 +13,8 @@
  * `@ton/ton` (the higher-level `WalletContractV4` wrapper) — `@ton/core`
  * is sufficient for the cross-check at the cell level.
  */
-import { beginCell, internal, SendMode, storeMessageRelaxed } from "@ton/core";
-import { describe, expect, it } from "vitest";
+import { beginCell, internal, SendMode, storeMessageRelaxed } from '@ton/core'
+import { describe, expect, it } from 'vitest'
 
 import {
   buildTonSendTx,
@@ -22,37 +22,37 @@ import {
   deriveTonAddress,
   TON_V4R2_SUB_WALLET_ID,
   validateTonMemo,
-} from "../../../src/chains/ton";
-import { buildV4R2Wallet } from "../../../src/chains/ton/walletV4R2";
+} from '../../../src/chains/ton'
+import { buildV4R2Wallet } from '../../../src/chains/ton/walletV4R2'
 
 // Deterministic 32-byte Ed25519 pubkey (all 0x01s) — avoids seed randomness
 // and keeps the byte-parity assertion stable across runs.
-const PUBKEY_HEX = "01".repeat(32);
-const RECIPIENT = "UQDy_zN0Mel7MItGcTQr0kxEJxa7dg_-OGv7_XToTMTKT1Cz";
+const PUBKEY_HEX = '01'.repeat(32)
+const RECIPIENT = 'UQDy_zN0Mel7MItGcTQr0kxEJxa7dg_-OGv7_XToTMTKT1Cz'
 
-describe("chains/ton", () => {
-  it("derives the same V4R2 address as @ton/ton", () => {
-    const addr = deriveTonAddress(PUBKEY_HEX, { bounceable: false });
+describe('chains/ton', () => {
+  it('derives the same V4R2 address as @ton/ton', () => {
+    const addr = deriveTonAddress(PUBKEY_HEX, { bounceable: false })
     // The address must be stable for a given pubkey + workchain. Any
     // change to the V4R2 code cell would break this.
     const wallet = buildV4R2Wallet({
       publicKeyEd25519: Uint8Array.from({ length: 32 }, () => 0x01),
-    });
-    expect(addr).toBe(wallet.addressString({ bounceable: false }));
-  });
+    })
+    expect(addr).toBe(wallet.addressString({ bounceable: false }))
+  })
 
-  it("rejects memos over 123 bytes", () => {
-    expect(() => validateTonMemo("x".repeat(124))).toThrow(/at most 123 bytes/);
-  });
+  it('rejects memos over 123 bytes', () => {
+    expect(() => validateTonMemo('x'.repeat(124))).toThrow(/at most 123 bytes/)
+  })
 
-  it("exposes the V4R2 subwallet ID constant", () => {
-    expect(TON_V4R2_SUB_WALLET_ID).toBe(698983191);
-  });
+  it('exposes the V4R2 subwallet ID constant', () => {
+    expect(TON_V4R2_SUB_WALLET_ID).toBe(698983191)
+  })
 
-  it("matches @ton/ton createTransfer byte-for-byte for a native send", () => {
-    const amount = 1_000_000_000n; // 1 TON
-    const seqno = 42;
-    const validUntil = 1_700_000_000; // pinned so hash is deterministic
+  it('matches @ton/ton createTransfer byte-for-byte for a native send', () => {
+    const amount = 1_000_000_000n // 1 TON
+    const seqno = 42
+    const validUntil = 1_700_000_000 // pinned so hash is deterministic
 
     const result = buildTonSendTx({
       publicKeyEd25519: PUBKEY_HEX,
@@ -61,7 +61,7 @@ describe("chains/ton", () => {
       bounceable: true,
       seqno,
       validUntil,
-    });
+    })
 
     // Reference: build the exact same signing payload manually using only
     // `@ton/core` primitives, mirroring what @ton/ton's WalletContractV4
@@ -69,9 +69,9 @@ describe("chains/ton", () => {
     // on-chain outcome as the reference implementation.
     const walletReference = buildV4R2Wallet({
       publicKeyEd25519: Uint8Array.from({ length: 32 }, () => 0x01),
-    });
-    const destination = walletReference.address; // re-used only for the check below
-    expect(destination).toBeDefined();
+    })
+    const destination = walletReference.address // re-used only for the check below
+    expect(destination).toBeDefined()
 
     const internalMsg = beginCell()
       .store(
@@ -80,12 +80,12 @@ describe("chains/ton", () => {
             to: RECIPIENT,
             value: amount,
             bounce: true,
-          }),
-        ),
+          })
+        )
       )
-      .endCell();
+      .endCell()
 
-    const sendMode = SendMode.PAY_GAS_SEPARATELY | SendMode.IGNORE_ERRORS;
+    const sendMode = SendMode.PAY_GAS_SEPARATELY | SendMode.IGNORE_ERRORS
     const expectedPayload = beginCell()
       .storeUint(TON_V4R2_SUB_WALLET_ID, 32)
       .storeUint(validUntil, 32)
@@ -93,14 +93,14 @@ describe("chains/ton", () => {
       .storeUint(0, 8)
       .storeUint(sendMode, 8)
       .storeRef(internalMsg)
-      .endCell();
+      .endCell()
 
-    const expectedHash = expectedPayload.hash().toString("hex");
-    expect(result.signingHashHex).toBe(expectedHash);
-  });
+    const expectedHash = expectedPayload.hash().toString('hex')
+    expect(result.signingHashHex).toBe(expectedHash)
+  })
 
-  it("includes StateInit when seqno === 0 and omits it otherwise", () => {
-    const fakeSig = "aa".repeat(64);
+  it('includes StateInit when seqno === 0 and omits it otherwise', () => {
+    const fakeSig = 'aa'.repeat(64)
 
     const deploySeqno0 = buildTonSendTx({
       publicKeyEd25519: PUBKEY_HEX,
@@ -109,7 +109,7 @@ describe("chains/ton", () => {
       bounceable: false,
       seqno: 0,
       validUntil: 1_700_000_000,
-    }).finalize(fakeSig);
+    }).finalize(fakeSig)
 
     const subsequentSeqno1 = buildTonSendTx({
       publicKeyEd25519: PUBKEY_HEX,
@@ -118,18 +118,16 @@ describe("chains/ton", () => {
       bounceable: false,
       seqno: 1,
       validUntil: 1_700_000_000,
-    }).finalize(fakeSig);
+    }).finalize(fakeSig)
 
     // The BOC including StateInit is longer than the one without (one more
     // referenced cell containing code+data). This is the cheapest way to
     // sanity-check inclusion without dragging a full BOC parser into the
     // unit harness.
-    expect(deploySeqno0.signedBocBase64.length).toBeGreaterThan(
-      subsequentSeqno1.signedBocBase64.length,
-    );
-  });
+    expect(deploySeqno0.signedBocBase64.length).toBeGreaterThan(subsequentSeqno1.signedBocBase64.length)
+  })
 
-  it("finalize rejects signatures of the wrong length", () => {
+  it('finalize rejects signatures of the wrong length', () => {
     const builder = buildTonSendTx({
       publicKeyEd25519: PUBKEY_HEX,
       to: RECIPIENT,
@@ -137,12 +135,12 @@ describe("chains/ton", () => {
       bounceable: false,
       seqno: 1,
       validUntil: 1_700_000_000,
-    });
-    expect(() => builder.finalize("aa".repeat(32))).toThrow(/must be 64 bytes/);
-  });
-});
+    })
+    expect(() => builder.finalize('aa'.repeat(32))).toThrow(/must be 64 bytes/)
+  })
+})
 
-describe("chains/ton / buildTonTxFromSigningPayload (prebuilt-payload signing)", () => {
+describe('chains/ton / buildTonTxFromSigningPayload (prebuilt-payload signing)', () => {
   // Round-trip parity: build a payload via buildTonSendTx, extract its
   // unsignedBocHex (the serialized signing-payload Cell), feed it back
   // through buildTonTxFromSigningPayload. signingHashHex MUST match
@@ -150,7 +148,7 @@ describe("chains/ton / buildTonTxFromSigningPayload (prebuilt-payload signing)",
   // BoC. This proves the primitive is a clean replacement for the
   // chain-specific builder when fed equivalent input — which is the
   // contract yield.xyz / dApp signing flows rely on.
-  it("produces the same signingHashHex as buildTonSendTx for an identical payload", () => {
+  it('produces the same signingHashHex as buildTonSendTx for an identical payload', () => {
     const reference = buildTonSendTx({
       publicKeyEd25519: PUBKEY_HEX,
       to: RECIPIENT,
@@ -158,28 +156,24 @@ describe("chains/ton / buildTonTxFromSigningPayload (prebuilt-payload signing)",
       bounceable: false,
       seqno: 7,
       validUntil: 1_700_000_000,
-    });
+    })
 
     const replay = buildTonTxFromSigningPayload({
       publicKeyEd25519: PUBKEY_HEX,
-      signingPayloadBoc: Buffer.from(reference.unsignedBocHex, "hex").toString(
-        "base64",
-      ),
+      signingPayloadBoc: Buffer.from(reference.unsignedBocHex, 'hex').toString('base64'),
       // seqno is non-zero → no StateInit envelope
       includeStateInit: false,
-    });
+    })
 
-    expect(replay.signingHashHex).toBe(reference.signingHashHex);
-    expect(replay.fromAddress).toBe(reference.fromAddress);
+    expect(replay.signingHashHex).toBe(reference.signingHashHex)
+    expect(replay.fromAddress).toBe(reference.fromAddress)
 
     // Same payload + same sig → same broadcastable BoC.
-    const sig = "cc".repeat(64);
-    expect(replay.finalize(sig).signedBocBase64).toBe(
-      reference.finalize(sig).signedBocBase64,
-    );
-  });
+    const sig = 'cc'.repeat(64)
+    expect(replay.finalize(sig).signedBocBase64).toBe(reference.finalize(sig).signedBocBase64)
+  })
 
-  it("accepts a hex-encoded signing payload (forward-compat with hex wire formats)", () => {
+  it('accepts a hex-encoded signing payload (forward-compat with hex wire formats)', () => {
     const reference = buildTonSendTx({
       publicKeyEd25519: PUBKEY_HEX,
       to: RECIPIENT,
@@ -187,15 +181,15 @@ describe("chains/ton / buildTonTxFromSigningPayload (prebuilt-payload signing)",
       bounceable: false,
       seqno: 5,
       validUntil: 1_700_000_000,
-    });
+    })
     const replay = buildTonTxFromSigningPayload({
       publicKeyEd25519: PUBKEY_HEX,
       signingPayloadBoc: reference.unsignedBocHex, // hex, not base64
-    });
-    expect(replay.signingHashHex).toBe(reference.signingHashHex);
-  });
+    })
+    expect(replay.signingHashHex).toBe(reference.signingHashHex)
+  })
 
-  it("emits a larger BoC when includeStateInit=true (first-send deployment envelope)", () => {
+  it('emits a larger BoC when includeStateInit=true (first-send deployment envelope)', () => {
     // The wallet address derives from the pubkey; we only test the BoC
     // size grows because adding StateInit appends a code+data ref.
     // Same payload + same sig + only the includeStateInit flag toggled.
@@ -206,46 +200,44 @@ describe("chains/ton / buildTonTxFromSigningPayload (prebuilt-payload signing)",
       bounceable: false,
       seqno: 0, // deploy + send
       validUntil: 1_700_000_000,
-    });
-    const bocBase64 = Buffer.from(ref.unsignedBocHex, "hex").toString("base64");
-    const fakeSig = "aa".repeat(64);
+    })
+    const bocBase64 = Buffer.from(ref.unsignedBocHex, 'hex').toString('base64')
+    const fakeSig = 'aa'.repeat(64)
 
     const withStateInit = buildTonTxFromSigningPayload({
       publicKeyEd25519: PUBKEY_HEX,
       signingPayloadBoc: bocBase64,
       includeStateInit: true,
-    }).finalize(fakeSig);
+    }).finalize(fakeSig)
 
     const withoutStateInit = buildTonTxFromSigningPayload({
       publicKeyEd25519: PUBKEY_HEX,
       signingPayloadBoc: bocBase64,
       includeStateInit: false,
-    }).finalize(fakeSig);
+    }).finalize(fakeSig)
 
-    expect(withStateInit.signedBocBase64.length).toBeGreaterThan(
-      withoutStateInit.signedBocBase64.length,
-    );
-  });
+    expect(withStateInit.signedBocBase64.length).toBeGreaterThan(withoutStateInit.signedBocBase64.length)
+  })
 
-  it("rejects an Ed25519 pubkey that is not 32 bytes", () => {
+  it('rejects an Ed25519 pubkey that is not 32 bytes', () => {
     expect(() =>
       buildTonTxFromSigningPayload({
-        publicKeyEd25519: "01".repeat(33), // 33 bytes
-        signingPayloadBoc: "AA==",
-      }),
-    ).toThrow(/32 bytes/);
-  });
+        publicKeyEd25519: '01'.repeat(33), // 33 bytes
+        signingPayloadBoc: 'AA==',
+      })
+    ).toThrow(/32 bytes/)
+  })
 
-  it("rejects an empty signing payload", () => {
+  it('rejects an empty signing payload', () => {
     expect(() =>
       buildTonTxFromSigningPayload({
         publicKeyEd25519: PUBKEY_HEX,
-        signingPayloadBoc: "",
-      }),
-    ).toThrow(/empty/);
-  });
+        signingPayloadBoc: '',
+      })
+    ).toThrow(/empty/)
+  })
 
-  it("finalize rejects signatures of the wrong length", () => {
+  it('finalize rejects signatures of the wrong length', () => {
     const reference = buildTonSendTx({
       publicKeyEd25519: PUBKEY_HEX,
       to: RECIPIENT,
@@ -253,13 +245,11 @@ describe("chains/ton / buildTonTxFromSigningPayload (prebuilt-payload signing)",
       bounceable: false,
       seqno: 1,
       validUntil: 1_700_000_000,
-    });
+    })
     const builder = buildTonTxFromSigningPayload({
       publicKeyEd25519: PUBKEY_HEX,
-      signingPayloadBoc: Buffer.from(reference.unsignedBocHex, "hex").toString(
-        "base64",
-      ),
-    });
-    expect(() => builder.finalize("aa".repeat(32))).toThrow(/must be 64 bytes/);
-  });
-});
+      signingPayloadBoc: Buffer.from(reference.unsignedBocHex, 'hex').toString('base64'),
+    })
+    expect(() => builder.finalize('aa'.repeat(32))).toThrow(/must be 64 bytes/)
+  })
+})

--- a/packages/sdk/tests/unit/chains/ton.test.ts
+++ b/packages/sdk/tests/unit/chains/ton.test.ts
@@ -13,8 +13,8 @@
  * `@ton/ton` (the higher-level `WalletContractV4` wrapper) — `@ton/core`
  * is sufficient for the cross-check at the cell level.
  */
-import { beginCell, internal, SendMode, storeMessageRelaxed } from '@ton/core'
-import { describe, expect, it } from 'vitest'
+import { beginCell, internal, SendMode, storeMessageRelaxed } from "@ton/core";
+import { describe, expect, it } from "vitest";
 
 import {
   buildTonSendTx,
@@ -22,37 +22,37 @@ import {
   deriveTonAddress,
   TON_V4R2_SUB_WALLET_ID,
   validateTonMemo,
-} from '../../../src/chains/ton'
-import { buildV4R2Wallet } from '../../../src/chains/ton/walletV4R2'
+} from "../../../src/chains/ton";
+import { buildV4R2Wallet } from "../../../src/chains/ton/walletV4R2";
 
 // Deterministic 32-byte Ed25519 pubkey (all 0x01s) — avoids seed randomness
 // and keeps the byte-parity assertion stable across runs.
-const PUBKEY_HEX = '01'.repeat(32)
-const RECIPIENT = 'UQDy_zN0Mel7MItGcTQr0kxEJxa7dg_-OGv7_XToTMTKT1Cz'
+const PUBKEY_HEX = "01".repeat(32);
+const RECIPIENT = "UQDy_zN0Mel7MItGcTQr0kxEJxa7dg_-OGv7_XToTMTKT1Cz";
 
-describe('chains/ton', () => {
-  it('derives the same V4R2 address as @ton/ton', () => {
-    const addr = deriveTonAddress(PUBKEY_HEX, { bounceable: false })
+describe("chains/ton", () => {
+  it("derives the same V4R2 address as @ton/ton", () => {
+    const addr = deriveTonAddress(PUBKEY_HEX, { bounceable: false });
     // The address must be stable for a given pubkey + workchain. Any
     // change to the V4R2 code cell would break this.
     const wallet = buildV4R2Wallet({
       publicKeyEd25519: Uint8Array.from({ length: 32 }, () => 0x01),
-    })
-    expect(addr).toBe(wallet.addressString({ bounceable: false }))
-  })
+    });
+    expect(addr).toBe(wallet.addressString({ bounceable: false }));
+  });
 
-  it('rejects memos over 123 bytes', () => {
-    expect(() => validateTonMemo('x'.repeat(124))).toThrow(/at most 123 bytes/)
-  })
+  it("rejects memos over 123 bytes", () => {
+    expect(() => validateTonMemo("x".repeat(124))).toThrow(/at most 123 bytes/);
+  });
 
-  it('exposes the V4R2 subwallet ID constant', () => {
-    expect(TON_V4R2_SUB_WALLET_ID).toBe(698983191)
-  })
+  it("exposes the V4R2 subwallet ID constant", () => {
+    expect(TON_V4R2_SUB_WALLET_ID).toBe(698983191);
+  });
 
-  it('matches @ton/ton createTransfer byte-for-byte for a native send', () => {
-    const amount = 1_000_000_000n // 1 TON
-    const seqno = 42
-    const validUntil = 1_700_000_000 // pinned so hash is deterministic
+  it("matches @ton/ton createTransfer byte-for-byte for a native send", () => {
+    const amount = 1_000_000_000n; // 1 TON
+    const seqno = 42;
+    const validUntil = 1_700_000_000; // pinned so hash is deterministic
 
     const result = buildTonSendTx({
       publicKeyEd25519: PUBKEY_HEX,
@@ -61,7 +61,7 @@ describe('chains/ton', () => {
       bounceable: true,
       seqno,
       validUntil,
-    })
+    });
 
     // Reference: build the exact same signing payload manually using only
     // `@ton/core` primitives, mirroring what @ton/ton's WalletContractV4
@@ -69,9 +69,9 @@ describe('chains/ton', () => {
     // on-chain outcome as the reference implementation.
     const walletReference = buildV4R2Wallet({
       publicKeyEd25519: Uint8Array.from({ length: 32 }, () => 0x01),
-    })
-    const destination = walletReference.address // re-used only for the check below
-    expect(destination).toBeDefined()
+    });
+    const destination = walletReference.address; // re-used only for the check below
+    expect(destination).toBeDefined();
 
     const internalMsg = beginCell()
       .store(
@@ -80,12 +80,12 @@ describe('chains/ton', () => {
             to: RECIPIENT,
             value: amount,
             bounce: true,
-          })
-        )
+          }),
+        ),
       )
-      .endCell()
+      .endCell();
 
-    const sendMode = SendMode.PAY_GAS_SEPARATELY | SendMode.IGNORE_ERRORS
+    const sendMode = SendMode.PAY_GAS_SEPARATELY | SendMode.IGNORE_ERRORS;
     const expectedPayload = beginCell()
       .storeUint(TON_V4R2_SUB_WALLET_ID, 32)
       .storeUint(validUntil, 32)
@@ -93,14 +93,14 @@ describe('chains/ton', () => {
       .storeUint(0, 8)
       .storeUint(sendMode, 8)
       .storeRef(internalMsg)
-      .endCell()
+      .endCell();
 
-    const expectedHash = expectedPayload.hash().toString('hex')
-    expect(result.signingHashHex).toBe(expectedHash)
-  })
+    const expectedHash = expectedPayload.hash().toString("hex");
+    expect(result.signingHashHex).toBe(expectedHash);
+  });
 
-  it('includes StateInit when seqno === 0 and omits it otherwise', () => {
-    const fakeSig = 'aa'.repeat(64)
+  it("includes StateInit when seqno === 0 and omits it otherwise", () => {
+    const fakeSig = "aa".repeat(64);
 
     const deploySeqno0 = buildTonSendTx({
       publicKeyEd25519: PUBKEY_HEX,
@@ -109,7 +109,7 @@ describe('chains/ton', () => {
       bounceable: false,
       seqno: 0,
       validUntil: 1_700_000_000,
-    }).finalize(fakeSig)
+    }).finalize(fakeSig);
 
     const subsequentSeqno1 = buildTonSendTx({
       publicKeyEd25519: PUBKEY_HEX,
@@ -118,16 +118,18 @@ describe('chains/ton', () => {
       bounceable: false,
       seqno: 1,
       validUntil: 1_700_000_000,
-    }).finalize(fakeSig)
+    }).finalize(fakeSig);
 
     // The BOC including StateInit is longer than the one without (one more
     // referenced cell containing code+data). This is the cheapest way to
     // sanity-check inclusion without dragging a full BOC parser into the
     // unit harness.
-    expect(deploySeqno0.signedBocBase64.length).toBeGreaterThan(subsequentSeqno1.signedBocBase64.length)
-  })
+    expect(deploySeqno0.signedBocBase64.length).toBeGreaterThan(
+      subsequentSeqno1.signedBocBase64.length,
+    );
+  });
 
-  it('finalize rejects signatures of the wrong length', () => {
+  it("finalize rejects signatures of the wrong length", () => {
     const builder = buildTonSendTx({
       publicKeyEd25519: PUBKEY_HEX,
       to: RECIPIENT,
@@ -135,12 +137,12 @@ describe('chains/ton', () => {
       bounceable: false,
       seqno: 1,
       validUntil: 1_700_000_000,
-    })
-    expect(() => builder.finalize('aa'.repeat(32))).toThrow(/must be 64 bytes/)
-  })
-})
+    });
+    expect(() => builder.finalize("aa".repeat(32))).toThrow(/must be 64 bytes/);
+  });
+});
 
-describe('chains/ton / buildTonTxFromSigningPayload (prebuilt-payload signing)', () => {
+describe("chains/ton / buildTonTxFromSigningPayload (prebuilt-payload signing)", () => {
   // Round-trip parity: build a payload via buildTonSendTx, extract its
   // unsignedBocHex (the serialized signing-payload Cell), feed it back
   // through buildTonTxFromSigningPayload. signingHashHex MUST match
@@ -148,7 +150,7 @@ describe('chains/ton / buildTonTxFromSigningPayload (prebuilt-payload signing)',
   // BoC. This proves the primitive is a clean replacement for the
   // chain-specific builder when fed equivalent input — which is the
   // contract yield.xyz / dApp signing flows rely on.
-  it('produces the same signingHashHex as buildTonSendTx for an identical payload', () => {
+  it("produces the same signingHashHex as buildTonSendTx for an identical payload", () => {
     const reference = buildTonSendTx({
       publicKeyEd25519: PUBKEY_HEX,
       to: RECIPIENT,
@@ -156,28 +158,28 @@ describe('chains/ton / buildTonTxFromSigningPayload (prebuilt-payload signing)',
       bounceable: false,
       seqno: 7,
       validUntil: 1_700_000_000,
-    })
+    });
 
     const replay = buildTonTxFromSigningPayload({
       publicKeyEd25519: PUBKEY_HEX,
-      signingPayloadBoc: Buffer.from(reference.unsignedBocHex, 'hex').toString(
-        'base64',
+      signingPayloadBoc: Buffer.from(reference.unsignedBocHex, "hex").toString(
+        "base64",
       ),
       // seqno is non-zero → no StateInit envelope
       includeStateInit: false,
-    })
+    });
 
-    expect(replay.signingHashHex).toBe(reference.signingHashHex)
-    expect(replay.fromAddress).toBe(reference.fromAddress)
+    expect(replay.signingHashHex).toBe(reference.signingHashHex);
+    expect(replay.fromAddress).toBe(reference.fromAddress);
 
     // Same payload + same sig → same broadcastable BoC.
-    const sig = 'cc'.repeat(64)
+    const sig = "cc".repeat(64);
     expect(replay.finalize(sig).signedBocBase64).toBe(
       reference.finalize(sig).signedBocBase64,
-    )
-  })
+    );
+  });
 
-  it('accepts a hex-encoded signing payload (forward-compat with hex wire formats)', () => {
+  it("accepts a hex-encoded signing payload (forward-compat with hex wire formats)", () => {
     const reference = buildTonSendTx({
       publicKeyEd25519: PUBKEY_HEX,
       to: RECIPIENT,
@@ -185,15 +187,15 @@ describe('chains/ton / buildTonTxFromSigningPayload (prebuilt-payload signing)',
       bounceable: false,
       seqno: 5,
       validUntil: 1_700_000_000,
-    })
+    });
     const replay = buildTonTxFromSigningPayload({
       publicKeyEd25519: PUBKEY_HEX,
       signingPayloadBoc: reference.unsignedBocHex, // hex, not base64
-    })
-    expect(replay.signingHashHex).toBe(reference.signingHashHex)
-  })
+    });
+    expect(replay.signingHashHex).toBe(reference.signingHashHex);
+  });
 
-  it('emits a larger BoC when includeStateInit=true (first-send deployment envelope)', () => {
+  it("emits a larger BoC when includeStateInit=true (first-send deployment envelope)", () => {
     // The wallet address derives from the pubkey; we only test the BoC
     // size grows because adding StateInit appends a code+data ref.
     // Same payload + same sig + only the includeStateInit flag toggled.
@@ -204,46 +206,46 @@ describe('chains/ton / buildTonTxFromSigningPayload (prebuilt-payload signing)',
       bounceable: false,
       seqno: 0, // deploy + send
       validUntil: 1_700_000_000,
-    })
-    const bocBase64 = Buffer.from(ref.unsignedBocHex, 'hex').toString('base64')
-    const fakeSig = 'aa'.repeat(64)
+    });
+    const bocBase64 = Buffer.from(ref.unsignedBocHex, "hex").toString("base64");
+    const fakeSig = "aa".repeat(64);
 
     const withStateInit = buildTonTxFromSigningPayload({
       publicKeyEd25519: PUBKEY_HEX,
       signingPayloadBoc: bocBase64,
       includeStateInit: true,
-    }).finalize(fakeSig)
+    }).finalize(fakeSig);
 
     const withoutStateInit = buildTonTxFromSigningPayload({
       publicKeyEd25519: PUBKEY_HEX,
       signingPayloadBoc: bocBase64,
       includeStateInit: false,
-    }).finalize(fakeSig)
+    }).finalize(fakeSig);
 
     expect(withStateInit.signedBocBase64.length).toBeGreaterThan(
       withoutStateInit.signedBocBase64.length,
-    )
-  })
+    );
+  });
 
-  it('rejects an Ed25519 pubkey that is not 32 bytes', () => {
+  it("rejects an Ed25519 pubkey that is not 32 bytes", () => {
     expect(() =>
       buildTonTxFromSigningPayload({
-        publicKeyEd25519: '01'.repeat(33), // 33 bytes
-        signingPayloadBoc: 'AA==',
+        publicKeyEd25519: "01".repeat(33), // 33 bytes
+        signingPayloadBoc: "AA==",
       }),
-    ).toThrow(/32 bytes/)
-  })
+    ).toThrow(/32 bytes/);
+  });
 
-  it('rejects an empty signing payload', () => {
+  it("rejects an empty signing payload", () => {
     expect(() =>
       buildTonTxFromSigningPayload({
         publicKeyEd25519: PUBKEY_HEX,
-        signingPayloadBoc: '',
+        signingPayloadBoc: "",
       }),
-    ).toThrow(/empty/)
-  })
+    ).toThrow(/empty/);
+  });
 
-  it('finalize rejects signatures of the wrong length', () => {
+  it("finalize rejects signatures of the wrong length", () => {
     const reference = buildTonSendTx({
       publicKeyEd25519: PUBKEY_HEX,
       to: RECIPIENT,
@@ -251,13 +253,13 @@ describe('chains/ton / buildTonTxFromSigningPayload (prebuilt-payload signing)',
       bounceable: false,
       seqno: 1,
       validUntil: 1_700_000_000,
-    })
+    });
     const builder = buildTonTxFromSigningPayload({
       publicKeyEd25519: PUBKEY_HEX,
-      signingPayloadBoc: Buffer.from(reference.unsignedBocHex, 'hex').toString(
-        'base64',
+      signingPayloadBoc: Buffer.from(reference.unsignedBocHex, "hex").toString(
+        "base64",
       ),
-    })
-    expect(() => builder.finalize('aa'.repeat(32))).toThrow(/must be 64 bytes/)
-  })
-})
+    });
+    expect(() => builder.finalize("aa".repeat(32))).toThrow(/must be 64 bytes/);
+  });
+});

--- a/packages/sdk/tests/unit/chains/ton.test.ts
+++ b/packages/sdk/tests/unit/chains/ton.test.ts
@@ -16,7 +16,13 @@
 import { beginCell, internal, SendMode, storeMessageRelaxed } from '@ton/core'
 import { describe, expect, it } from 'vitest'
 
-import { buildTonSendTx, deriveTonAddress, TON_V4R2_SUB_WALLET_ID, validateTonMemo } from '../../../src/chains/ton'
+import {
+  buildTonSendTx,
+  buildTonTxFromSigningPayload,
+  deriveTonAddress,
+  TON_V4R2_SUB_WALLET_ID,
+  validateTonMemo,
+} from '../../../src/chains/ton'
 import { buildV4R2Wallet } from '../../../src/chains/ton/walletV4R2'
 
 // Deterministic 32-byte Ed25519 pubkey (all 0x01s) — avoids seed randomness
@@ -129,6 +135,128 @@ describe('chains/ton', () => {
       bounceable: false,
       seqno: 1,
       validUntil: 1_700_000_000,
+    })
+    expect(() => builder.finalize('aa'.repeat(32))).toThrow(/must be 64 bytes/)
+  })
+})
+
+describe('chains/ton / buildTonTxFromSigningPayload (prebuilt-payload signing)', () => {
+  // Round-trip parity: build a payload via buildTonSendTx, extract its
+  // unsignedBocHex (the serialized signing-payload Cell), feed it back
+  // through buildTonTxFromSigningPayload. signingHashHex MUST match
+  // byte-for-byte and finalize(sig) MUST produce the same external
+  // BoC. This proves the primitive is a clean replacement for the
+  // chain-specific builder when fed equivalent input — which is the
+  // contract yield.xyz / dApp signing flows rely on.
+  it('produces the same signingHashHex as buildTonSendTx for an identical payload', () => {
+    const reference = buildTonSendTx({
+      publicKeyEd25519: PUBKEY_HEX,
+      to: RECIPIENT,
+      amount: 250_000_000n, // 0.25 TON
+      bounceable: false,
+      seqno: 7,
+      validUntil: 1_700_000_000,
+    })
+
+    const replay = buildTonTxFromSigningPayload({
+      publicKeyEd25519: PUBKEY_HEX,
+      signingPayloadBoc: Buffer.from(reference.unsignedBocHex, 'hex').toString(
+        'base64',
+      ),
+      // seqno is non-zero → no StateInit envelope
+      includeStateInit: false,
+    })
+
+    expect(replay.signingHashHex).toBe(reference.signingHashHex)
+    expect(replay.fromAddress).toBe(reference.fromAddress)
+
+    // Same payload + same sig → same broadcastable BoC.
+    const sig = 'cc'.repeat(64)
+    expect(replay.finalize(sig).signedBocBase64).toBe(
+      reference.finalize(sig).signedBocBase64,
+    )
+  })
+
+  it('accepts a hex-encoded signing payload (forward-compat with hex wire formats)', () => {
+    const reference = buildTonSendTx({
+      publicKeyEd25519: PUBKEY_HEX,
+      to: RECIPIENT,
+      amount: 100n,
+      bounceable: false,
+      seqno: 5,
+      validUntil: 1_700_000_000,
+    })
+    const replay = buildTonTxFromSigningPayload({
+      publicKeyEd25519: PUBKEY_HEX,
+      signingPayloadBoc: reference.unsignedBocHex, // hex, not base64
+    })
+    expect(replay.signingHashHex).toBe(reference.signingHashHex)
+  })
+
+  it('emits a larger BoC when includeStateInit=true (first-send deployment envelope)', () => {
+    // The wallet address derives from the pubkey; we only test the BoC
+    // size grows because adding StateInit appends a code+data ref.
+    // Same payload + same sig + only the includeStateInit flag toggled.
+    const ref = buildTonSendTx({
+      publicKeyEd25519: PUBKEY_HEX,
+      to: RECIPIENT,
+      amount: 1_000n,
+      bounceable: false,
+      seqno: 0, // deploy + send
+      validUntil: 1_700_000_000,
+    })
+    const bocBase64 = Buffer.from(ref.unsignedBocHex, 'hex').toString('base64')
+    const fakeSig = 'aa'.repeat(64)
+
+    const withStateInit = buildTonTxFromSigningPayload({
+      publicKeyEd25519: PUBKEY_HEX,
+      signingPayloadBoc: bocBase64,
+      includeStateInit: true,
+    }).finalize(fakeSig)
+
+    const withoutStateInit = buildTonTxFromSigningPayload({
+      publicKeyEd25519: PUBKEY_HEX,
+      signingPayloadBoc: bocBase64,
+      includeStateInit: false,
+    }).finalize(fakeSig)
+
+    expect(withStateInit.signedBocBase64.length).toBeGreaterThan(
+      withoutStateInit.signedBocBase64.length,
+    )
+  })
+
+  it('rejects an Ed25519 pubkey that is not 32 bytes', () => {
+    expect(() =>
+      buildTonTxFromSigningPayload({
+        publicKeyEd25519: '01'.repeat(33), // 33 bytes
+        signingPayloadBoc: 'AA==',
+      }),
+    ).toThrow(/32 bytes/)
+  })
+
+  it('rejects an empty signing payload', () => {
+    expect(() =>
+      buildTonTxFromSigningPayload({
+        publicKeyEd25519: PUBKEY_HEX,
+        signingPayloadBoc: '',
+      }),
+    ).toThrow(/empty/)
+  })
+
+  it('finalize rejects signatures of the wrong length', () => {
+    const reference = buildTonSendTx({
+      publicKeyEd25519: PUBKEY_HEX,
+      to: RECIPIENT,
+      amount: 1n,
+      bounceable: false,
+      seqno: 1,
+      validUntil: 1_700_000_000,
+    })
+    const builder = buildTonTxFromSigningPayload({
+      publicKeyEd25519: PUBKEY_HEX,
+      signingPayloadBoc: Buffer.from(reference.unsignedBocHex, 'hex').toString(
+        'base64',
+      ),
     })
     expect(() => builder.finalize('aa'.repeat(32))).toThrow(/must be 64 bytes/)
   })


### PR DESCRIPTION
## Goal

Sign TON external messages whose signing payload Cell is built UPSTREAM — yield.xyz staking actions, WalletConnect / dApp signing, delegated-staking backends — without shipping a TON contract-variant builder for every protocol the SDK doesn't own.

## Contract

```ts
buildTonTxFromSigningPayload({
  publicKeyEd25519: string,        // 32 bytes hex
  signingPayloadBoc: string,        // base64 OR hex (auto-detected)
  includeStateInit?: boolean,       // first-send deploy (seqno === 0)
  workchain?: number,               // default 0 (masterchain)
}): TonTxBuilderResult
```

Returns the same shape as the existing chain-specific builders — drop-in compatible.

## Why this exists

- **yield.xyz TON staking** (`ton-ton-tston-staking`, `ton-ton-nomination-staking`, `ton-ton-chorus-one-pools-staking`) returns the signing-payload BoC per step. Replicating every TON staking contract variant in the SDK would bloat the chain module; the prebuilt primitive is the right abstraction.

- **WalletConnect / dApp signing**: the dApp constructs the external-message body server-side; the wallet just signs.

## Seqno freshness — surfaced in docs, NOT auto-handled

This is the **most important design decision** in this PR. TON wallets reject any external message whose embedded seqno doesn't match the wallet's current seqno. yield.xyz pins the seqno at action-create time; if the user takes >30s to sign, the broadcast fails with `external message was not accepted`.

This primitive does NOT re-pin the seqno — it signs whatever payload it's given, deterministically. The consumer (vultiagent-app's signing flow) is responsible for either:
- (a) regenerating the payload with a fresh seqno right before signing (recommended for yield.xyz-style integrations), OR
- (b) accepting the stale-seqno risk with a clear retry path on broadcast failure.

Re-pinning would mean parsing the BoC, mutating the seqno cell, and re-hashing — a different abstraction that belongs in a separate helper.

## Tests

6 new tests added to `ton.test.ts`:
- Round-trip parity with `buildTonSendTx` (same `signingHashHex`, same `signedBocBase64` for identical payload + sig — proves drop-in equivalence)
- Hex-encoded payload accepted (forward-compat with hex wire formats)
- `includeStateInit=true` produces a larger BoC than `false` (the deploy envelope sanity check)
- Rejects 33-byte pubkey
- Rejects empty payload
- `finalize()` guards 64-byte sig length

```bash
$ npx vitest run packages/sdk/tests/unit/chains/ton.test.ts
 ✓ packages/sdk/tests/unit/chains/ton.test.ts (12 tests) 12ms
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

`biome check` clean on all touched files.

## Consumer integration

vultiagent-app companion PR (forthcoming):
- `ton-prebuilt` to `ParsedServerTx` union
- `ton-prebuilt` case in `signAndBroadcast` calling this SDK primitive
- `parseTonCanonical` extension: `{boc: <base64>, seqno: <int>}` → `ton-prebuilt`
- **Seqno re-pin step at sign time**: app must re-fetch the wallet's current seqno via `getTonWalletInfo` JUST before calling this primitive. If yield.xyz's pinned seqno is stale, the app re-builds the payload locally with the fresh seqno (mcp-ts will need to include enough state — innerMsg cell + validUntil — for the app to do this).

mcp-ts companion PR (forthcoming): `parseActionDisplay` TON branch emitting `{tx_encoding: 'ton-tx', chain: 'Ton', data: <base64-BoC>, seqno: <int>, valid_until: <unix-seconds>, ...}` per step.

Tracking: `vultiagent-poc-0tc.3` bead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Construct TON transactions from prebuilt signing payloads (accepts base64 or hex). Returns signing hash, unsigned payload, sender address, and a finalize(signature) flow; optional inclusion of state init for first-send cases.

* **Tests**
  * Added tests covering payload formats, parity with existing builders, state-init variations, and input validation.

* **Documentation**
  * Added a changeset describing the new helper and options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/516?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->