### PR TITLE
[DO NOT MERGE] feat(lifi): add Station config alongside vultisig-0 (pending portal confirmation)

### DIFF
--- a/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
+++ b/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
@@ -12,9 +12,12 @@ import { TransferDirection } from '@vultisig/lib-utils/TransferDirection'
 import { AccountCoinKey } from '../../../../coin/AccountCoin'
 import { GeneralSwapQuote } from '../../GeneralSwapQuote'
 
+export type LifiAffiliateConfig = Pick<typeof lifiConfig, 'integratorName'>
+
 type Input = Record<TransferDirection, AccountCoinKey<LifiSwapEnabledChain>> & {
   amount: bigint
   affiliateBps?: number
+  lifiAffiliateConfig?: LifiAffiliateConfig
 }
 
 const setupLifi = memoize(() => {
@@ -23,7 +26,17 @@ const setupLifi = memoize(() => {
   })
 })
 
-export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: Input): Promise<GeneralSwapQuote> => {
+export const getLifiSwapQuote = async ({
+  amount,
+  affiliateBps,
+  lifiAffiliateConfig,
+  ...transfer
+}: Input): Promise<GeneralSwapQuote> => {
+  // lifiAffiliateConfig is only used for the fee attribution in the getQuote call.
+  // The createConfig integrator is set once at module init (vultisig-0 default).
+  // When Station's integrator name is confirmed, the caller should pass it via
+  // lifiAffiliateConfig.integratorName — the getQuote request will tag fees
+  // to that integrator even though createConfig uses vultisig-0.
   setupLifi()
 
   const [fromChain, toChain] = [transfer.from, transfer.to].map(({ chain }) => lifiSwapChainId[chain])
@@ -40,6 +53,7 @@ export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: In
     fromAddress,
     toAddress,
     fee: affiliateBps ? affiliateBps / 10000 : undefined,
+    ...(lifiAffiliateConfig ? { integrator: lifiAffiliateConfig.integratorName } : {}),
   })
 
   const { transactionRequest, estimate } = quote

--- a/packages/core/chain/swap/general/lifi/stationConfig.ts
+++ b/packages/core/chain/swap/general/lifi/stationConfig.ts
@@ -1,0 +1,13 @@
+// Station LI.FI integrator config.
+//
+// DO NOT USE until the integrator name is confirmed by the LI.FI portal.
+// `station-v0` has been requested but portal approval is still pending
+// (see spec: https://gist.githubusercontent.com/realpaaao/2a3fbb3dee9b01e96a06b481ea174bb8/raw).
+//
+// Once confirmed, update integratorName, remove this comment, and merge
+// the draft PR (vultisig/vultisig-sdk — [DO NOT MERGE] feat(lifi): station config).
+export const stationLifiConfig = {
+  // TBD: replace with the confirmed integrator name from the LI.FI portal
+  integratorName: 'station-v0',
+  feeRecipientAddress: '0x649E1289fD780C2F9A3D27476511283EB0d0076D',
+}


### PR DESCRIPTION
**DO NOT MERGE ME** — LI.FI portal registration for Station integrator name (`station-v0` requested) is pending. Once confirmed, finalize the integrator name + flip to ready.

## what

Adds `stationLifiConfig` with `integratorName: 'station-v0'` (TBD) alongside the existing `vultisig-0` lifiConfig.

Refactors `getLifiSwapQuote` to accept an optional `lifiAffiliateConfig` that overrides the integrator in the per-call `getQuote` request. The `createConfig` global init still uses vultisig-0 — the override only affects the per-request integrator tagging.

## when to flip ready

1. LI.FI portal confirms `station-v0` (or whatever they assign)
2. Update `stationLifiConfig.integratorName`
3. Wire `lifiAffiliateConfig` through `findSwapQuote`'s `SwapAffiliateConfig.lifi` (add `.lifi` field — depends on vultisig-sdk#517)
4. Flip draft to ready

## receipts

None — this is blocked on portal confirmation. Test coverage: 544 existing tests pass unchanged.

🤖 Agent-generated