### PR TITLE
feat(swap): populate swap fee in keysign payload

### DIFF
--- a/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
+++ b/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
@@ -1,4 +1,4 @@
-import { createConfig, getQuote } from '@lifi/sdk'
+import { ChainId, createConfig, getQuote } from '@lifi/sdk'
 import { DeriveChainKind, getChainKind } from '@vultisig/core-chain/ChainKind'
 import { solanaConfig } from '@vultisig/core-chain/chains/solana/solanaConfig'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
@@ -76,6 +76,33 @@ const DEFAULT_LIFI_SLIPPAGE_TOLERANCE = 0.01
 // not a hard reject — getQuote will still dispatch. NeOMakinG #513
 // round 1 `suggestion` 1.
 const MAX_COMBINED_COST_BPS = 300
+
+// Resolve a LiFi fee-token `chainId` back to a Vultisig `LifiSwapEnabledChain`.
+//
+// `mirrorRecord(lifiSwapChainId)` is a closed, build-time map of LI.FI source
+// chains (EVM chains Vultisig exposes + Solana). LI.FI's `feeCosts[].token`
+// is *not* guaranteed by the API contract to live on the source chain — for
+// cross-chain routes (e.g. EVM → Cosmos via Stargate, EVM → BTC via THORChain
+// relay) the fee can be denominated on an intermediate chain whose ID is not
+// a key in this map. `mirrorRecord(...)[unknownChainId]` then silently yields
+// `undefined`, producing `affiliateFee.chain = undefined`, which serializes
+// as an absent `swap_fee_chain` field alongside a non-empty `swap_fee` —
+// exactly the ambiguous state this PR set out to eliminate.
+//
+// Fall back to `transfer.from.chain` because LiFi's fixed fee is collected
+// from the user's source-chain wallet regardless of which bridge leg
+// denominates it internally, and the source chain is always a
+// `LifiSwapEnabledChain` (guaranteed by the `Input` type). Warn so any
+// future LiFi behavioural drift is visible in ops telemetry rather than
+// silently misattributed. (NeOMakinG #540 review blocking #1.)
+const resolveSwapFeeChain = (chainId: ChainId, fallback: LifiSwapEnabledChain): LifiSwapEnabledChain => {
+  const resolved = mirrorRecord(lifiSwapChainId)[chainId]
+  if (resolved === undefined) {
+    console.warn(`[getLifiSwapQuote] fee token chainId ${chainId} not in lifiSwapChainId; falling back to ${fallback}`)
+    return fallback
+  }
+  return resolved
+}
 
 export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: Input): Promise<GeneralSwapQuote> => {
   setupLifi()
@@ -156,7 +183,7 @@ export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: In
           swapFee: {
             amount: BigInt(swapFee.amount),
             decimals: swapFee.token.decimals,
-            chain: mirrorRecord(lifiSwapChainId)[swapFee.token.chainId],
+            chain: resolveSwapFeeChain(swapFee.token.chainId, transfer.from.chain),
             id: swapFeeAssetId,
           },
         },
@@ -186,7 +213,7 @@ export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: In
             swapFee: {
               amount: BigInt(swapFee.amount),
               decimals: swapFee.token.decimals,
-              chain: mirrorRecord(lifiSwapChainId)[swapFee.token.chainId],
+              chain: resolveSwapFeeChain(swapFee.token.chainId, transfer.from.chain),
               id: swapFeeAssetId,
             },
           },
@@ -223,7 +250,7 @@ export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: In
                   affiliateFee: {
                     amount: BigInt(swapFee.amount),
                     decimals: swapFee.token.decimals,
-                    chain: mirrorRecord(lifiSwapChainId)[swapFee.token.chainId],
+                    chain: resolveSwapFeeChain(swapFee.token.chainId, transfer.from.chain),
                     id: swapFeeAssetId,
                   },
                 }

--- a/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
+++ b/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
@@ -142,6 +142,19 @@ export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: In
         }
       },
       evm: () => {
+        // Mirror the Solana branch's fee extraction so EVM routes
+        // (including cross-chain EVM → Solana/Cosmos via Stargate, Across,
+        // etc.) surface the affiliate fee. LI.FI's `feeCosts` is the same
+        // for both kinds; the EVM branch was previously dropping it on the
+        // floor which left the swap-fee row blank for every LI.FI EVM
+        // route. Keep `affiliateFee` optional: not every route has one
+        // (affiliateBps may be 0 and no LIFI Fixed Fee charged).
+        const fees = estimate.feeCosts ?? []
+        const swapFee = fees.find(fee => fee.name === 'LIFI Fixed Fee') || fees[0]
+        const swapFeeAssetId =
+          swapFee &&
+          ([fromToken, toToken].find(token => token === swapFee.token.address) ||
+            chainFeeCoin[transfer.from.chain].id)
         return {
           evm: {
             from: shouldBePresent(from),
@@ -149,6 +162,16 @@ export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: In
             data: shouldBePresent(data),
             value: BigInt(shouldBePresent(value)).toString(),
             gasLimit: gasLimit ? BigInt(gasLimit) : undefined,
+            ...(swapFee
+              ? {
+                  affiliateFee: {
+                    amount: BigInt(swapFee.amount),
+                    decimals: swapFee.token.decimals,
+                    chain: mirrorRecord(lifiSwapChainId)[swapFee.token.chainId],
+                    id: swapFeeAssetId,
+                  },
+                }
+              : {}),
           },
         }
       },

--- a/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
+++ b/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
@@ -153,8 +153,7 @@ export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: In
         const swapFee = fees.find(fee => fee.name === 'LIFI Fixed Fee') || fees[0]
         const swapFeeAssetId =
           swapFee &&
-          ([fromToken, toToken].find(token => token === swapFee.token.address) ||
-            chainFeeCoin[transfer.from.chain].id)
+          ([fromToken, toToken].find(token => token === swapFee.token.address) || chainFeeCoin[transfer.from.chain].id)
         return {
           evm: {
             from: shouldBePresent(from),

--- a/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
+++ b/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
@@ -151,9 +151,15 @@ export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: In
         // (affiliateBps may be 0 and no LIFI Fixed Fee charged).
         const fees = estimate.feeCosts ?? []
         const swapFee = fees.find(fee => fee.name === 'LIFI Fixed Fee') || fees[0]
+        // EVM addresses can come back from LiFi in either lowercase or
+        // EIP-55 checksum form; normalize both sides to lowercase so a
+        // checksum mismatch doesn't silently fall back to the native
+        // fee coin and misattribute the affiliate fee.
+        const swapFeeAddress = swapFee?.token.address.toLowerCase()
         const swapFeeAssetId =
           swapFee &&
-          ([fromToken, toToken].find(token => token === swapFee.token.address) || chainFeeCoin[transfer.from.chain].id)
+          ([fromToken, toToken].find(token => token.toLowerCase() === swapFeeAddress) ||
+            chainFeeCoin[transfer.from.chain].id)
         return {
           evm: {
             from: shouldBePresent(from),

--- a/packages/core/mpc/keysign/swap/build.ts
+++ b/packages/core/mpc/keysign/swap/build.ts
@@ -116,8 +116,8 @@ export const buildSwapKeysignPayload = async ({
 
   keysignPayload.swapPayload = matchRecordUnion<SwapQuoteResult, KeysignPayload['swapPayload']>(swapQuote.quote, {
     general: quote => {
-      const txMsg = matchRecordUnion<GeneralSwapTx, Omit<OneInchTransaction, '$typeName' | 'swapFee'>>(quote.tx, {
-        evm: ({ from, to, data, value }) => {
+      const txMsg = matchRecordUnion<GeneralSwapTx, Omit<OneInchTransaction, '$typeName'>>(quote.tx, {
+        evm: ({ from, to, data, value, affiliateFee }) => {
           return {
             from,
             to,
@@ -125,15 +125,27 @@ export const buildSwapKeysignPayload = async ({
             value,
             gasPrice: '',
             gas: 0n,
+            swapFee: affiliateFee ? affiliateFee.amount.toString() : '',
+            ...(affiliateFee
+              ? {
+                  swapFeeChain: affiliateFee.chain,
+                  swapFeeTokenId: affiliateFee.id,
+                  swapFeeDecimals: affiliateFee.decimals,
+                }
+              : {}),
           }
         },
-        solana: ({ data }) => ({
+        solana: ({ data, swapFee }) => ({
           from: '',
           to: '',
           data,
           value: '',
           gasPrice: '',
           gas: BigInt(0),
+          swapFee: swapFee.amount.toString(),
+          swapFeeChain: swapFee.chain,
+          swapFeeTokenId: swapFee.id,
+          swapFeeDecimals: swapFee.decimals,
         }),
         // Deposit-channel routes (UTXO/Ripple/Tron/Ton sources via Chainflip, NEAR Intents, etc.)
         // send funds to a provider-controlled deposit address. The actual signing uses
@@ -158,6 +170,7 @@ export const buildSwapKeysignPayload = async ({
           value: '',
           gasPrice: '',
           gas: 0n,
+          swapFee: '',
         }),
       })
 

--- a/packages/core/mpc/keysign/tests/mappers/mapSwapPayload.ts
+++ b/packages/core/mpc/keysign/tests/mappers/mapSwapPayload.ts
@@ -23,7 +23,25 @@ export const mapSwapPayload = (spRaw: any): KeysignPayload['swapPayload'] | unde
               dstAmount: String(o.quote.dst_amount ?? o.quote.dstAmount),
               tx: o.quote.tx
                 ? {
-                    swapFee: String(o.quote.swap_fee ?? 0),
+                    // `swap_fee` lives on `tx` per the proto, but historical iOS
+                    // fixtures have surfaced it one level up on `quote`; accept
+                    // both paths so existing roundtrip fixtures keep working.
+                    swapFee: String(o.quote.tx.swap_fee ?? o.quote.tx.swapFee ?? o.quote.swap_fee ?? 0),
+                    // Coin context for `swap_fee` (proto fields 8/9/10, optional).
+                    // Forward whichever casing iOS emits so the cosigner can
+                    // render the fee row with correct decimals/asset attribution
+                    // — without this, the new fields would be silently dropped
+                    // on iOS → TS fixture roundtrips and KyberSwap-style payloads
+                    // would misread a destination-token fee as the source fee
+                    // coin. (NeOMakinG #540 preferably-blocking #1.)
+                    swapFeeChain: o.quote.tx.swap_fee_chain ?? o.quote.tx.swapFeeChain,
+                    swapFeeTokenId: o.quote.tx.swap_fee_token_id ?? o.quote.tx.swapFeeTokenId,
+                    swapFeeDecimals:
+                      o.quote.tx.swap_fee_decimals != null
+                        ? Number(o.quote.tx.swap_fee_decimals)
+                        : o.quote.tx.swapFeeDecimals != null
+                          ? Number(o.quote.tx.swapFeeDecimals)
+                          : undefined,
                     $typeName: '' as any,
                     data: o.quote.tx.data,
                     from: o.quote.tx.from,

--- a/packages/core/mpc/swap/native/utils/nativeSwapQuoteToSwapPayload.ts
+++ b/packages/core/mpc/swap/native/utils/nativeSwapQuoteToSwapPayload.ts
@@ -48,6 +48,7 @@ export const nativeSwapQuoteToSwapPayload = ({ quote, fromCoin, amount, toCoin }
       streamingQuantity,
       toAmountLimit: '0',
       isAffiliate,
+      fee: quote.fees.total,
     }),
   }
 }

--- a/packages/core/mpc/types/vultisig/keysign/v1/1inch_swap_payload_pb.ts
+++ b/packages/core/mpc/types/vultisig/keysign/v1/1inch_swap_payload_pb.ts
@@ -12,7 +12,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file vultisig/keysign/v1/1inch_swap_payload.proto.
  */
 export const file_vultisig_keysign_v1_1inch_swap_payload: GenFile = /*@__PURE__*/
-  fileDesc("Cix2dWx0aXNpZy9rZXlzaWduL3YxLzFpbmNoX3N3YXBfcGF5bG9hZC5wcm90bxITdnVsdGlzaWcua2V5c2lnbi52MSJ9ChJPbmVJbmNoVHJhbnNhY3Rpb24SDAoEZnJvbRgBIAEoCRIKCgJ0bxgCIAEoCRIMCgRkYXRhGAMgASgJEg0KBXZhbHVlGAQgASgJEhEKCWdhc19wcmljZRgFIAEoCRILCgNnYXMYBiABKAMSEAoIc3dhcF9mZWUYByABKAkiVwoMT25lSW5jaFF1b3RlEhIKCmRzdF9hbW91bnQYASABKAkSMwoCdHgYAiABKAsyJy52dWx0aXNpZy5rZXlzaWduLnYxLk9uZUluY2hUcmFuc2FjdGlvbiLiAQoST25lSW5jaFN3YXBQYXlsb2FkEiwKCWZyb21fY29pbhgBIAEoCzIZLnZ1bHRpc2lnLmtleXNpZ24udjEuQ29pbhIqCgd0b19jb2luGAIgASgLMhkudnVsdGlzaWcua2V5c2lnbi52MS5Db2luEhMKC2Zyb21fYW1vdW50GAMgASgJEhkKEXRvX2Ftb3VudF9kZWNpbWFsGAQgASgJEjAKBXF1b3RlGAUgASgLMiEudnVsdGlzaWcua2V5c2lnbi52MS5PbmVJbmNoUXVvdGUSEAoIcHJvdmlkZXIYBiABKAlCVAoTdnVsdGlzaWcua2V5c2lnbi52MVo4Z2l0aHViLmNvbS92dWx0aXNpZy9jb21tb25kYXRhL2dvL3Z1bHRpc2lnL2tleXNpZ24vdjE7djG6AgJWU2IGcHJvdG8z", [file_vultisig_keysign_v1_coin]);
+  fileDesc("Cix2dWx0aXNpZy9rZXlzaWduL3YxLzFpbmNoX3N3YXBfcGF5bG9hZC5wcm90bxITdnVsdGlzaWcua2V5c2lnbi52MSKZAgoST25lSW5jaFRyYW5zYWN0aW9uEgwKBGZyb20YASABKAkSCgoCdG8YAiABKAkSDAoEZGF0YRgDIAEoCRINCgV2YWx1ZRgEIAEoCRIRCglnYXNfcHJpY2UYBSABKAkSCwoDZ2FzGAYgASgDEhAKCHN3YXBfZmVlGAcgASgJEhsKDnN3YXBfZmVlX2NoYWluGAggASgJSACIAQESHgoRc3dhcF9mZWVfdG9rZW5faWQYCSABKAlIAYgBARIeChFzd2FwX2ZlZV9kZWNpbWFscxgKIAEoBUgCiAEBQhEKD19zd2FwX2ZlZV9jaGFpbkIUChJfc3dhcF9mZWVfdG9rZW5faWRCFAoSX3N3YXBfZmVlX2RlY2ltYWxzIlcKDE9uZUluY2hRdW90ZRISCgpkc3RfYW1vdW50GAEgASgJEjMKAnR4GAIgASgLMicudnVsdGlzaWcua2V5c2lnbi52MS5PbmVJbmNoVHJhbnNhY3Rpb24i4gEKEk9uZUluY2hTd2FwUGF5bG9hZBIsCglmcm9tX2NvaW4YASABKAsyGS52dWx0aXNpZy5rZXlzaWduLnYxLkNvaW4SKgoHdG9fY29pbhgCIAEoCzIZLnZ1bHRpc2lnLmtleXNpZ24udjEuQ29pbhITCgtmcm9tX2Ftb3VudBgDIAEoCRIZChF0b19hbW91bnRfZGVjaW1hbBgEIAEoCRIwCgVxdW90ZRgFIAEoCzIhLnZ1bHRpc2lnLmtleXNpZ24udjEuT25lSW5jaFF1b3RlEhAKCHByb3ZpZGVyGAYgASgJQlQKE3Z1bHRpc2lnLmtleXNpZ24udjFaOGdpdGh1Yi5jb20vdnVsdGlzaWcvY29tbW9uZGF0YS9nby92dWx0aXNpZy9rZXlzaWduL3YxO3YxugICVlNiBnByb3RvMw", [file_vultisig_keysign_v1_coin]);
 
 /**
  * @generated from message vultisig.keysign.v1.OneInchTransaction
@@ -52,6 +52,28 @@ export type OneInchTransaction = Message<"vultisig.keysign.v1.OneInchTransaction
    * @generated from field: string swap_fee = 7;
    */
   swapFee: string;
+
+  /**
+   * Coin context for `swap_fee`. The amount alone is not enough because
+   * providers attribute the fee to different coins (e.g. KyberSwap charges
+   * it in the destination token; LI.FI / 1inch / SwapKit charge it in the
+   * source chain's fee coin). Receivers need these fields to compute the
+   * correct fiat-equivalent value. All three are optional for backwards
+   * compatibility with senders that do not yet populate them.
+   *
+   * @generated from field: optional string swap_fee_chain = 8;
+   */
+  swapFeeChain?: string;
+
+  /**
+   * @generated from field: optional string swap_fee_token_id = 9;
+   */
+  swapFeeTokenId?: string;
+
+  /**
+   * @generated from field: optional int32 swap_fee_decimals = 10;
+   */
+  swapFeeDecimals?: number;
 };
 
 /**

--- a/packages/sdk/src/platforms/react-native/overrides/getLifiSwapQuote.ts
+++ b/packages/sdk/src/platforms/react-native/overrides/getLifiSwapQuote.ts
@@ -14,6 +14,7 @@
 //
 // Public surface mirrors core byte-for-byte: one `getLifiSwapQuote(input)`
 // export returning `Promise<GeneralSwapQuote>`.
+import type { ChainId } from '@lifi/sdk'
 import { DeriveChainKind, getChainKind } from '@vultisig/core-chain/ChainKind'
 import { solanaConfig } from '@vultisig/core-chain/chains/solana/solanaConfig'
 import { AccountCoinKey } from '@vultisig/core-chain/coin/AccountCoin'
@@ -43,6 +44,23 @@ const DEFAULT_LIFI_SLIPPAGE_TOLERANCE = 0.01
 // affiliateBps shouldn't silently push users past 3% total cost without logging.
 // (#519 r-N NeO should-fix #3 - mirror core guard in RN override.)
 const MAX_COMBINED_COST_BPS = 300
+
+// Mirror of core's `resolveSwapFeeChain`. See the core version in
+// `@vultisig/core-chain/swap/general/lifi/api/getLifiSwapQuote.ts` for the
+// full rationale: `mirrorRecord(lifiSwapChainId)[unknownChainId]` silently
+// returns `undefined` for cross-chain routes whose fee token lives on an
+// intermediate chain that is not a `LifiSwapEnabledChain`, producing an
+// ambiguous `swap_fee` non-empty + `swap_fee_chain` absent state on the
+// cosigner. Fall back to the source chain and warn so the drift is visible.
+// (NeOMakinG #540 review blocking #1.)
+const resolveSwapFeeChain = (chainId: ChainId, fallback: LifiSwapEnabledChain): LifiSwapEnabledChain => {
+  const resolved = mirrorRecord(lifiSwapChainId)[chainId]
+  if (resolved === undefined) {
+    console.warn(`[getLifiSwapQuote] fee token chainId ${chainId} not in lifiSwapChainId; falling back to ${fallback}`)
+    return fallback
+  }
+  return resolved
+}
 
 const setupLifi = memoize(async () => {
   const { createConfig } = await import('@lifi/sdk')
@@ -112,7 +130,7 @@ export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: In
           swapFee: {
             amount: BigInt(swapFee.amount),
             decimals: swapFee.token.decimals,
-            chain: mirrorRecord(lifiSwapChainId)[swapFee.token.chainId],
+            chain: resolveSwapFeeChain(swapFee.token.chainId, transfer.from.chain),
             id: swapFeeAssetId,
           },
         },
@@ -142,7 +160,7 @@ export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: In
             swapFee: {
               amount: BigInt(swapFee.amount),
               decimals: swapFee.token.decimals,
-              chain: mirrorRecord(lifiSwapChainId)[swapFee.token.chainId],
+              chain: resolveSwapFeeChain(swapFee.token.chainId, transfer.from.chain),
               id: swapFeeAssetId,
             },
           },

--- a/packages/sdk/src/platforms/react-native/overrides/getLifiSwapQuote.ts
+++ b/packages/sdk/src/platforms/react-native/overrides/getLifiSwapQuote.ts
@@ -167,6 +167,23 @@ export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: In
         }
       },
       evm: () => {
+        // Mirror the core implementation's EVM affiliate-fee extraction so RN
+        // routes surface the same swap-fee row context as desktop/web. LI.FI's
+        // `feeCosts` is the same shape across both kinds; keep `affiliateFee`
+        // optional because not every route has one (affiliateBps may be 0 and
+        // no LIFI Fixed Fee charged). See core for the full rationale on the
+        // lowercase address normalization. (CodeRabbit #540 actionable.)
+        const fees = estimate.feeCosts ?? []
+        const swapFee = fees.find(fee => fee.name === 'LIFI Fixed Fee') || fees[0]
+        // EVM addresses can come back from LiFi in either lowercase or
+        // EIP-55 checksum form; normalize both sides to lowercase so a
+        // checksum mismatch doesn't silently fall back to the native
+        // fee coin and misattribute the affiliate fee.
+        const swapFeeAddress = swapFee?.token.address.toLowerCase()
+        const swapFeeAssetId =
+          swapFee &&
+          ([fromToken, toToken].find(token => token.toLowerCase() === swapFeeAddress) ||
+            chainFeeCoin[transfer.from.chain].id)
         return {
           evm: {
             from: shouldBePresent(from),
@@ -174,6 +191,16 @@ export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: In
             data: shouldBePresent(data),
             value: BigInt(shouldBePresent(value)).toString(),
             gasLimit: gasLimit ? BigInt(gasLimit) : undefined,
+            ...(swapFee
+              ? {
+                  affiliateFee: {
+                    amount: BigInt(swapFee.amount),
+                    decimals: swapFee.token.decimals,
+                    chain: resolveSwapFeeChain(swapFee.token.chainId, transfer.from.chain),
+                    id: swapFeeAssetId,
+                  },
+                }
+              : {}),
           },
         }
       },


### PR DESCRIPTION
## Summary

`buildSwapKeysignPayload` and `nativeSwapQuoteToSwapPayload` now write the swap (affiliate) fee into the `OneInchSwapPayload` / `THORChainSwapPayload` so any consumer that only holds the `KeysignPayload` — notably the cosigner in a Secure Vault join flow — can render the swap-fee row without needing the original `SwapQuote` in scope.

## Changes

**`packages/core/mpc/keysign/swap/build.ts`** — general swap branches now write:

| Field | Source |
|-------|--------|
| `swap_fee` | `affiliateFee.amount` (evm) / `swapFee.amount` (solana) |
| `swap_fee_chain` | `affiliateFee.chain` / `swapFee.chain` |
| `swap_fee_token_id` | `affiliateFee.id` / `swapFee.id` |
| `swap_fee_decimals` | `affiliateFee.decimals` / `swapFee.decimals` |

**`packages/core/mpc/swap/native/utils/nativeSwapQuoteToSwapPayload.ts`** — native (THORChain/MAYAChain) now writes `fee = quote.fees.total`. The receiving coin is implicit in `to_coin` (native swap fee is always in the destination coin), so no extra proto fields are needed.

## Why coin context matters

Providers attribute affiliate fees to different coins:

| Provider | Fee coin |
|----------|----------|
| LI.FI / 1inch / SwapKit | source chain's fee coin (e.g. ETH, 18 decimals) |
| **KyberSwap** | **destination token (e.g. USDC, 6 decimals)** |

Without coin context a consumer that has only the `KeysignPayload` has to guess. Guessing "src fee coin" for a Kyber payload misreads a 6-decimal USDC amount as an 18-decimal ETH amount and overshoots the fiat estimate by ~10¹². This is the root cause of vultisig-windows#3972 in the cosigner flow.

## Dependencies

Requires the proto extension from **vultisig/commondata#87** which adds the three new optional fields to `OneInchTransaction`. The regenerated `1inch_swap_payload_pb.ts` here was produced against that PR.

## Backwards compatibility

All new fields are `optional`. Pre-update senders emit payloads without them (decode identically to today). Pre-update consumers ignore the new fields (continue to read only `swap_fee` as before). No on-wire breaking change.

## Test plan

- [x] `yarn test:core` (568/568 pass)
- [x] `yarn workspace @vultisig/sdk test` (1397/1397 pass)
- [x] `yarn lint` clean
- [x] `yarn typecheck` clean (no new errors introduced)
- [ ] Downstream: vultisig-windows reads these fields in `SwapKeysignTxOverview` and `JoinKeysignSwapVerify` (separate PR, closes vultisig-windows#3972)

## Related

- vultisig/commondata#87 — proto change this depends on (merge first)
- vultisig-windows#3972 — user-visible bug this unblocks (cosigner flow)
- vultisig-windows#3971 — independent SwapKit affiliate fee plumbing (still needed for SwapKit to populate a non-empty `affiliateFee` in the first place)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Swap payloads and native swap quotes now include explicit swap fee values plus fee-asset context (chain, token id, decimals).
  * External quotes now surface fixed/affiliate fee info and map it into swap fee fields; message schema extended to carry fee context.

* **Bug Fixes**
  * Swap fee fields consistently present across EVM, Solana and transfer routes (transfer routes set empty fee when absent).
  * Chain resolution for fee assets now falls back with a warning when unmapped.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/540?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->