### PR TITLE
fix(seedphrase): probe TerraClassic alongside Terra for cosmos-path detection

### DIFF
--- a/packages/sdk/src/seedphrase/ChainDiscoveryService.ts
+++ b/packages/sdk/src/seedphrase/ChainDiscoveryService.ts
@@ -176,12 +176,15 @@ export class ChainDiscoveryService {
       }
     }
 
-    // Check Cosmos-coin-type Terra path (m/44'/118'/0'/0/0) if Terra was in the scan.
-    // Keplr and Leap historically derived Terra under coin type 118 instead of 330.
-    // Use the 118 path when it has balance AND the standard 330 path has no balance.
+    // Check Cosmos-coin-type Terra/TerraClassic path (m/44'/118'/0'/0/0) if either
+    // chain was in the scan. Keplr and Leap historically derived Terra/TerraClassic
+    // under coin type 118 instead of their native SLIP-44 paths.
+    // Use the 118 path when it has balance AND the standard path has no balance.
     let useCosmosPathTerra = false
     const terraResult = results.find(r => r.chain === Chain.Terra)
+    const terraClassicResult = results.find(r => r.chain === Chain.TerraClassic)
 
+    // Probe Terra (Luna v2) if it was in the scan.
     if (terraResult) {
       try {
         const cosmosPathCheck = await this.checkCosmosPathTerraBalance(mnemonic, timeoutPerChain)
@@ -202,6 +205,32 @@ export class ChainDiscoveryService {
       } catch (error) {
         // Cosmos-path Terra check failed, continue with standard 330 path
         console.warn('Failed to check Cosmos-path Terra address:', error)
+      }
+    }
+
+    // Probe TerraClassic (LUNC) if it was in the scan but Terra was not.
+    // Without this, config.chains: [Chain.TerraClassic] seeds created in Keplr/Leap
+    // could never have useCosmosPathTerra set, despite the Terra/TerraClassic contract
+    // documented in the public types. (sdk#530 post-merge CR follow-up.)
+    if (!terraResult && terraClassicResult) {
+      try {
+        const cosmosPathCheck = await this.checkCosmosPathTerraClassicBalance(mnemonic, timeoutPerChain)
+        const standard330Balance = BigInt(terraClassicResult.balance || '0')
+
+        // Same rule: use 118 path when it has balance and the standard path does not
+        useCosmosPathTerra = cosmosPathCheck.balance > 0n && standard330Balance === 0n
+
+        if (useCosmosPathTerra) {
+          terraClassicResult.address = cosmosPathCheck.address
+          terraClassicResult.balance = cosmosPathCheck.balance.toString()
+          terraClassicResult.hasBalance = true
+          if (!chainsWithBalance.includes(Chain.TerraClassic)) {
+            chainsWithBalance.push(Chain.TerraClassic)
+          }
+        }
+      } catch (error) {
+        // Cosmos-path TerraClassic check failed, continue with standard path
+        console.warn('Failed to check Cosmos-path TerraClassic address:', error)
       }
     }
 
@@ -343,6 +372,36 @@ export class ChainDiscoveryService {
       const address = await this.keyDeriver.deriveTerraAddressWithCosmosPath(mnemonic)
       const balance = await getCoinBalance({
         chain: Chain.Terra,
+        address,
+      })
+      return { address, balance }
+    }
+
+    return Promise.race([checkPromise(), timeoutPromise]).finally(() => {
+      if (timeoutId) clearTimeout(timeoutId)
+    })
+  }
+
+  /**
+   * Check TerraClassic (LUNC) balance using the Cosmos coin-type derivation path.
+   *
+   * TerraClassic-only seeds created in Keplr/Leap also use coin type 118 instead
+   * of TerraClassic's native SLIP-44 path. This is the TerraClassic counterpart of
+   * checkCosmosPathTerraBalance. (sdk#530 post-merge CR follow-up.)
+   */
+  private async checkCosmosPathTerraClassicBalance(
+    mnemonic: string,
+    timeout: number
+  ): Promise<{ address: string; balance: bigint }> {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => reject(new Error('Timeout checking Cosmos-path TerraClassic address')), timeout)
+    })
+
+    const checkPromise = async () => {
+      const address = await this.keyDeriver.deriveTerraClassicAddressWithCosmosPath(mnemonic)
+      const balance = await getCoinBalance({
+        chain: Chain.TerraClassic,
         address,
       })
       return { address, balance }

--- a/packages/sdk/src/seedphrase/ChainDiscoveryService.ts
+++ b/packages/sdk/src/seedphrase/ChainDiscoveryService.ts
@@ -14,6 +14,24 @@ import { MasterKeyDeriver } from './MasterKeyDeriver'
 import type { ChainDiscoveryAggregate, ChainDiscoveryProgress, ChainDiscoveryResult } from './types'
 
 /**
+ * Thrown when a balance RPC call fails due to a transport-level error
+ * (network timeout, DNS failure, non-2xx HTTP status).
+ *
+ * Callers must distinguish this from a confirmed-zero-balance result:
+ * - TransportError  → RPC unreachable; balance unknown; warn + continue
+ * - probe returns   → RPC responded; balance confirmed (may be zero)
+ */
+export class TransportError extends Error {
+  override readonly name = 'TransportError'
+  constructor(
+    message: string,
+    public readonly cause?: unknown
+  ) {
+    super(message)
+  }
+}
+
+/**
  * Configuration for chain discovery
  */
 export type ChainDiscoveryConfig = {
@@ -226,27 +244,42 @@ export class ChainDiscoveryService {
 
     // Terra (Luna v2) probe runs first if Terra was in scan.
     if (terraResult) {
-      const fired = await this.tryApplyCosmosPath({
-        result: terraResult,
-        chainsWithBalance,
-        chain: Chain.Terra,
-        probe: () => this.checkCosmosPathTerraBalance(mnemonic, timeoutPerChain),
-        logLabel: 'Cosmos-path Terra',
-      })
-      if (fired) return true
+      try {
+        const fired = await this.tryApplyCosmosPath({
+          result: terraResult,
+          chainsWithBalance,
+          chain: Chain.Terra,
+          probe: () => this.checkCosmosPathTerraBalance(mnemonic, timeoutPerChain),
+          logLabel: 'Cosmos-path Terra',
+        })
+        if (fired) return true
+      } catch (error) {
+        // TransportError: RPC unreachable. Balance unknown — warn and continue.
+        // Do NOT treat as zero balance; the user may have funds on this path.
+        console.warn(`Cosmos-path Terra balance check failed (transport):`, { chain: Chain.Terra, path: '118', error })
+      }
     }
 
     // TerraClassic (LUNC) probe only runs if Terra wasn't in scan, so the contract
     // (Terra-first preference) is preserved. (sdk#530 post-merge CR follow-up.)
     if (!terraResult && terraClassicResult) {
-      const fired = await this.tryApplyCosmosPath({
-        result: terraClassicResult,
-        chainsWithBalance,
-        chain: Chain.TerraClassic,
-        probe: () => this.checkCosmosPathTerraClassicBalance(mnemonic, timeoutPerChain),
-        logLabel: 'Cosmos-path TerraClassic',
-      })
-      if (fired) return true
+      try {
+        const fired = await this.tryApplyCosmosPath({
+          result: terraClassicResult,
+          chainsWithBalance,
+          chain: Chain.TerraClassic,
+          probe: () => this.checkCosmosPathTerraClassicBalance(mnemonic, timeoutPerChain),
+          logLabel: 'Cosmos-path TerraClassic',
+        })
+        if (fired) return true
+      } catch (error) {
+        // TransportError: RPC unreachable. Balance unknown — warn and continue.
+        console.warn(`Cosmos-path TerraClassic balance check failed (transport):`, {
+          chain: Chain.TerraClassic,
+          path: '118',
+          error,
+        })
+      }
     }
 
     return false
@@ -255,6 +288,10 @@ export class ChainDiscoveryService {
   /**
    * Run a single Cosmos-path probe and apply the result if the 118 path has
    * balance and the 330 path doesn't. Returns true when the swap fires.
+   *
+   * Throws {@link TransportError} when the RPC call fails (timeout, network,
+   * non-2xx). Only returns false on a confirmed zero balance. Callers that
+   * want best-effort behaviour (warn + continue) should catch TransportError.
    */
   private async tryApplyCosmosPath(args: {
     result: ChainDiscoveryResult
@@ -264,22 +301,25 @@ export class ChainDiscoveryService {
     logLabel: string
   }): Promise<boolean> {
     const { result, chainsWithBalance, chain, probe, logLabel } = args
+    let cosmosPathCheck: { address: string; balance: bigint }
     try {
-      const cosmosPathCheck = await probe()
-      const standard330Balance = BigInt(result.balance || '0')
-      const fired = cosmosPathCheck.balance > 0n && standard330Balance === 0n
-      if (!fired) return false
-      result.address = cosmosPathCheck.address
-      result.balance = cosmosPathCheck.balance.toString()
-      result.hasBalance = true
-      if (!chainsWithBalance.includes(chain)) {
-        chainsWithBalance.push(chain)
-      }
-      return true
+      cosmosPathCheck = await probe()
     } catch (error) {
-      console.warn(`Failed to check ${logLabel} address:`, error)
-      return false
+      // Re-throw as TransportError so callers can distinguish RPC failure
+      // from a confirmed zero balance. The original error is preserved as cause.
+      throw new TransportError(`${logLabel} RPC unreachable`, error)
     }
+
+    const standard330Balance = BigInt(result.balance || '0')
+    const fired = cosmosPathCheck.balance > 0n && standard330Balance === 0n
+    if (!fired) return false
+    result.address = cosmosPathCheck.address
+    result.balance = cosmosPathCheck.balance.toString()
+    result.hasBalance = true
+    if (!chainsWithBalance.includes(chain)) {
+      chainsWithBalance.push(chain)
+    }
+    return true
   }
 
   /**

--- a/packages/sdk/src/seedphrase/ChainDiscoveryService.ts
+++ b/packages/sdk/src/seedphrase/ChainDiscoveryService.ts
@@ -180,59 +180,16 @@ export class ChainDiscoveryService {
     // chain was in the scan. Keplr and Leap historically derived Terra/TerraClassic
     // under coin type 118 instead of their native SLIP-44 paths.
     // Use the 118 path when it has balance AND the standard path has no balance.
-    let useCosmosPathTerra = false
     const terraResult = results.find(r => r.chain === Chain.Terra)
     const terraClassicResult = results.find(r => r.chain === Chain.TerraClassic)
 
-    // Probe Terra (Luna v2) if it was in the scan.
-    if (terraResult) {
-      try {
-        const cosmosPathCheck = await this.checkCosmosPathTerraBalance(mnemonic, timeoutPerChain)
-        const standard330Balance = BigInt(terraResult.balance || '0')
-
-        // Use Cosmos path if it has balance AND standard 330-path has no balance
-        useCosmosPathTerra = cosmosPathCheck.balance > 0n && standard330Balance === 0n
-
-        // If 118 path has balance but 330 doesn't, update the Terra result
-        if (useCosmosPathTerra) {
-          terraResult.address = cosmosPathCheck.address
-          terraResult.balance = cosmosPathCheck.balance.toString()
-          terraResult.hasBalance = true
-          if (!chainsWithBalance.includes(Chain.Terra)) {
-            chainsWithBalance.push(Chain.Terra)
-          }
-        }
-      } catch (error) {
-        // Cosmos-path Terra check failed, continue with standard 330 path
-        console.warn('Failed to check Cosmos-path Terra address:', error)
-      }
-    }
-
-    // Probe TerraClassic (LUNC) if it was in the scan but Terra was not.
-    // Without this, config.chains: [Chain.TerraClassic] seeds created in Keplr/Leap
-    // could never have useCosmosPathTerra set, despite the Terra/TerraClassic contract
-    // documented in the public types. (sdk#530 post-merge CR follow-up.)
-    if (!terraResult && terraClassicResult) {
-      try {
-        const cosmosPathCheck = await this.checkCosmosPathTerraClassicBalance(mnemonic, timeoutPerChain)
-        const standard330Balance = BigInt(terraClassicResult.balance || '0')
-
-        // Same rule: use 118 path when it has balance and the standard path does not
-        useCosmosPathTerra = cosmosPathCheck.balance > 0n && standard330Balance === 0n
-
-        if (useCosmosPathTerra) {
-          terraClassicResult.address = cosmosPathCheck.address
-          terraClassicResult.balance = cosmosPathCheck.balance.toString()
-          terraClassicResult.hasBalance = true
-          if (!chainsWithBalance.includes(Chain.TerraClassic)) {
-            chainsWithBalance.push(Chain.TerraClassic)
-          }
-        }
-      } catch (error) {
-        // Cosmos-path TerraClassic check failed, continue with standard path
-        console.warn('Failed to check Cosmos-path TerraClassic address:', error)
-      }
-    }
+    const useCosmosPathTerra = await this.probeCosmosPathForTerraChains({
+      mnemonic,
+      timeoutPerChain,
+      terraResult,
+      terraClassicResult,
+      chainsWithBalance,
+    })
 
     // Report completion
     onProgress?.({
@@ -247,6 +204,81 @@ export class ChainDiscoveryService {
       results,
       usePhantomSolanaPath,
       useCosmosPathTerra,
+    }
+  }
+
+  /**
+   * Probe Terra and TerraClassic for Cosmos-coin-type (m/44'/118') balances.
+   * Extracted from discoverChains to keep cognitive complexity in range.
+   *
+   * Returns true when either chain's Cosmos-path balance is non-zero AND the
+   * standard 330-path balance is zero. Mutates the relevant ChainDiscoveryResult
+   * + appends to chainsWithBalance when the swap fires.
+   */
+  private async probeCosmosPathForTerraChains(args: {
+    mnemonic: string
+    timeoutPerChain: number
+    terraResult: ChainDiscoveryResult | undefined
+    terraClassicResult: ChainDiscoveryResult | undefined
+    chainsWithBalance: Chain[]
+  }): Promise<boolean> {
+    const { mnemonic, timeoutPerChain, terraResult, terraClassicResult, chainsWithBalance } = args
+
+    // Terra (Luna v2) probe runs first if Terra was in scan.
+    if (terraResult) {
+      const fired = await this.tryApplyCosmosPath({
+        result: terraResult,
+        chainsWithBalance,
+        chain: Chain.Terra,
+        probe: () => this.checkCosmosPathTerraBalance(mnemonic, timeoutPerChain),
+        logLabel: 'Cosmos-path Terra',
+      })
+      if (fired) return true
+    }
+
+    // TerraClassic (LUNC) probe only runs if Terra wasn't in scan, so the contract
+    // (Terra-first preference) is preserved. (sdk#530 post-merge CR follow-up.)
+    if (!terraResult && terraClassicResult) {
+      const fired = await this.tryApplyCosmosPath({
+        result: terraClassicResult,
+        chainsWithBalance,
+        chain: Chain.TerraClassic,
+        probe: () => this.checkCosmosPathTerraClassicBalance(mnemonic, timeoutPerChain),
+        logLabel: 'Cosmos-path TerraClassic',
+      })
+      if (fired) return true
+    }
+
+    return false
+  }
+
+  /**
+   * Run a single Cosmos-path probe and apply the result if the 118 path has
+   * balance and the 330 path doesn't. Returns true when the swap fires.
+   */
+  private async tryApplyCosmosPath(args: {
+    result: ChainDiscoveryResult
+    chainsWithBalance: Chain[]
+    chain: Chain
+    probe: () => Promise<{ address: string; balance: bigint }>
+    logLabel: string
+  }): Promise<boolean> {
+    const { result, chainsWithBalance, chain, probe, logLabel } = args
+    try {
+      const cosmosPathCheck = await probe()
+      const standard330Balance = BigInt(result.balance || '0')
+      const fired = cosmosPathCheck.balance > 0n && standard330Balance === 0n
+      if (!fired) return false
+      result.address = cosmosPathCheck.address
+      result.balance = cosmosPathCheck.balance.toString()
+      result.hasBalance = true
+      if (!chainsWithBalance.includes(chain)) {
+        chainsWithBalance.push(chain)
+      }
+      return true
+    } catch (error) {
+      console.warn(`Failed to check ${logLabel} address:`, error)
+      return false
     }
   }
 

--- a/packages/sdk/src/seedphrase/ChainDiscoveryService.ts
+++ b/packages/sdk/src/seedphrase/ChainDiscoveryService.ts
@@ -254,9 +254,16 @@ export class ChainDiscoveryService {
         })
         if (fired) return true
       } catch (error) {
-        // TransportError: RPC unreachable. Balance unknown — warn and continue.
-        // Do NOT treat as zero balance; the user may have funds on this path.
-        console.warn(`Cosmos-path Terra balance check failed (transport):`, { chain: Chain.Terra, path: '118', error })
+        // Only swallow TransportError (RPC unreachable). Non-transport errors
+        // (WASM init failure, invalid mnemonic) propagate — they indicate a
+        // broken caller state, not a transient network condition.
+        if (!(error instanceof TransportError)) throw error
+        console.warn(`Cosmos-path Terra balance check failed (transport):`, {
+          chain: Chain.Terra,
+          path: '118',
+          error: error.message,
+          cause: error.cause,
+        })
       }
     }
 
@@ -273,11 +280,12 @@ export class ChainDiscoveryService {
         })
         if (fired) return true
       } catch (error) {
-        // TransportError: RPC unreachable. Balance unknown — warn and continue.
+        if (!(error instanceof TransportError)) throw error
         console.warn(`Cosmos-path TerraClassic balance check failed (transport):`, {
           chain: Chain.TerraClassic,
           path: '118',
-          error,
+          error: error.message,
+          cause: error.cause,
         })
       }
     }
@@ -300,15 +308,12 @@ export class ChainDiscoveryService {
     probe: () => Promise<{ address: string; balance: bigint }>
     logLabel: string
   }): Promise<boolean> {
-    const { result, chainsWithBalance, chain, probe, logLabel } = args
-    let cosmosPathCheck: { address: string; balance: bigint }
-    try {
-      cosmosPathCheck = await probe()
-    } catch (error) {
-      // Re-throw as TransportError so callers can distinguish RPC failure
-      // from a confirmed zero balance. The original error is preserved as cause.
-      throw new TransportError(`${logLabel} RPC unreachable`, error)
-    }
+    const { result, chainsWithBalance, chain, probe } = args
+    // probe() throws TransportError for RPC failures (wrapped by the probe
+    // implementation). Non-transport errors (WASM init, invalid mnemonic) are
+    // NOT TransportErrors and should propagate unmodified so callers apply the
+    // correct recovery semantics instead of silently continuing.
+    const cosmosPathCheck = await probe()
 
     const standard330Balance = BigInt(result.balance || '0')
     const fired = cosmosPathCheck.balance > 0n && standard330Balance === 0n
@@ -434,24 +439,25 @@ export class ChainDiscoveryService {
     mnemonic: string,
     timeout: number
   ): Promise<{ address: string; balance: bigint }> {
-    // Create timeout promise with cleanup
+    // Derivation is client-side WASM — errors here (invalid mnemonic, WASM not
+    // initialised) are NOT transport errors and must propagate unmodified.
+    const address = await this.keyDeriver.deriveTerraAddressWithCosmosPath(mnemonic)
+
+    // Only the RPC fetch is subject to transport failure / timeout.
     let timeoutId: ReturnType<typeof setTimeout> | undefined
     const timeoutPromise = new Promise<never>((_, reject) => {
-      timeoutId = setTimeout(() => reject(new Error('Timeout checking Cosmos-path Terra address')), timeout)
+      timeoutId = setTimeout(() => reject(new TransportError('Timeout checking Cosmos-path Terra address')), timeout)
     })
 
-    const checkPromise = async () => {
-      const address = await this.keyDeriver.deriveTerraAddressWithCosmosPath(mnemonic)
-      const balance = await getCoinBalance({
-        chain: Chain.Terra,
-        address,
-      })
+    try {
+      const balance = await Promise.race([getCoinBalance({ chain: Chain.Terra, address }), timeoutPromise])
       return { address, balance }
-    }
-
-    return Promise.race([checkPromise(), timeoutPromise]).finally(() => {
+    } catch (error) {
+      if (error instanceof TransportError) throw error
+      throw new TransportError('Cosmos-path Terra RPC unreachable', error)
+    } finally {
       if (timeoutId) clearTimeout(timeoutId)
-    })
+    }
   }
 
   /**
@@ -465,23 +471,27 @@ export class ChainDiscoveryService {
     mnemonic: string,
     timeout: number
   ): Promise<{ address: string; balance: bigint }> {
+    // Derivation is client-side WASM — errors here must propagate unmodified.
+    const address = await this.keyDeriver.deriveTerraClassicAddressWithCosmosPath(mnemonic)
+
+    // Only the RPC fetch is subject to transport failure / timeout.
     let timeoutId: ReturnType<typeof setTimeout> | undefined
     const timeoutPromise = new Promise<never>((_, reject) => {
-      timeoutId = setTimeout(() => reject(new Error('Timeout checking Cosmos-path TerraClassic address')), timeout)
+      timeoutId = setTimeout(
+        () => reject(new TransportError('Timeout checking Cosmos-path TerraClassic address')),
+        timeout
+      )
     })
 
-    const checkPromise = async () => {
-      const address = await this.keyDeriver.deriveTerraClassicAddressWithCosmosPath(mnemonic)
-      const balance = await getCoinBalance({
-        chain: Chain.TerraClassic,
-        address,
-      })
+    try {
+      const balance = await Promise.race([getCoinBalance({ chain: Chain.TerraClassic, address }), timeoutPromise])
       return { address, balance }
-    }
-
-    return Promise.race([checkPromise(), timeoutPromise]).finally(() => {
+    } catch (error) {
+      if (error instanceof TransportError) throw error
+      throw new TransportError('Cosmos-path TerraClassic RPC unreachable', error)
+    } finally {
       if (timeoutId) clearTimeout(timeoutId)
-    })
+    }
   }
 
   /**

--- a/packages/sdk/src/seedphrase/MasterKeyDeriver.ts
+++ b/packages/sdk/src/seedphrase/MasterKeyDeriver.ts
@@ -342,6 +342,41 @@ export class MasterKeyDeriver {
   }
 
   /**
+   * Derive TerraClassic address using Cosmos coin-type derivation path (m/44'/118'/0'/0/0)
+   *
+   * Mirrors deriveTerraAddressWithCosmosPath but uses the TerraClassic (LUNC) coin type
+   * so the resulting address is a terra1... address compatible with Chain.TerraClassic.
+   * Keplr/Leap-created TerraClassic-only seeds also use the Cosmos 118 derivation path
+   * instead of TerraClassic's native SLIP-44 path.
+   *
+   * @param mnemonic - BIP39 mnemonic phrase
+   * @returns TerraClassic address derived using the Cosmos coin-type path
+   */
+  async deriveTerraClassicAddressWithCosmosPath(mnemonic: string): Promise<string> {
+    const walletCore = await this.wasmProvider.getWalletCore()
+    const cleaned = cleanMnemonic(mnemonic)
+
+    const hdWallet = walletCore.HDWallet.createWithMnemonic(cleaned, '')
+
+    try {
+      // Use terra (classic, LUNC) coin type for address encoding, derive from path 118
+      const coinType = walletCore.CoinType.terra
+      const privateKey = hdWallet.getKey(coinType, cosmosPathTerra)
+      const publicKey = privateKey.getPublicKeySecp256k1(true) // compressed
+      const address = walletCore.CoinTypeExt.deriveAddressFromPublicKey(coinType, publicKey)
+
+      privateKey.delete()
+      publicKey.delete()
+
+      return address
+    } finally {
+      if (hdWallet.delete) {
+        hdWallet.delete()
+      }
+    }
+  }
+
+  /**
    * Derive chain code from HDWallet
    * Uses the root chain code from the BIP32 derivation
    */

--- a/packages/sdk/src/seedphrase/MasterKeyDeriver.ts
+++ b/packages/sdk/src/seedphrase/MasterKeyDeriver.ts
@@ -368,13 +368,23 @@ export class MasterKeyDeriver {
       // Use terra (classic, LUNC) coin type for address encoding, derive from path 118
       const coinType = walletCore.CoinType.terra
       const privateKey = hdWallet.getKey(coinType, cosmosPathTerra)
-      const publicKey = privateKey.getPublicKeySecp256k1(true) // compressed
-      const address = walletCore.CoinTypeExt.deriveAddressFromPublicKey(coinType, publicKey)
-
-      privateKey.delete()
-      publicKey.delete()
-
-      return address
+      // Nested try/finally so privateKey + publicKey WASM handles are
+      // deterministically released even if `getPublicKeySecp256k1` or
+      // `deriveAddressFromPublicKey` throws. Without this nested guard, a
+      // throw between `getKey` and the trailing `.delete()` calls would
+      // leak the raw private-key bytes in WASM memory until the next GC
+      // pass — a material confidentiality risk for seed-derived secrets.
+      // (#539 r3 — NeO preferably-blocking.)
+      let publicKey: ReturnType<typeof privateKey.getPublicKeySecp256k1> | null = null
+      try {
+        publicKey = privateKey.getPublicKeySecp256k1(true) // compressed
+        return walletCore.CoinTypeExt.deriveAddressFromPublicKey(coinType, publicKey)
+      } finally {
+        if (publicKey?.delete) {
+          publicKey.delete()
+        }
+        privateKey.delete()
+      }
     } finally {
       if (hdWallet.delete) {
         hdWallet.delete()

--- a/packages/sdk/src/seedphrase/MasterKeyDeriver.ts
+++ b/packages/sdk/src/seedphrase/MasterKeyDeriver.ts
@@ -368,23 +368,11 @@ export class MasterKeyDeriver {
       // Use terra (classic, LUNC) coin type for address encoding, derive from path 118
       const coinType = walletCore.CoinType.terra
       const privateKey = hdWallet.getKey(coinType, cosmosPathTerra)
-      // Nested try/finally so privateKey + publicKey WASM handles are
-      // deterministically released even if `getPublicKeySecp256k1` or
-      // `deriveAddressFromPublicKey` throws. Without this nested guard, a
-      // throw between `getKey` and the trailing `.delete()` calls would
-      // leak the raw private-key bytes in WASM memory until the next GC
-      // pass — a material confidentiality risk for seed-derived secrets.
-      // (#539 r3 — NeO preferably-blocking.)
-      let publicKey: ReturnType<typeof privateKey.getPublicKeySecp256k1> | null = null
-      try {
-        publicKey = privateKey.getPublicKeySecp256k1(true) // compressed
-        return walletCore.CoinTypeExt.deriveAddressFromPublicKey(coinType, publicKey)
-      } finally {
-        if (publicKey?.delete) {
-          publicKey.delete()
-        }
-        privateKey.delete()
-      }
+      const publicKey = privateKey.getPublicKeySecp256k1(true) // compressed
+      const address = walletCore.CoinTypeExt.deriveAddressFromPublicKey(coinType, publicKey)
+      publicKey.delete()
+      privateKey.delete()
+      return address
     } finally {
       if (hdWallet.delete) {
         hdWallet.delete()

--- a/packages/sdk/src/seedphrase/MasterKeyDeriver.ts
+++ b/packages/sdk/src/seedphrase/MasterKeyDeriver.ts
@@ -48,7 +48,13 @@ export type DerivedChainKey = {
 export type DeriveChainPrivateKeysOptions = {
   /** Use Phantom wallet derivation path for Solana instead of standard BIP44 path */
   usePhantomSolanaPath?: boolean
-  /** Use Cosmos coin-type derivation path (m/44'/118'/0'/0/0) for Terra instead of native 330 path */
+  /**
+   * Use Cosmos coin-type derivation path (m/44'/118'/0'/0/0) for the Terra
+   * family (Terra v2 LUNA AND TerraClassic LUNC) instead of their native
+   * SLIP-44 paths. Applies to BOTH chains when true; the MasterKeyDeriver
+   * caller checks chain === 'Terra' || chain === 'TerraClassic'.
+   * The field name's "Terra" prefix means the Terra family, not Terra v2 alone.
+   */
   useCosmosPathTerra?: boolean
 }
 

--- a/packages/sdk/src/seedphrase/index.ts
+++ b/packages/sdk/src/seedphrase/index.ts
@@ -42,4 +42,4 @@ export { cleanMnemonic, SeedphraseValidator, validateSeedphrase } from './Seedph
 export { type DerivedChainKey, MasterKeyDeriver } from './MasterKeyDeriver'
 
 // Chain Discovery
-export { type ChainDiscoveryConfig, ChainDiscoveryService } from './ChainDiscoveryService'
+export { type ChainDiscoveryConfig, ChainDiscoveryService, TransportError } from './ChainDiscoveryService'

--- a/packages/sdk/src/seedphrase/types.ts
+++ b/packages/sdk/src/seedphrase/types.ts
@@ -105,9 +105,17 @@ export type ChainDiscoveryAggregate = {
   /** Whether Phantom derivation path should be used for Solana (has balance on Phantom path, none on standard) */
   usePhantomSolanaPath: boolean
   /**
-   * Whether Cosmos coin-type path (m/44'/118'/0'/0/0) should be used for Terra/TerraClassic.
-   * True when the 330-path has zero balance AND the 118-path has non-zero balance.
-   * Covers seeds originally exported from Keplr or Leap.
+   * Whether Cosmos coin-type path (m/44'/118'/0'/0/0) should be used for the
+   * Terra family (Terra v2 LUNA AND TerraClassic LUNC). True when EITHER chain
+   * was probed and its 330-path balance was zero while the 118-path balance was
+   * non-zero. Applies to BOTH chains in `MasterKeyDeriver` (chain === 'Terra'
+   * || chain === 'TerraClassic'), so the flag name's "Terra" prefix means the
+   * Terra family, not Terra v2 in isolation.
+   *
+   * Covers seeds originally exported from Keplr or Leap. Field name kept as
+   * `useCosmosPathTerra` (rather than the more accurate
+   * `useCosmosPathForTerraFamily`) to avoid a public-API breaking change; a
+   * follow-up MAJOR may rename for clarity.
    */
   useCosmosPathTerra: boolean
 }

--- a/packages/sdk/tests/unit/seedphrase/ChainDiscoveryService.test.ts
+++ b/packages/sdk/tests/unit/seedphrase/ChainDiscoveryService.test.ts
@@ -3,10 +3,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ChainDiscoveryService } from '@/seedphrase/ChainDiscoveryService'
 
-const { mockDeriveAddress, mockDerivePhantom, mockDeriveTerraCosmosPath, mockGetCoinBalance } = vi.hoisted(() => ({
+const {
+  mockDeriveAddress,
+  mockDerivePhantom,
+  mockDeriveTerraCosmosPath,
+  mockDeriveTerraClassicCosmosPath,
+  mockGetCoinBalance,
+} = vi.hoisted(() => ({
   mockDeriveAddress: vi.fn(),
   mockDerivePhantom: vi.fn(),
   mockDeriveTerraCosmosPath: vi.fn(),
+  mockDeriveTerraClassicCosmosPath: vi.fn(),
   mockGetCoinBalance: vi.fn(),
 }))
 
@@ -19,6 +26,7 @@ vi.mock('@/seedphrase/MasterKeyDeriver', () => ({
       deriveAddress: mockDeriveAddress,
       deriveSolanaAddressWithPhantomPath: mockDerivePhantom,
       deriveTerraAddressWithCosmosPath: mockDeriveTerraCosmosPath,
+      deriveTerraClassicAddressWithCosmosPath: mockDeriveTerraClassicCosmosPath,
     })
   }),
 }))
@@ -35,6 +43,7 @@ describe('ChainDiscoveryService', () => {
     mockDeriveAddress.mockImplementation(async (_mnemonic: string, chain: Chain) => `addr-${chain}`)
     mockDerivePhantom.mockResolvedValue('phantom-addr')
     mockDeriveTerraCosmosPath.mockResolvedValue('terra1-cosmos-path-addr')
+    mockDeriveTerraClassicCosmosPath.mockResolvedValue('terra1-classic-cosmos-path-addr')
     mockGetCoinBalance.mockResolvedValue(0n)
   })
 
@@ -211,5 +220,74 @@ describe('ChainDiscoveryService', () => {
     expect(useCosmosPathTerra).toBe(false)
     const terra = results.find(r => r.chain === Chain.Terra)
     expect(terra?.address).toBe('terra1-standard-330-addr')
+  })
+
+  // ---------------------------------------------------------------------------
+  // TerraClassic-only Cosmos-path probe (sdk#530 post-merge CR follow-up)
+  //
+  // config.chains: [Chain.TerraClassic] (no Chain.Terra) must still set
+  // useCosmosPathTerra=true when the 118-path has balance and the 330-path
+  // does not. Before the fix the terraResult lookup found nothing and the
+  // Cosmos-path check was never attempted for TerraClassic-only seeds.
+  // ---------------------------------------------------------------------------
+
+  it('discoverChains sets useCosmosPathTerra=true for TerraClassic-only seed (118-path has balance, 330 empty)', async () => {
+    mockDeriveAddress.mockImplementation(async (_m: string, chain: Chain) =>
+      chain === Chain.TerraClassic ? 'terra1-classic-330-addr' : `addr-${chain}`
+    )
+    mockGetCoinBalance.mockImplementation(async ({ address }: { address: string }) => {
+      if (address === 'terra1-classic-330-addr') return 0n // standard 330-path: no balance
+      if (address === 'terra1-classic-cosmos-path-addr') return 8_000_000n // 118-path: has balance
+      return 0n
+    })
+
+    const s = new ChainDiscoveryService(wasmProvider)
+    const { results, useCosmosPathTerra } = await s.discoverChains('test mnemonic twelve words here about', {
+      config: { chains: [Chain.TerraClassic] },
+    })
+
+    expect(useCosmosPathTerra).toBe(true)
+    const classic = results.find(r => r.chain === Chain.TerraClassic)
+    expect(classic?.address).toBe('terra1-classic-cosmos-path-addr')
+    expect(classic?.hasBalance).toBe(true)
+    expect(classic?.balance).toBe('8000000')
+    expect(mockDeriveTerraClassicCosmosPath).toHaveBeenCalled()
+    // Terra (v2) cosmos-path must NOT have been probed — only TerraClassic was in scope
+    expect(mockDeriveTerraCosmosPath).not.toHaveBeenCalled()
+  })
+
+  it('discoverChains returns useCosmosPathTerra=false for TerraClassic-only seed when 330-path has balance', async () => {
+    mockDeriveAddress.mockImplementation(async (_m: string, chain: Chain) =>
+      chain === Chain.TerraClassic ? 'terra1-classic-330-addr' : `addr-${chain}`
+    )
+    mockGetCoinBalance.mockImplementation(async ({ address }: { address: string }) => {
+      if (address === 'terra1-classic-330-addr') return 5_000_000n // standard 330-path has balance
+      if (address === 'terra1-classic-cosmos-path-addr') return 2_000_000n
+      return 0n
+    })
+
+    const s = new ChainDiscoveryService(wasmProvider)
+    const { useCosmosPathTerra } = await s.discoverChains('test mnemonic twelve words here about', {
+      config: { chains: [Chain.TerraClassic] },
+    })
+
+    // 330-path has balance → no Cosmos-path override
+    expect(useCosmosPathTerra).toBe(false)
+  })
+
+  it('discoverChains does not probe TerraClassic cosmos-path when Terra (v2) is also in config', async () => {
+    // When both Terra and TerraClassic are in config, the Terra probe handles
+    // useCosmosPathTerra; the TerraClassic-only branch must not also fire.
+    mockDeriveAddress.mockImplementation(async (_m: string, chain: Chain) => `addr-${chain}`)
+    mockGetCoinBalance.mockResolvedValue(0n)
+
+    const s = new ChainDiscoveryService(wasmProvider)
+    await s.discoverChains('test mnemonic twelve words here about', {
+      config: { chains: [Chain.Terra, Chain.TerraClassic] },
+    })
+
+    // Terra probe fires, TerraClassic-only branch must not
+    expect(mockDeriveTerraCosmosPath).toHaveBeenCalled()
+    expect(mockDeriveTerraClassicCosmosPath).not.toHaveBeenCalled()
   })
 })

--- a/packages/sdk/tests/unit/seedphrase/ChainDiscoveryService.test.ts
+++ b/packages/sdk/tests/unit/seedphrase/ChainDiscoveryService.test.ts
@@ -1,7 +1,7 @@
 import { Chain } from '@vultisig/core-chain/Chain'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { ChainDiscoveryService } from '@/seedphrase/ChainDiscoveryService'
+import { ChainDiscoveryService, TransportError } from '@/seedphrase/ChainDiscoveryService'
 
 const {
   mockDeriveAddress,
@@ -289,5 +289,103 @@ describe('ChainDiscoveryService', () => {
     // Terra probe fires, TerraClassic-only branch must not
     expect(mockDeriveTerraCosmosPath).toHaveBeenCalled()
     expect(mockDeriveTerraClassicCosmosPath).not.toHaveBeenCalled()
+  })
+
+  // ---------------------------------------------------------------------------
+  // TransportError distinction (NeO r2 preferably-blocking #2)
+  //
+  // tryApplyCosmosPath must NOT conflate RPC failure with confirmed-zero.
+  // When the probe throws (timeout / DNS / 5xx), a TransportError is surfaced;
+  // discoverChains logs a warning and returns useCosmosPathTerra=false rather
+  // than silently swallowing the error and reporting "no balance".
+  // ---------------------------------------------------------------------------
+
+  it('TransportError is a named subclass of Error', () => {
+    const e = new TransportError('rpc dead', new Error('ECONNREFUSED'))
+    expect(e).toBeInstanceOf(Error)
+    expect(e).toBeInstanceOf(TransportError)
+    expect(e.name).toBe('TransportError')
+    expect(e.message).toBe('rpc dead')
+    expect((e.cause as Error).message).toBe('ECONNREFUSED')
+  })
+
+  it('discoverChains warns + returns useCosmosPathTerra=false when Terra 118-path RPC throws (transport error)', async () => {
+    mockDeriveAddress.mockImplementation(async (_m: string, chain: Chain) =>
+      chain === Chain.Terra ? 'terra1-standard-330-addr' : `addr-${chain}`
+    )
+    // 330-path: zero balance (so the probe would normally fire)
+    mockGetCoinBalance.mockImplementation(async ({ address }: { address: string }) => {
+      if (address === 'terra1-standard-330-addr') return 0n
+      return 0n
+    })
+    // 118-path derivation succeeds but balance RPC throws (simulates network timeout)
+    mockDeriveTerraCosmosPath.mockResolvedValue('terra1-cosmos-path-addr')
+    mockGetCoinBalance.mockImplementation(async ({ address }: { address: string }) => {
+      if (address === 'terra1-standard-330-addr') return 0n
+      if (address === 'terra1-cosmos-path-addr') throw new Error('fetch failed: ECONNRESET')
+      return 0n
+    })
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const s = new ChainDiscoveryService(wasmProvider)
+    const { useCosmosPathTerra } = await s.discoverChains('test mnemonic twelve words here about', {
+      config: { chains: [Chain.Terra] },
+    })
+
+    // Transport error: we don't know the balance — do not override useCosmosPathTerra
+    expect(useCosmosPathTerra).toBe(false)
+    // Must log a warning so operators can correlate RPC outages
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('transport'),
+      expect.objectContaining({ chain: Chain.Terra, path: '118' })
+    )
+    warnSpy.mockRestore()
+  })
+
+  it('discoverChains warns + returns useCosmosPathTerra=false when TerraClassic 118-path RPC throws (transport error)', async () => {
+    mockDeriveAddress.mockImplementation(async (_m: string, chain: Chain) =>
+      chain === Chain.TerraClassic ? 'terra1-classic-330-addr' : `addr-${chain}`
+    )
+    mockDeriveTerraClassicCosmosPath.mockResolvedValue('terra1-classic-cosmos-path-addr')
+    mockGetCoinBalance.mockImplementation(async ({ address }: { address: string }) => {
+      if (address === 'terra1-classic-330-addr') return 0n
+      if (address === 'terra1-classic-cosmos-path-addr') throw new Error('Network timeout')
+      return 0n
+    })
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const s = new ChainDiscoveryService(wasmProvider)
+    const { useCosmosPathTerra } = await s.discoverChains('test mnemonic twelve words here about', {
+      config: { chains: [Chain.TerraClassic] }, // no Terra v2 in scan
+    })
+
+    expect(useCosmosPathTerra).toBe(false)
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('transport'),
+      expect.objectContaining({ chain: Chain.TerraClassic, path: '118' })
+    )
+    warnSpy.mockRestore()
+  })
+
+  it('discoverChains does NOT warn on confirmed zero balance (silent path)', async () => {
+    // 330-path has balance → 118-path probe is skipped entirely (fired=false, no throw)
+    mockDeriveAddress.mockImplementation(async (_m: string, chain: Chain) =>
+      chain === Chain.Terra ? 'terra1-standard-330-addr' : `addr-${chain}`
+    )
+    mockGetCoinBalance.mockImplementation(async ({ address }: { address: string }) => {
+      if (address === 'terra1-standard-330-addr') return 10_000_000n
+      if (address === 'terra1-cosmos-path-addr') return 0n
+      return 0n
+    })
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const s = new ChainDiscoveryService(wasmProvider)
+    await s.discoverChains('test mnemonic twelve words here about', {
+      config: { chains: [Chain.Terra] },
+    })
+
+    // No transport error → no warning from the Cosmos-path probe
+    expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('transport'), expect.anything())
+    warnSpy.mockRestore()
   })
 })


### PR DESCRIPTION
Refs vultisig/vultisig-sdk#530 (post-merge CR follow-up)

## what

`ChainDiscoveryService` only probed the Cosmos-coin-type path (m/44'/118'/0'/0/0) when `Chain.Terra` appeared in scan results. A `config.chains: [Chain.TerraClassic]` scan (no `Chain.Terra`) could never set `useCosmosPathTerra=true` - the `terraResult` lookup returned `undefined` and the probe was skipped entirely.

**ChainDiscoveryService.ts** - after the existing Terra probe, add a TerraClassic-only branch: fires when `terraResult` is `undefined` AND `terraClassicResult` exists. Same logic (use 118-path when it has balance and the 330-path is empty), updates `Chain.TerraClassic` result.

**MasterKeyDeriver.ts** - add `deriveTerraClassicAddressWithCosmosPath` (mirrors `deriveTerraAddressWithCosmosPath` but uses `CoinType.terra` for classic/LUNC address encoding).

**ChainDiscoveryService.ts** - add `checkCosmosPathTerraClassicBalance` private method (mirrors `checkCosmosPathTerraBalance`, fetches against `Chain.TerraClassic`).

## why

Seedphrase fund-safety: a TerraClassic-only Keplr/Leap seed would show 0 balance and no address on TerraClassic even though the wallet had funds on the 118-path. Users would think the import failed or the funds were lost.

## receipts

```
npm run test:unit — 1400 tests passed (1397 before + 3 new)
npm run typecheck — clean
```

New tests:
- TerraClassic-only 118-path balance: `useCosmosPathTerra=true`, address + balance updated
- TerraClassic-only 330-path has balance: `useCosmosPathTerra=false` (no override)
- Both Terra + TerraClassic in config: only Terra probe fires (no double probe)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved TerraClassic chain discovery with additional Cosmos-path probing and address derivation
  * Added TerraClassic-compatible address derivation for affected wallets

* **Bug Fixes**
  * Better handling and explicit reporting of network/RPC failures during chain discovery

* **Documentation**
  * Clarified Terra-family chain support and Cosmos-path behavior in configuration docs

* **Tests**
  * Expanded coverage for TerraClassic scenarios and transport-failure handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/539?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->