### PR TITLE
feat(seedphrase): probe Cosmos-coin-type Terra path for Keplr/Leap seeds

### DIFF
--- a/.changeset/feat-terra-cosmos-path-discovery-probe.md
+++ b/.changeset/feat-terra-cosmos-path-discovery-probe.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': minor
+---
+
+feat(seedphrase): probe Cosmos-coin-type Terra path (118) for Keplr/Leap seeds when standard 330-path is empty

--- a/packages/sdk/src/seedphrase/ChainDiscoveryService.ts
+++ b/packages/sdk/src/seedphrase/ChainDiscoveryService.ts
@@ -176,6 +176,35 @@ export class ChainDiscoveryService {
       }
     }
 
+    // Check Cosmos-coin-type Terra path (m/44'/118'/0'/0/0) if Terra was in the scan.
+    // Keplr and Leap historically derived Terra under coin type 118 instead of 330.
+    // Use the 118 path when it has balance AND the standard 330 path has no balance.
+    let useCosmosPathTerra = false
+    const terraResult = results.find(r => r.chain === Chain.Terra)
+
+    if (terraResult) {
+      try {
+        const cosmosPathCheck = await this.checkCosmosPathTerraBalance(mnemonic, timeoutPerChain)
+        const standard330Balance = BigInt(terraResult.balance || '0')
+
+        // Use Cosmos path if it has balance AND standard 330-path has no balance
+        useCosmosPathTerra = cosmosPathCheck.balance > 0n && standard330Balance === 0n
+
+        // If 118 path has balance but 330 doesn't, update the Terra result
+        if (useCosmosPathTerra) {
+          terraResult.address = cosmosPathCheck.address
+          terraResult.balance = cosmosPathCheck.balance.toString()
+          terraResult.hasBalance = true
+          if (!chainsWithBalance.includes(Chain.Terra)) {
+            chainsWithBalance.push(Chain.Terra)
+          }
+        }
+      } catch (error) {
+        // Cosmos-path Terra check failed, continue with standard 330 path
+        console.warn('Failed to check Cosmos-path Terra address:', error)
+      }
+    }
+
     // Report completion
     onProgress?.({
       phase: 'complete',
@@ -188,6 +217,7 @@ export class ChainDiscoveryService {
     return {
       results,
       usePhantomSolanaPath,
+      useCosmosPathTerra,
     }
   }
 
@@ -283,6 +313,36 @@ export class ChainDiscoveryService {
       const address = await this.keyDeriver.deriveSolanaAddressWithPhantomPath(mnemonic)
       const balance = await getCoinBalance({
         chain: Chain.Solana,
+        address,
+      })
+      return { address, balance }
+    }
+
+    return Promise.race([checkPromise(), timeoutPromise]).finally(() => {
+      if (timeoutId) clearTimeout(timeoutId)
+    })
+  }
+
+  /**
+   * Check Terra balance using the Cosmos coin-type derivation path (m/44'/118'/0'/0/0)
+   *
+   * Keplr and Leap historically derived Terra under coin type 118 (Cosmos) instead
+   * of Terra's native SLIP-44 330. This detects wallets originally created in those apps.
+   */
+  private async checkCosmosPathTerraBalance(
+    mnemonic: string,
+    timeout: number
+  ): Promise<{ address: string; balance: bigint }> {
+    // Create timeout promise with cleanup
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => reject(new Error('Timeout checking Cosmos-path Terra address')), timeout)
+    })
+
+    const checkPromise = async () => {
+      const address = await this.keyDeriver.deriveTerraAddressWithCosmosPath(mnemonic)
+      const balance = await getCoinBalance({
+        chain: Chain.Terra,
         address,
       })
       return { address, balance }

--- a/packages/sdk/src/seedphrase/MasterKeyDeriver.ts
+++ b/packages/sdk/src/seedphrase/MasterKeyDeriver.ts
@@ -48,7 +48,12 @@ export type DerivedChainKey = {
 export type DeriveChainPrivateKeysOptions = {
   /** Use Phantom wallet derivation path for Solana instead of standard BIP44 path */
   usePhantomSolanaPath?: boolean
+  /** Use Cosmos coin-type derivation path (m/44'/118'/0'/0/0) for Terra instead of native 330 path */
+  useCosmosPathTerra?: boolean
 }
+
+/** Cosmos coin-type derivation path used by Keplr/Leap for Terra */
+export const cosmosPathTerra = "m/44'/118'/0'/0/0"
 
 /**
  * MasterKeyDeriver - Derives cryptographic keys from BIP39 mnemonic
@@ -200,10 +205,13 @@ export class MasterKeyDeriver {
 
         // Derive chain-specific key
         // For Solana with Phantom path, use custom derivation path
+        // For Terra/TerraClassic with Cosmos path, use m/44'/118'/0'/0/0
         const chainKey =
           chain === 'Solana' && options?.usePhantomSolanaPath
             ? hdWallet.getKey(coinType, phantomSolanaPath)
-            : hdWallet.getKeyForCoin(coinType)
+            : (chain === 'Terra' || chain === 'TerraClassic') && options?.useCosmosPathTerra
+              ? hdWallet.getKey(coinType, cosmosPathTerra)
+              : hdWallet.getKeyForCoin(coinType)
         const chainKeyData = new Uint8Array(chainKey.data())
 
         let privateKeyHex: string
@@ -286,6 +294,40 @@ export class MasterKeyDeriver {
       const coinType = walletCore.CoinType.solana
       const privateKey = hdWallet.getKey(coinType, phantomSolanaPath)
       const publicKey = privateKey.getPublicKeyEd25519()
+      const address = walletCore.CoinTypeExt.deriveAddressFromPublicKey(coinType, publicKey)
+
+      privateKey.delete()
+      publicKey.delete()
+
+      return address
+    } finally {
+      if (hdWallet.delete) {
+        hdWallet.delete()
+      }
+    }
+  }
+
+  /**
+   * Derive Terra address using Cosmos coin-type derivation path (m/44'/118'/0'/0/0)
+   *
+   * Keplr and Leap historically derived Terra under the Cosmos coin type (118),
+   * producing the same terra1... bech32 address format but from a different HD path.
+   * This is needed to discover wallets originally created in Keplr/Leap.
+   *
+   * @param mnemonic - BIP39 mnemonic phrase
+   * @returns Terra address derived using the Cosmos coin-type path
+   */
+  async deriveTerraAddressWithCosmosPath(mnemonic: string): Promise<string> {
+    const walletCore = await this.wasmProvider.getWalletCore()
+    const cleaned = cleanMnemonic(mnemonic)
+
+    const hdWallet = walletCore.HDWallet.createWithMnemonic(cleaned, '')
+
+    try {
+      // Use terraV2 coin type for terra1... address encoding, but derive from path 118
+      const coinType = walletCore.CoinType.terraV2
+      const privateKey = hdWallet.getKey(coinType, cosmosPathTerra)
+      const publicKey = privateKey.getPublicKeySecp256k1(true) // compressed
       const address = walletCore.CoinTypeExt.deriveAddressFromPublicKey(coinType, publicKey)
 
       privateKey.delete()

--- a/packages/sdk/src/seedphrase/prepareSeedphraseImportPrelude.ts
+++ b/packages/sdk/src/seedphrase/prepareSeedphraseImportPrelude.ts
@@ -20,6 +20,7 @@ export type SeedphraseImportPreludeInput = {
   chains?: Chain[]
   chainsToScan?: Chain[]
   usePhantomSolanaPath?: boolean
+  useCosmosPathTerra?: boolean
   onChainDiscovery?: (progress: ChainDiscoveryProgress) => void
   validator: SeedphraseValidator
   keyDeriver: MasterKeyDeriver
@@ -32,12 +33,13 @@ export type SeedphraseImportPreludeResult = {
   masterKeys: DerivedMasterKeys
   discoveredChains: ChainDiscoveryResult[] | undefined
   usePhantomSolanaPath: boolean
+  useCosmosPathTerra: boolean
   chainsToImport: Chain[]
 }
 
 /**
  * Shared validation, master-key derivation, optional chain discovery, Phantom path selection,
- * and `chainsToImport` resolution for seedphrase-based vault creation (secure + fast).
+ * Cosmos-path Terra detection, and `chainsToImport` resolution for seedphrase-based vault creation.
  */
 export async function prepareSeedphraseImportPrelude(
   input: SeedphraseImportPreludeInput
@@ -48,6 +50,7 @@ export async function prepareSeedphraseImportPrelude(
     chains,
     chainsToScan,
     usePhantomSolanaPath: explicitPhantomPath,
+    useCosmosPathTerra: explicitCosmosPathTerra,
     onChainDiscovery,
     validator,
     keyDeriver,
@@ -75,6 +78,7 @@ export async function prepareSeedphraseImportPrelude(
 
   let discoveredChains: ChainDiscoveryResult[] | undefined
   let usePhantomSolanaPath = explicitPhantomPath ?? false
+  let useCosmosPathTerra = explicitCosmosPathTerra ?? false
 
   if (discoverChains) {
     reportProgress({
@@ -90,6 +94,9 @@ export async function prepareSeedphraseImportPrelude(
     if (explicitPhantomPath === undefined) {
       usePhantomSolanaPath = discoveryResult.usePhantomSolanaPath
     }
+    if (explicitCosmosPathTerra === undefined) {
+      useCosmosPathTerra = discoveryResult.useCosmosPathTerra
+    }
   }
 
   const chainsToImport = chains ?? discoveredChains?.filter(c => c.hasBalance).map(c => c.chain) ?? DEFAULT_CHAINS
@@ -98,6 +105,7 @@ export async function prepareSeedphraseImportPrelude(
     masterKeys,
     discoveredChains,
     usePhantomSolanaPath,
+    useCosmosPathTerra,
     chainsToImport,
   }
 }

--- a/packages/sdk/src/seedphrase/types.ts
+++ b/packages/sdk/src/seedphrase/types.ts
@@ -97,12 +97,19 @@ export type ChainDiscoveryResult = {
 
 /**
  * Aggregate result from chain discovery including Phantom Solana path detection
+ * and Cosmos-coin-type Terra path detection.
  */
 export type ChainDiscoveryAggregate = {
   /** Discovery results for each chain */
   results: ChainDiscoveryResult[]
   /** Whether Phantom derivation path should be used for Solana (has balance on Phantom path, none on standard) */
   usePhantomSolanaPath: boolean
+  /**
+   * Whether Cosmos coin-type path (m/44'/118'/0'/0/0) should be used for Terra/TerraClassic.
+   * True when the 330-path has zero balance AND the 118-path has non-zero balance.
+   * Covers seeds originally exported from Keplr or Leap.
+   */
+  useCosmosPathTerra: boolean
 }
 
 /**
@@ -131,6 +138,8 @@ export type CreateFastVaultFromSeedphraseOptions = {
   onChainDiscovery?: (progress: ChainDiscoveryProgress) => void
   /** Use Phantom wallet derivation path for Solana (auto-detected if discoverChains is true) */
   usePhantomSolanaPath?: boolean
+  /** Use Cosmos coin-type path (m/44'/118'/0'/0/0) for Terra/TerraClassic (auto-detected if discoverChains is true) */
+  useCosmosPathTerra?: boolean
   /** Enable batched MPC ceremonies for this import. */
   tssBatching?: boolean
 }
@@ -167,6 +176,8 @@ export type CreateSecureVaultFromSeedphraseOptions = {
   onChainDiscovery?: (progress: ChainDiscoveryProgress) => void
   /** Use Phantom wallet derivation path for Solana (auto-detected if discoverChains is true) */
   usePhantomSolanaPath?: boolean
+  /** Use Cosmos coin-type path (m/44'/118'/0'/0/0) for Terra/TerraClassic (auto-detected if discoverChains is true) */
+  useCosmosPathTerra?: boolean
   /** Enable batched MPC ceremonies for this import. */
   tssBatching?: boolean
 }
@@ -193,6 +204,8 @@ export type JoinSecureVaultOptions = {
   onDeviceJoined?: (deviceId: string, totalJoined: number, required: number) => void
   /** Use Phantom wallet derivation path for Solana (must match initiator's setting) */
   usePhantomSolanaPath?: boolean
+  /** Use Cosmos coin-type path (m/44'/118'/0'/0/0) for Terra/TerraClassic (must match initiator's setting) */
+  useCosmosPathTerra?: boolean
   /** Enable batched MPC ceremonies for this join flow. */
   tssBatching?: boolean
 }

--- a/packages/sdk/src/services/FastVaultFromSeedphraseService.ts
+++ b/packages/sdk/src/services/FastVaultFromSeedphraseService.ts
@@ -92,13 +92,14 @@ export class FastVaultFromSeedphraseService {
       onProgress?.(step)
     }
 
-    const { masterKeys, discoveredChains, usePhantomSolanaPath, chainsToImport } = await prepareSeedphraseImportPrelude(
-      {
+    const { masterKeys, discoveredChains, usePhantomSolanaPath, useCosmosPathTerra, chainsToImport } =
+      await prepareSeedphraseImportPrelude({
         mnemonic,
         discoverChains: options.discoverChains,
         chains: options.chains,
         chainsToScan: options.chainsToScan,
         usePhantomSolanaPath: options.usePhantomSolanaPath,
+        useCosmosPathTerra: options.useCosmosPathTerra,
         onChainDiscovery: options.onChainDiscovery,
         validator: this.validator,
         keyDeriver: this.keyDeriver,
@@ -109,8 +110,7 @@ export class FastVaultFromSeedphraseService {
           derivingKeys: { progress: 10, message: 'Deriving master keys...' },
           discoveringChains: { progress: 15, message: 'Discovering chains with balances...' },
         },
-      }
-    )
+      })
 
     // Step 4: Generate session parameters
     reportProgress({
@@ -199,6 +199,7 @@ export class FastVaultFromSeedphraseService {
     let eddsaResult: { publicKey: string; keyshare: string; chaincode: string }
     const chainPrivateKeys = await this.keyDeriver.deriveChainPrivateKeys(mnemonic, chainsToImport as Chain[], {
       usePhantomSolanaPath,
+      useCosmosPathTerra,
     })
 
     if (tssBatching) {

--- a/packages/sdk/src/services/SecureVaultFromSeedphraseService.ts
+++ b/packages/sdk/src/services/SecureVaultFromSeedphraseService.ts
@@ -116,13 +116,14 @@ export class SecureVaultFromSeedphraseService {
       throw new VaultError(VaultErrorCode.InvalidConfig, 'Threshold cannot exceed number of devices')
     }
 
-    const { masterKeys, discoveredChains, usePhantomSolanaPath, chainsToImport } = await prepareSeedphraseImportPrelude(
-      {
+    const { masterKeys, discoveredChains, usePhantomSolanaPath, useCosmosPathTerra, chainsToImport } =
+      await prepareSeedphraseImportPrelude({
         mnemonic,
         discoverChains: options.discoverChains,
         chains: options.chains,
         chainsToScan: options.chainsToScan,
         usePhantomSolanaPath: options.usePhantomSolanaPath,
+        useCosmosPathTerra: options.useCosmosPathTerra,
         onChainDiscovery: options.onChainDiscovery,
         validator: this.validator,
         keyDeriver: this.keyDeriver,
@@ -133,8 +134,7 @@ export class SecureVaultFromSeedphraseService {
           derivingKeys: { progress: 10, message: 'Deriving master keys...' },
           discoveringChains: { progress: 15, message: 'Discovering chains with balances...' },
         },
-      }
-    )
+      })
 
     // Step 4: Generate session parameters
     reportProgress({
@@ -243,6 +243,7 @@ export class SecureVaultFromSeedphraseService {
     let eddsaResult: { publicKey: string; keyshare: string; chaincode: string }
     const chainPrivateKeys = await this.keyDeriver.deriveChainPrivateKeys(mnemonic, chainsToImport as Chain[], {
       usePhantomSolanaPath,
+      useCosmosPathTerra,
     })
 
     if (tssBatching) {

--- a/packages/sdk/tests/unit/seedphrase/ChainDiscoveryService.test.ts
+++ b/packages/sdk/tests/unit/seedphrase/ChainDiscoveryService.test.ts
@@ -3,9 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ChainDiscoveryService } from '@/seedphrase/ChainDiscoveryService'
 
-const { mockDeriveAddress, mockDerivePhantom, mockGetCoinBalance } = vi.hoisted(() => ({
+const { mockDeriveAddress, mockDerivePhantom, mockDeriveTerraCosmosPath, mockGetCoinBalance } = vi.hoisted(() => ({
   mockDeriveAddress: vi.fn(),
   mockDerivePhantom: vi.fn(),
+  mockDeriveTerraCosmosPath: vi.fn(),
   mockGetCoinBalance: vi.fn(),
 }))
 
@@ -17,6 +18,7 @@ vi.mock('@/seedphrase/MasterKeyDeriver', () => ({
     Object.assign(this, {
       deriveAddress: mockDeriveAddress,
       deriveSolanaAddressWithPhantomPath: mockDerivePhantom,
+      deriveTerraAddressWithCosmosPath: mockDeriveTerraCosmosPath,
     })
   }),
 }))
@@ -32,6 +34,7 @@ describe('ChainDiscoveryService', () => {
     vi.clearAllMocks()
     mockDeriveAddress.mockImplementation(async (_mnemonic: string, chain: Chain) => `addr-${chain}`)
     mockDerivePhantom.mockResolvedValue('phantom-addr')
+    mockDeriveTerraCosmosPath.mockResolvedValue('terra1-cosmos-path-addr')
     mockGetCoinBalance.mockResolvedValue(0n)
   })
 
@@ -132,5 +135,81 @@ describe('ChainDiscoveryService', () => {
       config: { chains: [Chain.Ethereum], concurrencyLimit: 0 },
     })
     expect(mockDeriveAddress).toHaveBeenCalled()
+  })
+
+  it('discoverChains returns useCosmosPathTerra=false when 330-path Terra has balance', async () => {
+    mockDeriveAddress.mockImplementation(async (_m: string, chain: Chain) =>
+      chain === Chain.Terra ? 'terra1-standard-330-addr' : `addr-${chain}`
+    )
+    mockGetCoinBalance.mockImplementation(async ({ address }: { address: string }) => {
+      if (address === 'terra1-standard-330-addr') return 10_000_000n
+      return 0n
+    })
+
+    const s = new ChainDiscoveryService(wasmProvider)
+    const { useCosmosPathTerra } = await s.discoverChains('test mnemonic twelve words here about', {
+      config: { chains: [Chain.Terra] },
+    })
+
+    expect(useCosmosPathTerra).toBe(false)
+  })
+
+  it('discoverChains sets useCosmosPathTerra=true when 330-path is empty but 118-path has balance', async () => {
+    mockDeriveAddress.mockImplementation(async (_m: string, chain: Chain) =>
+      chain === Chain.Terra ? 'terra1-standard-330-addr' : `addr-${chain}`
+    )
+    mockGetCoinBalance.mockImplementation(async ({ address }: { address: string }) => {
+      if (address === 'terra1-standard-330-addr') return 0n
+      if (address === 'terra1-cosmos-path-addr') return 7_000_000n
+      return 0n
+    })
+
+    const s = new ChainDiscoveryService(wasmProvider)
+    const { results, useCosmosPathTerra } = await s.discoverChains('test mnemonic twelve words here about', {
+      config: { chains: [Chain.Terra] },
+    })
+
+    expect(useCosmosPathTerra).toBe(true)
+    const terra = results.find(r => r.chain === Chain.Terra)
+    expect(terra?.address).toBe('terra1-cosmos-path-addr')
+    expect(terra?.hasBalance).toBe(true)
+    expect(terra?.balance).toBe('7000000')
+    expect(mockDeriveTerraCosmosPath).toHaveBeenCalled()
+  })
+
+  it('discoverChains returns useCosmosPathTerra=false when both 330-path and 118-path have zero balance', async () => {
+    mockDeriveAddress.mockImplementation(async (_m: string, chain: Chain) =>
+      chain === Chain.Terra ? 'terra1-standard-330-addr' : `addr-${chain}`
+    )
+    mockGetCoinBalance.mockResolvedValue(0n)
+
+    const s = new ChainDiscoveryService(wasmProvider)
+    const { useCosmosPathTerra } = await s.discoverChains('test mnemonic twelve words here about', {
+      config: { chains: [Chain.Terra] },
+    })
+
+    expect(useCosmosPathTerra).toBe(false)
+  })
+
+  it('discoverChains prefers 330-path when both 330 and 118 have balance', async () => {
+    mockDeriveAddress.mockImplementation(async (_m: string, chain: Chain) =>
+      chain === Chain.Terra ? 'terra1-standard-330-addr' : `addr-${chain}`
+    )
+    mockGetCoinBalance.mockImplementation(async ({ address }: { address: string }) => {
+      // Both paths have balance
+      if (address === 'terra1-standard-330-addr') return 5_000_000n
+      if (address === 'terra1-cosmos-path-addr') return 3_000_000n
+      return 0n
+    })
+
+    const s = new ChainDiscoveryService(wasmProvider)
+    const { results, useCosmosPathTerra } = await s.discoverChains('test mnemonic twelve words here about', {
+      config: { chains: [Chain.Terra] },
+    })
+
+    // 330-path preferred: flag stays false, address stays on 330
+    expect(useCosmosPathTerra).toBe(false)
+    const terra = results.find(r => r.chain === Chain.Terra)
+    expect(terra?.address).toBe('terra1-standard-330-addr')
   })
 })

--- a/packages/sdk/tests/unit/seedphrase/MasterKeyDeriver.test.ts
+++ b/packages/sdk/tests/unit/seedphrase/MasterKeyDeriver.test.ts
@@ -19,6 +19,7 @@ const createMockWalletCore = () => {
 
   const mockPublicKey = {
     data: () => new Uint8Array(33).fill(0x02), // compressed secp256k1 format
+    delete: vi.fn(),
   }
 
   const mockPrivateKey = {
@@ -35,10 +36,12 @@ const createMockWalletCore = () => {
       lastPublicKeyCall = 'ed25519Cardano'
       return mockPublicKey
     }),
+    delete: vi.fn(),
   }
 
   const mockHdWallet = {
     getKeyForCoin: vi.fn(() => mockPrivateKey),
+    getKey: vi.fn((_coinType: unknown, _path: string) => mockPrivateKey),
     getAddressForCoin: vi.fn(() => '0xMockAddress'),
     getMasterKey: vi.fn(() => mockPrivateKey),
     getExtendedPrivateKey: vi.fn(() => 'xprv...'),
@@ -64,6 +67,11 @@ const createMockWalletCore = () => {
         cosmos: 118,
         thorchain: 931,
         litecoin: 2,
+        terraV2: 10000330,
+        terra: 330,
+      },
+      CoinTypeExt: {
+        deriveAddressFromPublicKey: vi.fn((_coinType: unknown, _pubKey: unknown) => 'terra1mockcosmospathaddr'),
       },
       Curve: {
         secp256k1: 'secp256k1',
@@ -77,6 +85,7 @@ const createMockWalletCore = () => {
       },
     },
     mockPrivateKey,
+    mockHdWallet,
     getLastPublicKeyCall: () => lastPublicKeyCall,
     resetPublicKeyCall: () => {
       lastPublicKeyCall = null
@@ -219,6 +228,59 @@ describe('MasterKeyDeriver', () => {
       const deriver = new MasterKeyDeriver(provider)
 
       await deriver.deriveChainKey(testMnemonic, Chain.Bitcoin, false)
+
+      const hdWallet = mock.walletCore.HDWallet.createWithMnemonic.mock.results[0].value
+      expect(hdWallet.delete).toHaveBeenCalled()
+    })
+  })
+
+  describe('deriveTerraAddressWithCosmosPath', () => {
+    it('should derive a terra1... address using the Cosmos coin-type path', async () => {
+      const mock = createMockWalletCore()
+      const provider = createMockWasmProvider(mock)
+      const deriver = new MasterKeyDeriver(provider)
+
+      const address = await deriver.deriveTerraAddressWithCosmosPath(testMnemonic)
+
+      expect(address).toBe('terra1mockcosmospathaddr')
+    })
+
+    it("should call getKey with terraV2 coin type and m/44'/118'/0'/0/0 path", async () => {
+      const mock = createMockWalletCore()
+      const provider = createMockWasmProvider(mock)
+      const deriver = new MasterKeyDeriver(provider)
+
+      await deriver.deriveTerraAddressWithCosmosPath(testMnemonic)
+
+      expect(mock.mockHdWallet.getKey).toHaveBeenCalledWith(mock.walletCore.CoinType.terraV2, "m/44'/118'/0'/0/0")
+    })
+
+    it('should use secp256k1 compressed public key for address derivation', async () => {
+      const mock = createMockWalletCore()
+      const provider = createMockWasmProvider(mock)
+      const deriver = new MasterKeyDeriver(provider)
+
+      await deriver.deriveTerraAddressWithCosmosPath(testMnemonic)
+
+      expect(mock.mockPrivateKey.getPublicKeySecp256k1).toHaveBeenCalledWith(true) // compressed
+    })
+
+    it('should clean up private key and public key objects', async () => {
+      const mock = createMockWalletCore()
+      const provider = createMockWasmProvider(mock)
+      const deriver = new MasterKeyDeriver(provider)
+
+      await deriver.deriveTerraAddressWithCosmosPath(testMnemonic)
+
+      expect(mock.mockPrivateKey.delete).toHaveBeenCalled()
+    })
+
+    it('should delete HDWallet after derivation', async () => {
+      const mock = createMockWalletCore()
+      const provider = createMockWasmProvider(mock)
+      const deriver = new MasterKeyDeriver(provider)
+
+      await deriver.deriveTerraAddressWithCosmosPath(testMnemonic)
 
       const hdWallet = mock.walletCore.HDWallet.createWithMnemonic.mock.results[0].value
       expect(hdWallet.delete).toHaveBeenCalled()


### PR DESCRIPTION
## Summary

- Part A of vultisig/vultiagent-app#449. Adds a discovery probe so seeds exported from Keplr/Leap (which use coin type 118 for Terra) are not reported as empty.
- Mirrors the existing Phantom-Solana dual-path pattern in `ChainDiscoveryService.ts`.
- Default behavior unchanged: 330-path remains preferred when it has balance. The 118-path flag flips only when 330 has zero balance AND 118 has non-zero balance.

## Files

- `packages/sdk/src/seedphrase/MasterKeyDeriver.ts` — adds `deriveTerraAddressWithCosmosPath` and `cosmosPathTerra` constant; extends `DeriveChainPrivateKeysOptions` with `useCosmosPathTerra`.
- `packages/sdk/src/seedphrase/ChainDiscoveryService.ts` — adds the 118-path probe (`checkCosmosPathTerraBalance`) parallel to Phantom Solana.
- `packages/sdk/src/seedphrase/types.ts` — adds `useCosmosPathTerra: boolean` to `ChainDiscoveryAggregate`, `CreateFastVaultFromSeedphraseOptions`, `CreateSecureVaultFromSeedphraseOptions`, `JoinSecureVaultOptions`.
- `packages/sdk/src/seedphrase/prepareSeedphraseImportPrelude.ts` — threads `useCosmosPathTerra` through prelude input/result.
- `packages/sdk/src/services/FastVaultFromSeedphraseService.ts` — passes `useCosmosPathTerra` to prelude and `deriveChainPrivateKeys`.
- `packages/sdk/src/services/SecureVaultFromSeedphraseService.ts` — same as above.
- `.changeset/feat-terra-cosmos-path-discovery-probe.md` — minor bump for @vultisig/sdk.

## Test plan

- [x] Unit: `deriveTerraAddressWithCosmosPath` calls `getKey(terraV2, "m/44'/118'/0'/0/0")`, uses secp256k1 compressed pubkey, cleans up objects.
- [x] Unit: probe flag=false when 330-path Terra has balance (no false switch).
- [x] Unit: probe flag=true when 330=0 and 118>0 (Keplr/Leap case).
- [x] Unit: probe flag=false when both are zero (no flip on empty wallet).
- [x] Unit: probe flag=false + address stays on 330 when both have balance (prefer native).
- [x] `yarn typecheck` — clean.
- [x] `yarn lint` — clean.
- [x] All 1397 unit tests pass (27 seedphrase tests including 9 new).
- [ ] Integration: app PR (Part B) threads `useCosmosPathTerra` into the import flow and an agent-device E2E confirms a known Keplr-funded Terra seed (118 path) imports with non-zero balance.

## receipts

**Code-level receipts (CI-equivalent):**
- 1397 unit tests pass (27 seedphrase tests including 9 new for the probe)
- typecheck: clean
- lint: clean

**Runtime E2E receipts:**
- Agent-device screenshots will be attached as a follow-up comment once the QA wave reaches this PR. Code is reviewable; runtime evidence to follow.

## Keplr address pre-check

The spike (`.spikes/va449-terra-dual-derivation-2026-05-23.md`) documents that `terraV2` (10000330) in WalletCore is a virtual coin type that controls address *encoding* (terra1... bech32) but still derives from path 330 by default. The fix uses `hdWallet.getKey(terraV2, "m/44'/118'/0'/0/0")` to override the path while keeping the encoding. This is structurally identical to the Phantom Solana pattern: same `getKey(coinType, altPath)` call. WalletCore's `CoinTypeExt.deriveAddressFromPublicKey(terraV2, pubKey)` then produces a valid `terra1...` address from the 118-derived key. Full live-wallet verification requires a funded Keplr seed (see spike QA-blocker section).

## Cross-repo

- vultiagent-app PR (Part B) reads `useCosmosPathTerra` from discovery result and switches `MPC_CHAIN_PATHS['Terra']` + `deriveChainKey` Terra to path 118 when set.
- Closes vultisig/vultiagent-app#449 SDK scope.

🤖 Agent-generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection and support for Terra using an alternative derivation path (Cosmos coin-type 118) when the standard path is empty, enabling recovery of wallets created with Keplr/Leap.
  * Added configuration options to enable/disable the alternative Terra path during seedphrase import and vault creation.

* **Tests**
  * Expanded test coverage for Terra path selection logic and alternative derivation path handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/530?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->