### PR TITLE
fix(polkadot): use transfer_keep_alive (method 3) instead of transfer_allow_death (method 0)

### DIFF
--- a/packages/core/mpc/keysign/signingInputs/resolvers/polkadot.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/polkadot.test.ts
@@ -1,0 +1,63 @@
+import { create } from '@bufbuild/protobuf'
+import { initWasm, type WalletCore } from '@trustwallet/wallet-core'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { PolkadotSpecificSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
+import { CoinSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/coin_pb'
+import { KeysignPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import { getPolkadotSigningInputs } from './polkadot'
+
+// Polkadot Asset Hub genesis hash (statemint)
+const GENESIS_HASH = '0x68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f'
+// Arbitrary valid SS58-0 Polkadot address
+const TO_ADDRESS = '15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Srd'
+const FROM_ADDRESS = '14E5nqKAp3oAJcmzgs25fyAmgeNL66XceFLiTqAZkdVH5T38'
+const BLOCK_HASH = '0xaabbccddeeff00112233445566778899aabbccddeeff00112233445566778899'
+
+const buildPayload = () =>
+  create(KeysignPayloadSchema, {
+    coin: create(CoinSchema, {
+      chain: Chain.Polkadot,
+      ticker: 'DOT',
+      address: FROM_ADDRESS,
+      decimals: 10,
+      isNativeToken: true,
+    }),
+    toAddress: TO_ADDRESS,
+    toAmount: '10000000000',
+    blockchainSpecific: {
+      case: 'polkadotSpecific',
+      value: create(PolkadotSpecificSchema, {
+        recentBlockHash: BLOCK_HASH,
+        nonce: 0n,
+        currentBlockNumber: '20000000',
+        specVersion: 1003004,
+        transactionVersion: 26,
+        genesisHash: GENESIS_HASH,
+      }),
+    },
+  })
+
+describe('getPolkadotSigningInputs', () => {
+  let walletCore: WalletCore
+
+  beforeAll(async () => {
+    walletCore = await initWasm()
+  })
+
+  it('uses methodIndex 3 (transfer_keep_alive) not 0 (transfer_allow_death)', () => {
+    const [input] = getPolkadotSigningInputs({ keysignPayload: buildPayload(), walletCore })
+
+    const callIndices = input.balanceCall?.assetTransfer?.callIndices?.custom
+    expect(callIndices).toBeDefined()
+    expect(callIndices?.methodIndex).toBe(3)
+  })
+
+  it('keeps moduleIndex 10 (pallet_balances on Asset Hub)', () => {
+    const [input] = getPolkadotSigningInputs({ keysignPayload: buildPayload(), walletCore })
+
+    const callIndices = input.balanceCall?.assetTransfer?.callIndices?.custom
+    expect(callIndices?.moduleIndex).toBe(10)
+  })
+})

--- a/packages/core/mpc/keysign/signingInputs/resolvers/polkadot.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/polkadot.ts
@@ -23,10 +23,14 @@ export const getPolkadotSigningInputs: SigningInputsResolver<'polkadot'> = ({ ke
   // Amount: converted to hexadecimal, stripped of '0x'
   const amountHex = Buffer.from(stripHexPrefix(bigIntToHex(BigInt(keysignPayload.toAmount))), 'hex')
 
+  // methodIndex 3 = transfer_keep_alive on Asset Hub (statemint pallet_balances).
+  // method 0 = transfer_allow_death which can reap the sender's account when the
+  // remaining balance drops below ED (0.01 DOT). app + mcp-ts already use method 3;
+  // this aligns the SDK keysign path with them.
   const callIndices = TW.Polkadot.Proto.CallIndices.create({
     custom: TW.Polkadot.Proto.CustomCallIndices.create({
       moduleIndex: 10,
-      methodIndex: 0,
+      methodIndex: 3,
     }),
   })
 


### PR DESCRIPTION
Tackles BUG-1 (MEDIUM) from the 2026-05-25 Polkadot audit.

## what

`packages/core/mpc/keysign/signingInputs/resolvers/polkadot.ts:29` was using `methodIndex: 0` which maps to `pallet_balances::transfer_allow_death` on Asset Hub (statemint). This call can permanently reap the sender's account when the remaining balance drops below the existential deposit (0.01 DOT on Asset Hub).

`methodIndex: 3` = `transfer_keep_alive` - it reverts the tx rather than destroying the account.

## context

The app and mcp-ts already had this right:
- `vultiagent-app/src/features/agent/lib/polkadotTx.ts:194`: `METHOD_TRANSFER_KEEP_ALIVE = 3`
- `vultisig-mcp-ts`: `api.tx.balances.transferKeepAlive`

The SDK was the outlier. iOS and Android also use method 0 but those are separate teams - separate PRs needed.

## receipts

jest / vitest output:

```
PASS packages/core/mpc/keysign/signingInputs/resolvers/polkadot.test.ts
  getPolkadotSigningInputs
    ✓ uses methodIndex 3 (transfer_keep_alive) not 0 (transfer_allow_death) 8ms
    ✓ keeps moduleIndex 10 (pallet_balances on Asset Hub) 0ms
```

🤖 Agent-generated

## cross-client tracking

iOS and Android still ship `methodIndex: 0` (transfer_allow_death). They are out of scope here (different teams) but the divergence is real:
- If a vault has mixed iOS + agent-app devices participating in the same MPC keysign session for Polkadot, the SCALE pre-image hashes will diverge → silent session failure (no fund loss, just user confusion).
- Single-device fast-vault flows are unaffected.

Companion work to track separately:
- iOS: `Polkadot.swift:74` (`methodIndex: 0`) + the misleading comment at line 60-70 saying "WalletCore encodes as TransferAllowDeath when assetId=0" - verified against TW 4.6.9 WASM that this is NOT what happens; TW respects custom callIndices.
- Android: `PolkadotHelper.kt:47` (`methodIndex: 0`)

closes #N/A (no GH issue yet for the audit BUG-1)

🤖 codex adversarial verdict: APPROVE (no correctness blockers; cross-client tracking is coordination work)