### PR TITLE
fix(tron): fetch energy price dynamically from chain params

### DIFF
--- a/packages/core/mpc/keysign/chainSpecific/resolvers/tron/energyPrice.test.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/tron/energyPrice.test.ts
@@ -38,10 +38,9 @@ describe('getEnergyPrice', () => {
   it('falls back to 280n when fetch throws', async () => {
     queryUrlMock.mockRejectedValue(new Error('network error'))
 
-    const { getEnergyPrice, _FALLBACK_ENERGY_PRICE_FOR_TEST } = await loadModule()
+    const { getEnergyPrice } = await loadModule()
     const price = await getEnergyPrice()
 
-    expect(price).toBe(_FALLBACK_ENERGY_PRICE_FOR_TEST)
     expect(price).toBe(280n)
   })
 
@@ -63,6 +62,35 @@ describe('getEnergyPrice', () => {
     const price = await getEnergyPrice()
 
     expect(price).toBe(280n)
+  })
+
+  it('falls back to 280n when getEnergyFee value is 0', async () => {
+    // value: 0 would produce BigInt(0) -> totalEnergy * 0n = 0n -> free fees -> tx fails on-chain
+    queryUrlMock.mockResolvedValue({
+      chainParameter: [{ key: 'getEnergyFee', value: 0 }],
+    })
+
+    const { getEnergyPrice } = await loadModule()
+    const price = await getEnergyPrice()
+
+    expect(price).toBe(280n)
+  })
+
+  it('recovers immediately after a failed fetch (errors are not cached)', async () => {
+    // Call 1: network error -> fallback
+    queryUrlMock.mockRejectedValue(new Error('network error'))
+    const { getEnergyPrice } = await loadModule()
+    const fallbackPrice = await getEnergyPrice()
+    expect(fallbackPrice).toBe(280n)
+
+    // Call 2: TronGrid recovers -> should return live price, NOT cached fallback
+    queryUrlMock.mockResolvedValue({
+      chainParameter: [{ key: 'getEnergyFee', value: 420 }],
+    })
+    const recoveredPrice = await getEnergyPrice()
+    expect(recoveredPrice).toBe(420n)
+    // queryUrl was called twice: once for the error, once for the recovery
+    expect(queryUrlMock).toHaveBeenCalledTimes(2)
   })
 
   it('returns cached result on second call within TTL', async () => {

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/tron/energyPrice.test.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/tron/energyPrice.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Mock queryUrl BEFORE importing the module so the in-memory cache starts
+// clean for each test via vi.resetModules() in afterEach.
+vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
+  queryUrl: vi.fn(),
+}))
+
+import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+
+const queryUrlMock = vi.mocked(queryUrl)
+
+// Re-import fresh module after resetting module registry so the memoize
+// cache (module-level singleton) starts empty for every test.
+const loadModule = () => import('./energyPrice?t=' + Date.now())
+
+afterEach(() => {
+  vi.resetModules()
+  queryUrlMock.mockReset()
+})
+
+describe('getEnergyPrice', () => {
+  it('returns fetched energy price when endpoint responds', async () => {
+    queryUrlMock.mockResolvedValue({
+      chainParameter: [
+        { key: 'getEnergyFee', value: 420 },
+        { key: 'someOtherParam', value: 999 },
+      ],
+    })
+
+    const { getEnergyPrice } = await loadModule()
+    const price = await getEnergyPrice()
+
+    expect(price).toBe(420n)
+    expect(queryUrlMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to 280n when fetch throws', async () => {
+    queryUrlMock.mockRejectedValue(new Error('network error'))
+
+    const { getEnergyPrice, _FALLBACK_ENERGY_PRICE_FOR_TEST } = await loadModule()
+    const price = await getEnergyPrice()
+
+    expect(price).toBe(_FALLBACK_ENERGY_PRICE_FOR_TEST)
+    expect(price).toBe(280n)
+  })
+
+  it('falls back to 280n when getEnergyFee key is absent', async () => {
+    queryUrlMock.mockResolvedValue({
+      chainParameter: [{ key: 'someOtherParam', value: 999 }],
+    })
+
+    const { getEnergyPrice } = await loadModule()
+    const price = await getEnergyPrice()
+
+    expect(price).toBe(280n)
+  })
+
+  it('falls back to 280n when chainParameter array is missing', async () => {
+    queryUrlMock.mockResolvedValue({})
+
+    const { getEnergyPrice } = await loadModule()
+    const price = await getEnergyPrice()
+
+    expect(price).toBe(280n)
+  })
+
+  it('returns cached result on second call within TTL', async () => {
+    queryUrlMock.mockResolvedValue({
+      chainParameter: [{ key: 'getEnergyFee', value: 300 }],
+    })
+
+    const { getEnergyPrice } = await loadModule()
+    const first = await getEnergyPrice()
+    const second = await getEnergyPrice()
+
+    expect(first).toBe(300n)
+    expect(second).toBe(300n)
+    // memoizeAsync should have only hit the network once
+    expect(queryUrlMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/tron/energyPrice.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/tron/energyPrice.ts
@@ -25,29 +25,27 @@ const fetchEnergyPriceRaw = async (): Promise<bigint> => {
   })
 
   const param = data.chainParameter?.find(p => p.key === 'getEnergyFee')
-  if (param?.value == null) {
+  if (param?.value == null || param.value <= 0) {
     return FALLBACK_ENERGY_PRICE
   }
 
   return BigInt(param.value)
 }
 
+// Only successful fetches are memoized. Errors bubble up so the catch below
+// never caches the fallback as if it were a real price (fixes error-caching bug).
+const memoizedFetchEnergyPrice = memoizeAsync(fetchEnergyPriceRaw, { cacheTime: CACHE_TTL_MS })
+
 /**
  * Returns the current energy price in sun/energy from Tron chain params.
- * Cached for 5 min. Falls back to 280 sun/energy (2023 governance default)
- * if the endpoint is unreachable.
+ * Successful fetches cached for 5 min. Falls back to 280 sun/energy (2023
+ * governance default) if the endpoint is unreachable - recovery is immediate
+ * once TronGrid comes back (errors are never cached).
  */
-export const getEnergyPrice = memoizeAsync(
-  async (): Promise<bigint> => {
-    try {
-      return await fetchEnergyPriceRaw()
-    } catch {
-      return FALLBACK_ENERGY_PRICE
-    }
-  },
-  { cacheTime: CACHE_TTL_MS }
-)
-
-// Test-only export so unit tests can assert the fallback value without
-// repeating the magic number.
-export const _FALLBACK_ENERGY_PRICE_FOR_TEST = FALLBACK_ENERGY_PRICE
+export const getEnergyPrice = async (): Promise<bigint> => {
+  try {
+    return await memoizedFetchEnergyPrice()
+  } catch {
+    return FALLBACK_ENERGY_PRICE
+  }
+}

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/tron/energyPrice.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/tron/energyPrice.ts
@@ -1,0 +1,53 @@
+import { memoizeAsync } from '@vultisig/lib-utils/memoizeAsync'
+import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+
+const FALLBACK_ENERGY_PRICE = 280n
+
+const CHAIN_PARAMS_URL = 'https://api.trongrid.io/wallet/getchainparameters'
+
+// 5 min TTL - governance proposals that change energy price are extremely
+// rare (last change was 2023) so this trades one RPC call per 5 min window
+// against always paying the right price post any future proposal.
+const CACHE_TTL_MS = 5 * 60 * 1000
+
+type ChainParameter = {
+  key: string
+  value?: number
+}
+
+type GetChainParametersResponse = {
+  chainParameter?: ChainParameter[]
+}
+
+const fetchEnergyPriceRaw = async (): Promise<bigint> => {
+  const data = await queryUrl<GetChainParametersResponse>(CHAIN_PARAMS_URL, {
+    headers: { accept: 'application/json' },
+  })
+
+  const param = data.chainParameter?.find(p => p.key === 'getEnergyFee')
+  if (param?.value == null) {
+    return FALLBACK_ENERGY_PRICE
+  }
+
+  return BigInt(param.value)
+}
+
+/**
+ * Returns the current energy price in sun/energy from Tron chain params.
+ * Cached for 5 min. Falls back to 280 sun/energy (2023 governance default)
+ * if the endpoint is unreachable.
+ */
+export const getEnergyPrice = memoizeAsync(
+  async (): Promise<bigint> => {
+    try {
+      return await fetchEnergyPriceRaw()
+    } catch {
+      return FALLBACK_ENERGY_PRICE
+    }
+  },
+  { cacheTime: CACHE_TTL_MS }
+)
+
+// Test-only export so unit tests can assert the fallback value without
+// repeating the magic number.
+export const _FALLBACK_ENERGY_PRICE_FOR_TEST = FALLBACK_ENERGY_PRICE

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/tron/fee.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/tron/fee.ts
@@ -3,6 +3,8 @@ import { AccountCoinKey } from '@vultisig/core-chain/coin/AccountCoin'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 import base58 from 'bs58'
 
+import { getEnergyPrice } from './energyPrice'
+
 type TriggerContractResponse = {
   energy_used?: number
   energy_penalty?: number
@@ -53,7 +55,8 @@ export const getTrc20TransferFee = async ({ coin, receiver, amount }: GetTrc20Tr
   const energyUsed = responseData.energy_used ?? 0
   const energyPenalty = responseData.energy_penalty ?? 0
   const totalEnergy = BigInt(energyUsed) + BigInt(energyPenalty)
-  const totalSun = totalEnergy * 280n
+  const energyPrice = await getEnergyPrice()
+  const totalSun = totalEnergy * energyPrice
 
   return totalSun
 }

--- a/packages/core/mpc/package.json
+++ b/packages/core/mpc/package.json
@@ -266,6 +266,11 @@
       "import": "./dist/keysign/chainSpecific/resolvers/tron/index.js",
       "default": "./dist/keysign/chainSpecific/resolvers/tron/index.js"
     },
+    "./keysign/chainSpecific/resolvers/tron/energyPrice": {
+      "types": "./dist/keysign/chainSpecific/resolvers/tron/energyPrice.d.ts",
+      "import": "./dist/keysign/chainSpecific/resolvers/tron/energyPrice.js",
+      "default": "./dist/keysign/chainSpecific/resolvers/tron/energyPrice.js"
+    },
     "./keysign/chainSpecific/resolvers/tron/fee": {
       "types": "./dist/keysign/chainSpecific/resolvers/tron/fee.d.ts",
       "import": "./dist/keysign/chainSpecific/resolvers/tron/fee.js",


### PR DESCRIPTION
Tackles BUG-4 (LOW) from the 2026-05-25 Tron audit.

## what

`getTrc20TransferFee` was multiplying `totalEnergy * 280n` (hardcoded). 280 sun/energy was set by a 2023 Tron governance proposal. The network can change this value at any time via an on-chain proposal - and historically has.

iOS fetches the live value from `/wallet/getchainparameters` and reads the `getEnergyFee` key. This PR mirrors that pattern.

## how

New `energyPrice.ts` module:
- calls `GET /wallet/getchainparameters` via the existing `queryUrl` helper
- finds the `getEnergyFee` entry and returns `BigInt(value)` (with a `> 0` guard - value:0 would produce 0n fees and fail on-chain)
- memoizes successful fetches for 5 min; errors are never cached (try/catch lives outside the memoize boundary so TronGrid recovery is immediate)
- falls back to 280n on any fetch error

Cache TTL rationale: governance proposals that touch `getEnergyFee` require a DAO vote and an on-chain activation, both taking hours to days. A 5 min cache means we pick up the new price within 5 min of it going live, while paying at most one extra RPC call per 5 min window across all active fee quotes.

Fallback value rationale: `280n` matches the 2023 governance value - historically stable and matches current network state. A more conservative fallback (e.g. `420n` to over-quote) would never fail an on-chain tx but would over-charge users ~50% on each estimate during outage. Trade-off chosen: stay accurate at the cost of one failed-tx-during-outage edge case. Revisit if governance changes the rate.

`fee.ts` change is two lines: import + replace the literal with `await getEnergyPrice()`.

## receipts

```
 RUN  v4.1.6 /private/tmp/sdk-tron-bug4

 ✓ packages/core/mpc/keysign/chainSpecific/resolvers/tron/energyPrice.test.ts > getEnergyPrice > returns fetched energy price when endpoint responds 26ms
 ✓ packages/core/mpc/keysign/chainSpecific/resolvers/tron/energyPrice.test.ts > getEnergyPrice > falls back to 280n when fetch throws 2ms
 ✓ packages/core/mpc/keysign/chainSpecific/resolvers/tron/energyPrice.test.ts > getEnergyPrice > falls back to 280n when getEnergyFee key is absent 3ms
 ✓ packages/core/mpc/keysign/chainSpecific/resolvers/tron/energyPrice.test.ts > getEnergyPrice > falls back to 280n when chainParameter array is missing 1ms
 ✓ packages/core/mpc/keysign/chainSpecific/resolvers/tron/energyPrice.test.ts > getEnergyPrice > falls back to 280n when getEnergyFee value is 0 6ms
 ✓ packages/core/mpc/keysign/chainSpecific/resolvers/tron/energyPrice.test.ts > getEnergyPrice > recovers immediately after a failed fetch (errors are not cached) 42ms
 ✓ packages/core/mpc/keysign/chainSpecific/resolvers/tron/energyPrice.test.ts > getEnergyPrice > returns cached result on second call within TTL 4ms

 Test Files  1 passed (1)
      Tests  7 passed (7)
   Duration  541ms
```

note: BUG-5 (walletsolidity endpoint) is a separate PR at fix_tron_fee_estimator_use_wallet_endpoint - not included here.

🤖 Agent-generated