### PR TITLE
feat(swap/quote): thor-bias for L1 swaps when both direct THORChain + SwapKit return routes

### DIFF
--- a/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
@@ -229,6 +229,30 @@ describe('findSwapQuote parallel selection', () => {
     expect(quote.quote.general.provider).toBe('kyber')
   })
 
+  it('tie-break: 1inch wins over SwapKit on equal output by declared preference', async () => {
+    // 1inch is ranked 2nd, SwapKit is ranked 4th in aggregatorPreferenceOrder.
+    // On an equal-output tie, 1inch must win regardless of fetcher array order
+    // (which is determined dynamically by shouldPreferGeneralSwap). This
+    // exercises the declared-preference tie-break introduced in #521 r3 to
+    // replace the previous implicit index-based tie-break. (NeO should-fix.)
+    vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('skip kyber'))
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
+    vi.mocked(getNativeSwapQuote).mockRejectedValue(new Error('skip native'))
+    vi.mocked(getOneInchSwapQuote).mockResolvedValue(minimalGeneralQuote('500', '1inch'))
+    vi.mocked(getSwapKitQuote).mockResolvedValue(minimalGeneralQuote('500', 'swapkit'))
+
+    const quote = await findSwapQuote({
+      ...evmSameChainCoins,
+      amount: 1n,
+    })
+
+    expect('general' in quote.quote).toBe(true)
+    if (!('general' in quote.quote)) {
+      throw new Error('Expected general quote')
+    }
+    expect(quote.quote.general.provider).toBe('1inch')
+  })
+
   it('when all providers fail, reports every attempted provider', async () => {
     const mayaError = 'maya last error'
     vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('first fail'))

--- a/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
@@ -112,16 +112,14 @@ describe('findSwapQuote parallel selection', () => {
     expect(getNativeSwapQuote).toHaveBeenCalled()
   })
 
-  it('ranks by destination-decimal-normalized output (higher raw native can still lose)', async () => {
+  it('ranks by destination-decimal-normalized output among aggregators when no native route exists', async () => {
     vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('skip inch'))
     vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
-    vi.mocked(getSwapKitQuote).mockRejectedValue(new Error('skip swapkit'))
-    // 1 USDC (6 decimals) on the general side.
+    vi.mocked(getSwapKitQuote).mockResolvedValue(minimalGeneralQuote('900000', 'swapkit'))
+    // 1 USDC (6 decimals) on the general side via kyber — higher comparable output.
     vi.mocked(getKyberSwapQuote).mockResolvedValue(minimalGeneralQuote('1000000', 'kyber'))
-    vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) =>
-      // 50_000_000 in 8-decimal is > 1_000_000 raw, but 50_000_000 / 1e2 = 500_000 < 1_000_000 comparable.
-      minimalNativeQuote(swapChain, '50000000')
-    )
+    // No native quote available — hard THOR priority doesn't apply.
+    vi.mocked(getNativeSwapQuote).mockRejectedValue(new Error('native unavailable'))
 
     const quote = await findSwapQuote({
       ...evmSameChainCoins,
@@ -391,13 +389,13 @@ describe('findSwapQuote THOR/Maya bias (paaao directive 2026-05-22)', () => {
     expect(quote.quote.native.expected_amount_out).toBe('100000000')
   })
 
-  it('does NOT prefer THORChain when SwapKit is better by 10% (outside 5% bias)', async () => {
+  it('prefers THORChain over SwapKit even when SwapKit is 10% better (hard priority, no output comparison)', async () => {
     vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('skip kyber'))
     vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('skip inch'))
     vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
-    // SwapKit: gross output 1_100_000.
+    // SwapKit: gross output 1_100_000 (10% higher than THORChain).
     vi.mocked(getSwapKitQuote).mockResolvedValue(minimalGeneralQuote('1100000', 'swapkit'))
-    // THORChain native: comparable 1_000_000 (raw 100_000_000 in 8-dec). 9.09% lower → outside bias.
+    // THORChain native: comparable 1_000_000. Hard priority means THOR still wins.
     vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) => {
       if (swapChain === Chain.THORChain) {
         return minimalNativeQuote(swapChain, '100000000')
@@ -410,11 +408,10 @@ describe('findSwapQuote THOR/Maya bias (paaao directive 2026-05-22)', () => {
       amount: 1n,
     })
 
-    if (!('general' in quote.quote)) {
-      throw new Error('Expected aggregator quote when bias is exceeded')
+    if (!('native' in quote.quote)) {
+      throw new Error('Expected THORChain to win via hard priority regardless of SwapKit output')
     }
-    expect(quote.quote.general.provider).toBe('swapkit')
-    expect(quote.quote.general.dstAmount).toBe('1100000')
+    expect(quote.quote.native.swapChain).toBe(Chain.THORChain)
   })
 
   it('only SwapKit available → SwapKit wins (no native bias applies)', async () => {

--- a/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
@@ -483,6 +483,38 @@ describe('findSwapQuote THOR/Maya bias (paaao directive 2026-05-22)', () => {
     expect(quote.quote.native.swapChain).toBe(Chain.THORChain)
   })
 
+  it('when both THORChain and MayaChain succeed, returns the one with higher comparable output', async () => {
+    // Ethereum is supported by both THORChain and MayaChain.
+    // dst.decimals = 6 (evmSameChainCoins); native amounts are 8-dec canonical,
+    // so comparable = raw / 100.
+    vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('skip kyber'))
+    vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('skip inch'))
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
+    vi.mocked(getSwapKitQuote).mockRejectedValue(new Error('skip swapkit'))
+    // THORChain: 100_000_000 raw → 1_000_000 comparable.
+    // MayaChain:  120_000_000 raw → 1_200_000 comparable. Maya wins.
+    vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) => {
+      if (swapChain === Chain.THORChain) {
+        return minimalNativeQuote(swapChain, '100000000')
+      }
+      if (swapChain === Chain.MayaChain) {
+        return minimalNativeQuote(swapChain, '120000000')
+      }
+      throw new Error(`unexpected swapChain: ${swapChain}`)
+    })
+
+    const quote = await findSwapQuote({
+      ...evmSameChainCoins,
+      amount: 1n,
+    })
+
+    if (!('native' in quote.quote)) {
+      throw new Error('Expected a native quote')
+    }
+    expect(quote.quote.native.swapChain).toBe(Chain.MayaChain)
+    expect(quote.quote.native.expected_amount_out).toBe('120000000')
+  })
+
   it('MayaChain also benefits from the bias when it is the only native option', async () => {
     // Use Arbitrum ↔ Arbitrum: Maya supports Arbitrum (per nativeSwapEnabledChainsRecord),
     // SwapKit supports Arbitrum as well. THORChain does NOT support Arbitrum.

--- a/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
@@ -350,3 +350,183 @@ describe('findSwapQuote parallel selection', () => {
     ).rejects.toThrow('Swap amount too small. Please increase the amount to proceed.')
   })
 })
+
+describe('findSwapQuote THOR/Maya bias (paaao directive 2026-05-22)', () => {
+  beforeEach(() => {
+    vi.mocked(getKyberSwapQuote).mockReset()
+    vi.mocked(getOneInchSwapQuote).mockReset()
+    vi.mocked(getLifiSwapQuote).mockReset()
+    vi.mocked(getSwapKitQuote).mockReset()
+    vi.mocked(getNativeSwapQuote).mockReset()
+  })
+
+  // `evmSameChainCoins` has dst.decimals = 6. Aggregator dstAmount is already in
+  // dst decimals. Native THORChain amounts are 8-decimal canonical → comparable
+  // value = raw / 10^(8 - 6) = raw / 100. So to make THOR comparable-output ≈ X
+  // (in 6 decimals), set native expected_amount_out = X * 100.
+
+  it('prefers direct THORChain when SwapKit is better by 2% (inside 5% bias)', async () => {
+    vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('skip kyber'))
+    vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('skip inch'))
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
+    // SwapKit: gross output 1_020_000 (in 6 dec).
+    vi.mocked(getSwapKitQuote).mockResolvedValue(minimalGeneralQuote('1020000', 'swapkit'))
+    // THORChain native: comparable 1_000_000 (raw 100_000_000 in 8-dec). 1.96% lower → inside bias.
+    vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) => {
+      if (swapChain === Chain.THORChain) {
+        return minimalNativeQuote(swapChain, '100000000')
+      }
+      throw new Error('maya skip')
+    })
+
+    const quote = await findSwapQuote({
+      ...evmSameChainCoins,
+      amount: 1n,
+    })
+
+    if (!('native' in quote.quote)) {
+      throw new Error('Expected native THORChain quote to win via bias')
+    }
+    expect(quote.quote.native.swapChain).toBe(Chain.THORChain)
+    expect(quote.quote.native.expected_amount_out).toBe('100000000')
+  })
+
+  it('does NOT prefer THORChain when SwapKit is better by 10% (outside 5% bias)', async () => {
+    vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('skip kyber'))
+    vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('skip inch'))
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
+    // SwapKit: gross output 1_100_000.
+    vi.mocked(getSwapKitQuote).mockResolvedValue(minimalGeneralQuote('1100000', 'swapkit'))
+    // THORChain native: comparable 1_000_000 (raw 100_000_000 in 8-dec). 9.09% lower → outside bias.
+    vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) => {
+      if (swapChain === Chain.THORChain) {
+        return minimalNativeQuote(swapChain, '100000000')
+      }
+      throw new Error('maya skip')
+    })
+
+    const quote = await findSwapQuote({
+      ...evmSameChainCoins,
+      amount: 1n,
+    })
+
+    if (!('general' in quote.quote)) {
+      throw new Error('Expected aggregator quote when bias is exceeded')
+    }
+    expect(quote.quote.general.provider).toBe('swapkit')
+    expect(quote.quote.general.dstAmount).toBe('1100000')
+  })
+
+  it('only SwapKit available → SwapKit wins (no native bias applies)', async () => {
+    vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('skip kyber'))
+    vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('skip inch'))
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
+    vi.mocked(getSwapKitQuote).mockResolvedValue(minimalGeneralQuote('1000000', 'swapkit'))
+    vi.mocked(getNativeSwapQuote).mockRejectedValue(new Error('native unavailable'))
+
+    const quote = await findSwapQuote({
+      ...evmSameChainCoins,
+      amount: 1n,
+    })
+
+    if (!('general' in quote.quote)) {
+      throw new Error('Expected SwapKit quote')
+    }
+    expect(quote.quote.general.provider).toBe('swapkit')
+  })
+
+  it('only THORChain available → THORChain wins', async () => {
+    vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('skip kyber'))
+    vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('skip inch'))
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
+    vi.mocked(getSwapKitQuote).mockRejectedValue(new Error('swapkit unavailable'))
+    vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) => {
+      if (swapChain === Chain.THORChain) {
+        return minimalNativeQuote(swapChain, '100000000')
+      }
+      throw new Error('maya skip')
+    })
+
+    const quote = await findSwapQuote({
+      ...evmSameChainCoins,
+      amount: 1n,
+    })
+
+    if (!('native' in quote.quote)) {
+      throw new Error('Expected THORChain native quote')
+    }
+    expect(quote.quote.native.swapChain).toBe(Chain.THORChain)
+  })
+
+  it('SwapKit ties THORChain on output → THORChain wins via bias (Δ=0 is within any bias)', async () => {
+    vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('skip kyber'))
+    vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('skip inch'))
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
+    // SwapKit: 1_000_000 (6-dec).
+    vi.mocked(getSwapKitQuote).mockResolvedValue(minimalGeneralQuote('1000000', 'swapkit'))
+    // THORChain native: 100_000_000 raw (8-dec) → 1_000_000 comparable.
+    vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) => {
+      if (swapChain === Chain.THORChain) {
+        return minimalNativeQuote(swapChain, '100000000')
+      }
+      throw new Error('maya skip')
+    })
+
+    const quote = await findSwapQuote({
+      ...evmSameChainCoins,
+      amount: 1n,
+    })
+
+    // On an exact tie, the EVM-EVM same-chain path puts general first, so
+    // tie-break makes SwapKit the initial `best`. But THORChain is within bias
+    // (Δ=0) so it should be selected by the bias step.
+    if (!('native' in quote.quote)) {
+      throw new Error('Expected THORChain native quote to win on tie via bias')
+    }
+    expect(quote.quote.native.swapChain).toBe(Chain.THORChain)
+  })
+
+  it('MayaChain also benefits from the bias when it is the only native option', async () => {
+    // Use Arbitrum ↔ Arbitrum: Maya supports Arbitrum (per nativeSwapEnabledChainsRecord),
+    // SwapKit supports Arbitrum as well. THORChain does NOT support Arbitrum.
+    const arbCoins = {
+      from: {
+        chain: Chain.Arbitrum,
+        address: '0xsender',
+        id: '0xsrc',
+        decimals: 18,
+        ticker: 'SRC',
+      },
+      to: {
+        chain: Chain.Arbitrum,
+        address: '0xsender',
+        id: '0xdst',
+        decimals: 6,
+        ticker: 'DST',
+      },
+    } as const
+
+    vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('skip kyber'))
+    vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('skip inch'))
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
+    // SwapKit better by ~2%.
+    vi.mocked(getSwapKitQuote).mockResolvedValue(minimalGeneralQuote('1020000', 'swapkit'))
+    // Maya native: 8-dec canonical → 1_000_000 comparable.
+    vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) => {
+      if (swapChain === Chain.MayaChain) {
+        return minimalNativeQuote(swapChain, '100000000')
+      }
+      throw new Error('thor skip')
+    })
+
+    const quote = await findSwapQuote({
+      ...arbCoins,
+      amount: 1n,
+    })
+
+    if (!('native' in quote.quote)) {
+      throw new Error('Expected Maya native quote to win via bias on Arbitrum')
+    }
+    expect(quote.quote.native.swapChain).toBe(Chain.MayaChain)
+  })
+})

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -1,4 +1,11 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { isChainOfKind } from '@vultisig/core-chain/ChainKind'
 import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+import { getSwapAffiliateBps, VultDiscountTier } from '@vultisig/core-chain/swap/affiliate'
+import { SwapDiscount } from '@vultisig/core-chain/swap/discount/SwapDiscount'
+import { getKyberSwapQuote } from '@vultisig/core-chain/swap/general/kyber/api/quote'
+import { kyberSwapEnabledChains } from '@vultisig/core-chain/swap/general/kyber/chains'
+import { KyberSwapBaseAffiliateConfig } from '@vultisig/core-chain/swap/general/kyber/config'
 import { getLifiSwapQuote } from '@vultisig/core-chain/swap/general/lifi/api/getLifiSwapQuote'
 import { lifiSwapEnabledChains } from '@vultisig/core-chain/swap/general/lifi/LifiSwapEnabledChains'
 import {
@@ -11,6 +18,10 @@ import {
   swapKitEnabledChains,
   swapKitSourceChains,
 } from '@vultisig/core-chain/swap/general/swapkit/SwapKitEnabledChains'
+import { NativeSwapAffiliateConfig } from '@vultisig/core-chain/swap/native/api/affiliate'
+import { getNativeSwapQuote } from '@vultisig/core-chain/swap/native/api/getNativeSwapQuote'
+import { nativeSwapChains, nativeSwapEnabledChainsRecord } from '@vultisig/core-chain/swap/native/NativeSwapChain'
+import { getNativeSwapDecimals } from '@vultisig/core-chain/swap/native/utils/getNativeSwapDecimals'
 import { NoSwapRoutesError } from '@vultisig/core-chain/swap/NoSwapRoutesError'
 import { isEmpty } from '@vultisig/lib-utils/array/isEmpty'
 import { isOneOf } from '@vultisig/lib-utils/array/isOneOf'
@@ -19,17 +30,6 @@ import { isInError } from '@vultisig/lib-utils/error/isInError'
 import { pick } from '@vultisig/lib-utils/record/pick'
 import { TransferDirection } from '@vultisig/lib-utils/TransferDirection'
 
-import { Chain } from '../../Chain'
-import { isChainOfKind } from '../../ChainKind'
-import { getSwapAffiliateBps, VultDiscountTier } from '../affiliate'
-import { SwapDiscount } from '../discount/SwapDiscount'
-import { getKyberSwapQuote } from '../general/kyber/api/quote'
-import { kyberSwapEnabledChains } from '../general/kyber/chains'
-import { KyberSwapBaseAffiliateConfig } from '../general/kyber/config'
-import { NativeSwapAffiliateConfig } from '../native/api/affiliate'
-import { getNativeSwapQuote } from '../native/api/getNativeSwapQuote'
-import { nativeSwapChains, nativeSwapEnabledChainsRecord } from '../native/NativeSwapChain'
-import { getNativeSwapDecimals } from '../native/utils/getNativeSwapDecimals'
 import { SwapQuote } from './SwapQuote'
 
 /** Optional per-aggregator affiliate overrides. When absent each aggregator

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -60,7 +60,32 @@ type SwapQuoteFetcher = {
 type RankedSwapQuote = {
   quote: SwapQuote
   outputAmount: bigint
+  providerName: SwapQuoteProviderName
 }
+
+/**
+ * Bias window (in bps of best comparable output) within which a direct native
+ * THORChain / MayaChain route is preferred over a higher-output aggregator route.
+ *
+ * Rationale (paaao, 2026-05-22): for L1 ↔ L1 swaps that THORChain natively serves,
+ * the protocol-aligned route is preferred even when an aggregator (e.g. SwapKit)
+ * gross-output is slightly higher. Direct THORChain captures full vultisig
+ * affiliate revenue (50bps) and avoids the SwapKit fee skim; the protocol is the
+ * moat. Mirrors the priority-order short-circuit used in vultisig-ios's
+ * `SwapService.fetchQuote` + `Coin+Swaps.swapProviders`, ported as a soft bias
+ * here so a clearly-better aggregator route (>5% above THOR) still wins.
+ *
+ * 500 bps = 5%. Conservative: covers normal LP slippage / pool depth variance
+ * without ceding obviously-better aggregator routes.
+ */
+export const nativeSwapBiasOutputBps = 500n
+
+const nativeProviderNames = ['THORChain', 'MayaChain'] as const satisfies readonly SwapQuoteProviderName[]
+
+type NativeProviderName = (typeof nativeProviderNames)[number]
+
+const isNativeProvider = (name: SwapQuoteProviderName): name is NativeProviderName =>
+  (nativeProviderNames as readonly SwapQuoteProviderName[]).includes(name)
 
 /** Re-base an integer amount from `fromDecimals` fixed-point to `toDecimals`. */
 function rebaseDecimals(value: bigint, fromDecimals: number, toDecimals: number): bigint {
@@ -95,8 +120,7 @@ function getComparableOutputAmount(q: SwapQuote, to: AccountCoin): bigint {
 }
 
 function selectBestEligibleQuote(settled: PromiseSettledResult<RankedSwapQuote>[]): SwapQuote | null {
-  let best: SwapQuote | null = null
-  let bestAmount: bigint | null = null
+  let best: RankedSwapQuote | null = null
   let bestIndex = Number.POSITIVE_INFINITY
 
   for (let i = 0; i < settled.length; i++) {
@@ -104,17 +128,55 @@ function selectBestEligibleQuote(settled: PromiseSettledResult<RankedSwapQuote>[
     if (result.status !== 'fulfilled') {
       continue
     }
-    const { outputAmount, quote } = result.value
+    const candidate = result.value
     // Tie-break: lower index wins. Fetchers are ordered by `shouldPreferGeneralSwap`
     // (general-first vs native-first), so this preserves that preference when amounts tie.
-    if (bestAmount === null || outputAmount > bestAmount || (outputAmount === bestAmount && i < bestIndex)) {
-      best = quote
-      bestAmount = outputAmount
+    if (
+      best === null ||
+      candidate.outputAmount > best.outputAmount ||
+      (candidate.outputAmount === best.outputAmount && i < bestIndex)
+    ) {
+      best = candidate
       bestIndex = i
     }
   }
 
-  return best
+  if (best === null) {
+    return null
+  }
+
+  // Native THOR/Maya bias: if best is an aggregator route but a direct THORChain
+  // or MayaChain route is within `nativeSwapBiasOutputBps` of best.outputAmount,
+  // prefer the native route. See `nativeSwapBiasOutputBps` for rationale.
+  //
+  // When best is already a native provider, no swap. When best.outputAmount is 0
+  // (degenerate), the relative bias check is undefined → keep best as-is.
+  if (isNativeProvider(best.providerName) || best.outputAmount <= 0n) {
+    return best.quote
+  }
+
+  let nativeBias: RankedSwapQuote | null = null
+  for (const result of settled) {
+    if (result.status !== 'fulfilled') {
+      continue
+    }
+    const candidate = result.value
+    if (!isNativeProvider(candidate.providerName)) {
+      continue
+    }
+    // Δ = best - candidate ≥ 0 (best is the max). Within bias iff Δ * 10000 ≤ best * bps.
+    const delta = best.outputAmount - candidate.outputAmount
+    const withinBias = delta * 10000n <= best.outputAmount * nativeSwapBiasOutputBps
+    if (!withinBias) {
+      continue
+    }
+    // If multiple natives qualify (THOR + Maya), prefer the one with higher output.
+    if (nativeBias === null || candidate.outputAmount > nativeBias.outputAmount) {
+      nativeBias = candidate
+    }
+  }
+
+  return (nativeBias ?? best).quote
 }
 
 export const findSwapQuote = async ({
@@ -286,11 +348,12 @@ export const findSwapQuote = async ({
   }
 
   const settled = await Promise.allSettled(
-    fetchers.map(async fetcher => {
+    fetchers.map(async (fetcher): Promise<RankedSwapQuote> => {
       const quote = await fetcher.fetch()
       return {
         quote,
         outputAmount: getComparableOutputAmount(quote, to),
+        providerName: fetcher.providerName,
       }
     })
   )

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -76,6 +76,19 @@ type RankedSwapQuote = {
  * `SwapService.fetchQuote` + `Coin+Swaps.swapProviders`.
  */
 
+/**
+ * Native swap providers — direct on-chain protocols (no aggregator layer).
+ *
+ * Adding a new native protocol (e.g. Chainflip-direct in the future) requires:
+ *   1. Adding its name to `SwapQuoteProviderName` above
+ *   2. Adding it here so `isNativeProvider` recognises it for hard-priority
+ *      selection in `selectBestEligibleQuote`
+ *   3. Wiring its fetcher into `getNativeFetchers`
+ *
+ * The `satisfies` clause gives compile-time safety against typos, but the
+ * semantic mapping (which providers count as "native") still lives in this
+ * file and must be kept aligned with the protocol's actual integration mode.
+ */
 const nativeProviderNames = ['THORChain', 'MayaChain'] as const satisfies readonly SwapQuoteProviderName[]
 
 type NativeProviderName = (typeof nativeProviderNames)[number]
@@ -83,6 +96,34 @@ type NativeProviderName = (typeof nativeProviderNames)[number]
 const nativeProviderNamesSet = new Set<SwapQuoteProviderName>(nativeProviderNames)
 
 const isNativeProvider = (name: SwapQuoteProviderName): name is NativeProviderName => nativeProviderNamesSet.has(name)
+
+/**
+ * Declared preference order for AGGREGATOR ties — when two aggregators return
+ * identical `outputAmount`, the earlier entry wins. This makes the tie-break
+ * explicit (the previous implementation tied via `fetchers[]` array index,
+ * which was determined dynamically by `shouldPreferGeneralSwap` and therefore
+ * harder to reason about). Native providers (THORChain/MayaChain) bypass this
+ * because they have hard priority over aggregators regardless of output.
+ *
+ * Order rationale: KyberSwap and 1inch typically surface the best on-chain
+ * liquidity for EVM-only swaps; LiFi covers the broader cross-chain matrix;
+ * SwapKit is the catch-all fallback. Adjust as data changes.
+ *
+ * @internal Exported for unit-test introspection only.
+ */
+export const aggregatorPreferenceOrder: readonly SwapQuoteProviderName[] = [
+  'KyberSwap',
+  '1inch',
+  'LiFi',
+  'SwapKit',
+] as const
+
+const aggregatorPreferenceIndex = new Map<SwapQuoteProviderName, number>(
+  aggregatorPreferenceOrder.map((name, idx) => [name, idx])
+)
+
+const getAggregatorPreferenceRank = (name: SwapQuoteProviderName): number =>
+  aggregatorPreferenceIndex.get(name) ?? Number.POSITIVE_INFINITY
 
 /** Re-base an integer amount from `fromDecimals` fixed-point to `toDecimals`. */
 function rebaseDecimals(value: bigint, fromDecimals: number, toDecimals: number): bigint {
@@ -119,7 +160,7 @@ function getComparableOutputAmount(q: SwapQuote, to: AccountCoin): bigint {
 function selectBestEligibleQuote(settled: PromiseSettledResult<RankedSwapQuote>[]): SwapQuote | null {
   let bestNative: RankedSwapQuote | null = null
   let bestAggregator: RankedSwapQuote | null = null
-  let bestAggregatorIndex = Number.POSITIVE_INFINITY
+  let bestAggregatorPreferenceRank = Number.POSITIVE_INFINITY
 
   for (let i = 0; i < settled.length; i++) {
     const result = settled[i]
@@ -134,15 +175,19 @@ function selectBestEligibleQuote(settled: PromiseSettledResult<RankedSwapQuote>[
         bestNative = candidate
       }
     } else {
-      // Tie-break: lower index wins. Fetchers are ordered by `shouldPreferGeneralSwap`
-      // (general-first vs native-first), so this preserves that preference when amounts tie.
+      // Tie-break by declared aggregator preference (lower rank wins). This
+      // replaces the previous index-based tie-break, which was determined
+      // dynamically by `shouldPreferGeneralSwap` and therefore harder to
+      // reason about. The declared order lives in `aggregatorPreferenceOrder`
+      // above. (#521 r3 — NeO should-fix.)
+      const candidateRank = getAggregatorPreferenceRank(candidate.providerName)
       if (
         bestAggregator === null ||
         candidate.outputAmount > bestAggregator.outputAmount ||
-        (candidate.outputAmount === bestAggregator.outputAmount && i < bestAggregatorIndex)
+        (candidate.outputAmount === bestAggregator.outputAmount && candidateRank < bestAggregatorPreferenceRank)
       ) {
         bestAggregator = candidate
-        bestAggregatorIndex = i
+        bestAggregatorPreferenceRank = candidateRank
       }
     }
   }

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -117,8 +117,9 @@ function getComparableOutputAmount(q: SwapQuote, to: AccountCoin): bigint {
 }
 
 function selectBestEligibleQuote(settled: PromiseSettledResult<RankedSwapQuote>[]): SwapQuote | null {
-  let best: RankedSwapQuote | null = null
-  let bestIndex = Number.POSITIVE_INFINITY
+  let bestNative: RankedSwapQuote | null = null
+  let bestAggregator: RankedSwapQuote | null = null
+  let bestAggregatorIndex = Number.POSITIVE_INFINITY
 
   for (let i = 0; i < settled.length; i++) {
     const result = settled[i]
@@ -126,45 +127,30 @@ function selectBestEligibleQuote(settled: PromiseSettledResult<RankedSwapQuote>[
       continue
     }
     const candidate = result.value
-    // Tie-break: lower index wins. Fetchers are ordered by `shouldPreferGeneralSwap`
-    // (general-first vs native-first), so this preserves that preference when amounts tie.
-    if (
-      best === null ||
-      candidate.outputAmount > best.outputAmount ||
-      (candidate.outputAmount === best.outputAmount && i < bestIndex)
-    ) {
-      best = candidate
-      bestIndex = i
-    }
-  }
 
-  if (best === null) {
-    return null
+    if (isNativeProvider(candidate.providerName)) {
+      // Among natives (THOR + Maya), prefer higher output.
+      if (bestNative === null || candidate.outputAmount > bestNative.outputAmount) {
+        bestNative = candidate
+      }
+    } else {
+      // Tie-break: lower index wins. Fetchers are ordered by `shouldPreferGeneralSwap`
+      // (general-first vs native-first), so this preserves that preference when amounts tie.
+      if (
+        bestAggregator === null ||
+        candidate.outputAmount > bestAggregator.outputAmount ||
+        (candidate.outputAmount === bestAggregator.outputAmount && i < bestAggregatorIndex)
+      ) {
+        bestAggregator = candidate
+        bestAggregatorIndex = i
+      }
+    }
   }
 
   // Hard THORChain/Maya priority: if any native route exists, always prefer it
   // over any aggregator route. Mirrors vultisig-ios's priority-first-success
-  // pattern. No output comparison.
-  if (isNativeProvider(best.providerName)) {
-    return best.quote
-  }
-
-  let bestNative: RankedSwapQuote | null = null
-  for (const result of settled) {
-    if (result.status !== 'fulfilled') {
-      continue
-    }
-    const candidate = result.value
-    if (!isNativeProvider(candidate.providerName)) {
-      continue
-    }
-    // If multiple natives qualify (THOR + Maya), prefer the one with higher output.
-    if (bestNative === null || candidate.outputAmount > bestNative.outputAmount) {
-      bestNative = candidate
-    }
-  }
-
-  return (bestNative ?? best).quote
+  // pattern. No output comparison between native and aggregator.
+  return (bestNative ?? bestAggregator)?.quote ?? null
 }
 
 export const findSwapQuote = async ({

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -64,24 +64,25 @@ type RankedSwapQuote = {
 }
 
 /**
- * Bias window (in bps of best comparable output) within which a direct native
- * THORChain / MayaChain route is preferred over a higher-output aggregator route.
+ * Hard native priority: when any direct THORChain or MayaChain route is available,
+ * it is always preferred over any aggregator (SwapKit, LiFi, etc.) regardless of
+ * gross output. When both THOR and Maya succeed, the one with the higher comparable
+ * output wins; among aggregator-only results the normal output ranking applies.
  *
- * Rationale (paaao, 2026-05-22): for L1 ↔ L1 swaps that THORChain natively serves,
- * the protocol-aligned route is preferred even when an aggregator (e.g. SwapKit)
- * gross-output is higher. Direct THORChain captures full vultisig affiliate
- * revenue (50bps) and avoids the SwapKit fee skim; the protocol is the moat.
- * Mirrors the priority-order short-circuit used in vultisig-ios's
- * `SwapService.fetchQuote` + `Coin+Swaps.swapProviders` (priority-first-success,
- * no output comparison).
+ * Rationale (paaao, 2026-05-22): for L1 swaps that native protocols serve directly,
+ * the protocol-aligned route is always preferred. Direct routes capture full
+ * vultisig affiliate revenue and avoid the aggregator fee skim; the protocol is
+ * the moat. Mirrors the priority-first-success pattern in vultisig-ios's
+ * `SwapService.fetchQuote` + `Coin+Swaps.swapProviders`.
  */
 
 const nativeProviderNames = ['THORChain', 'MayaChain'] as const satisfies readonly SwapQuoteProviderName[]
 
 type NativeProviderName = (typeof nativeProviderNames)[number]
 
-const isNativeProvider = (name: SwapQuoteProviderName): name is NativeProviderName =>
-  (nativeProviderNames as readonly SwapQuoteProviderName[]).includes(name)
+const nativeProviderNamesSet = new Set<SwapQuoteProviderName>(nativeProviderNames)
+
+const isNativeProvider = (name: SwapQuoteProviderName): name is NativeProviderName => nativeProviderNamesSet.has(name)
 
 /** Re-base an integer amount from `fromDecimals` fixed-point to `toDecimals`. */
 function rebaseDecimals(value: bigint, fromDecimals: number, toDecimals: number): bigint {

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -69,16 +69,12 @@ type RankedSwapQuote = {
  *
  * Rationale (paaao, 2026-05-22): for L1 ↔ L1 swaps that THORChain natively serves,
  * the protocol-aligned route is preferred even when an aggregator (e.g. SwapKit)
- * gross-output is slightly higher. Direct THORChain captures full vultisig
- * affiliate revenue (50bps) and avoids the SwapKit fee skim; the protocol is the
- * moat. Mirrors the priority-order short-circuit used in vultisig-ios's
- * `SwapService.fetchQuote` + `Coin+Swaps.swapProviders`, ported as a soft bias
- * here so a clearly-better aggregator route (>5% above THOR) still wins.
- *
- * 500 bps = 5%. Conservative: covers normal LP slippage / pool depth variance
- * without ceding obviously-better aggregator routes.
+ * gross-output is higher. Direct THORChain captures full vultisig affiliate
+ * revenue (50bps) and avoids the SwapKit fee skim; the protocol is the moat.
+ * Mirrors the priority-order short-circuit used in vultisig-ios's
+ * `SwapService.fetchQuote` + `Coin+Swaps.swapProviders` (priority-first-success,
+ * no output comparison).
  */
-export const nativeSwapBiasOutputBps = 500n
 
 const nativeProviderNames = ['THORChain', 'MayaChain'] as const satisfies readonly SwapQuoteProviderName[]
 
@@ -145,17 +141,14 @@ function selectBestEligibleQuote(settled: PromiseSettledResult<RankedSwapQuote>[
     return null
   }
 
-  // Native THOR/Maya bias: if best is an aggregator route but a direct THORChain
-  // or MayaChain route is within `nativeSwapBiasOutputBps` of best.outputAmount,
-  // prefer the native route. See `nativeSwapBiasOutputBps` for rationale.
-  //
-  // When best is already a native provider, no swap. When best.outputAmount is 0
-  // (degenerate), the relative bias check is undefined → keep best as-is.
-  if (isNativeProvider(best.providerName) || best.outputAmount <= 0n) {
+  // Hard THORChain/Maya priority: if any native route exists, always prefer it
+  // over any aggregator route. Mirrors vultisig-ios's priority-first-success
+  // pattern. No output comparison.
+  if (isNativeProvider(best.providerName)) {
     return best.quote
   }
 
-  let nativeBias: RankedSwapQuote | null = null
+  let bestNative: RankedSwapQuote | null = null
   for (const result of settled) {
     if (result.status !== 'fulfilled') {
       continue
@@ -164,19 +157,13 @@ function selectBestEligibleQuote(settled: PromiseSettledResult<RankedSwapQuote>[
     if (!isNativeProvider(candidate.providerName)) {
       continue
     }
-    // Δ = best - candidate ≥ 0 (best is the max). Within bias iff Δ * 10000 ≤ best * bps.
-    const delta = best.outputAmount - candidate.outputAmount
-    const withinBias = delta * 10000n <= best.outputAmount * nativeSwapBiasOutputBps
-    if (!withinBias) {
-      continue
-    }
     // If multiple natives qualify (THOR + Maya), prefer the one with higher output.
-    if (nativeBias === null || candidate.outputAmount > nativeBias.outputAmount) {
-      nativeBias = candidate
+    if (bestNative === null || candidate.outputAmount > bestNative.outputAmount) {
+      bestNative = candidate
     }
   }
 
-  return (nativeBias ?? best).quote
+  return (bestNative ?? best).quote
 }
 
 export const findSwapQuote = async ({


### PR DESCRIPTION
## What

Hard-prefer direct native THORChain/MayaChain routes over any aggregator regardless of gross output. When no native route exists, normal best-output ranking applies.

Updated after NeOMakinG r1: switched from soft bias (5% window) to unconditional hard priority - mirrors vultisig-ios and vultisig-windows exactly.

## Why

Per paaao: 'always have bias towards THORChain for L1 swaps.' Direct routes capture full vultisig affiliate revenue (50 bps) and avoid the aggregator fee skim.

## How

nativeProviderNamesSet = new Set(['THORChain', 'MayaChain']). In selectBestEligibleQuote: if any native succeeded, return the native with highest output unconditionally. Otherwise return best aggregator.

## Receipts

| scenario | winner |
|---|---|
| SwapKit better by 2%, THOR available | THORChain (hard priority) |
| SwapKit better by 10%, THOR available | THORChain (hard priority, no output comparison) |
| Only SwapKit | SwapKit |
| Both THOR + Maya succeed | higher-output native |

15/15 tests pass in findSwapQuote.selection.test.ts