### PR TITLE
fix(swap/lifi/solana): tackle NeO post-merge review on #519

### DIFF
--- a/packages/core/chain/swap/general/lifi/api/injectSolanaAtaIfMissing.test.ts
+++ b/packages/core/chain/swap/general/lifi/api/injectSolanaAtaIfMissing.test.ts
@@ -1,5 +1,12 @@
 import { getAssociatedTokenAddressSync, TOKEN_PROGRAM_ID } from '@solana/spl-token'
-import { Keypair, PublicKey, SystemProgram, TransactionMessage, VersionedTransaction } from '@solana/web3.js'
+import {
+  AddressLookupTableAccount,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  TransactionMessage,
+  VersionedTransaction,
+} from '@solana/web3.js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { injectSolanaAtaIfMissing } from './injectSolanaAtaIfMissing'
@@ -38,6 +45,40 @@ function buildMinimalLifiTx(): string {
     recentBlockhash: blockhash,
     instructions: [ix],
   }).compileToV0Message()
+  const tx = new VersionedTransaction(message)
+  return Buffer.from(tx.serialize()).toString('base64')
+}
+
+/**
+ * Build a V0 VersionedTransaction that references a LUT. The LUT address is
+ * embedded in the message's addressTableLookups so the decompile path actually
+ * exercises the LUT-fetch branch. We include a single address from the LUT in
+ * the instruction so the entry makes it into the compiled message.
+ */
+function buildLutLifiTx(lutKey: PublicKey, lutAddress: PublicKey): string {
+  const payerKey = new PublicKey(payer)
+  // An instruction that uses the LUT-provided address so the compiler includes
+  // the LUT reference in the compiled V0 message.
+  const ix = SystemProgram.transfer({
+    fromPubkey: payerKey,
+    toPubkey: lutAddress,
+    lamports: 0,
+  })
+  const lut = new AddressLookupTableAccount({
+    key: lutKey,
+    state: {
+      deactivationSlot: BigInt('18446744073709551615'),
+      lastExtendedSlot: 0,
+      lastExtendedSlotStartIndex: 0,
+      authority: undefined,
+      addresses: [lutAddress],
+    },
+  })
+  const message = new TransactionMessage({
+    payerKey,
+    recentBlockhash: blockhash,
+    instructions: [ix],
+  }).compileToV0Message([lut])
   const tx = new VersionedTransaction(message)
   return Buffer.from(tx.serialize()).toString('base64')
 }
@@ -232,5 +273,84 @@ describe('injectSolanaAtaIfMissing', () => {
 
     // Must still inject the ATA even if LUT fetching failed/didn't run.
     expect(result.ataInjected).toBe(true)
+  })
+
+  it('throws with a clear error when LUT decompile fails due to missing LUT accounts', async () => {
+    // This test actually exercises the LUT path: buildLutLifiTx embeds a real
+    // LUT reference in the V0 message. The mock returns null for the LUT fetch
+    // (simulates all retries exhausted), so decompile will throw because it
+    // cannot resolve the LUT-referenced accounts — and we expect a clear
+    // re-thrown error rather than the SDK's opaque message.
+    // (#519 r-N NeO should-fix #1 + should-fix #4.)
+    const lutKey = Keypair.generate().publicKey
+    const lutAddress = Keypair.generate().publicKey
+    const txData = buildLutLifiTx(lutKey, lutAddress)
+
+    const mockClient = {
+      // mint account exists, ATA does not (so we proceed to decompile)
+      getAccountInfo: vi.fn().mockResolvedValueOnce(MOCK_MINT_INFO).mockResolvedValueOnce(null),
+      // LUT fetch returns null — simulates exhausted retries
+      getAddressLookupTable: vi.fn().mockResolvedValue({ value: null }),
+    }
+    vi.mocked(getSolanaClient).mockReturnValue(mockClient as any)
+
+    await expect(injectSolanaAtaIfMissing(txData, USDC_MINT, owner, payer)).rejects.toThrow(
+      /Failed to decompile LiFi transaction message/
+    )
+    // Confirm LUT fetch was actually attempted (LUT path exercised).
+    expect(mockClient.getAddressLookupTable).toHaveBeenCalledWith(lutKey)
+  })
+
+  it('successfully injects ATA when LUT is fetched and decompile succeeds', async () => {
+    // Exercises the full LUT path: a tx with a real LUT reference is fetched,
+    // the LUT account is returned, decompile succeeds, and the ATA is injected.
+    // (#519 r-N NeO should-fix #4 — LUT path actually exercised.)
+    const lutKey = Keypair.generate().publicKey
+    const lutAddress = Keypair.generate().publicKey
+    const txData = buildLutLifiTx(lutKey, lutAddress)
+
+    const lut = new AddressLookupTableAccount({
+      key: lutKey,
+      state: {
+        deactivationSlot: BigInt('18446744073709551615'),
+        lastExtendedSlot: 0,
+        lastExtendedSlotStartIndex: 0,
+        authority: undefined,
+        addresses: [lutAddress],
+      },
+    })
+
+    const mockClient = {
+      getAccountInfo: vi.fn().mockResolvedValueOnce(MOCK_MINT_INFO).mockResolvedValueOnce(null),
+      getAddressLookupTable: vi.fn().mockResolvedValue({ value: lut }),
+    }
+    vi.mocked(getSolanaClient).mockReturnValue(mockClient as any)
+
+    const result = await injectSolanaAtaIfMissing(txData, USDC_MINT, owner, payer)
+
+    expect(result.ataInjected).toBe(true)
+    expect(mockClient.getAddressLookupTable).toHaveBeenCalledWith(lutKey)
+  })
+
+  it('throws when the owner address is off the ed25519 curve (PDA or invalid key)', async () => {
+    // Off-curve addresses (PDAs) should not be used as swap destinations in
+    // Vultisig LiFi flows. Passing one with allowOwnerOffCurve silently would
+    // derive an ATA the user can't sign for. (#519 r-N NeO should-fix #2.)
+    //
+    // We construct an off-curve public key by finding a PDA (createProgramAddress
+    // always produces an off-curve address by definition).
+    const programId = SystemProgram.programId
+    const pdaOwner = PublicKey.findProgramAddressSync([Buffer.from('test')], programId)[0]
+    expect(PublicKey.isOnCurve(pdaOwner.toBytes())).toBe(false)
+
+    const mockClient = {
+      getAccountInfo: vi.fn().mockResolvedValueOnce(MOCK_MINT_INFO),
+      getAddressLookupTable: vi.fn(),
+    }
+    vi.mocked(getSolanaClient).mockReturnValue(mockClient as any)
+
+    await expect(injectSolanaAtaIfMissing(buildMinimalLifiTx(), USDC_MINT, pdaOwner.toBase58(), payer)).rejects.toThrow(
+      /off the ed25519 curve/
+    )
   })
 })

--- a/packages/core/chain/swap/general/lifi/api/injectSolanaAtaIfMissing.ts
+++ b/packages/core/chain/swap/general/lifi/api/injectSolanaAtaIfMissing.ts
@@ -54,6 +54,16 @@ export type InjectSolanaAtaResult = {
  * runtime so the correct token program (Token or Token-2022) is used for ATA
  * derivation and instruction creation.
  *
+ * Token-2022 extension limitation: this function handles ATA derivation and
+ * creation correctly for Token-2022 mints, but it does NOT inspect or handle
+ * Token-2022 extension data (e.g. TransferFee, ConfidentialTransfer,
+ * InterestBearingMint). Extensions that affect transfer semantics (e.g.
+ * TransferFee withholding, MemoRequired) are the responsibility of the LiFi
+ * route builder, not of this ATA injection layer. If a Token-2022 mint has
+ * extensions that require special instruction handling beyond ATA creation,
+ * the LiFi transaction itself must already encode those requirements.
+ * (#519 r-N NeO preferably-blocking #1 - document limitation.)
+ *
  * @param txData       Base64-encoded serialized VersionedTransaction from LiFi.
  * @param mintAddress  SPL token mint address (e.g. USDC mint on Solana).
  * @param owner        Wallet address that will own the ATA (swap destination).
@@ -95,11 +105,25 @@ export const injectSolanaAtaIfMissing = async (
     )
   }
 
-  // allowOwnerOffCurve=true: PDAs are valid ATA owners (e.g. multisig destinations).
+  // Validate that the owner is on the ed25519 curve (i.e. a normal wallet keypair).
+  // In Vultisig flows the swap destination is always a user wallet — off-curve
+  // addresses are PDAs (Program Derived Addresses) and are valid ATA owners in the
+  // broader Solana ecosystem but should never appear as the destination in a LiFi
+  // quote. Silently passing an off-curve owner with allowOwnerOffCurve=true would
+  // derive an ATA that the user likely can never sign for, producing an opaque
+  // simulation failure. (#519 r-N NeO should-fix #2.)
+  if (!PublicKey.isOnCurve(ownerPubkey.toBytes())) {
+    throw new Error(
+      `Owner ${owner} is off the ed25519 curve (PDA or invalid key) - Vultisig LiFi swaps require an on-curve wallet address as destination`
+    )
+  }
+
+  // allowOwnerOffCurve=false (default): we already validated above that the owner
+  // is on-curve, so we don't need to pass the flag — keeping it explicit for clarity.
   const ataAddress = getAssociatedTokenAddressSync(
     mintPubkey,
     ownerPubkey,
-    /* allowOwnerOffCurve */ true,
+    /* allowOwnerOffCurve */ false,
     tokenProgramId
   )
 
@@ -145,9 +169,22 @@ export const injectSolanaAtaIfMissing = async (
   // accepts both legacy and V0 messages, and compileToV0Message always produces
   // a V0 message. LiFi does not send legacy Solana transactions in practice but
   // the path is safe regardless.
-  const decompiledMessage = TransactionMessage.decompile(versionedTx.message, {
-    addressLookupTableAccounts: lutAccounts,
-  })
+  //
+  // When the tx references LUTs, decompile can fail if a referenced LUT account
+  // was not fetched (e.g. all retry attempts exhausted). Rather than letting the
+  // SDK throw an opaque "unknown account" message, we wrap here and re-throw with
+  // context so callers can distinguish a LUT-dependency failure from any other
+  // decompile error. (#519 r-N NeO should-fix #1.)
+  let decompiledMessage: TransactionMessage
+  try {
+    decompiledMessage = TransactionMessage.decompile(versionedTx.message, {
+      addressLookupTableAccounts: lutAccounts,
+    })
+  } catch (err) {
+    throw new Error(
+      `Failed to decompile LiFi transaction message - one or more LUT accounts could not be resolved (fetched ${lutAccounts.length} of ${(versionedTx.message as { addressTableLookups?: unknown[] }).addressTableLookups?.length ?? 0} referenced LUTs). Original error: ${err instanceof Error ? err.message : String(err)}`
+    )
+  }
 
   // Validate the caller-supplied payer matches the tx's actual fee-payer.
   // If LiFi ever changes the fee-payer convention (or the caller passes a

--- a/packages/sdk/src/platforms/react-native/overrides/getLifiSwapQuote.ts
+++ b/packages/sdk/src/platforms/react-native/overrides/getLifiSwapQuote.ts
@@ -37,6 +37,13 @@ type Input = Record<TransferDirection, AccountCoinKey<LifiSwapEnabledChain>> & {
 // MPC keysign ceremony latency makes the default LiFi 0.5% too tight for Vultisig flows.
 const DEFAULT_LIFI_SLIPPAGE_TOLERANCE = 0.01
 
+// Mirror of core's MAX_COMBINED_COST_BPS guard. Defensive: logs when affiliate
+// + slippage combined cost crosses 3%. Today affiliateBps is typically 0 and
+// slippage is 1% (100bps total) — well under the ceiling — but a future bump to
+// affiliateBps shouldn't silently push users past 3% total cost without logging.
+// (#519 r-N NeO should-fix #3 - mirror core guard in RN override.)
+const MAX_COMBINED_COST_BPS = 300
+
 const setupLifi = memoize(async () => {
   const { createConfig } = await import('@lifi/sdk')
   createConfig({
@@ -46,6 +53,13 @@ const setupLifi = memoize(async () => {
 
 export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: Input): Promise<GeneralSwapQuote> => {
   await setupLifi()
+
+  const combinedCostBps = (affiliateBps ?? 0) + DEFAULT_LIFI_SLIPPAGE_TOLERANCE * 10000
+  if (combinedCostBps > MAX_COMBINED_COST_BPS) {
+    console.warn(
+      `[getLifiSwapQuote] affiliate + slippage combined cost exceeds ${MAX_COMBINED_COST_BPS}bps: ${combinedCostBps}bps`
+    )
+  }
 
   const { getQuote } = await import('@lifi/sdk')
 


### PR DESCRIPTION
This PR tackles NeO's review on #519 (post-merge follow-up).

## Findings addressed

- [x] **blocking #1** - unsupported mint owner program throw - already landed in #519, preserved + covered by existing test (`packages/core/chain/swap/general/lifi/api/injectSolanaAtaIfMissing.ts:103`)
- [x] **blocking #2** - ATA owner validation before early-return - already in #519, preserved + covered (`injectSolanaAtaIfMissing.ts:139`)
- [x] **should-fix #1** - LUT decompile failure: wrap `TransactionMessage.decompile` in try/catch, re-throw with context (fetched N of M LUTs) (`injectSolanaAtaIfMissing.ts:178-187`)
- [x] **should-fix #2** - `allowOwnerOffCurve=true` allows invalid owners: validate `PublicKey.isOnCurve(ownerPubkey.toBytes())` before `getAssociatedTokenAddressSync`, throw with clear message for off-curve (PDA) owners (`injectSolanaAtaIfMissing.ts:115-119`)
- [x] **should-fix #3** - RN override missing `MAX_COMBINED_COST_BPS` guard: mirrored the `combinedCostBps` log from core into `packages/sdk/src/platforms/react-native/overrides/getLifiSwapQuote.ts:51-57`
- [x] **should-fix #4** - LUT tolerance test didn't exercise LUT path: added `buildLutLifiTx` helper that builds a real V0 tx with a LUT reference; two new tests use it (`injectSolanaAtaIfMissing.test.ts:46-95`)
- [x] **preferably-blocking #1** - Token-2022 extension limitation: documented in jsdoc (`injectSolanaAtaIfMissing.ts:57-65`)
- [x] **preferably-blocking #2** - hardcoded `ataRentLamports` trade-off: comment already in #519 (`getLifiSwapQuote.ts:139-146`), preserved

Skipped suggestions (jitter + backoff increase) - low value vs noise ratio for this path.

## Tests

12 tests pass (9 from #519 + 3 new):
- `throws with a clear error when LUT decompile fails due to missing LUT accounts` - covers should-fix #1 + #4 (LUT path actually exercised; `getAddressLookupTable` called)
- `successfully injects ATA when LUT is fetched and decompile succeeds` - happy path with real LUT reference
- `throws when the owner address is off the ed25519 curve (PDA or invalid key)` - covers should-fix #2

## Receipts

Pending - this is SDK-only, will need a vultiagent-app file:// install drive for the SOL->SPL swap flow. Opening as draft until receipts are captured.

🤖 Agent-generated