### PR TITLE
fix(tron): set feeLimit=0 for FreezeBalanceV2 and UnfreezeBalanceV2

### DIFF
--- a/packages/core/mpc/keysign/signingInputs/resolvers/tron.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/tron.test.ts
@@ -91,8 +91,9 @@ describe('getTronSigningInputs -- FREEZE: / UNFREEZE: feeLimit semantics (BUG-7)
     })
 
     const [input] = getTronSigningInputs({ keysignPayload: payload, walletCore })
+    // Anti-regression: prior to fix, feeLimit was passed gasEstimation
+    // (a non-zero energy estimate that's semantically meaningless for
+    // system contracts and only served to confuse the UI fee display).
     expect(input.transaction?.feeLimit?.equals(Long.ZERO)).toBe(true)
-    // Explicit anti-regression: feeLimit must NOT equal gasEstimation.
-    expect(input.transaction?.feeLimit?.toNumber()).not.toBe(Number(GAS_ESTIMATION))
   })
 })

--- a/packages/core/mpc/keysign/signingInputs/resolvers/tron.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/tron.test.ts
@@ -1,0 +1,98 @@
+import { create } from '@bufbuild/protobuf'
+import { type WalletCore } from '@trustwallet/wallet-core'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { TronSpecificSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
+import { CoinSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/coin_pb'
+import { KeysignPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import Long from 'long'
+import { describe, expect, it } from 'vitest'
+
+import { getTronSigningInputs } from './tron'
+
+// getTronSigningInputs does not use walletCore internally (no address
+// validation or signing helpers required for Tron system ops), so a
+// bare cast to satisfy the resolver type constraint is fine here.
+const walletCore = {} as unknown as WalletCore
+
+// Minimal TronSpecific with a nonzero gasEstimation so we can assert
+// it is NOT forwarded to feeLimit in system-contract branches.
+const makeTronSpecific = (gasEstimation = 100_000_000n) =>
+  create(TronSpecificSchema, {
+    timestamp: 1_700_000_000_000n,
+    expiration: 1_700_003_600_000n,
+    blockHeaderTimestamp: 1_699_999_940_000n,
+    blockHeaderNumber: 1234n,
+    blockHeaderVersion: 28n,
+    blockHeaderTxTrieRoot: '0000000000000000000000000000000000000000000000000000000000000000',
+    blockHeaderParentHash: '0000000000000000000000000000000000000000000000000000000000000000',
+    blockHeaderWitnessAddress: '0000000000000000000000000000000000000000',
+    gasEstimation,
+  })
+
+const OWNER = 'T9yED5xMV5ARV98BexN97aLZ1UUq7eKSxm'
+
+const buildPayload = (memo: string, toAmount = '1000000000') =>
+  create(KeysignPayloadSchema, {
+    coin: create(CoinSchema, {
+      chain: Chain.Tron,
+      ticker: 'TRX',
+      address: OWNER,
+      decimals: 6,
+      isNativeToken: true,
+    }),
+    toAddress: OWNER,
+    toAmount,
+    memo,
+    blockchainSpecific: {
+      case: 'tronSpecific',
+      value: makeTronSpecific(100_000_000n),
+    },
+  })
+
+describe('getTronSigningInputs -- FREEZE: / UNFREEZE: feeLimit semantics (BUG-7)', () => {
+  it('FREEZE:BANDWIDTH sets feeLimit to 0 regardless of gasEstimation', () => {
+    const [input] = getTronSigningInputs({ keysignPayload: buildPayload('FREEZE:BANDWIDTH'), walletCore })
+    // FreezeBalanceV2 is a bandwidth op; energy feeLimit is semantically irrelevant.
+    expect(input.transaction?.feeLimit?.toNumber()).toBe(0)
+  })
+
+  it('FREEZE:ENERGY sets feeLimit to 0 regardless of gasEstimation', () => {
+    const [input] = getTronSigningInputs({ keysignPayload: buildPayload('FREEZE:ENERGY'), walletCore })
+    expect(input.transaction?.feeLimit?.toNumber()).toBe(0)
+  })
+
+  it('UNFREEZE:BANDWIDTH sets feeLimit to 0 regardless of gasEstimation', () => {
+    const [input] = getTronSigningInputs({ keysignPayload: buildPayload('UNFREEZE:BANDWIDTH'), walletCore })
+    expect(input.transaction?.feeLimit?.toNumber()).toBe(0)
+  })
+
+  it('UNFREEZE:ENERGY sets feeLimit to 0 regardless of gasEstimation', () => {
+    const [input] = getTronSigningInputs({ keysignPayload: buildPayload('UNFREEZE:ENERGY'), walletCore })
+    expect(input.transaction?.feeLimit?.toNumber()).toBe(0)
+  })
+
+  it('gasEstimation value does not leak into FREEZE feeLimit', () => {
+    // Pre-fix behaviour: feeLimit would have been Long.fromString('100000000').
+    // Post-fix: always 0. This assertion pins the regression explicitly.
+    const GAS_ESTIMATION = 100_000_000n
+    const specific = makeTronSpecific(GAS_ESTIMATION)
+    const payload = create(KeysignPayloadSchema, {
+      coin: create(CoinSchema, {
+        chain: Chain.Tron,
+        ticker: 'TRX',
+        address: OWNER,
+        decimals: 6,
+        isNativeToken: true,
+      }),
+      toAddress: OWNER,
+      toAmount: '1000000000',
+      memo: 'FREEZE:ENERGY',
+      blockchainSpecific: { case: 'tronSpecific', value: specific },
+    })
+
+    const [input] = getTronSigningInputs({ keysignPayload: payload, walletCore })
+    expect(input.transaction?.feeLimit?.equals(Long.ZERO)).toBe(true)
+    // Explicit anti-regression: feeLimit must NOT equal gasEstimation.
+    expect(input.transaction?.feeLimit?.toNumber()).not.toBe(Number(GAS_ESTIMATION))
+  })
+})

--- a/packages/core/mpc/keysign/signingInputs/resolvers/tron.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/tron.ts
@@ -54,7 +54,11 @@ export const getTronSigningInputs: SigningInputsResolver<'tron'> = ({ keysignPay
         }),
         timestamp: Long.fromString(tronSpecific.timestamp.toString()),
         expiration: Long.fromString(tronSpecific.expiration.toString()),
-        feeLimit: Long.fromString(tronSpecific.gasEstimation.toString()),
+        // FreezeBalanceV2 is a system (bandwidth) op, not a smart-contract call.
+        // feeLimit caps energy for TriggerSmartContract only; the node ignores it
+        // for native staking ops. Set to 0 so the UI does not inherit the energy
+        // estimate and mislead users about the actual cost of the operation.
+        feeLimit: Long.ZERO,
         blockHeader: createTronBlockHeader(tronSpecific),
       }),
     })
@@ -83,7 +87,11 @@ export const getTronSigningInputs: SigningInputsResolver<'tron'> = ({ keysignPay
         }),
         timestamp: Long.fromString(tronSpecific.timestamp.toString()),
         expiration: Long.fromString(tronSpecific.expiration.toString()),
-        feeLimit: Long.fromString(tronSpecific.gasEstimation.toString()),
+        // UnfreezeBalanceV2 is a system (bandwidth) op, not a smart-contract call.
+        // feeLimit caps energy for TriggerSmartContract only; the node ignores it
+        // for native staking ops. Set to 0 so the UI does not inherit the energy
+        // estimate and mislead users about the actual cost of the operation.
+        feeLimit: Long.ZERO,
         blockHeader: createTronBlockHeader(tronSpecific),
       }),
     })


### PR DESCRIPTION
Tackles BUG-7 (LOW) from the 2026-05-25 Tron audit.

## what

`FreezeBalanceV2` and `UnfreezeBalanceV2` are system ops (bandwidth only), not smart-contract calls. The `feeLimit` field in the Tron protobuf is the max-energy cap for `TriggerSmartContract` only. For native staking ops the node ignores it entirely.

Before this PR, both branches were setting `feeLimit = Long.fromString(tronSpecific.gasEstimation.toString())`. That gasEstimation is an energy estimate - semantically irrelevant for bandwidth ops. The UI-visible "estimated fee" was inheriting this value and showing users a misleading non-zero figure.

Fix: set `feeLimit: Long.ZERO` in both `FREEZE:` and `UNFREEZE:` branches.

## receipts

All 5 new unit tests pass, full core suite clean (71 files, 627 tests):

```
 ✓ FREEZE:BANDWIDTH sets feeLimit to 0 regardless of gasEstimation
 ✓ FREEZE:ENERGY sets feeLimit to 0 regardless of gasEstimation
 ✓ UNFREEZE:BANDWIDTH sets feeLimit to 0 regardless of gasEstimation
 ✓ UNFREEZE:ENERGY sets feeLimit to 0 regardless of gasEstimation
 ✓ gasEstimation value does not leak into FREEZE feeLimit

 Test Files  71 passed (71)
      Tests  627 passed (627)
```

🤖 Agent-generated

## scope

This PR is **SDK-only**. iOS (`vultisig-ios/.../Tron.swift:329,368`) and Android (`vultisig-android/.../TronHelper.kt:269,298`) have the same `feeLimit = gasEstimation` issue on FreezeBalanceV2 / UnfreezeBalanceV2. Those are separate teams' codepaths; not touching them in this SDK PR. They should track follow-up issues in their respective repos. The audit (2026-05-25) flagged BUG-7 across the stack; this PR closes the SDK side.