### PR TITLE
feat(affiliate): add Station affiliate config alongside vultisig-0

### DIFF
--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -1250,6 +1250,11 @@
       "import": "./dist/swap/affiliate/config.js",
       "default": "./dist/swap/affiliate/config.js"
     },
+    "./swap/affiliate/station": {
+      "types": "./dist/swap/affiliate/station.d.ts",
+      "import": "./dist/swap/affiliate/station.js",
+      "default": "./dist/swap/affiliate/station.js"
+    },
     "./swap/discount/SwapDiscount": {
       "types": "./dist/swap/discount/SwapDiscount.d.ts",
       "import": "./dist/swap/discount/SwapDiscount.js",
@@ -1295,6 +1300,11 @@
       "import": "./dist/swap/general/kyber/config.js",
       "default": "./dist/swap/general/kyber/config.js"
     },
+    "./swap/general/kyber/stationConfig": {
+      "types": "./dist/swap/general/kyber/stationConfig.d.ts",
+      "import": "./dist/swap/general/kyber/stationConfig.js",
+      "default": "./dist/swap/general/kyber/stationConfig.js"
+    },
     "./swap/general/lifi/api/getLifiSwapQuote": {
       "types": "./dist/swap/general/lifi/api/getLifiSwapQuote.d.ts",
       "import": "./dist/swap/general/lifi/api/getLifiSwapQuote.js",
@@ -1324,6 +1334,11 @@
       "types": "./dist/swap/general/oneInch/oneInchAffiliateConfig.d.ts",
       "import": "./dist/swap/general/oneInch/oneInchAffiliateConfig.js",
       "default": "./dist/swap/general/oneInch/oneInchAffiliateConfig.js"
+    },
+    "./swap/general/oneInch/stationOneInchAffiliateConfig": {
+      "types": "./dist/swap/general/oneInch/stationOneInchAffiliateConfig.d.ts",
+      "import": "./dist/swap/general/oneInch/stationOneInchAffiliateConfig.js",
+      "default": "./dist/swap/general/oneInch/stationOneInchAffiliateConfig.js"
     },
     "./swap/general/oneInch/OneInchSwapEnabledChains": {
       "types": "./dist/swap/general/oneInch/OneInchSwapEnabledChains.d.ts",
@@ -1369,6 +1384,11 @@
       "types": "./dist/swap/native/nativeSwapAffiliateConfig.d.ts",
       "import": "./dist/swap/native/nativeSwapAffiliateConfig.js",
       "default": "./dist/swap/native/nativeSwapAffiliateConfig.js"
+    },
+    "./swap/native/stationNativeSwapAffiliateConfig": {
+      "types": "./dist/swap/native/stationNativeSwapAffiliateConfig.d.ts",
+      "import": "./dist/swap/native/stationNativeSwapAffiliateConfig.js",
+      "default": "./dist/swap/native/stationNativeSwapAffiliateConfig.js"
     },
     "./swap/native/NativeSwapChain": {
       "types": "./dist/swap/native/NativeSwapChain.d.ts",

--- a/packages/core/chain/swap/affiliate/station.test.ts
+++ b/packages/core/chain/swap/affiliate/station.test.ts
@@ -1,0 +1,114 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+import { describe, expect, it, vi } from 'vitest'
+
+import { stationKyberSwapAffiliateConfig } from '../general/kyber/stationConfig'
+import { stationNativeSwapAffiliateConfig } from '../native/stationNativeSwapAffiliateConfig'
+import { stationOneInchAffiliateConfig } from '../general/oneInch/stationOneInchAffiliateConfig'
+
+vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
+  queryUrl: vi.fn(),
+}))
+vi.mock('i18next', () => ({ t: (key: string) => key }))
+
+const btcFrom = {
+  chain: Chain.Bitcoin,
+  ticker: 'BTC',
+  decimals: 8,
+  address: 'bc1qtest',
+} as any
+
+const ethTo = {
+  chain: Chain.Ethereum,
+  ticker: 'ETH',
+  decimals: 18,
+  address: '0x86d526d6624AbC0178cF7296cD538Ecc080A95F1',
+} as any
+
+const baseOkBody = {
+  expected_amount_out: '1000',
+  expiry: 1_700_000_000,
+  fees: { affiliate: '0', asset: 'BTC.BTC', outbound: '0', total: '100', total_bps: 50 },
+  memo: '=:e:0x86d526d6624AbC0178cF7296cD538Ecc080A95F1',
+  notes: '',
+  outbound_delay_blocks: 0,
+  outbound_delay_seconds: 0,
+  recommended_min_amount_in: '0',
+  warning: '',
+}
+
+describe('Station affiliate config', () => {
+  it('stationNativeSwapAffiliateConfig uses stvs as affiliate address', async () => {
+    vi.mocked(queryUrl).mockResolvedValueOnce(baseOkBody)
+
+    const { buildAffiliateParams } = await import('../native/api/affiliate')
+    const result = buildAffiliateParams({
+      swapChain: Chain.THORChain,
+      affiliateBps: 50,
+      config: stationNativeSwapAffiliateConfig,
+    })
+
+    expect(result.affiliate).toBe('stvs')
+    expect(result.affiliate_bps).toBe('50')
+  })
+
+  it('stationOneInchAffiliateConfig uses Station EVM address as referrer', async () => {
+    vi.mocked(queryUrl).mockReset()
+    vi.mocked(queryUrl).mockResolvedValueOnce({
+      dstAmount: '999000000',
+      tx: { from: '0xsender', to: '0xrouter', data: '0x', value: '0', gasPrice: '1000000000', gas: 200000 },
+    })
+
+    const { getOneInchSwapQuote } = await import('../general/oneInch/api/getOneInchSwapQuote')
+    await getOneInchSwapQuote({
+      account: { chain: Chain.Ethereum, address: '0xsender' },
+      fromCoinId: '0xsrc',
+      toCoinId: '0xdst',
+      amount: 1_000_000n,
+      affiliateBps: 50,
+      oneInchConfig: stationOneInchAffiliateConfig,
+    })
+
+    const [url] = vi.mocked(queryUrl).mock.calls[0]
+    expect(String(url)).toContain(`referrer=${stationOneInchAffiliateConfig.referrer}`)
+    expect(String(url)).toContain('fee=0.5')
+  })
+
+  it('stationKyberSwapAffiliateConfig uses Station EVM address as feeReceiver', async () => {
+    vi.mocked(queryUrl).mockReset()
+    vi.mocked(queryUrl)
+      .mockResolvedValueOnce({
+        code: 0,
+        message: 'OK',
+        data: {
+          routeSummary: { amountOut: '10000000' },
+          routerAddress: '0xrouter',
+        },
+        requestId: 'req1',
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: { amountOut: '10000000', data: '0xswap', gas: '210000', routerAddress: '0xrouter' },
+      })
+
+    const { getKyberSwapQuote } = await import('../general/kyber/api/quote')
+    await getKyberSwapQuote({
+      from: { chain: Chain.Ethereum, address: '0xsender', id: '0xsrc', decimals: 18, ticker: 'SRC' },
+      to: { chain: Chain.Ethereum, address: '0xsender', id: '0xdst', decimals: 6, ticker: 'DST' },
+      amount: 1_000_000n,
+      affiliateBps: 50,
+      kyberConfig: stationKyberSwapAffiliateConfig,
+    })
+
+    const [routeUrl, routeOptions] = vi.mocked(queryUrl).mock.calls[0]
+    expect(String(routeUrl)).toContain(`feeReceiver=${stationKyberSwapAffiliateConfig.referral}`)
+    expect(routeOptions).toMatchObject({
+      headers: { 'X-Client-Id': stationKyberSwapAffiliateConfig.source },
+    })
+
+    const [, buildOptions] = vi.mocked(queryUrl).mock.calls[1]
+    expect(buildOptions?.body).toMatchObject({
+      feeReceiver: stationKyberSwapAffiliateConfig.referral,
+    })
+  })
+})

--- a/packages/core/chain/swap/affiliate/station.test.ts
+++ b/packages/core/chain/swap/affiliate/station.test.ts
@@ -3,27 +3,13 @@ import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 import { describe, expect, it, vi } from 'vitest'
 
 import { stationKyberSwapAffiliateConfig } from '../general/kyber/stationConfig'
-import { stationNativeSwapAffiliateConfig } from '../native/stationNativeSwapAffiliateConfig'
 import { stationOneInchAffiliateConfig } from '../general/oneInch/stationOneInchAffiliateConfig'
+import { stationNativeSwapAffiliateConfig } from '../native/stationNativeSwapAffiliateConfig'
 
 vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
   queryUrl: vi.fn(),
 }))
 vi.mock('i18next', () => ({ t: (key: string) => key }))
-
-const btcFrom = {
-  chain: Chain.Bitcoin,
-  ticker: 'BTC',
-  decimals: 8,
-  address: 'bc1qtest',
-} as any
-
-const ethTo = {
-  chain: Chain.Ethereum,
-  ticker: 'ETH',
-  decimals: 18,
-  address: '0x86d526d6624AbC0178cF7296cD538Ecc080A95F1',
-} as any
 
 const baseOkBody = {
   expected_amount_out: '1000',

--- a/packages/core/chain/swap/affiliate/station.ts
+++ b/packages/core/chain/swap/affiliate/station.ts
@@ -1,3 +1,3 @@
-export { stationNativeSwapAffiliateConfig } from '../native/stationNativeSwapAffiliateConfig'
-export { stationOneInchAffiliateConfig } from '../general/oneInch/stationOneInchAffiliateConfig'
 export { stationKyberSwapAffiliateConfig } from '../general/kyber/stationConfig'
+export { stationOneInchAffiliateConfig } from '../general/oneInch/stationOneInchAffiliateConfig'
+export { stationNativeSwapAffiliateConfig } from '../native/stationNativeSwapAffiliateConfig'

--- a/packages/core/chain/swap/affiliate/station.ts
+++ b/packages/core/chain/swap/affiliate/station.ts
@@ -1,0 +1,3 @@
+export { stationNativeSwapAffiliateConfig } from '../native/stationNativeSwapAffiliateConfig'
+export { stationOneInchAffiliateConfig } from '../general/oneInch/stationOneInchAffiliateConfig'
+export { stationKyberSwapAffiliateConfig } from '../general/kyber/stationConfig'

--- a/packages/core/chain/swap/general/kyber/api/quote.ts
+++ b/packages/core/chain/swap/general/kyber/api/quote.ts
@@ -5,20 +5,23 @@ import { TransferDirection } from '@vultisig/lib-utils/TransferDirection'
 
 import { GeneralSwapQuote } from '../../GeneralSwapQuote'
 import { KyberSwapEnabledChain } from '../chains'
+import { KyberSwapBaseAffiliateConfig } from '../config'
 import { getKyberSwapRoute } from './route'
 import { getKyberSwapTx } from './tx'
 
 type Input = Record<TransferDirection, AccountCoin<KyberSwapEnabledChain>> & {
   amount: bigint
   affiliateBps?: number
+  kyberConfig?: KyberSwapBaseAffiliateConfig
 }
 
-export const getKyberSwapQuote = async ({ from, to, amount, affiliateBps }: Input): Promise<GeneralSwapQuote> => {
+export const getKyberSwapQuote = async ({ from, to, amount, affiliateBps, kyberConfig }: Input): Promise<GeneralSwapQuote> => {
   const { routeSummary, routerAddress } = await getKyberSwapRoute({
     from,
     to,
     amount,
     affiliateBps,
+    kyberConfig,
   })
 
   const tx = await attempt(
@@ -30,6 +33,7 @@ export const getKyberSwapQuote = async ({ from, to, amount, affiliateBps }: Inpu
       amount,
       enableGasEstimation: true,
       affiliateBps,
+      kyberConfig,
     })
   )
 
@@ -44,6 +48,7 @@ export const getKyberSwapQuote = async ({ from, to, amount, affiliateBps }: Inpu
         amount,
         enableGasEstimation: false,
         affiliateBps,
+        kyberConfig,
       })
     }
 

--- a/packages/core/chain/swap/general/kyber/api/quote.ts
+++ b/packages/core/chain/swap/general/kyber/api/quote.ts
@@ -15,7 +15,13 @@ type Input = Record<TransferDirection, AccountCoin<KyberSwapEnabledChain>> & {
   kyberConfig?: KyberSwapBaseAffiliateConfig
 }
 
-export const getKyberSwapQuote = async ({ from, to, amount, affiliateBps, kyberConfig }: Input): Promise<GeneralSwapQuote> => {
+export const getKyberSwapQuote = async ({
+  from,
+  to,
+  amount,
+  affiliateBps,
+  kyberConfig,
+}: Input): Promise<GeneralSwapQuote> => {
   const { routeSummary, routerAddress } = await getKyberSwapRoute({
     from,
     to,

--- a/packages/core/chain/swap/general/kyber/api/route.ts
+++ b/packages/core/chain/swap/general/kyber/api/route.ts
@@ -9,6 +9,7 @@ import {
   getKyberSwapAffiliateParams,
   kyberSwapAffiliateConfig,
   KyberSwapAffiliateParams,
+  KyberSwapBaseAffiliateConfig,
   kyberSwapSlippageTolerance,
 } from '../config'
 import { getKyberSwapBaseUrl } from './baseUrl'
@@ -16,6 +17,7 @@ import { getKyberSwapBaseUrl } from './baseUrl'
 type Input = Record<TransferDirection, AccountCoin<KyberSwapEnabledChain>> & {
   amount: bigint
   affiliateBps?: number
+  kyberConfig?: KyberSwapBaseAffiliateConfig
 }
 
 type KyberSwapRoute = {
@@ -39,7 +41,13 @@ type KyberSwapRouteParams = {
   slippageTolerance: number
 } & Partial<KyberSwapAffiliateParams>
 
-export const getKyberSwapRoute = async ({ from, to, amount, affiliateBps }: Input): Promise<KyberSwapRoute> => {
+export const getKyberSwapRoute = async ({
+  from,
+  to,
+  amount,
+  affiliateBps,
+  kyberConfig = kyberSwapAffiliateConfig,
+}: Input): Promise<KyberSwapRoute> => {
   const [tokenIn, tokenOut] = [from, to].map(({ id }) => id || evmNativeCoinAddress)
 
   const routeParams: KyberSwapRouteParams = {
@@ -49,14 +57,14 @@ export const getKyberSwapRoute = async ({ from, to, amount, affiliateBps }: Inpu
     saveGas: true,
     gasInclude: true,
     slippageTolerance: kyberSwapSlippageTolerance,
-    ...getKyberSwapAffiliateParams(affiliateBps),
+    ...getKyberSwapAffiliateParams(affiliateBps, kyberConfig),
   }
 
   const routeUrl = addQueryParams(`${getKyberSwapBaseUrl(from.chain)}/routes`, routeParams)
 
   const { data } = await queryUrl<KyberSwapRouteResponse>(routeUrl, {
     headers: {
-      'X-Client-Id': kyberSwapAffiliateConfig.source,
+      'X-Client-Id': kyberConfig.source,
     },
   })
 

--- a/packages/core/chain/swap/general/kyber/api/tx.ts
+++ b/packages/core/chain/swap/general/kyber/api/tx.ts
@@ -13,6 +13,7 @@ import {
   getKyberSwapAffiliateParams,
   hasAffiliateBps,
   kyberSwapAffiliateConfig,
+  KyberSwapBaseAffiliateConfig,
   kyberSwapSlippageTolerance,
   kyberSwapTxLifespan,
 } from '../config'
@@ -24,6 +25,7 @@ type GetKyberSwapTxInput = Record<TransferDirection, AccountCoin<KyberSwapEnable
   amount: bigint
   enableGasEstimation: boolean
   affiliateBps?: number
+  kyberConfig?: KyberSwapBaseAffiliateConfig
 }
 
 type KyberSwapBuildResponse = {
@@ -70,6 +72,7 @@ export const getKyberSwapTx = async ({
   amount,
   enableGasEstimation,
   affiliateBps,
+  kyberConfig = kyberSwapAffiliateConfig,
 }: GetKyberSwapTxInput): Promise<GeneralSwapQuote> => {
   const buildPayload = {
     routeSummary,
@@ -78,13 +81,13 @@ export const getKyberSwapTx = async ({
     slippageTolerance: kyberSwapSlippageTolerance,
     deadline: Math.round(convertDuration(Date.now() + convertDuration(kyberSwapTxLifespan, 'min', 'ms'), 'ms', 's')),
     enableGasEstimation,
-    ...getKyberSwapAffiliateParams(affiliateBps),
+    ...getKyberSwapAffiliateParams(affiliateBps, kyberConfig),
     ignoreCappedSlippage: false,
   }
 
   const buildResponse = await queryUrl<KyberSwapBuildResponse>(`${getKyberSwapBaseUrl(from.chain)}/route/build`, {
     headers: {
-      'X-Client-Id': kyberSwapAffiliateConfig.source,
+      'X-Client-Id': kyberConfig.source,
     },
     body: buildPayload,
   })

--- a/packages/core/chain/swap/general/kyber/config.ts
+++ b/packages/core/chain/swap/general/kyber/config.ts
@@ -9,7 +9,9 @@ export const kyberSwapAffiliateConfig = {
   referral: '0x8E247a480449c84a5fDD25974A8501f3EFa4ABb9',
 }
 
-export type KyberSwapAffiliateParams = typeof kyberSwapAffiliateConfig & {
+export type KyberSwapBaseAffiliateConfig = typeof kyberSwapAffiliateConfig
+
+export type KyberSwapAffiliateParams = KyberSwapBaseAffiliateConfig & {
   feeAmount: number
   chargeFeeBy: 'currency_out'
   isInBps: true
@@ -19,13 +21,16 @@ export type KyberSwapAffiliateParams = typeof kyberSwapAffiliateConfig & {
 export const hasAffiliateBps = (affiliateBps?: number): affiliateBps is number =>
   affiliateBps !== undefined && affiliateBps > 0 && affiliateBps < 10000
 
-export const getKyberSwapAffiliateParams = (affiliateBps?: number): KyberSwapAffiliateParams | Record<string, never> =>
+export const getKyberSwapAffiliateParams = (
+  affiliateBps?: number,
+  config: KyberSwapBaseAffiliateConfig = kyberSwapAffiliateConfig
+): KyberSwapAffiliateParams | Record<string, never> =>
   hasAffiliateBps(affiliateBps)
     ? {
-        ...kyberSwapAffiliateConfig,
+        ...config,
         feeAmount: affiliateBps,
         chargeFeeBy: 'currency_out',
         isInBps: true,
-        feeReceiver: kyberSwapAffiliateConfig.referral,
+        feeReceiver: config.referral,
       }
     : {}

--- a/packages/core/chain/swap/general/kyber/stationConfig.ts
+++ b/packages/core/chain/swap/general/kyber/stationConfig.ts
@@ -1,0 +1,10 @@
+import { Minutes } from '@vultisig/lib-utils/time'
+
+export const stationKyberSwapAffiliateConfig = {
+  // Station source ID pending Kyber partner-team confirmation.
+  // Using vultisig-v0 as a temp fallback per spec — fees still flow to
+  // Station's feeReceiver correctly; only Kyber's attribution dashboard
+  // is mis-tagged until the new source ID is registered.
+  source: 'vultisig-v0',
+  referral: '0x649E1289fD780C2F9A3D27476511283EB0d0076D',
+}

--- a/packages/core/chain/swap/general/kyber/stationConfig.ts
+++ b/packages/core/chain/swap/general/kyber/stationConfig.ts
@@ -1,5 +1,3 @@
-import { Minutes } from '@vultisig/lib-utils/time'
-
 export const stationKyberSwapAffiliateConfig = {
   // Station source ID pending Kyber partner-team confirmation.
   // Using vultisig-v0 as a temp fallback per spec — fees still flow to

--- a/packages/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.ts
+++ b/packages/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.ts
@@ -12,12 +12,15 @@ import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
 import { evmNativeCoinAddress } from '../../../../chains/evm/config'
 
+export type OneInchAffiliateConfig = typeof oneInchAffiliateConfig
+
 type Input = {
   account: ChainAccount
   fromCoinId: string
   toCoinId: string
   amount: bigint
   affiliateBps?: number
+  oneInchConfig?: OneInchAffiliateConfig
 }
 
 const getBaseUrl = (chainId: number) => `${rootApiUrl}/1inch/swap/v6.0/${chainId}/swap`
@@ -28,6 +31,7 @@ export const getOneInchSwapQuote = async ({
   toCoinId,
   amount,
   affiliateBps,
+  oneInchConfig = oneInchAffiliateConfig,
 }: Input): Promise<GeneralSwapQuote> => {
   const chain = account.chain as EvmChain
   const chainId = hexToNumber(getEvmChainId(chain))
@@ -42,7 +46,7 @@ export const getOneInchSwapQuote = async ({
     includeGas: true,
     ...(affiliateBps
       ? {
-          referrer: oneInchAffiliateConfig.referrer,
+          referrer: oneInchConfig.referrer,
           fee: affiliateBps / 100,
         }
       : {}),

--- a/packages/core/chain/swap/general/oneInch/stationOneInchAffiliateConfig.ts
+++ b/packages/core/chain/swap/general/oneInch/stationOneInchAffiliateConfig.ts
@@ -1,0 +1,3 @@
+export const stationOneInchAffiliateConfig = {
+  referrer: '0x649E1289fD780C2F9A3D27476511283EB0d0076D',
+}

--- a/packages/core/chain/swap/native/api/affiliate.ts
+++ b/packages/core/chain/swap/native/api/affiliate.ts
@@ -32,10 +32,7 @@ export const buildAffiliateParams = ({
     })
     affiliateParams.push({
       affiliate: config.affiliateFeeAddress,
-      bps: Math.max(
-        0,
-        affiliateBps - (baseAffiliateBps - config.referralDiscountAffiliateFeeRateBps)
-      ),
+      bps: Math.max(0, affiliateBps - (baseAffiliateBps - config.referralDiscountAffiliateFeeRateBps)),
     })
   } else {
     affiliateParams.push({

--- a/packages/core/chain/swap/native/api/affiliate.ts
+++ b/packages/core/chain/swap/native/api/affiliate.ts
@@ -3,10 +3,13 @@ import { baseAffiliateBps } from '../../affiliate/config'
 import { nativeSwapAffiliateConfig } from '../nativeSwapAffiliateConfig'
 import { NativeSwapChain } from '../NativeSwapChain'
 
+export type NativeSwapAffiliateConfig = typeof nativeSwapAffiliateConfig
+
 type BuildAffiliateParamsInput = {
   swapChain: NativeSwapChain
   referral?: string
   affiliateBps: number
+  config?: NativeSwapAffiliateConfig
 }
 
 type AffiliateParams = {
@@ -18,24 +21,25 @@ export const buildAffiliateParams = ({
   swapChain,
   referral,
   affiliateBps,
+  config = nativeSwapAffiliateConfig,
 }: BuildAffiliateParamsInput): AffiliateParams => {
   const affiliateParams: Array<{ affiliate: string; bps: number }> = []
 
   if (swapChain === Chain.THORChain && referral) {
     affiliateParams.push({
       affiliate: referral,
-      bps: nativeSwapAffiliateConfig.referrerFeeRateBps,
+      bps: config.referrerFeeRateBps,
     })
     affiliateParams.push({
-      affiliate: nativeSwapAffiliateConfig.affiliateFeeAddress,
+      affiliate: config.affiliateFeeAddress,
       bps: Math.max(
         0,
-        affiliateBps - (baseAffiliateBps - nativeSwapAffiliateConfig.referralDiscountAffiliateFeeRateBps)
+        affiliateBps - (baseAffiliateBps - config.referralDiscountAffiliateFeeRateBps)
       ),
     })
   } else {
     affiliateParams.push({
-      affiliate: nativeSwapAffiliateConfig.affiliateFeeAddress,
+      affiliate: config.affiliateFeeAddress,
       bps: affiliateBps,
     })
   }

--- a/packages/core/chain/swap/native/api/getNativeSwapQuote.ts
+++ b/packages/core/chain/swap/native/api/getNativeSwapQuote.ts
@@ -16,7 +16,7 @@ import {
 } from '../NativeSwapChain'
 import { NativeSwapQuote } from '../NativeSwapQuote'
 import { getNativeSwapDecimals } from '../utils/getNativeSwapDecimals'
-import { buildAffiliateParams } from './affiliate'
+import { buildAffiliateParams, NativeSwapAffiliateConfig } from './affiliate'
 
 type GetNativeSwapQuoteInput = Record<TransferDirection, AccountCoin> & {
   swapChain: NativeSwapChain
@@ -24,6 +24,7 @@ type GetNativeSwapQuoteInput = Record<TransferDirection, AccountCoin> & {
   amount: number
   referral?: string
   affiliateBps?: number
+  nativeAffiliateConfig?: NativeSwapAffiliateConfig
 }
 
 type NativeSwapQuoteErrorResponse = {
@@ -45,6 +46,7 @@ const requestNativeSwapQuote = async ({
   streamingQuantity,
   affiliateBps,
   referral,
+  nativeAffiliateConfig,
 }: {
   swapChain: NativeSwapChain
   swapBaseUrl: string
@@ -56,6 +58,7 @@ const requestNativeSwapQuote = async ({
   streamingQuantity?: number
   affiliateBps?: number
   referral?: string
+  nativeAffiliateConfig?: NativeSwapAffiliateConfig
 }): Promise<NativeSwapQuoteResponse | NativeSwapQuoteErrorResponse> => {
   const params = new URLSearchParams({
     from_asset: fromAsset,
@@ -69,6 +72,7 @@ const requestNativeSwapQuote = async ({
           swapChain,
           referral,
           affiliateBps,
+          config: nativeAffiliateConfig,
         })
       : {}),
   })
@@ -100,6 +104,7 @@ export const getNativeSwapQuote = async ({
   amount,
   affiliateBps,
   referral,
+  nativeAffiliateConfig,
 }: GetNativeSwapQuoteInput): Promise<NativeSwapQuote> => {
   const [fromAsset, toAsset] = [from, to].map(asset => toNativeSwapAsset(asset))
 
@@ -120,6 +125,7 @@ export const getNativeSwapQuote = async ({
       streamingInterval: nativeSwapStreamingInterval[swapChain],
       affiliateBps,
       referral,
+      nativeAffiliateConfig,
     })
 
     return {
@@ -138,6 +144,7 @@ export const getNativeSwapQuote = async ({
     streamingInterval: nativeSwapStreamingInterval[swapChain],
     affiliateBps,
     referral,
+    nativeAffiliateConfig,
   })
 
   const rapid = assertOkQuote(rapidResult, from)
@@ -165,6 +172,7 @@ export const getNativeSwapQuote = async ({
       streamingQuantity,
       affiliateBps,
       referral,
+      nativeAffiliateConfig,
     })
     streaming = assertOkQuote(streamingRes, from)
   } catch (error) {

--- a/packages/core/chain/swap/native/stationNativeSwapAffiliateConfig.ts
+++ b/packages/core/chain/swap/native/stationNativeSwapAffiliateConfig.ts
@@ -1,0 +1,5 @@
+export const stationNativeSwapAffiliateConfig = {
+  affiliateFeeAddress: 'stvs',
+  referralDiscountAffiliateFeeRateBps: 35,
+  referrerFeeRateBps: 10,
+}

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -1,7 +1,10 @@
 import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
 import { getLifiSwapQuote } from '@vultisig/core-chain/swap/general/lifi/api/getLifiSwapQuote'
 import { lifiSwapEnabledChains } from '@vultisig/core-chain/swap/general/lifi/LifiSwapEnabledChains'
-import { getOneInchSwapQuote, OneInchAffiliateConfig } from '@vultisig/core-chain/swap/general/oneInch/api/getOneInchSwapQuote'
+import {
+  getOneInchSwapQuote,
+  OneInchAffiliateConfig,
+} from '@vultisig/core-chain/swap/general/oneInch/api/getOneInchSwapQuote'
 import { oneInchSwapEnabledChains } from '@vultisig/core-chain/swap/general/oneInch/OneInchSwapEnabledChains'
 import { getSwapKitQuote } from '@vultisig/core-chain/swap/general/swapkit/api/getSwapKitQuote'
 import {
@@ -23,8 +26,8 @@ import { SwapDiscount } from '../discount/SwapDiscount'
 import { getKyberSwapQuote } from '../general/kyber/api/quote'
 import { kyberSwapEnabledChains } from '../general/kyber/chains'
 import { KyberSwapBaseAffiliateConfig } from '../general/kyber/config'
-import { getNativeSwapQuote } from '../native/api/getNativeSwapQuote'
 import { NativeSwapAffiliateConfig } from '../native/api/affiliate'
+import { getNativeSwapQuote } from '../native/api/getNativeSwapQuote'
 import { nativeSwapChains, nativeSwapEnabledChainsRecord } from '../native/NativeSwapChain'
 import { getNativeSwapDecimals } from '../native/utils/getNativeSwapDecimals'
 import { SwapQuote } from './SwapQuote'

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -1,7 +1,7 @@
 import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
 import { getLifiSwapQuote } from '@vultisig/core-chain/swap/general/lifi/api/getLifiSwapQuote'
 import { lifiSwapEnabledChains } from '@vultisig/core-chain/swap/general/lifi/LifiSwapEnabledChains'
-import { getOneInchSwapQuote } from '@vultisig/core-chain/swap/general/oneInch/api/getOneInchSwapQuote'
+import { getOneInchSwapQuote, OneInchAffiliateConfig } from '@vultisig/core-chain/swap/general/oneInch/api/getOneInchSwapQuote'
 import { oneInchSwapEnabledChains } from '@vultisig/core-chain/swap/general/oneInch/OneInchSwapEnabledChains'
 import { getSwapKitQuote } from '@vultisig/core-chain/swap/general/swapkit/api/getSwapKitQuote'
 import {
@@ -22,15 +22,27 @@ import { getSwapAffiliateBps, VultDiscountTier } from '../affiliate'
 import { SwapDiscount } from '../discount/SwapDiscount'
 import { getKyberSwapQuote } from '../general/kyber/api/quote'
 import { kyberSwapEnabledChains } from '../general/kyber/chains'
+import { KyberSwapBaseAffiliateConfig } from '../general/kyber/config'
 import { getNativeSwapQuote } from '../native/api/getNativeSwapQuote'
+import { NativeSwapAffiliateConfig } from '../native/api/affiliate'
 import { nativeSwapChains, nativeSwapEnabledChainsRecord } from '../native/NativeSwapChain'
 import { getNativeSwapDecimals } from '../native/utils/getNativeSwapDecimals'
 import { SwapQuote } from './SwapQuote'
+
+/** Optional per-aggregator affiliate overrides. When absent each aggregator
+ * falls back to its own vultisig-0 default — no behavior change for existing
+ * callers. Station consumers pass the station* configs from the station barrel. */
+export type SwapAffiliateConfig = {
+  native?: NativeSwapAffiliateConfig
+  oneInch?: OneInchAffiliateConfig
+  kyber?: KyberSwapBaseAffiliateConfig
+}
 
 export type FindSwapQuoteInput = Record<TransferDirection, AccountCoin> & {
   amount: bigint
   referral?: string
   vultDiscountTier?: VultDiscountTier | null
+  affiliateConfig?: SwapAffiliateConfig
 }
 
 type SwapQuoteProviderName = 'KyberSwap' | '1inch' | 'LiFi' | 'SwapKit' | 'THORChain' | 'MayaChain'
@@ -106,6 +118,7 @@ export const findSwapQuote = async ({
   amount,
   referral,
   vultDiscountTier,
+  affiliateConfig,
 }: FindSwapQuoteInput): Promise<SwapQuote> => {
   const affiliateBps = getSwapAffiliateBps(vultDiscountTier ?? null)
 
@@ -133,6 +146,7 @@ export const findSwapQuote = async ({
           amount: amountNumber,
           referral,
           affiliateBps,
+          nativeAffiliateConfig: affiliateConfig?.native,
         })
 
         return {
@@ -168,6 +182,7 @@ export const findSwapQuote = async ({
             },
             amount: chainAmount,
             affiliateBps,
+            kyberConfig: affiliateConfig?.kyber,
           })
 
           return { quote: { general }, discounts: vultDiscount }
@@ -185,6 +200,7 @@ export const findSwapQuote = async ({
             toCoinId: to.id ?? to.ticker,
             amount: chainAmount,
             affiliateBps,
+            oneInchConfig: affiliateConfig?.oneInch,
           })
 
           return { quote: { general }, discounts: vultDiscount }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -195,12 +195,12 @@ export type { SwapKitConfig } from '@vultisig/core-chain/swap/general/swapkit/co
 export { configureSwapKit, getSwapKitConfig } from '@vultisig/core-chain/swap/general/swapkit/config'
 
 // Station affiliate configs — parallel to vultisig-0 defaults, for Station consumers
-export type { SwapAffiliateConfig } from '@vultisig/core-chain/swap/quote/findSwapQuote'
 export {
+  stationKyberSwapAffiliateConfig,
   stationNativeSwapAffiliateConfig,
   stationOneInchAffiliateConfig,
-  stationKyberSwapAffiliateConfig,
 } from '@vultisig/core-chain/swap/affiliate/station'
+export type { SwapAffiliateConfig } from '@vultisig/core-chain/swap/quote/findSwapQuote'
 
 // THORChain LP primitives (v2: auto-pair, lockup, halts, mimir pause gate)
 export { getThorchainInboundAddress } from '@vultisig/core-chain/chains/cosmos/thor/getThorchainInboundAddress'

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -194,6 +194,14 @@ export {
 export type { SwapKitConfig } from '@vultisig/core-chain/swap/general/swapkit/config'
 export { configureSwapKit, getSwapKitConfig } from '@vultisig/core-chain/swap/general/swapkit/config'
 
+// Station affiliate configs — parallel to vultisig-0 defaults, for Station consumers
+export type { SwapAffiliateConfig } from '@vultisig/core-chain/swap/quote/findSwapQuote'
+export {
+  stationNativeSwapAffiliateConfig,
+  stationOneInchAffiliateConfig,
+  stationKyberSwapAffiliateConfig,
+} from '@vultisig/core-chain/swap/affiliate/station'
+
 // THORChain LP primitives (v2: auto-pair, lockup, halts, mimir pause gate)
 export { getThorchainInboundAddress } from '@vultisig/core-chain/chains/cosmos/thor/getThorchainInboundAddress'
 export * from '@vultisig/core-chain/chains/cosmos/thor/lp'

--- a/packages/sdk/src/tools/swap/findSwapQuote.ts
+++ b/packages/sdk/src/tools/swap/findSwapQuote.ts
@@ -1,8 +1,10 @@
 import { Chain } from '@vultisig/core-chain/Chain'
 import type { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
 import type { VultDiscountTier } from '@vultisig/core-chain/swap/affiliate'
-import { findSwapQuote as coreFindSwapQuote } from '@vultisig/core-chain/swap/quote/findSwapQuote'
+import { findSwapQuote as coreFindSwapQuote, SwapAffiliateConfig } from '@vultisig/core-chain/swap/quote/findSwapQuote'
 import type { SwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
+
+export type { SwapAffiliateConfig }
 
 export type FindSwapQuoteParams = {
   fromChain: Chain
@@ -20,6 +22,7 @@ export type FindSwapQuoteParams = {
   amount: bigint
   referral?: string
   vultDiscountTier?: VultDiscountTier | null
+  affiliateConfig?: SwapAffiliateConfig
 }
 
 export type { SwapQuote }
@@ -66,5 +69,6 @@ export const findSwapQuote = async (params: FindSwapQuoteParams): Promise<SwapQu
     amount: params.amount,
     referral: params.referral,
     vultDiscountTier: params.vultDiscountTier,
+    affiliateConfig: params.affiliateConfig,
   })
 }


### PR DESCRIPTION
## what

Adds Station-affiliate config siblings alongside the existing vultisig-0 configs. Zero behavior change for Vultisig Windows/iOS — those import the unchanged vultisig-0 constants.

Station consumers (mcp-ts — separate PR) will import the station* configs.

## config values

| Aggregator | Field | Value |
|---|---|---|
| THORChain + Maya | `affiliateFeeAddress` | `stvs` (live on-chain) |
| 1inch | `referrer` | `0x649E1289fD780C2F9A3D27476511283EB0d0076D` |
| KyberSwap | `referral` / `feeReceiver` | `0x649E1289fD780C2F9A3D27476511283EB0d0076D` |
| KyberSwap | `source` | `vultisig-v0` (temp fallback — Station source ID pending Kyber confirmation, fees still flow correctly) |

## injection seam

`findSwapQuote` now accepts an optional `affiliateConfig?: SwapAffiliateConfig` that carries all three per-aggregator configs and threads them through. When absent, each aggregator falls back to its vultisig-0 default — zero blast radius for existing callers.

The individual functions (`buildAffiliateParams`, `getOneInchSwapQuote`, `getKyberSwapRoute`, `getKyberSwapTx`) each get an optional config param with the same default-to-vultisig-0 pattern.

## files added

- `swap/native/stationNativeSwapAffiliateConfig.ts`
- `swap/general/oneInch/stationOneInchAffiliateConfig.ts`
- `swap/general/kyber/stationConfig.ts`
- `swap/affiliate/station.ts` (barrel re-export)

## tests

547 tests pass (544 existing unchanged + 3 new proving Station config flows through buildAffiliateParams / getOneInchSwapQuote / getKyberSwapQuote).

## receipts

```
$ curl -s https://gateway.liquify.com/chain/thorchain_api/thorchain/thorname/stvs | jq
{
  "name": "stvs",
  "expire_block_height": 56539837,
  "owner": "thor18g2rlr8845g64xr60qvljyk3n3pnf8s5w352fm",
  "preferred_asset": "ETH.USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48",
  "aliases": [
    {"chain": "THOR", "address": "thor18g2rlr8845g64xr60qvljyk3n3pnf8s5w352fm"},
    {"chain": "ETH", "address": "0x649E1289fD780C2F9A3D27476511283EB0d0076D"}
  ]
}
```

`stvs` is live. ETH alias matches the Station EVM address in the config. Affiliate revenue accumulates as RUNE and auto-swaps to ETH USDC at threshold.

🤖 Agent-generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added station-specific affiliate configurations for multiple swap providers (native, Kyber, 1inch), enabling customizable affiliate settings per aggregator.
  * Enhanced swap quoting system to accept optional affiliate configuration overrides, providing greater control over affiliate parameters across different swap routes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/517?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->