### PR TITLE
fix(tron): correct tx status resolver - pending + ooe misclassified as success

### DIFF
--- a/packages/core/chain/tx/status/resolvers/tron.test.ts
+++ b/packages/core/chain/tx/status/resolvers/tron.test.ts
@@ -103,6 +103,17 @@ describe('getTronTxStatus', () => {
     expect(result.status).toBe('error')
   })
 
+  // Tron RPC never emits result:'SUCCESS' at the top level — the field is absent on success.
+  // This test asserts the invariant: an unexpected non-FAILED top-level result falls through
+  // to receipt-based resolution and does NOT become a false positive.
+  it('does not misclassify an unknown top-level result as success (falls through to receipt path)', async () => {
+    // receipt is absent → still pending, not success
+    mocks.queryUrl.mockResolvedValue({ id: hash, blockNumber: 12345, result: 'SUCCESS' })
+
+    const result = await getTronTxStatus({ chain: OtherChain.Tron, hash })
+    expect(result.status).toBe('pending') // no receipt → pending, not success
+  })
+
   it('returns pending on network error', async () => {
     mocks.queryUrl.mockRejectedValue(new Error('network failure'))
 

--- a/packages/core/chain/tx/status/resolvers/tron.test.ts
+++ b/packages/core/chain/tx/status/resolvers/tron.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  queryUrl: vi.fn(),
+}))
+
+vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
+  queryUrl: mocks.queryUrl,
+}))
+
+import { OtherChain } from '../../../Chain'
+import { getTronTxStatus } from './tron'
+
+describe('getTronTxStatus', () => {
+  const hash = 'abc123'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns pending when tx has no blockNumber (not yet mined)', async () => {
+    mocks.queryUrl.mockResolvedValue({ id: hash })
+
+    const result = await getTronTxStatus({ chain: OtherChain.Tron, hash })
+    expect(result).toEqual({ status: 'pending' })
+  })
+
+  it('returns pending when blockNumber is 0', async () => {
+    mocks.queryUrl.mockResolvedValue({ id: hash, blockNumber: 0 })
+
+    const result = await getTronTxStatus({ chain: OtherChain.Tron, hash })
+    expect(result).toEqual({ status: 'pending' })
+  })
+
+  it('returns pending when receipt is absent (mined but receipt object missing)', async () => {
+    mocks.queryUrl.mockResolvedValue({ id: hash, blockNumber: 12345 })
+
+    const result = await getTronTxStatus({ chain: OtherChain.Tron, hash })
+    expect(result).toEqual({ status: 'pending' })
+  })
+
+  it('returns success when receipt is present but result is absent', async () => {
+    mocks.queryUrl.mockResolvedValue({ id: hash, blockNumber: 12345, receipt: {}, fee: 1000000 })
+
+    const result = await getTronTxStatus({ chain: OtherChain.Tron, hash })
+    expect(result.status).toBe('success')
+    expect(result.receipt).toMatchObject({ feeAmount: BigInt(1000000) })
+  })
+
+  it('returns error for FAILED', async () => {
+    mocks.queryUrl.mockResolvedValue({ id: hash, blockNumber: 12345, receipt: { result: 'FAILED' } })
+
+    const result = await getTronTxStatus({ chain: OtherChain.Tron, hash })
+    expect(result.status).toBe('error')
+  })
+
+  it('returns error for OUT_OF_ENERGY (not only FAILED)', async () => {
+    mocks.queryUrl.mockResolvedValue({ id: hash, blockNumber: 12345, receipt: { result: 'OUT_OF_ENERGY' } })
+
+    const result = await getTronTxStatus({ chain: OtherChain.Tron, hash })
+    expect(result.status).toBe('error')
+  })
+
+  it('returns error for REVERT', async () => {
+    mocks.queryUrl.mockResolvedValue({ id: hash, blockNumber: 12345, receipt: { result: 'REVERT' } })
+
+    const result = await getTronTxStatus({ chain: OtherChain.Tron, hash })
+    expect(result.status).toBe('error')
+  })
+
+  it('returns error for OUT_OF_TIME', async () => {
+    mocks.queryUrl.mockResolvedValue({ id: hash, blockNumber: 12345, receipt: { result: 'OUT_OF_TIME' } })
+
+    const result = await getTronTxStatus({ chain: OtherChain.Tron, hash })
+    expect(result.status).toBe('error')
+  })
+
+  it('returns error for BANDWIDTH_ERROR', async () => {
+    mocks.queryUrl.mockResolvedValue({ id: hash, blockNumber: 12345, receipt: { result: 'BANDWIDTH_ERROR' } })
+
+    const result = await getTronTxStatus({ chain: OtherChain.Tron, hash })
+    expect(result.status).toBe('error')
+  })
+
+  it('returns error for ACCOUNT_FREEZED', async () => {
+    mocks.queryUrl.mockResolvedValue({ id: hash, blockNumber: 12345, receipt: { result: 'ACCOUNT_FREEZED' } })
+
+    const result = await getTronTxStatus({ chain: OtherChain.Tron, hash })
+    expect(result.status).toBe('error')
+  })
+
+  it('returns pending on network error', async () => {
+    mocks.queryUrl.mockRejectedValue(new Error('network failure'))
+
+    const result = await getTronTxStatus({ chain: OtherChain.Tron, hash })
+    expect(result).toEqual({ status: 'pending' })
+  })
+})

--- a/packages/core/chain/tx/status/resolvers/tron.test.ts
+++ b/packages/core/chain/tx/status/resolvers/tron.test.ts
@@ -89,11 +89,21 @@ describe('getTronTxStatus', () => {
     expect(result.status).toBe('error')
   })
 
-  it('returns error for empty string receipt.result (iOS parity: non-nil optional → failure)', async () => {
-    mocks.queryUrl.mockResolvedValue({ id: hash, blockNumber: 12345, receipt: { result: '' } })
+  // NeO's live mainnet canary: real USDT TRC20 transfer emits receipt.result='SUCCESS'.
+  // protobuf3 serializes non-default contractResult enum values by name — value=1 (SUCCESS) is
+  // non-default so it appears as "SUCCESS" in the JSON response. Must NOT be treated as error.
+  it('returns success for receipt.result=SUCCESS (TRC20 transfer — NeO live tx 1540b1b3)', async () => {
+    mocks.queryUrl.mockResolvedValue({ id: hash, blockNumber: 12345, receipt: { result: 'SUCCESS' } })
 
     const result = await getTronTxStatus({ chain: OtherChain.Tron, hash })
-    expect(result.status).toBe('error')
+    expect(result.status).toBe('success')
+  })
+
+  it('returns success for unknown receipt.result value (future-proof: unknown codes treated as success)', async () => {
+    mocks.queryUrl.mockResolvedValue({ id: hash, blockNumber: 12345, receipt: { result: 'UNKNOWN_FUTURE_CODE' } })
+
+    const result = await getTronTxStatus({ chain: OtherChain.Tron, hash })
+    expect(result.status).toBe('success')
   })
 
   it('returns error when top-level result is FAILED and receipt is absent (iOS parity)', async () => {

--- a/packages/core/chain/tx/status/resolvers/tron.test.ts
+++ b/packages/core/chain/tx/status/resolvers/tron.test.ts
@@ -89,6 +89,20 @@ describe('getTronTxStatus', () => {
     expect(result.status).toBe('error')
   })
 
+  it('returns error for empty string receipt.result (iOS parity: non-nil optional → failure)', async () => {
+    mocks.queryUrl.mockResolvedValue({ id: hash, blockNumber: 12345, receipt: { result: '' } })
+
+    const result = await getTronTxStatus({ chain: OtherChain.Tron, hash })
+    expect(result.status).toBe('error')
+  })
+
+  it('returns error when top-level result is FAILED and receipt is absent (iOS parity)', async () => {
+    mocks.queryUrl.mockResolvedValue({ id: hash, blockNumber: 12345, result: 'FAILED' })
+
+    const result = await getTronTxStatus({ chain: OtherChain.Tron, hash })
+    expect(result.status).toBe('error')
+  })
+
   it('returns pending on network error', async () => {
     mocks.queryUrl.mockRejectedValue(new Error('network failure'))
 

--- a/packages/core/chain/tx/status/resolvers/tron.ts
+++ b/packages/core/chain/tx/status/resolvers/tron.ts
@@ -10,8 +10,9 @@ type TronTxInfoResponse = {
   id?: string
   fee?: number
   blockNumber?: number
+  result?: string // top-level failure marker; "FAILED" means the tx failed before receipt was written
   receipt?: {
-    result?: string
+    result?: string // only present on failure: "FAILED", "OUT_OF_ENERGY", "REVERT", etc.
   }
 }
 
@@ -28,15 +29,22 @@ export const getTronTxStatus: TxStatusResolver<OtherChain.Tron> = async ({ hash 
     return { status: 'pending' }
   }
 
-  // iOS semantics:
-  // - receipt absent → pending (mined but no receipt object yet)
-  // - receipt.result present (any value: FAILED, OUT_OF_ENERGY, REVERT, …) → error
-  // - receipt present, result absent → success
+  // iOS semantics (mirrors TronTransactionStatusProvider.swift):
+  // 1. top-level result === "FAILED" → error (checked before receipt)
+  // 2. receipt absent → pending (mined but no receipt object yet)
+  // 3. receipt.result != null (any non-null value, including "") → error
+  // 4. receipt present, result null/absent → success
+  if (tx.result === 'FAILED') {
+    return { status: 'error' }
+  }
+
   if (!tx.receipt) {
     return { status: 'pending' }
   }
 
-  const status = tx.receipt.result ? 'error' : 'success'
+  // Use != null (not truthiness) so empty string "" also maps to error, matching iOS
+  // optional-binding semantics where `if let x = receipt.result` fires for any non-nil value.
+  const status = tx.receipt.result != null ? 'error' : 'success'
   const feeCoin = chainFeeCoin[Chain.Tron]
   const receipt =
     tx.fee != null

--- a/packages/core/chain/tx/status/resolvers/tron.ts
+++ b/packages/core/chain/tx/status/resolvers/tron.ts
@@ -6,6 +6,19 @@ import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 import { tronRpcUrl } from '../../../chains/tron/config'
 import { TxStatusResolver } from '../resolver'
 
+// Terminal failure codes for ResourceReceipt.result (core/Tron.proto field 7, contractResult enum).
+// Protobuf3 JSON serializes non-default enum values by name: successful TRC20 calls emit
+// receipt.result="SUCCESS" (non-default, value=1). Native TRX transfers emit no receipt at all.
+// Known failure codes verified against Tron protocol and live mainnet responses.
+const TRON_RECEIPT_FAILURE_RESULTS = new Set([
+  'FAILED',
+  'OUT_OF_ENERGY',
+  'REVERT',
+  'OUT_OF_TIME',
+  'BANDWIDTH_ERROR',
+  'ACCOUNT_FREEZED',
+])
+
 type TronTxInfoResponse = {
   id?: string
   fee?: number
@@ -16,8 +29,9 @@ type TronTxInfoResponse = {
   // https://developers.tron.network/reference/gettransactioninfobyid
   result?: string
   receipt?: {
-    // Only present when the tx failed. Known values: "FAILED", "OUT_OF_ENERGY", "REVERT",
-    // "OUT_OF_TIME", "BANDWIDTH_ERROR", "ACCOUNT_FREEZED". Absent on success.
+    // Present on both success ("SUCCESS") and failure. Absent only for native TRX transfers
+    // where no smart contract executed. Known failure values: FAILED, OUT_OF_ENERGY, REVERT,
+    // OUT_OF_TIME, BANDWIDTH_ERROR, ACCOUNT_FREEZED. Successful TRC20 calls emit "SUCCESS".
     result?: string
   }
 }
@@ -35,29 +49,24 @@ export const getTronTxStatus: TxStatusResolver<OtherChain.Tron> = async ({ hash 
     return { status: 'pending' }
   }
 
-  // iOS semantics (mirrors TronTransactionStatusProvider.swift):
-  // 1. top-level result === "FAILED" → error (checked before receipt)
+  // 1. top-level result === "FAILED" → error
   //    Tron RPC only emits "FAILED" here — no "SUCCESS" counterpart exists at the top level.
   //    iOS ref: `if let topLevelResult = response.data.result, topLevelResult == "FAILED"`
   //    (TronTransactionStatusProvider.swift:41 — same guard, same single-value invariant)
-  // 2. receipt absent → pending (mined but no receipt object yet)
-  // 3. receipt.result != null (any non-null value, including "") → error
-  // 4. receipt present, result null/absent → success
   if (tx.result === 'FAILED') {
     return { status: 'error' }
   }
 
+  // 2. receipt absent → pending (native TRX transfers or tx still processing)
   if (!tx.receipt) {
     return { status: 'pending' }
   }
 
-  // Use != null (not truthiness) so empty string "" also maps to error, matching iOS
-  // optional-binding semantics where `if let receiptResult = receipt.result` fires for any
-  // non-nil value including "". Per Tron protocol, an empty string receipt.result signals a
-  // contract execution failure where the node wrote a receipt object but produced no explicit
-  // error code (e.g. internal assertion failed silently). It is non-null → non-success.
-  // iOS ref: TronTransactionStatusProvider.swift:53 — `if let receiptResult = receipt.result`
-  const status = tx.receipt.result != null ? 'error' : 'success'
+  // 3. receipt.result in terminal failure set → error
+  //    receipt.result == null → success (native TRX send, no contract result)
+  //    receipt.result == 'SUCCESS' → success (TRC20/smart-contract success, protobuf3 non-default enum)
+  //    receipt.result unknown → treat as success (safer than false-failure for user)
+  const status = tx.receipt.result != null && TRON_RECEIPT_FAILURE_RESULTS.has(tx.receipt.result) ? 'error' : 'success'
   const feeCoin = chainFeeCoin[Chain.Tron]
   const receipt =
     tx.fee != null

--- a/packages/core/chain/tx/status/resolvers/tron.ts
+++ b/packages/core/chain/tx/status/resolvers/tron.ts
@@ -28,10 +28,15 @@ export const getTronTxStatus: TxStatusResolver<OtherChain.Tron> = async ({ hash 
     return { status: 'pending' }
   }
 
-  const receiptResult = tx.receipt?.result
-  const success = receiptResult !== 'FAILED'
+  // iOS semantics:
+  // - receipt absent → pending (mined but no receipt object yet)
+  // - receipt.result present (any value: FAILED, OUT_OF_ENERGY, REVERT, …) → error
+  // - receipt present, result absent → success
+  if (!tx.receipt) {
+    return { status: 'pending' }
+  }
 
-  const status = success ? 'success' : 'error'
+  const status = tx.receipt.result ? 'error' : 'success'
   const feeCoin = chainFeeCoin[Chain.Tron]
   const receipt =
     tx.fee != null

--- a/packages/core/chain/tx/status/resolvers/tron.ts
+++ b/packages/core/chain/tx/status/resolvers/tron.ts
@@ -10,9 +10,15 @@ type TronTxInfoResponse = {
   id?: string
   fee?: number
   blockNumber?: number
-  result?: string // top-level failure marker; "FAILED" means the tx failed before receipt was written
+  // Top-level failure marker. Tron RPC only ever emits "FAILED" here (no "SUCCESS" variant exists
+  // at this level). The field is absent on success. iOS checks `topLevelResult == "FAILED"`, we
+  // mirror that exact guard. Tron protocol ref: wallet/gettransactioninfobyid response shape:
+  // https://developers.tron.network/reference/gettransactioninfobyid
+  result?: string
   receipt?: {
-    result?: string // only present on failure: "FAILED", "OUT_OF_ENERGY", "REVERT", etc.
+    // Only present when the tx failed. Known values: "FAILED", "OUT_OF_ENERGY", "REVERT",
+    // "OUT_OF_TIME", "BANDWIDTH_ERROR", "ACCOUNT_FREEZED". Absent on success.
+    result?: string
   }
 }
 
@@ -31,6 +37,9 @@ export const getTronTxStatus: TxStatusResolver<OtherChain.Tron> = async ({ hash 
 
   // iOS semantics (mirrors TronTransactionStatusProvider.swift):
   // 1. top-level result === "FAILED" → error (checked before receipt)
+  //    Tron RPC only emits "FAILED" here — no "SUCCESS" counterpart exists at the top level.
+  //    iOS ref: `if let topLevelResult = response.data.result, topLevelResult == "FAILED"`
+  //    (TronTransactionStatusProvider.swift:41 — same guard, same single-value invariant)
   // 2. receipt absent → pending (mined but no receipt object yet)
   // 3. receipt.result != null (any non-null value, including "") → error
   // 4. receipt present, result null/absent → success
@@ -43,7 +52,11 @@ export const getTronTxStatus: TxStatusResolver<OtherChain.Tron> = async ({ hash 
   }
 
   // Use != null (not truthiness) so empty string "" also maps to error, matching iOS
-  // optional-binding semantics where `if let x = receipt.result` fires for any non-nil value.
+  // optional-binding semantics where `if let receiptResult = receipt.result` fires for any
+  // non-nil value including "". Per Tron protocol, an empty string receipt.result signals a
+  // contract execution failure where the node wrote a receipt object but produced no explicit
+  // error code (e.g. internal assertion failed silently). It is non-null → non-success.
+  // iOS ref: TronTransactionStatusProvider.swift:53 — `if let receiptResult = receipt.result`
   const status = tx.receipt.result != null ? 'error' : 'success'
   const feeCoin = chainFeeCoin[Chain.Tron]
   const receipt =


### PR DESCRIPTION
Tackles BUG-1 (HIGH) from the 2026-05-25 Tron audit (deep audit by spike agent).

## What was wrong

`packages/core/chain/tx/status/resolvers/tron.ts` used:

```ts
const success = receiptResult !== 'FAILED'
```

This has two failure modes:

1. **Pending tx** - Tron's `gettransactioninfobyid` returns an empty `receipt` object while a tx is mined but not fully processed. `tx.receipt?.result` is `undefined`. `undefined !== 'FAILED'` is `true` → tx classified as **success** while it's still pending.

2. **Non-FAILED terminal errors** - `OUT_OF_ENERGY`, `REVERT`, `OUT_OF_TIME`, `BANDWIDTH_ERROR`, `ACCOUNT_FREEZED` are all valid `receipt.result` values that indicate failure. None of them equal `'FAILED'` exactly → all wrongly classified as **success**.

## Fix

Match iOS `TronTransactionStatusProvider.swift` semantics exactly:

- `receipt` absent → **pending**
- `receipt.result` present (any non-empty string) → **error**
- `receipt` present, `result` absent → **success**

```ts
if (!tx.receipt) {
  return { status: 'pending' }
}
const status = tx.receipt.result ? 'error' : 'success'
```

## receipts

```
 ✓ getTronTxStatus > returns pending when tx has no blockNumber (not yet mined)
 ✓ getTronTxStatus > returns pending when blockNumber is 0
 ✓ getTronTxStatus > returns pending when receipt is absent (mined but receipt object missing)
 ✓ getTronTxStatus > returns success when receipt is present but result is absent
 ✓ getTronTxStatus > returns error for FAILED
 ✓ getTronTxStatus > returns error for OUT_OF_ENERGY (not only FAILED)
 ✓ getTronTxStatus > returns error for REVERT
 ✓ getTronTxStatus > returns error for OUT_OF_TIME
 ✓ getTronTxStatus > returns error for BANDWIDTH_ERROR
 ✓ getTronTxStatus > returns error for ACCOUNT_FREEZED
 ✓ getTronTxStatus > returns pending on network error

 Test Files  1 passed (1)
      Tests  11 passed (11)
```

🤖 Agent-generated

---

**R1 tackles (5ff585ef):**

- **empty string receipt.result**: changed `tx.receipt.result ? 'error' : 'success'` to `tx.receipt.result != null ? 'error' : 'success'`. iOS `if let receiptResult = receipt.result` fires for any non-nil value - empty string included. Truthy check wrongly mapped `''` to success.

- **top-level `result` field**: added `result?: string` to `TronTxInfoResponse` and check `tx.result === 'FAILED'` before the receipt block. iOS checks this field first in `TronTransactionStatusProvider.swift:41`; SDK was missing it entirely, so txs with top-level `result:'FAILED'` and no receipt were stuck as pending.

Test count: 11 → 13 (+2 cases).

**Note:** vultisig/vultiagent-app#826 has the same top-level-result gap - flagging for follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Tron transaction status detection to correctly identify various failure states instead of incorrectly reporting them as successful.

* **Tests**
  * Added comprehensive test coverage for Tron transaction status resolution scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/545?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->