### PR TITLE
fix(evm/keysign): use pending block tag for nonce

### DIFF
--- a/packages/core/mpc/keysign/chainSpecific/resolvers/evm.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/evm.ts
@@ -18,11 +18,20 @@ export const getEvmChainSpecific: GetChainSpecificResolver<'ethereumSpecific'> =
   const { chain, address } = coin
   const client = getEvmClient(chain)
 
-  const nonce = BigInt(
-    await client.getTransactionCount({
-      address: address as `0x${string}`,
-    })
-  )
+  // Use the `pending` block tag so mempool txs are counted. Without this,
+  // back-to-back dApp transactions (e.g. CCTP v2 approve() followed
+  // immediately by depositForBurn()) get the same nonce because the first
+  // tx hasn't been mined yet. Fall back to `latest` for chains that don't
+  // support the pending tag cleanly (zkSync Era, Hyperliquid, some alt-EVMs).
+  const getNonce = async () => {
+    const params = { address: address as `0x${string}` }
+    try {
+      return await client.getTransactionCount({ ...params, blockTag: 'pending' })
+    } catch {
+      return client.getTransactionCount({ ...params, blockTag: 'latest' })
+    }
+  }
+  const nonce = BigInt(await getNonce())
 
   const getData = () => {
     const swapPayload = getKeysignSwapPayload(keysignPayload)


### PR DESCRIPTION
## Description

The EVM `chainSpecific` resolver fetches the nonce with viem's default `latest` block tag, which only counts confirmed transactions. When a dApp signs an `approve()` and immediately follows with another tx (e.g. CCTP v2 `depositForBurn()` on Circle's TokenMessenger `0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d`), the RPC returns the same nonce for both — the approve is still in the mempool — and the second tx is rejected as a duplicate.

This switches `getEvmChainSpecific` to use `blockTag: 'pending'`, mirroring the pattern already established in `packages/sdk/src/platforms/react-native/chains/evm/rpc.ts`. Falls back to `'latest'` for chains that don't support the pending tag cleanly (zkSync Era, Hyperliquid, some alt-EVMs).

Fixes vultisig/vultisig-windows#3944

## Which feature is affected?

- [x] Sending — back-to-back EVM dApp transactions (e.g. CCTP v2 approve → depositForBurn)
- [ ] Swap
- [ ] New Chain / Chain related feature
- [ ] Create vault

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Additional context

Reference working MetaMask CCTP v2 tx from the linked issue: `0x45ac4bec153c8c1c6d6e52ecdd725cb382a0a4ae9016ddc850f5a5073fbcb6f8` (Base). MetaMask uses the same `pending`-tag approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EVM transaction nonce calculation to better account for pending transactions in the mempool, reducing the risk of transaction ordering issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/528?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->