### PR TITLE
fix(swap): surface provider below-minimum errors instead of generic no-route message

### DIFF
--- a/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.test.ts
+++ b/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.test.ts
@@ -5,13 +5,16 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { getSwapKitQuote } from './getSwapKitQuote'
 
-const response = (body: unknown, ok = true, status = 200) =>
-  ({
+const response = (body: unknown, ok = true, status = 200) => {
+  const serialized = JSON.stringify(body)
+  return {
     ok,
     status,
     statusText: ok ? 'OK' : 'Bad Request',
+    text: vi.fn(async () => serialized),
     json: vi.fn(async () => body),
-  }) as unknown as Response
+  } as unknown as Response
+}
 
 type TransferSourceFixture = readonly [string, SwapKitSourceChain, string, number, string, string]
 
@@ -533,6 +536,48 @@ describe('getSwapKitQuote', () => {
         amount: 100n,
       })
     ).rejects.toThrow('NEAR: min amount not met for this swap')
+  })
+
+  it('throws a below-minimum error when providerErrors are present alongside valid routes (signal-loss regression)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      response({
+        routes: [
+          {
+            routeId: 'near-route',
+            providers: ['NEAR'],
+            expectedBuyAmount: '0.001',
+          },
+        ],
+        providerErrors: [
+          {
+            provider: 'CHAINFLIP',
+            message: 'Amount below minimum: 0.0003 BTC required',
+            errorCode: 'BELOW_MINIMUM',
+          },
+        ],
+      })
+    )
+
+    vi.stubGlobal('fetch', fetchMock)
+    configureSwapKit({ apiKey: undefined })
+
+    await expect(
+      getSwapKitQuote({
+        from: {
+          chain: Chain.Bitcoin,
+          address: 'bc1qsource',
+          ticker: 'BTC',
+          decimals: 8,
+        },
+        to: {
+          chain: Chain.Ethereum,
+          address: '0xdestination',
+          ticker: 'ETH',
+          decimals: 18,
+        },
+        amount: 1000n,
+      })
+    ).rejects.toThrow('CHAINFLIP: Amount below minimum: 0.0003 BTC required')
   })
 
   it('falls back to focused provider groups when the broad SwapKit provider query misses a route', async () => {

--- a/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.test.ts
+++ b/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.test.ts
@@ -538,46 +538,72 @@ describe('getSwapKitQuote', () => {
     ).rejects.toThrow('NEAR: min amount not met for this swap')
   })
 
-  it('throws a below-minimum error when providerErrors are present alongside valid routes (signal-loss regression)', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      response({
-        routes: [
-          {
-            routeId: 'near-route',
-            providers: ['NEAR'],
-            expectedBuyAmount: '0.001',
+  it('returns a valid route when providerErrors carry below-minimum alongside valid routes (no UX regression)', async () => {
+    // Updated #535 r3 (NeO preferably-blocking): when SwapKit returns a usable
+    // route AND a below-minimum providerError, we MUST return the route. The
+    // earlier behavior (throwing the providerError) blocked users from a
+    // route they could otherwise execute. Below-min surfacing is now gated
+    // on `allowedRoutes.length === 0`. EVM→Sui path so we can reuse the
+    // existing NEAR-route mock shape (UTXO source would need different
+    // tx envelope structure).
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        response({
+          routes: [
+            {
+              routeId: 'near-route',
+              providers: ['NEAR'],
+              expectedBuyAmount: '9.4',
+            },
+          ],
+          providerErrors: [
+            {
+              provider: 'CHAINFLIP',
+              message: 'Amount below minimum: 0.0003 BTC required',
+              errorCode: 'BELOW_MINIMUM',
+            },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(
+        // Second call: route-detail fetch for the selected NEAR route.
+        response({
+          expectedBuyAmount: '9.3',
+          providers: ['NEAR'],
+          tx: {
+            to: '0xnear-deposit',
+            value: '5000000000000000',
+            gasLimit: '21000',
           },
-        ],
-        providerErrors: [
-          {
-            provider: 'CHAINFLIP',
-            message: 'Amount below minimum: 0.0003 BTC required',
-            errorCode: 'BELOW_MINIMUM',
-          },
-        ],
-      })
-    )
+        })
+      )
 
     vi.stubGlobal('fetch', fetchMock)
     configureSwapKit({ apiKey: undefined })
 
-    await expect(
-      getSwapKitQuote({
-        from: {
-          chain: Chain.Bitcoin,
-          address: 'bc1qsource',
-          ticker: 'BTC',
-          decimals: 8,
-        },
-        to: {
-          chain: Chain.Ethereum,
-          address: '0xdestination',
-          ticker: 'ETH',
-          decimals: 18,
-        },
-        amount: 1000n,
-      })
-    ).rejects.toThrow('CHAINFLIP: Amount below minimum: 0.0003 BTC required')
+    // Must NOT throw — the NEAR route is valid and should be returned even
+    // though CHAINFLIP rejected for below-minimum.
+    const quote = await getSwapKitQuote({
+      from: {
+        chain: Chain.Ethereum,
+        address: '0xsender',
+        ticker: 'ETH',
+        decimals: 18,
+      },
+      to: {
+        chain: Chain.Sui,
+        address: '0xsui',
+        ticker: 'SUI',
+        decimals: 9,
+      },
+      amount: 5_000_000_000_000_000n,
+    })
+
+    expect(quote).toMatchObject({
+      provider: 'swapkit',
+      routeProvider: 'NEAR',
+    })
   })
 
   it('falls back to focused provider groups when the broad SwapKit provider query misses a route', async () => {

--- a/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.test.ts
+++ b/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.test.ts
@@ -458,6 +458,83 @@ describe('getSwapKitQuote', () => {
     expect(JSON.parse(fetchMock.mock.calls[1][1].body).routeId).toBe('valid-route')
   })
 
+  it('throws a below-minimum error when providerErrors carry a minimum-size rejection (no-route response)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      response(
+        {
+          routes: [],
+          error: 'noRoutesFound',
+          message: 'No routes found for BTC.BTC -> ETH.ETH',
+          providerErrors: [
+            {
+              provider: 'CHAINFLIP',
+              message: 'Amount below minimum: 0.0003 BTC required',
+              errorCode: 'BELOW_MINIMUM',
+            },
+          ],
+        },
+        false,
+        400
+      )
+    )
+
+    vi.stubGlobal('fetch', fetchMock)
+    configureSwapKit({ apiKey: undefined })
+
+    await expect(
+      getSwapKitQuote({
+        from: {
+          chain: Chain.Bitcoin,
+          address: 'bc1qsource',
+          ticker: 'BTC',
+          decimals: 8,
+        },
+        to: {
+          chain: Chain.Ethereum,
+          address: '0xdestination',
+          ticker: 'ETH',
+          decimals: 18,
+        },
+        amount: 1000n,
+      })
+    ).rejects.toThrow('CHAINFLIP: Amount below minimum: 0.0003 BTC required')
+  })
+
+  it('throws a below-minimum error when providerErrors carry a minimum-size rejection (200 with empty routes)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      response({
+        routes: [],
+        providerErrors: [
+          {
+            provider: 'NEAR',
+            message: 'min amount not met for this swap',
+          },
+        ],
+      })
+    )
+
+    vi.stubGlobal('fetch', fetchMock)
+    configureSwapKit({ apiKey: undefined })
+
+    await expect(
+      getSwapKitQuote({
+        from: {
+          chain: Chain.Bitcoin,
+          address: 'bc1qsource',
+          ticker: 'BTC',
+          decimals: 8,
+        },
+        to: {
+          chain: Chain.Ethereum,
+          address: '0xdestination',
+          ticker: 'ETH',
+          decimals: 18,
+        },
+        amount: 100n,
+      })
+    ).rejects.toThrow('NEAR: min amount not met for this swap')
+  })
+
   it('falls back to focused provider groups when the broad SwapKit provider query misses a route', async () => {
     const fetchMock = vi
       .fn()

--- a/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.ts
+++ b/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.ts
@@ -195,6 +195,23 @@ const isNoRouteError = (message: string) => {
 const isBelowMinimumError = (message: string) => {
   const lower = message.toLowerCase()
 
+  // Rejection tokens that anchor the minimum-size patterns to actual failures.
+  // Without them, phrases like 'minimum amount of gas used' (success context)
+  // would produce false positives.
+  const hasRejectionToken =
+    lower.includes('rejected') ||
+    lower.includes('failed') ||
+    lower.includes('not met') ||
+    lower.includes('required') ||
+    lower.includes('too small') ||
+    lower.includes('below') ||
+    lower.includes('error') ||
+    lower.includes('threshold')
+
+  if (!hasRejectionToken) {
+    return false
+  }
+
   return (
     lower.includes('below minimum') ||
     lower.includes('belowminimum') ||
@@ -206,6 +223,9 @@ const isBelowMinimumError = (message: string) => {
   )
 }
 
+const isBelowMinimumErrorCode = (errorCode: string | undefined): boolean =>
+  typeof errorCode === 'string' && errorCode.toUpperCase().includes('BELOW_MINIMUM')
+
 /** Extracts the first below-minimum signal from providerErrors, if any. */
 const extractBelowMinimumProviderError = (errors: SwapKitQuoteResponse['providerErrors']): string | undefined => {
   if (!errors?.length) {
@@ -213,10 +233,18 @@ const extractBelowMinimumProviderError = (errors: SwapKitQuoteResponse['provider
   }
 
   for (const err of errors) {
-    const msg = err.message ?? ''
-    if (isBelowMinimumError(msg)) {
+    const raw = err.message
+    // Guard: SwapKit schema marks message as optional string, but runtime values
+    // may be numeric or nested objects. Skip non-string entries to avoid TypeError
+    // from calling .toLowerCase() on a non-string.
+    const isStringMsg = typeof raw === 'string'
+
+    // Accept if the message pattern matches OR if the errorCode explicitly signals
+    // a below-minimum rejection (handles cases where the message text is vague).
+    if ((isStringMsg && isBelowMinimumError(raw)) || isBelowMinimumErrorCode(err.errorCode)) {
       const provider = err.provider ? `${err.provider}: ` : ''
-      return `${provider}${msg}`
+      const msgText = isStringMsg ? raw : 'Amount below minimum'
+      return `${provider}${msgText}`
     }
   }
 
@@ -489,12 +517,19 @@ const fetchSwapKitQuoteResponse = async (body: Record<string, unknown>): Promise
     body: JSON.stringify(body),
   })
 
-  // Parse the body regardless of HTTP status — SwapKit embeds providerErrors
-  // inside 400/error responses that we need to inspect for minimum-size signals.
-  const data = await response.json().catch(() => undefined)
+  // Capture raw text first so non-JSON error bodies (e.g. HTML from a load
+  // balancer) are preserved for debugging instead of being swallowed silently.
+  const rawText = await response.text().catch(() => '')
+  let data: unknown
+  try {
+    data = rawText ? JSON.parse(rawText) : undefined
+  } catch {
+    data = undefined
+  }
 
   if (!response.ok && !isRecord(data)) {
-    throw new Error(`SwapKit request failed (${response.status}): ${response.statusText}`)
+    const bodyHint = rawText ? ` body: ${rawText.slice(0, 200)}` : ''
+    throw new Error(`SwapKit request failed (${response.status}): ${response.statusText}${bodyHint}`)
   }
 
   return (isRecord(data) ? data : {}) as SwapKitQuoteResponse
@@ -531,13 +566,12 @@ const getSwapKitRoutes = async (
 
     const allowedRoutes = quoteResponse.routes?.filter(isAllowedRoute) ?? []
 
-    // Even with routes present, check providerErrors for minimum signals on partial failures.
-    // If every allowed route was filtered out but a provider told us why, surface it.
-    if (allowedRoutes.length === 0) {
-      const belowMinMsg = extractBelowMinimumProviderError(quoteResponse.providerErrors)
-      if (belowMinMsg) {
-        throw new Error(belowMinMsg)
-      }
+    // Check providerErrors unconditionally — a provider rejecting for below-minimum
+    // is an actionable signal even when other routes exist. The user could increase
+    // their amount to unlock that provider's (potentially better) route.
+    const belowMinMsg = extractBelowMinimumProviderError(quoteResponse.providerErrors)
+    if (belowMinMsg) {
+      throw new Error(belowMinMsg)
     }
 
     return allowedRoutes

--- a/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.ts
+++ b/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.ts
@@ -192,6 +192,37 @@ const isNoRouteError = (message: string) => {
   return normalizedMessage.includes('noroutesfound') || normalizedMessage.includes('noroutes')
 }
 
+const isBelowMinimumError = (message: string) => {
+  const lower = message.toLowerCase()
+
+  return (
+    lower.includes('below minimum') ||
+    lower.includes('belowminimum') ||
+    lower.includes('minimum amount') ||
+    lower.includes('min amount') ||
+    lower.includes('amount too small') ||
+    lower.includes('dust threshold') ||
+    lower.includes('below the minimum')
+  )
+}
+
+/** Extracts the first below-minimum signal from providerErrors, if any. */
+const extractBelowMinimumProviderError = (errors: SwapKitQuoteResponse['providerErrors']): string | undefined => {
+  if (!errors?.length) {
+    return undefined
+  }
+
+  for (const err of errors) {
+    const msg = err.message ?? ''
+    if (isBelowMinimumError(msg)) {
+      const provider = err.provider ? `${err.provider}: ` : ''
+      return `${provider}${msg}`
+    }
+  }
+
+  return undefined
+}
+
 const getRouteProviderName = (route: Pick<SwapKitQuoteRoute, 'providers' | 'legs'>) => {
   const [firstProvider] = routeProviderNames(route).filter(provider => !swapKitExcludedProviders.has(provider))
 
@@ -445,13 +476,36 @@ const sortRoutesByExpectedBuyAmount = (routes: SwapKitQuoteRoute[], decimals: nu
     return oneAmount > anotherAmount ? -1 : 1
   })
 
+const fetchSwapKitQuoteResponse = async (body: Record<string, unknown>): Promise<SwapKitQuoteResponse> => {
+  const { apiKey, baseUrl } = getSwapKitConfig()
+  const trimmedApiKey = apiKey?.trim()
+
+  const response = await fetch(`${baseUrl.replace(/\/$/, '')}/v3/quote`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(trimmedApiKey ? { 'x-api-key': trimmedApiKey } : {}),
+    },
+    body: JSON.stringify(body),
+  })
+
+  // Parse the body regardless of HTTP status — SwapKit embeds providerErrors
+  // inside 400/error responses that we need to inspect for minimum-size signals.
+  const data = await response.json().catch(() => undefined)
+
+  if (!response.ok && !isRecord(data)) {
+    throw new Error(`SwapKit request failed (${response.status}): ${response.statusText}`)
+  }
+
+  return (isRecord(data) ? data : {}) as SwapKitQuoteResponse
+}
+
 const getSwapKitRoutes = async (
   body: Record<string, unknown>,
   providers: SwapKitProvider[]
 ): Promise<SwapKitQuoteRoute[]> => {
   try {
-    const quoteResponse = await postSwapKit<SwapKitQuoteResponse>(
-      '/v3/quote',
+    const quoteResponse = await fetchSwapKitQuoteResponse(
       withoutUndefinedFields({
         ...body,
         providers,
@@ -462,13 +516,31 @@ const getSwapKitRoutes = async (
       const message = quoteResponse.message ?? quoteResponse.error
 
       if (isNoRouteError(message)) {
+        // Before swallowing the no-route response, check if any provider
+        // told us the amount is below their minimum — that's more actionable.
+        const belowMinMsg = extractBelowMinimumProviderError(quoteResponse.providerErrors)
+        if (belowMinMsg) {
+          throw new Error(belowMinMsg)
+        }
+
         return []
       }
 
       throw new Error(message)
     }
 
-    return quoteResponse.routes?.filter(isAllowedRoute) ?? []
+    const allowedRoutes = quoteResponse.routes?.filter(isAllowedRoute) ?? []
+
+    // Even with routes present, check providerErrors for minimum signals on partial failures.
+    // If every allowed route was filtered out but a provider told us why, surface it.
+    if (allowedRoutes.length === 0) {
+      const belowMinMsg = extractBelowMinimumProviderError(quoteResponse.providerErrors)
+      if (belowMinMsg) {
+        throw new Error(belowMinMsg)
+      }
+    }
+
+    return allowedRoutes
   } catch (error) {
     if (error instanceof Error && isNoRouteError(error.message)) {
       return []

--- a/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.ts
+++ b/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.ts
@@ -566,12 +566,22 @@ const getSwapKitRoutes = async (
 
     const allowedRoutes = quoteResponse.routes?.filter(isAllowedRoute) ?? []
 
-    // Check providerErrors unconditionally — a provider rejecting for below-minimum
-    // is an actionable signal even when other routes exist. The user could increase
-    // their amount to unlock that provider's (potentially better) route.
-    const belowMinMsg = extractBelowMinimumProviderError(quoteResponse.providerErrors)
-    if (belowMinMsg) {
-      throw new Error(belowMinMsg)
+    // Below-minimum surfacing is gated on having NO allowed routes. The earlier
+    // unconditional throw was a UX regression: when SwapKit returns
+    // `routes: [NEAR_route], providerErrors: [{CHAINFLIP below-minimum}]`,
+    // throwing the CHAINFLIP-below-min error would block the user from the
+    // NEAR route they could otherwise execute. The actionable-hint argument
+    // ("user could increase amount to unlock the rejected provider") is real
+    // but a second-order optimization that doesn't justify breaking the
+    // primary "we found a route, let them swap" path. If we later want to
+    // surface "could be better with $larger amount" as a non-blocking hint,
+    // the right place is the route metadata (separate channel from the
+    // throw/return contract here). (#535 r3 — NeO preferably-blocking.)
+    if (allowedRoutes.length === 0) {
+      const belowMinMsg = extractBelowMinimumProviderError(quoteResponse.providerErrors)
+      if (belowMinMsg) {
+        throw new Error(belowMinMsg)
+      }
     }
 
     return allowedRoutes

--- a/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
@@ -280,6 +280,41 @@ describe('findSwapQuote parallel selection', () => {
     }
   })
 
+  it('surfaces a below-minimum message from SwapKit providerErrors when all providers fail', async () => {
+    vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('kyber fail'))
+    vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('inch fail'))
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('lifi fail'))
+    vi.mocked(getSwapKitQuote).mockRejectedValue(new Error('CHAINFLIP: Amount below minimum: 0.0003 BTC required'))
+    vi.mocked(getNativeSwapQuote).mockRejectedValue(new Error('native fail'))
+
+    await expect(
+      findSwapQuote({
+        ...evmSameChainCoins,
+        amount: 1n,
+      })
+    ).rejects.toThrow('Amount below the minimum required by a swap provider.')
+  })
+
+  it('prefers dust-threshold message over below-minimum when both signals are present', async () => {
+    vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('kyber fail'))
+    vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('inch fail'))
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('lifi fail'))
+    vi.mocked(getSwapKitQuote).mockRejectedValue(new Error('CHAINFLIP: Amount below minimum: 0.0003 BTC required'))
+    vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) => {
+      if (swapChain === Chain.THORChain) {
+        throw new Error('amount less than dust threshold')
+      }
+      throw new Error('maya fail')
+    })
+
+    await expect(
+      findSwapQuote({
+        ...evmSameChainCoins,
+        amount: 1n,
+      })
+    ).rejects.toThrow('Swap amount too small. Please increase the amount to proceed.')
+  })
+
   it('maps dust threshold on any provider to the user-facing message (Maya in this setup)', async () => {
     vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('kyber fail'))
     vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('inch fail'))

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -304,10 +304,15 @@ export const findSwapQuote = async ({
   // specific message available: a provider's "below minimum" hint beats the
   // generic no-route fallback.
   //
-  // Provider preference order mirrors fetcher preference: KyberSwap first (most
-  // specific EVM messages), then 1inch, LiFi, SwapKit (cross-chain specifics),
-  // THORChain, MayaChain. This ensures deterministic selection regardless of
-  // Promise.allSettled resolution order.
+  // Provider preference order is INTENTIONALLY stable here — it does NOT mirror
+  // the runtime `fetchers[]` array order, which shifts based on
+  // `shouldPreferGeneralSwap`. The below-min preference is a separate concept:
+  // we pick which provider's hint to surface, not which provider to query
+  // first. KyberSwap typically surfaces the cleanest EVM messages, then 1inch
+  // and LiFi (cross-chain matrix), then SwapKit (catch-all), then the two
+  // native protocols. This ordering is independent of routing and gives
+  // deterministic message selection regardless of `Promise.allSettled`
+  // resolution order. (#535 r3 — NeO preferably-blocking response.)
   const belowMinimumProviderOrder: SwapQuoteProviderName[] = [
     'KyberSwap',
     '1inch',

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -303,9 +303,35 @@ export const findSwapQuote = async ({
   // Scan rejected results for actionable size-related signals. Prefer the most
   // specific message available: a provider's "below minimum" hint beats the
   // generic no-route fallback.
-  let belowMinimumMessage: string | undefined
+  //
+  // Provider preference order mirrors fetcher preference: KyberSwap first (most
+  // specific EVM messages), then 1inch, LiFi, SwapKit (cross-chain specifics),
+  // THORChain, MayaChain. This ensures deterministic selection regardless of
+  // Promise.allSettled resolution order.
+  const belowMinimumProviderOrder: SwapQuoteProviderName[] = [
+    'KyberSwap',
+    '1inch',
+    'LiFi',
+    'SwapKit',
+    'THORChain',
+    'MayaChain',
+  ]
 
-  for (const result of settled) {
+  const isBelowMinimumMsg = (msg: string) => {
+    const lower = msg.toLowerCase()
+    return (
+      lower.includes('below minimum') ||
+      lower.includes('minimum amount') ||
+      lower.includes('min amount') ||
+      lower.includes('amount too small') ||
+      lower.includes('below the minimum')
+    )
+  }
+
+  const belowMinimumByProvider = new Map<SwapQuoteProviderName, string>()
+
+  for (let i = 0; i < settled.length; i++) {
+    const result = settled[i]
     if (result.status !== 'rejected') {
       continue
     }
@@ -316,19 +342,20 @@ export const findSwapQuote = async ({
       throw new Error('Swap amount too small. Please increase the amount to proceed.')
     }
 
-    if (
-      !belowMinimumMessage &&
-      (msg.toLowerCase().includes('below minimum') ||
-        msg.toLowerCase().includes('minimum amount') ||
-        msg.toLowerCase().includes('min amount') ||
-        msg.toLowerCase().includes('amount too small') ||
-        msg.toLowerCase().includes('below the minimum'))
-    ) {
-      belowMinimumMessage = msg
+    if (isBelowMinimumMsg(msg)) {
+      const providerName = fetchers[i].providerName
+      if (!belowMinimumByProvider.has(providerName)) {
+        belowMinimumByProvider.set(providerName, msg)
+      }
     }
   }
 
-  if (belowMinimumMessage) {
+  if (belowMinimumByProvider.size > 0) {
+    // Pick the message from the highest-preference provider that has one.
+    const preferred = belowMinimumProviderOrder.find(p => belowMinimumByProvider.has(p))
+    const belowMinimumMessage = preferred
+      ? belowMinimumByProvider.get(preferred)!
+      : [...belowMinimumByProvider.values()][0]
     throw new Error(`Amount below the minimum required by a swap provider. ${belowMinimumMessage}`)
   }
 

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -300,10 +300,36 @@ export const findSwapQuote = async ({
     return best
   }
 
+  // Scan rejected results for actionable size-related signals. Prefer the most
+  // specific message available: a provider's "below minimum" hint beats the
+  // generic no-route fallback.
+  let belowMinimumMessage: string | undefined
+
   for (const result of settled) {
-    if (result.status === 'rejected' && isInError(result.reason, 'dust threshold')) {
+    if (result.status !== 'rejected') {
+      continue
+    }
+
+    const msg: string = result.reason instanceof Error ? result.reason.message : String(result.reason)
+
+    if (isInError(result.reason, 'dust threshold') || isInError(result.reason, 'amount less than')) {
       throw new Error('Swap amount too small. Please increase the amount to proceed.')
     }
+
+    if (
+      !belowMinimumMessage &&
+      (msg.toLowerCase().includes('below minimum') ||
+        msg.toLowerCase().includes('minimum amount') ||
+        msg.toLowerCase().includes('min amount') ||
+        msg.toLowerCase().includes('amount too small') ||
+        msg.toLowerCase().includes('below the minimum'))
+    ) {
+      belowMinimumMessage = msg
+    }
+  }
+
+  if (belowMinimumMessage) {
+    throw new Error(`Amount below the minimum required by a swap provider. ${belowMinimumMessage}`)
   }
 
   const failedProviders = settled


### PR DESCRIPTION
## what

When a swap amount is below a provider's minimum, the SDK was swallowing the structured rejection and bubbling up the generic \"No swap route found after trying...\" error. Users had no idea whether they needed to increase the amount or whether the pair simply wasn't supported.

This PR threads the actual provider signal through when one exists.

## how

Two files changed:

**`getSwapKitQuote.ts`**
- `postSwapKit` throws on non-2xx before the caller can read `providerErrors`. Replaced it with `fetchSwapKitQuoteResponse` that always parses the JSON body regardless of HTTP status - SwapKit embeds `providerErrors` in 400-range error bodies and we need to inspect them.
- Added `isBelowMinimumError(message)` - matches the common surface strings: `"below minimum"`, `"belowminimum"`, `"minimum amount"`, `"min amount"`, `"amount too small"`, `"dust threshold"`, `"below the minimum"`.
- Added `extractBelowMinimumProviderError(providerErrors)` - iterates `providerErrors[]` and returns the first match, prefixed with the provider name when available (e.g. `"CHAINFLIP: Amount below minimum: 0.0003 BTC required"`).
- `getSwapKitRoutes` now checks `providerErrors` on both the no-route path (error response) and the empty-routes path (200 with `routes: []`), and throws the extracted message instead of silently returning `[]`.

**`findSwapQuote.ts`**
- Broadened the existing dust-threshold check to also match `"amount less than"` (THORChain native variant).
- Added a second pass over rejected settlements: any rejection whose message contains a below-minimum signal gets captured. If no dust-threshold hit was found but a below-minimum one was, the error is re-thrown as `"Amount below the minimum required by a swap provider. <provider>: <message>"`.

## spike findings (curl receipts)

SwapKit proxy — sub-minimum BTC→ETH (0.00001 BTC, ~\$1):
```
POST https://api.vultisig.com/swapkit/v3/quote
{"sellAsset":"BTC.BTC","buyAsset":"ETH.ETH","sellAmount":"0.00001","slippage":1}

HTTP 404
{"error":"noRoutesFound","message":"No routes found for BTC.BTC -> ETH.ETH","data":{...}}
providerErrors: null
```

SwapKit proxy — working amount (0.0001 BTC, ~\$10):
```
HTTP 200 - routes returned with NEAR provider, no providerErrors populated
```

THORChain native — all pairs:
```
{"code":3,"message":"failed to simulate swap: failed to simulate handler: trading is halted"}
```
THORChain has `HALTTRADING: 1` globally set (confirmed via mimir endpoint). All native THORChain/MayaChain quotes are erroring out during this spike window.

The SwapKit proxy does not currently populate `providerErrors` for sub-minimum rejections (it returns generic `noRoutesFound`). The code is wired up correctly for when providers start sending structured errors through the proxy - particularly Chainflip and NEAR which do surface minimum-size messages per the SwapKit API schema (`{ provider?, message?, errorCode? }[]`).

## sim receipt

App running SDK 0.26.1 (current published), sub-minimum swap request "swap 0.0001 ETH for BTC" (~\$0.25, well below any provider minimum):

![before - generic error](https://files.catbox.moe/ec8mj2.png)

Current behavior: "Something went wrong. Please try again." - no actionable signal for the user.

With this fix: when a provider populates `providerErrors[]` with a minimum-size message, the app would surface e.g. "Amount below the minimum required by a swap provider. CHAINFLIP: Amount below minimum: 0.0003 BTC required" instead.

**sim "after" receipt gap:** the SDK local-link approach hits a Metro/shim incompatibility (the published SDK bundles `viem` etc. internally; `file://` linking causes Metro to re-shim those via the app's `SDK_EXTERNAL_STUBS`, breaking module resolution). The after-receipt will land when this version is published to npm and the app is updated to pull it. The before-receipt above confirms the current broken behavior is real.

## tests

564 tests pass. New cases:

- `getSwapKitQuote.test.ts`: two new tests covering 400-body providerErrors extraction and 200+empty-routes providerErrors extraction
- `findSwapQuote.selection.test.ts`: two new tests covering below-minimum surfacing from SwapKit providerErrors and dust-threshold precedence over below-minimum

```
Test Files  66 passed (66)
Tests  564 passed (564)
```

🤖 Agent-generated

closes #532

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Surface provider-prefixed "below minimum" errors instead of generic "no route found"; prioritize dust-threshold and provider-specific minimum messages.
  * Ensure below-minimum signals are detected even when routes are present or responses are 200 with empty routes.

* **Tests**
  * Added tests covering below-minimum detection, provider-prefixed messages, regression cases, and message-prioritization across providers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/535?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->