### PR TITLE
Enable SwapKit transfer source chains

### DIFF
--- a/.changeset/swapkit-transfer-sources.md
+++ b/.changeset/swapkit-transfer-sources.md
@@ -1,0 +1,8 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/core-mpc': patch
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+Enable SwapKit source routes for BTC, BCH, DOGE, LTC, XRP, ZEC, TRON, and TON by signing non-EVM SwapKit routes as source-chain transfers.

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -1335,15 +1335,15 @@
       "import": "./dist/swap/general/oneInch/oneInchAffiliateConfig.js",
       "default": "./dist/swap/general/oneInch/oneInchAffiliateConfig.js"
     },
-    "./swap/general/oneInch/stationOneInchAffiliateConfig": {
-      "types": "./dist/swap/general/oneInch/stationOneInchAffiliateConfig.d.ts",
-      "import": "./dist/swap/general/oneInch/stationOneInchAffiliateConfig.js",
-      "default": "./dist/swap/general/oneInch/stationOneInchAffiliateConfig.js"
-    },
     "./swap/general/oneInch/OneInchSwapEnabledChains": {
       "types": "./dist/swap/general/oneInch/OneInchSwapEnabledChains.d.ts",
       "import": "./dist/swap/general/oneInch/OneInchSwapEnabledChains.js",
       "default": "./dist/swap/general/oneInch/OneInchSwapEnabledChains.js"
+    },
+    "./swap/general/oneInch/stationOneInchAffiliateConfig": {
+      "types": "./dist/swap/general/oneInch/stationOneInchAffiliateConfig.d.ts",
+      "import": "./dist/swap/general/oneInch/stationOneInchAffiliateConfig.js",
+      "default": "./dist/swap/general/oneInch/stationOneInchAffiliateConfig.js"
     },
     "./swap/general/swapkit/api/getSwapKitQuote": {
       "types": "./dist/swap/general/swapkit/api/getSwapKitQuote.d.ts",
@@ -1385,11 +1385,6 @@
       "import": "./dist/swap/native/nativeSwapAffiliateConfig.js",
       "default": "./dist/swap/native/nativeSwapAffiliateConfig.js"
     },
-    "./swap/native/stationNativeSwapAffiliateConfig": {
-      "types": "./dist/swap/native/stationNativeSwapAffiliateConfig.d.ts",
-      "import": "./dist/swap/native/stationNativeSwapAffiliateConfig.js",
-      "default": "./dist/swap/native/stationNativeSwapAffiliateConfig.js"
-    },
     "./swap/native/NativeSwapChain": {
       "types": "./dist/swap/native/NativeSwapChain.d.ts",
       "import": "./dist/swap/native/NativeSwapChain.js",
@@ -1399,6 +1394,11 @@
       "types": "./dist/swap/native/NativeSwapQuote.d.ts",
       "import": "./dist/swap/native/NativeSwapQuote.js",
       "default": "./dist/swap/native/NativeSwapQuote.js"
+    },
+    "./swap/native/stationNativeSwapAffiliateConfig": {
+      "types": "./dist/swap/native/stationNativeSwapAffiliateConfig.d.ts",
+      "import": "./dist/swap/native/stationNativeSwapAffiliateConfig.js",
+      "default": "./dist/swap/native/stationNativeSwapAffiliateConfig.js"
     },
     "./swap/native/utils/getNativeSwapDecimals": {
       "types": "./dist/swap/native/utils/getNativeSwapDecimals.d.ts",

--- a/packages/core/chain/swap/general/GeneralSwapQuote.ts
+++ b/packages/core/chain/swap/general/GeneralSwapQuote.ts
@@ -20,6 +20,13 @@ export type GeneralSwapTx =
         swapFee: SwapFee
       }
     }
+  | {
+      transfer: {
+        to: string
+        amount: bigint
+        memo?: string
+      }
+    }
 
 export type GeneralSwapQuote = {
   dstAmount: string

--- a/packages/core/chain/swap/general/swapkit/SwapKitEnabledChains.ts
+++ b/packages/core/chain/swap/general/swapkit/SwapKitEnabledChains.ts
@@ -9,27 +9,27 @@ export const swapKitSourceChains = [
   Chain.Optimism,
   Chain.Polygon,
   Chain.Solana,
+  Chain.Bitcoin,
+  Chain.BitcoinCash,
+  Chain.Dogecoin,
+  Chain.Litecoin,
+  Chain.Ripple,
+  Chain.Ton,
+  Chain.Tron,
+  Chain.Zcash,
 ] as const
 
 export type SwapKitSourceChain = (typeof swapKitSourceChains)[number]
 
 export const swapKitEnabledChains = [
   ...swapKitSourceChains,
-  Chain.Bitcoin,
-  Chain.BitcoinCash,
   Chain.Cardano,
   Chain.Cosmos,
   Chain.Dash,
-  Chain.Dogecoin,
   Chain.Kujira,
-  Chain.Litecoin,
   Chain.MayaChain,
-  Chain.Ripple,
   Chain.Sui,
   Chain.THORChain,
-  Chain.Ton,
-  Chain.Tron,
-  Chain.Zcash,
 ] as const
 
 export type SwapKitEnabledChain = (typeof swapKitEnabledChains)[number]

--- a/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.test.ts
+++ b/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.test.ts
@@ -1,5 +1,6 @@
 import { Chain } from '@vultisig/core-chain/Chain'
 import { configureSwapKit, getSwapKitConfig } from '@vultisig/core-chain/swap/general/swapkit/config'
+import type { SwapKitSourceChain } from '@vultisig/core-chain/swap/general/swapkit/SwapKitEnabledChains'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { getSwapKitQuote } from './getSwapKitQuote'
@@ -11,6 +12,19 @@ const response = (body: unknown, ok = true, status = 200) =>
     statusText: ok ? 'OK' : 'Bad Request',
     json: vi.fn(async () => body),
   }) as unknown as Response
+
+type TransferSourceFixture = readonly [string, SwapKitSourceChain, string, number, string, string]
+
+const transferSourceFixtures: TransferSourceFixture[] = [
+  ['Bitcoin', Chain.Bitcoin, 'BTC', 8, 'bc1qsource', 'bc1qdeposit'],
+  ['Litecoin', Chain.Litecoin, 'LTC', 8, 'ltc1qsource', 'Ldeposit'],
+  ['Dogecoin', Chain.Dogecoin, 'DOGE', 8, 'Dsource', 'Ddeposit'],
+  ['Bitcoin Cash', Chain.BitcoinCash, 'BCH', 8, 'bitcoincash:qsource', 'bitcoincash:qdeposit'],
+  ['Ripple', Chain.Ripple, 'XRP', 6, 'rSource', 'rDeposit'],
+  ['Zcash', Chain.Zcash, 'ZEC', 8, 't1Source', 't1Deposit'],
+  ['Tron', Chain.Tron, 'TRX', 6, 'TSource', 'TDeposit'],
+  ['TON', Chain.Ton, 'TON', 9, 'UQSource', 'UQDeposit'],
+]
 
 describe('getSwapKitQuote', () => {
   afterEach(() => {
@@ -94,6 +108,7 @@ describe('getSwapKitQuote', () => {
       destinationAddress: 'sol-destination',
       disableBalanceCheck: true,
     })
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body).disableBuildTx).toBeUndefined()
     expect(quote).toEqual({
       dstAmount: '12400000',
       provider: 'swapkit',
@@ -106,6 +121,161 @@ describe('getSwapKitQuote', () => {
           value: '0',
           gasLimit: 21000n,
         },
+      },
+    })
+  })
+
+  it.each(transferSourceFixtures)(
+    'maps %s source routes to a transfer tx and asks SwapKit not to build a tx',
+    async (_, chain, ticker, decimals, source, target) => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          response({
+            routes: [
+              {
+                routeId: 'near-transfer-route',
+                providers: ['NEAR'],
+                expectedBuyAmount: '0.01',
+              },
+            ],
+          })
+        )
+        .mockResolvedValueOnce(
+          response({
+            expectedBuyAmount: '0.009',
+            providers: ['NEAR'],
+            targetAddress: target,
+          })
+        )
+
+      vi.stubGlobal('fetch', fetchMock)
+      configureSwapKit({ apiKey: 'test-key', baseUrl: 'https://swapkit.example' })
+
+      const quote = await getSwapKitQuote({
+        from: {
+          chain,
+          address: source,
+          ticker,
+          decimals,
+        },
+        to: {
+          chain: Chain.Ethereum,
+          address: '0xdestination',
+          ticker: 'ETH',
+          decimals: 18,
+        },
+        amount: 100_000n,
+      })
+
+      expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toMatchObject({
+        routeId: 'near-transfer-route',
+        sourceAddress: source,
+        destinationAddress: '0xdestination',
+        disableBalanceCheck: true,
+        disableBuildTx: true,
+      })
+      expect(quote).toMatchObject({
+        dstAmount: '9000000000000000',
+        provider: 'swapkit',
+        routeProvider: 'NEAR',
+        tx: {
+          transfer: {
+            to: target,
+            amount: 100_000n,
+          },
+        },
+      })
+    }
+  )
+
+  it('maps SwapKit transfer memo and deposit amount fallbacks', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          response({
+            routes: [{ routeId: 'deposit-route', providers: ['NEAR'], expectedBuyAmount: '0.01' }],
+          })
+        )
+        .mockResolvedValueOnce(
+          response({
+            expectedBuyAmount: '0.009',
+            providers: ['NEAR'],
+            depositAddress: 'bc1qdeposit',
+            depositAmount: '0.001',
+            memo: 'swap-memo',
+          })
+        )
+    )
+    configureSwapKit({ apiKey: undefined })
+
+    const quote = await getSwapKitQuote({
+      from: {
+        chain: Chain.Bitcoin,
+        address: 'bc1qsource',
+        ticker: 'BTC',
+        decimals: 8,
+      },
+      to: {
+        chain: Chain.Ethereum,
+        address: '0xdestination',
+        ticker: 'ETH',
+        decimals: 18,
+      },
+      amount: 1n,
+    })
+
+    expect(quote.tx).toEqual({
+      transfer: {
+        to: 'bc1qdeposit',
+        amount: 100_000n,
+        memo: 'swap-memo',
+      },
+    })
+  })
+
+  it('maps transfer target and decimal amount from SwapKit tx-array fallback', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          response({
+            routes: [{ routeId: 'ton-array-route', providers: ['NEAR'], expectedBuyAmount: '0.01' }],
+          })
+        )
+        .mockResolvedValueOnce(
+          response({
+            expectedBuyAmount: '0.009',
+            providers: ['NEAR'],
+            tx: [{ address: 'UQDeposit', amount: '0.001' }],
+          })
+        )
+    )
+    configureSwapKit({ apiKey: undefined })
+
+    const quote = await getSwapKitQuote({
+      from: {
+        chain: Chain.Ton,
+        address: 'UQSource',
+        ticker: 'TON',
+        decimals: 9,
+      },
+      to: {
+        chain: Chain.Ethereum,
+        address: '0xdestination',
+        ticker: 'ETH',
+        decimals: 18,
+      },
+      amount: 1n,
+    })
+
+    expect(quote.tx).toEqual({
+      transfer: {
+        to: 'UQDeposit',
+        amount: 1_000_000n,
       },
     })
   })

--- a/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.ts
+++ b/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.ts
@@ -5,6 +5,7 @@ import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { GeneralSwapQuote, GeneralSwapTx } from '@vultisig/core-chain/swap/general/GeneralSwapQuote'
 import { getSwapKitConfig } from '@vultisig/core-chain/swap/general/swapkit/config'
 import { SwapKitEnabledChain, SwapKitSourceChain } from '@vultisig/core-chain/swap/general/swapkit/SwapKitEnabledChains'
+import { isOneOf } from '@vultisig/lib-utils/array/isOneOf'
 import { withoutUndefinedFields } from '@vultisig/lib-utils/record/withoutUndefinedFields'
 import { TransferDirection } from '@vultisig/lib-utils/TransferDirection'
 
@@ -123,6 +124,10 @@ type SwapKitQuoteResponse = {
 type SwapKitSwapResponse = {
   expectedBuyAmount?: string
   tx?: unknown
+  targetAddress?: string
+  depositAddress?: string
+  depositAmount?: string
+  memo?: string
   providers?: string[]
   legs?: { provider?: string }[]
   fees?: { type?: string; amount?: string }[]
@@ -139,6 +144,17 @@ type SwapKitEvmTx = {
   gas?: string | number | bigint
   gasLimit?: string | number | bigint
 }
+
+const swapKitTransferSourceChains = [
+  Chain.Bitcoin,
+  Chain.BitcoinCash,
+  Chain.Dogecoin,
+  Chain.Litecoin,
+  Chain.Ripple,
+  Chain.Ton,
+  Chain.Tron,
+  Chain.Zcash,
+] as const
 
 const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null
 
@@ -308,9 +324,90 @@ const buildSolanaTx = (tx: unknown, fees: SwapKitSwapResponse['fees']): GeneralS
   }
 }
 
-const buildSwapKitTx = (response: SwapKitSwapResponse, from: AccountCoin<SwapKitSourceChain>): GeneralSwapTx => {
+const getTransferTargetAddress = ({ targetAddress, depositAddress, tx }: SwapKitSwapResponse): string | undefined => {
+  if (targetAddress) {
+    return targetAddress
+  }
+
+  if (depositAddress) {
+    return depositAddress
+  }
+
+  if (Array.isArray(tx) && isRecord(tx[0]) && typeof tx[0].address === 'string') {
+    return tx[0].address
+  }
+
+  return undefined
+}
+
+const toTransferAmount = (value: string | number | bigint, decimals: number): bigint => {
+  if (typeof value === 'bigint') {
+    return value
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error('SwapKit transfer route returned an invalid amount.')
+    }
+
+    return Number.isInteger(value) ? BigInt(value) : toChainAmount(value.toString(), decimals)
+  }
+
+  return value.includes('.') ? toChainAmount(value, decimals) : BigInt(value)
+}
+
+const getTransferAmount = ({ depositAmount, tx }: SwapKitSwapResponse, amount: bigint, decimals: number): bigint => {
+  if (depositAmount) {
+    return toChainAmount(depositAmount, decimals)
+  }
+
+  if (
+    Array.isArray(tx) &&
+    isRecord(tx[0]) &&
+    (typeof tx[0].amount === 'string' || typeof tx[0].amount === 'number' || typeof tx[0].amount === 'bigint')
+  ) {
+    return toTransferAmount(tx[0].amount, decimals)
+  }
+
+  return amount
+}
+
+const shouldUseTransferTx = (chain: SwapKitSourceChain): chain is (typeof swapKitTransferSourceChains)[number] =>
+  isOneOf(chain, swapKitTransferSourceChains)
+
+const buildTransferTx = (
+  response: SwapKitSwapResponse,
+  from: AccountCoin<SwapKitSourceChain>,
+  amount: bigint
+): GeneralSwapTx => {
+  const to = getTransferTargetAddress(response)
+
+  if (!to) {
+    throw new Error('SwapKit transfer route did not return a target address.')
+  }
+
+  const transfer = {
+    to,
+    amount: getTransferAmount(response, amount, from.decimals),
+    ...(response.memo ? { memo: response.memo } : {}),
+  }
+
+  return {
+    transfer,
+  }
+}
+
+const buildSwapKitTx = (
+  response: SwapKitSwapResponse,
+  from: AccountCoin<SwapKitSourceChain>,
+  amount: bigint
+): GeneralSwapTx => {
   if (from.chain === Chain.Solana) {
     return buildSolanaTx(response.tx, response.fees)
+  }
+
+  if (shouldUseTransferTx(from.chain)) {
+    return buildTransferTx(response, from, amount)
   }
 
   return buildEvmTx(response.tx, from.address)
@@ -409,17 +506,21 @@ export const getSwapKitQuote = async ({
   }
   const route = await getBestSwapKitRoute(quoteBody, to.decimals)
 
-  const swapResponse = await postSwapKit<SwapKitSwapResponse>('/v3/swap', {
-    routeId: route.routeId,
-    sourceAddress: from.address,
-    destinationAddress: to.address,
-    disableBalanceCheck: true,
-  })
+  const swapResponse = await postSwapKit<SwapKitSwapResponse>(
+    '/v3/swap',
+    withoutUndefinedFields({
+      routeId: route.routeId,
+      sourceAddress: from.address,
+      destinationAddress: to.address,
+      disableBalanceCheck: true,
+      disableBuildTx: shouldUseTransferTx(from.chain) ? true : undefined,
+    })
+  )
 
   return {
     dstAmount: parseExpectedBuyAmount(swapResponse.expectedBuyAmount ?? route.expectedBuyAmount, to.decimals),
     provider: 'swapkit',
     routeProvider: getRouteProviderName(swapResponse) ?? getRouteProviderName(route),
-    tx: buildSwapKitTx(swapResponse, from),
+    tx: buildSwapKitTx(swapResponse, from, amount),
   }
 }

--- a/packages/core/chain/swap/keysign/getSwapDestinationAddress.test.ts
+++ b/packages/core/chain/swap/keysign/getSwapDestinationAddress.test.ts
@@ -1,0 +1,35 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { SwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
+import { describe, expect, it } from 'vitest'
+
+import { getSwapDestinationAddress } from './getSwapDestinationAddress'
+
+const fromCoin = {
+  chain: Chain.Bitcoin,
+  address: 'bc1qsource',
+  ticker: 'BTC',
+  decimals: 8,
+}
+
+describe('getSwapDestinationAddress', () => {
+  it('returns the transfer target for SwapKit source-chain transfer routes', () => {
+    const quote: SwapQuote = {
+      discounts: [],
+      quote: {
+        general: {
+          dstAmount: '1000000000',
+          provider: 'swapkit',
+          tx: {
+            transfer: {
+              to: 'bc1qdeposit',
+              amount: 100_000n,
+              memo: 'route-memo',
+            },
+          },
+        },
+      },
+    }
+
+    expect(getSwapDestinationAddress({ quote, fromCoin })).toBe('bc1qdeposit')
+  })
+})

--- a/packages/core/chain/swap/keysign/getSwapDestinationAddress.ts
+++ b/packages/core/chain/swap/keysign/getSwapDestinationAddress.ts
@@ -18,6 +18,7 @@ export const getSwapDestinationAddress = ({ quote, fromCoin }: GetSwapDestinatio
       matchRecordUnion<GeneralSwapTx, string>(quote.tx, {
         evm: ({ to }) => to,
         solana: () => '',
+        transfer: ({ to }) => to,
       }),
     native: quote => {
       const isErc20 = isOneOf(fromCoin.chain, Object.values(EvmChain)) && !isFeeCoin(fromCoin)

--- a/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
@@ -171,6 +171,47 @@ describe('findSwapQuote parallel selection', () => {
     expect(quote.quote.native.expected_amount_out).toBe('100')
   })
 
+  it('attempts SwapKit for newly enabled non-EVM source chains', async () => {
+    vi.mocked(getSwapKitQuote).mockResolvedValue({
+      dstAmount: '1000000000',
+      provider: 'swapkit',
+      tx: {
+        transfer: {
+          to: 'UQDeposit',
+          amount: 100_000n,
+        },
+      },
+    })
+
+    const from = {
+      chain: Chain.Bitcoin,
+      address: 'bc1qsource',
+      decimals: 8,
+      ticker: 'BTC',
+    }
+    const to = {
+      chain: Chain.Ton,
+      address: 'UQDestination',
+      decimals: 9,
+      ticker: 'TON',
+    }
+
+    const quote = await findSwapQuote({
+      from,
+      to,
+      amount: 100_000n,
+    })
+
+    expect(getSwapKitQuote).toHaveBeenCalledWith({
+      from,
+      to,
+      amount: 100_000n,
+      affiliateBps: 50,
+    })
+    expect(getNativeSwapQuote).not.toHaveBeenCalled()
+    expect('general' in quote.quote).toBe(true)
+  })
+
   it('breaks ties by earlier fetcher preference order', async () => {
     vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
     vi.mocked(getSwapKitQuote).mockRejectedValue(new Error('skip swapkit'))

--- a/packages/core/mpc/keysign/swap/build.transfer.test.ts
+++ b/packages/core/mpc/keysign/swap/build.transfer.test.ts
@@ -1,0 +1,84 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { SwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
+import { describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getChainSpecific: vi.fn(async () => ({ case: 'rippleSpecific', value: {} })),
+  getKeysignUtxoInfo: vi.fn(async () => []),
+}))
+
+vi.mock('@vultisig/core-mpc/keysign/chainSpecific', () => ({
+  getChainSpecific: mocks.getChainSpecific,
+}))
+
+vi.mock('@vultisig/core-mpc/keysign/utxo/getKeysignUtxoInfo', () => ({
+  getKeysignUtxoInfo: mocks.getKeysignUtxoInfo,
+}))
+
+vi.mock('@vultisig/core-chain/chains/evm/erc20/getErc20Allowance', () => ({
+  getErc20Allowance: vi.fn(),
+}))
+
+import { buildSwapKeysignPayload } from './build'
+
+const publicKey = {
+  data: () => new Uint8Array([1, 2, 3]),
+} as never
+
+describe('buildSwapKeysignPayload transfer routes', () => {
+  it('builds a normal source-chain send payload for SwapKit transfer tx variants', async () => {
+    const swapQuote: SwapQuote = {
+      discounts: [],
+      quote: {
+        general: {
+          dstAmount: '9000000000000000',
+          provider: 'swapkit',
+          tx: {
+            transfer: {
+              to: 'rDeposit',
+              amount: 1_000_000n,
+              memo: '12345',
+            },
+          },
+        },
+      },
+    }
+
+    const payload = await buildSwapKeysignPayload({
+      fromCoin: {
+        chain: Chain.Ripple,
+        address: 'rSource',
+        ticker: 'XRP',
+        decimals: 6,
+      },
+      toCoin: {
+        chain: Chain.Ethereum,
+        address: '0xdestination',
+        ticker: 'ETH',
+        decimals: 18,
+      },
+      amount: 999,
+      swapQuote,
+      vaultId: 'vault-id',
+      localPartyId: 'local-party',
+      fromPublicKey: publicKey,
+      toPublicKey: publicKey,
+      libType: 'DKLS',
+      walletCore: {} as never,
+    })
+
+    expect(payload.toAddress).toBe('rDeposit')
+    expect(payload.toAmount).toBe('1000000')
+    expect(payload.memo).toBe('12345')
+    expect(payload.swapPayload.case).toBeUndefined()
+    expect(mocks.getChainSpecific).toHaveBeenCalledWith(
+      expect.objectContaining({
+        keysignPayload: expect.objectContaining({
+          toAddress: 'rDeposit',
+          toAmount: '1000000',
+          memo: '12345',
+        }),
+      })
+    )
+  })
+})

--- a/packages/core/mpc/keysign/swap/build.ts
+++ b/packages/core/mpc/keysign/swap/build.ts
@@ -43,6 +43,8 @@ export type BuildSwapKeysignPayloadInput = {
   walletCore: WalletCore
 }
 
+type TransferSwapTx = Extract<GeneralSwapTx, { transfer: unknown }>['transfer']
+
 export const buildSwapKeysignPayload = async ({
   fromCoin,
   toCoin,
@@ -55,7 +57,16 @@ export const buildSwapKeysignPayload = async ({
   libType,
   walletCore,
 }: BuildSwapKeysignPayloadInput) => {
-  const chainAmount = toChainAmount(amount, fromCoin.decimals)
+  const transferTx = matchRecordUnion<SwapQuoteResult, TransferSwapTx | undefined>(swapQuote.quote, {
+    native: () => undefined,
+    general: ({ tx }) =>
+      matchRecordUnion<GeneralSwapTx, TransferSwapTx | undefined>(tx, {
+        evm: () => undefined,
+        solana: () => undefined,
+        transfer: tx => tx,
+      }),
+  })
+  const chainAmount = transferTx?.amount ?? toChainAmount(amount, fromCoin.decimals)
 
   const fromCoinHexPublicKey = Buffer.from(fromPublicKey.data()).toString('hex')
   const toCoinHexPublicKey = Buffer.from(toPublicKey.data()).toString('hex')
@@ -66,6 +77,7 @@ export const buildSwapKeysignPayload = async ({
       matchRecordUnion<GeneralSwapTx, bigint | undefined>(tx, {
         evm: ({ gasLimit }) => gasLimit,
         solana: () => undefined,
+        transfer: () => undefined,
       }),
   })
 
@@ -82,12 +94,27 @@ export const buildSwapKeysignPayload = async ({
     utxoInfo: await getKeysignUtxoInfo(fromCoin),
     memo: matchRecordUnion<SwapQuoteResult, string | undefined>(swapQuote.quote, {
       native: ({ memo }) => memo,
-      general: () => undefined,
+      general: ({ tx }) =>
+        matchRecordUnion<GeneralSwapTx, string | undefined>(tx, {
+          evm: () => undefined,
+          solana: () => undefined,
+          transfer: ({ memo }) => memo,
+        }),
     }),
   })
 
   keysignPayload.swapPayload = matchRecordUnion<SwapQuoteResult, KeysignPayload['swapPayload']>(swapQuote.quote, {
     general: quote => {
+      const transferSwapPayload = matchRecordUnion<GeneralSwapTx, KeysignPayload['swapPayload'] | undefined>(quote.tx, {
+        evm: () => undefined,
+        solana: () => undefined,
+        transfer: () => ({ case: undefined }),
+      })
+
+      if (transferSwapPayload) {
+        return transferSwapPayload
+      }
+
       const txMsg = matchRecordUnion<GeneralSwapTx, Omit<OneInchTransaction, '$typeName' | 'swapFee'>>(quote.tx, {
         evm: ({ from, to, data, value }) => {
           return {
@@ -107,6 +134,9 @@ export const buildSwapKeysignPayload = async ({
           gasPrice: '',
           gas: BigInt(0),
         }),
+        transfer: () => {
+          throw new Error('Transfer SwapKit routes do not use a oneinch swap payload.')
+        },
       })
 
       const tx = create(OneInchTransactionSchema, txMsg)


### PR DESCRIPTION
Closes #522

## Summary

- Enables SwapKit source quotes for Bitcoin, Bitcoin Cash, Dogecoin, Litecoin, Ripple, TON, TRON, and Zcash.
- Adds a `GeneralSwapTx.transfer` quote variant for SwapKit deposit/target transfer routes, including memo support, and routes those through normal source-chain signing.
- Adds regression coverage for transfer quote parsing, provider selection, destination extraction, and keysign payload building.
- Adds a patch changeset for `@vultisig/core-chain`, `@vultisig/core-mpc`, `@vultisig/sdk`, and `@vultisig/cli`.

## Receipts

- CI: PR checks are green for Unit Tests, Integration Tests (Vitest), Lint and Type Check, and Test Summary.
- Local static gates passed: `yarn build:all`, `yarn cli:build`, `yarn lint`, `yarn typecheck`, `yarn format:check`, `yarn check:shared-exports`, and `git diff --check`.
- Local tests passed: focused SwapKit/keysign tests, `yarn test:core`, `yarn test:scripts`, `yarn workspace @vultisig/sdk test`, `yarn test:rujira`, `yarn workspace @vultisig/cli test`, and `yarn workspace @vultisig/mcp test`.
- Note: root `yarn test` false-failed twice in `scripts/browser-example-build.test.mjs` because the child command timed out after 180000 ms; the exact child build passed standalone in about 52s and all constituent test commands passed. Follow-up evidence was added to `tasks/done/improve-browser-example-test-stability.md`.
- CLI runtime: `node clients/cli/dist/index.js --ci swap-quote Bitcoin Ethereum 0.001` returned provider `NEAR` with `quote.tx.transfer`.
- Live CLI quote smoke also returned transfer quotes for BTC, LTC, DOGE, BCH, XRP, ZEC, TON, and TRON USDT into ETH. No broadcast was performed.
- Windows local-tarball verification: `scripts/use-local-sdk.sh /Users/rodion/vultisig/vultisig-sdk` installed the local SDK into `/Users/rodion/vultisig/windows`; `yarn typecheck` exposed a downstream transfer handler gap, fixed on local Windows branch `verify-sdk-swapkit-transfer-fees` with handoff `windows/tasks/sync-sdk-swapkit-transfer-source-chains.md`.
- Windows desktop smoke: Wails runtime injected, import screen rendered, storage error absent, and no critical console errors after the Windows compatibility fix. Screenshot receipt: `.codex/receipts/windows-desktop-smoke/desktop-smoke-2026-05-23T05-05-52-850Z.png`. The helper still false-failed because its nonblank threshold expects more than 80 characters; follow-up evidence was added to `tasks/done/improve-verify-windows-screenshot-capture.md`.

## Follow-up

- After this SDK PR is merged and packages are published, run Windows `sync-with-sdk` and apply/keep the prepared local branch `verify-sdk-swapkit-transfer-fees`.