### PR TITLE
fix(polkadot/dapp): add missing asset hub signed-extension bytes to constructPolkadotSigningPayload

### DIFF
--- a/packages/core/chain/chains/polkadot/dapp/constructSigningPayload.test.ts
+++ b/packages/core/chain/chains/polkadot/dapp/constructSigningPayload.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest'
+
+import { constructPolkadotSigningPayload } from './constructSigningPayload'
+import { PolkadotSignerPayloadJSON } from './PolkadotSignerPayload'
+
+// ---------------------------------------------------------------------------
+// Byte-fixture test for the Asset Hub Polkadot signed-extension shape.
+//
+// Ported from vultiagent-app/src/services/__tests__/polkadotTx.test.ts
+// (assembleSignerPayload describe block) which serves as the canonical
+// source of truth. That fixture was verified against @polkadot/api and
+// the live Asset Hub runtime (statemint 2002001).
+//
+// The three AH-required bytes are:
+//   ChargeAssetTxPayment::extra  Option<MultiLocation>=None   0x00
+//   CheckMetadataHash::extra     mode=Disabled                0x00
+//   CheckMetadataHash::additional_signed  Option<H256>=None   0x00
+//
+// Without these the runtime computes a different payload hash than the
+// wallet - BadProof on-chain.
+// ---------------------------------------------------------------------------
+
+const toHex = (b: Uint8Array) => Array.from(b, x => x.toString(16).padStart(2, '0')).join('')
+
+// Deterministic test vectors - no live RPC.
+//
+// method: Balances.transferKeepAlive(Alice, 100_000_000 Planck)
+//   pallet 0x0a | method 0x03 | MultiAddress::Id 0x00 | Alice 32B | compact(100_000_000)
+const METHOD = '0x0a0300d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d0284d717'
+
+// era: mortal (blockNumber=42, period=64) - 0xa502
+const ERA = '0xa502'
+
+// nonce: 0 - compact 0x00
+const NONCE = '0x0'
+
+// tip: 0
+const TIP = '0x0'
+
+// specVersion: statemint 2002001 = 0x001E8B11
+const SPEC_VERSION = '0x001e8b11'
+
+// transactionVersion: 15 = 0x0f
+const TX_VERSION = '0x0000000f'
+
+// genesisHash: 32-byte AH genesis (live prefix pinned, rest zeros for fixture stability)
+const GENESIS_HASH = '0x68d56f15f4d3e1ec0000000000000000000000000000000000000000000000aa'
+
+// blockHash: 32 bytes of 0x11 (deterministic stand-in for a real block hash)
+const BLOCK_HASH = '0x1111111111111111111111111111111111111111111111111111111111111111'
+
+const basePayload: PolkadotSignerPayloadJSON = {
+  address: '15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5',
+  blockHash: BLOCK_HASH,
+  blockNumber: '0x00',
+  era: ERA,
+  genesisHash: GENESIS_HASH,
+  method: METHOD,
+  nonce: NONCE,
+  specVersion: SPEC_VERSION,
+  tip: TIP,
+  transactionVersion: TX_VERSION,
+  signedExtensions: [
+    'CheckNonZeroSender',
+    'CheckSpecVersion',
+    'CheckTxVersion',
+    'CheckGenesis',
+    'CheckMortality',
+    'CheckNonce',
+    'CheckWeight',
+    'ChargeAssetTxPayment',
+    'CheckMetadataHash',
+  ],
+  version: 4,
+}
+
+describe('constructPolkadotSigningPayload', () => {
+  it('matches AH-required canonical layout including all three signed-extension bytes', () => {
+    const result = constructPolkadotSigningPayload(basePayload)
+
+    // Layout (ported from vultiagent-app assembleSignerPayload fixture):
+    //   call || era || nonce || tip
+    //   || ChargeAssetTxPayment(0x00) || CheckMetadataHash mode(0x00)
+    //   || specVersion || txVersion || genesisHash || blockHash
+    //   || CheckMetadataHash additional-signed(0x00)
+    const expected =
+      // call: 0a 03 00 <Alice 32B> compact(100_000_000)=02 84 d7 17
+      '0a0300d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d0284d717' +
+      // era (mortal blockNumber=42, period=64): a5 02
+      'a502' +
+      // nonce: 00
+      '00' +
+      // tip: 00
+      '00' +
+      // ChargeAssetTxPayment::extra Option<MultiLocation>=None: 00
+      '00' +
+      // CheckMetadataHash::extra mode=Disabled: 00
+      '00' +
+      // specVersion LE-u32: 11 8b 1e 00
+      '118b1e00' +
+      // txVersion LE-u32: 0f 00 00 00
+      '0f000000' +
+      // genesisHash (32B)
+      '68d56f15f4d3e1ec0000000000000000000000000000000000000000000000aa' +
+      // blockHash (32B)
+      '1111111111111111111111111111111111111111111111111111111111111111' +
+      // CheckMetadataHash::additional_signed Option<H256>=None: 00
+      '00'
+
+    expect(toHex(result)).toBe(expected)
+  })
+
+  it('is exactly 3 bytes longer than the pre-fix (missing AH ext bytes) shape', () => {
+    // Proves the fixture is sensitive to the new bytes. The pre-fix payload
+    // was: method || era || nonce || tip || specVersion || txVersion ||
+    //      genesisHash || blockHash  (no AH signed-extension bytes at all).
+    const result = constructPolkadotSigningPayload(basePayload)
+
+    // The payload is short (< 256 bytes), so no blake2 hashing kicks in -
+    // we can count raw bytes directly.
+    // call(39) + era(2) + nonce(1) + tip(1) + AH-ext(3) + spec(4) + txv(4) + genesis(32) + block(32) = 118
+    // call breakdown: pallet(0x0a)+method(0x03)+MultiAddr-discriminant(0x00)=3B
+    //   + Alice AccountId=32B + compact(100_000_000)=4B = 39B total
+    expect(result.length).toBe(118)
+    // 3 bytes = the two payload-phase bytes (assetIdNone, metaHashMode) +
+    // the additional-signed byte (metaHashNone)
+    const preFix = result.length - 3
+    expect(preFix).toBe(115)
+  })
+
+  it('returns blake2b-256 hash when raw payload would exceed 256 bytes', () => {
+    // Craft a method payload long enough to push raw over threshold.
+    // Non-AH fields (era+nonce+tip+spec+txv+genesis+block+AH-ext) = 79 bytes.
+    // So method needs > 177 bytes = 354 hex chars after '0x'.
+    const longMethod = '0x' + '00'.repeat(178)
+    const result = constructPolkadotSigningPayload({ ...basePayload, method: longMethod })
+    // blake2b-256 always produces exactly 32 bytes
+    expect(result.length).toBe(32)
+  })
+
+  it('encodes zero tip correctly (compact 0x00)', () => {
+    const result = constructPolkadotSigningPayload({ ...basePayload, tip: '0x0' })
+    const hex = toHex(result)
+    // method is 39 bytes (78 hex chars): positions [0..77]
+    // era: [78..81], nonce: [82..83], tip: [84..85]
+    expect(hex.slice(84, 86)).toBe('00')
+  })
+})

--- a/packages/core/chain/chains/polkadot/dapp/constructSigningPayload.test.ts
+++ b/packages/core/chain/chains/polkadot/dapp/constructSigningPayload.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { constructPolkadotSigningPayload } from './constructSigningPayload'
+import { constructAssetHubPolkadotSigningPayload } from './constructSigningPayload'
 import { PolkadotSignerPayloadJSON } from './PolkadotSignerPayload'
 
 // ---------------------------------------------------------------------------
@@ -9,7 +9,7 @@ import { PolkadotSignerPayloadJSON } from './PolkadotSignerPayload'
 // Ported from vultiagent-app/src/services/__tests__/polkadotTx.test.ts
 // (assembleSignerPayload describe block) which serves as the canonical
 // source of truth. That fixture was verified against @polkadot/api and
-// the live Asset Hub runtime (statemint 2002001).
+// the live Asset Hub runtime (statemint 2001681).
 //
 // The three AH-required bytes are:
 //   ChargeAssetTxPayment::extra  Option<MultiLocation>=None   0x00
@@ -37,13 +37,13 @@ const NONCE = '0x0'
 // tip: 0
 const TIP = '0x0'
 
-// specVersion: statemint 2002001 = 0x001E8B11
+// specVersion: statemint 2001681 = 0x001E8B11
 const SPEC_VERSION = '0x001e8b11'
 
 // transactionVersion: 15 = 0x0f
 const TX_VERSION = '0x0000000f'
 
-// genesisHash: 32-byte AH genesis (live prefix pinned, rest zeros for fixture stability)
+// First 8 bytes are real AH genesis prefix; rest is fixture-stable zeros + sentinel `aa` trailer
 const GENESIS_HASH = '0x68d56f15f4d3e1ec0000000000000000000000000000000000000000000000aa'
 
 // blockHash: 32 bytes of 0x11 (deterministic stand-in for a real block hash)
@@ -74,9 +74,9 @@ const basePayload: PolkadotSignerPayloadJSON = {
   version: 4,
 }
 
-describe('constructPolkadotSigningPayload', () => {
+describe('constructAssetHubPolkadotSigningPayload', () => {
   it('matches AH-required canonical layout including all three signed-extension bytes', () => {
-    const result = constructPolkadotSigningPayload(basePayload)
+    const result = constructAssetHubPolkadotSigningPayload(basePayload)
 
     // Layout (ported from vultiagent-app assembleSignerPayload fixture):
     //   call || era || nonce || tip
@@ -114,7 +114,7 @@ describe('constructPolkadotSigningPayload', () => {
     // Proves the fixture is sensitive to the new bytes. The pre-fix payload
     // was: method || era || nonce || tip || specVersion || txVersion ||
     //      genesisHash || blockHash  (no AH signed-extension bytes at all).
-    const result = constructPolkadotSigningPayload(basePayload)
+    const result = constructAssetHubPolkadotSigningPayload(basePayload)
 
     // The payload is short (< 256 bytes), so no blake2 hashing kicks in -
     // we can count raw bytes directly.
@@ -128,18 +128,24 @@ describe('constructPolkadotSigningPayload', () => {
     expect(preFix).toBe(115)
   })
 
-  it('returns blake2b-256 hash when raw payload would exceed 256 bytes', () => {
-    // Craft a method payload long enough to push raw over threshold.
+  it('does NOT hash when raw payload is exactly 256 bytes (boundary)', () => {
     // Non-AH fields (era+nonce+tip+spec+txv+genesis+block+AH-ext) = 79 bytes.
-    // So method needs > 177 bytes = 354 hex chars after '0x'.
+    // method = 177 bytes -> total = 256 -> condition is `> 256` -> no hash.
+    const boundaryMethod = '0x' + '00'.repeat(177)
+    const result = constructAssetHubPolkadotSigningPayload({ ...basePayload, method: boundaryMethod })
+    expect(result.length).toBe(256)
+  })
+
+  it('returns blake2b-256 hash when raw payload exceeds 256 bytes', () => {
+    // method = 178 bytes -> total = 257 -> condition is `> 256` -> hash fires.
     const longMethod = '0x' + '00'.repeat(178)
-    const result = constructPolkadotSigningPayload({ ...basePayload, method: longMethod })
+    const result = constructAssetHubPolkadotSigningPayload({ ...basePayload, method: longMethod })
     // blake2b-256 always produces exactly 32 bytes
     expect(result.length).toBe(32)
   })
 
   it('encodes zero tip correctly (compact 0x00)', () => {
-    const result = constructPolkadotSigningPayload({ ...basePayload, tip: '0x0' })
+    const result = constructAssetHubPolkadotSigningPayload({ ...basePayload, tip: '0x0' })
     const hex = toHex(result)
     // method is 39 bytes (78 hex chars): positions [0..77]
     // era: [78..81], nonce: [82..83], tip: [84..85]

--- a/packages/core/chain/chains/polkadot/dapp/constructSigningPayload.test.ts
+++ b/packages/core/chain/chains/polkadot/dapp/constructSigningPayload.test.ts
@@ -144,6 +144,12 @@ describe('constructAssetHubPolkadotSigningPayload', () => {
     expect(result.length).toBe(32)
   })
 
+  it('throws when signedExtensions is an empty array (cannot bypass guard)', () => {
+    expect(() => constructAssetHubPolkadotSigningPayload({ ...basePayload, signedExtensions: [] })).toThrow(
+      /missing required Asset Hub extensions/
+    )
+  })
+
   it('encodes zero tip correctly (compact 0x00)', () => {
     const result = constructAssetHubPolkadotSigningPayload({ ...basePayload, tip: '0x0' })
     const hex = toHex(result)

--- a/packages/core/chain/chains/polkadot/dapp/constructSigningPayload.ts
+++ b/packages/core/chain/chains/polkadot/dapp/constructSigningPayload.ts
@@ -6,7 +6,11 @@ import { PolkadotSignerPayloadJSON } from './PolkadotSignerPayload'
 const polkadotSigningPayloadHashThreshold = 256
 
 /**
- * Construct the raw signing payload bytes from a Polkadot SignerPayloadJSON.
+ * Construct the raw signing payload bytes from an Asset Hub Polkadot SignerPayloadJSON.
+ *
+ * SCOPE: Asset Hub (statemint/statemine) payloads ONLY. The payload must include
+ * both `ChargeAssetTxPayment` and `CheckMetadataHash` in `signedExtensions`.
+ * Relay-chain payloads use different extensions and must NOT use this function.
  *
  * Follows the Asset Hub Polkadot (statemint) extrinsic payload v4 encoding:
  * method + era + compact(nonce) + compact(tip)
@@ -24,7 +28,16 @@ const polkadotSigningPayloadHashThreshold = 256
  *
  * If the payload exceeds 256 bytes, it is blake2b-256 hashed before signing.
  */
-export const constructPolkadotSigningPayload = (payload: PolkadotSignerPayloadJSON): Uint8Array => {
+export const constructAssetHubPolkadotSigningPayload = (payload: PolkadotSignerPayloadJSON): Uint8Array => {
+  const required = ['ChargeAssetTxPayment', 'CheckMetadataHash']
+  if (payload.signedExtensions && payload.signedExtensions.length > 0) {
+    const missing = required.filter(ext => !payload.signedExtensions!.includes(ext))
+    if (missing.length > 0) {
+      throw new Error(
+        `constructAssetHubPolkadotSigningPayload: payload signedExtensions missing required Asset Hub extensions: ${missing.join(', ')}. This function only encodes Asset Hub (statemint) payloads.`
+      )
+    }
+  }
   const method = hexToU8a(payload.method)
   const era = hexToU8a(payload.era)
   const nonce = compactToU8a(parseInt(payload.nonce, 16))

--- a/packages/core/chain/chains/polkadot/dapp/constructSigningPayload.ts
+++ b/packages/core/chain/chains/polkadot/dapp/constructSigningPayload.ts
@@ -8,9 +8,19 @@ const polkadotSigningPayloadHashThreshold = 256
 /**
  * Construct the raw signing payload bytes from a Polkadot SignerPayloadJSON.
  *
- * Follows the Polkadot extrinsic payload v4 encoding:
- * method + era + compact(nonce) + compact(tip) + LE-u32(specVersion) +
- * LE-u32(transactionVersion) + genesisHash + blockHash
+ * Follows the Asset Hub Polkadot (statemint) extrinsic payload v4 encoding:
+ * method + era + compact(nonce) + compact(tip)
+ * + ChargeAssetTxPayment::extra (Option<MultiLocation>=None = 0x00)
+ * + CheckMetadataHash::extra (mode=Disabled = 0x00)
+ * + LE-u32(specVersion) + LE-u32(transactionVersion)
+ * + genesisHash + blockHash
+ * + CheckMetadataHash::additional_signed (Option<H256>=None = 0x00)
+ *
+ * The three Asset Hub signed-extension bytes (ChargeAssetTxPayment option byte,
+ * CheckMetadataHash mode byte, CheckMetadataHash additional-signed byte) are
+ * required by the Asset Hub runtime. Without them the node rejects the
+ * extrinsic with BadProof because the payload hash the node computes differs
+ * from the one the wallet signed.
  *
  * If the payload exceeds 256 bytes, it is blake2b-256 hashed before signing.
  */
@@ -19,6 +29,11 @@ export const constructPolkadotSigningPayload = (payload: PolkadotSignerPayloadJS
   const era = hexToU8a(payload.era)
   const nonce = compactToU8a(parseInt(payload.nonce, 16))
   const tip = compactToU8a(payload.tip ? BigInt(payload.tip) : 0n)
+
+  // ChargeAssetTxPayment::extra - Option<MultiLocation> = None
+  const chargeAssetTxPaymentNone = new Uint8Array([0x00])
+  // CheckMetadataHash::extra - mode byte = Disabled
+  const checkMetadataHashMode = new Uint8Array([0x00])
 
   const specVersion = new Uint8Array(4)
   new DataView(specVersion.buffer).setUint32(0, parseInt(payload.specVersion, 16), true)
@@ -29,7 +44,22 @@ export const constructPolkadotSigningPayload = (payload: PolkadotSignerPayloadJS
   const genesisHash = hexToU8a(payload.genesisHash)
   const blockHash = hexToU8a(payload.blockHash)
 
-  const raw = u8aConcat(method, era, nonce, tip, specVersion, transactionVersion, genesisHash, blockHash)
+  // CheckMetadataHash::additional_signed - Option<H256> = None
+  const checkMetadataHashNone = new Uint8Array([0x00])
+
+  const raw = u8aConcat(
+    method,
+    era,
+    nonce,
+    tip,
+    chargeAssetTxPaymentNone,
+    checkMetadataHashMode,
+    specVersion,
+    transactionVersion,
+    genesisHash,
+    blockHash,
+    checkMetadataHashNone
+  )
 
   if (raw.length > polkadotSigningPayloadHashThreshold) {
     return blake2AsU8a(raw, 256)

--- a/packages/core/chain/chains/polkadot/dapp/constructSigningPayload.ts
+++ b/packages/core/chain/chains/polkadot/dapp/constructSigningPayload.ts
@@ -30,7 +30,7 @@ const polkadotSigningPayloadHashThreshold = 256
  */
 export const constructAssetHubPolkadotSigningPayload = (payload: PolkadotSignerPayloadJSON): Uint8Array => {
   const required = ['ChargeAssetTxPayment', 'CheckMetadataHash']
-  if (payload.signedExtensions && payload.signedExtensions.length > 0) {
+  if (payload.signedExtensions != null) {
     const missing = required.filter(ext => !payload.signedExtensions!.includes(ext))
     if (missing.length > 0) {
       throw new Error(


### PR DESCRIPTION
Tackles BUG-2 (HIGH, latent) from the 2026-05-25 Polkadot audit.

## what

`constructAssetHubPolkadotSigningPayload` (renamed from `constructPolkadotSigningPayload` - see R1/F4 below) in `packages/core/chain/chains/polkadot/dapp/` was missing three bytes required by the Asset Hub Polkadot runtime's signed-extension list:

| Signed extension | field | value |
|---|---|---|
| `ChargeAssetTxPayment` | `extra` - `Option<MultiLocation>` | `None` = `0x00` |
| `CheckMetadataHash` | `extra` - mode byte | `Disabled` = `0x00` |
| `CheckMetadataHash` | `additional_signed` - `Option<H256>` | `None` = `0x00` |

Without these three bytes the node computes a different payload hash from what the wallet signed. Result: `BadProof` rejection on-chain for any extrinsic signed via this helper.

## impact

No callers today - this is a latent bug. Any future walletconnect or Polkadot extension integration that routes through this function would produce invalid signatures immediately.

## source of truth

Byte sequence ported from `vultiagent-app/src/services/polkadotTx.ts:362-378` (`assembleSignerPayloadInner`), which has the correct five-byte AH shape and is covered by the golden-fixture assertion in `polkadotTx.test.ts` (the `assembleSignerPayload` describe block). That fixture was verified against `@polkadot/api` and the live Asset Hub runtime (statemint 2001681, `0x001e8b11`).

The new byte ordering matches that app source of truth exactly:
```
method || era || nonce || tip
  || ChargeAssetTxPayment(0x00)    <- was missing
  || CheckMetadataHash mode(0x00) <- was missing
  || specVersion || txVersion || genesisHash || blockHash
  || CheckMetadataHash additional-signed(0x00) <- was missing
```

## R1 review tackles

- **F4 (rename + scope guard)**: renamed to `constructAssetHubPolkadotSigningPayload` to make the AH-only scope unambiguous. Added runtime guard: if `signedExtensions` is provided and non-empty, throws if `ChargeAssetTxPayment` or `CheckMetadataHash` is absent - prevents BadProof corruption on relay-chain payloads passed by mistake.
- **F3 (fixture comment)**: `GENESIS_HASH` comment updated to accurately describe the fixture bytes ("First 8 bytes are real AH genesis prefix; rest is fixture-stable zeros + sentinel `aa` trailer").
- **F6 (boundary test)**: added the `= 256` boundary case - `method=177B` -> total=256 -> no hash (condition is `> 256`). The `> 256` case was already covered; both are now pinned.
- **F9 (specVersion)**: `0x001e8b11` decodes to `2001681`, not `2002001`. Fixed in PR body and in the test file comment.

## tests

`constructSigningPayload.test.ts` - five vitest assertions (was four):
- golden-fixture hex match against the canonical AH layout (ported from the app fixture)
- raw length = 118 bytes, exactly 3 more than the pre-fix shape
- raw = 256 bytes exactly does NOT hash (boundary pin, new)
- raw > 256 bytes returns blake2b-256 hash (32 bytes)
- tip=0 compact encoding lands at the correct byte offset

## receipts

```
 RUN  v4.1.6

 Test Files  71 passed (71)
      Tests  627 passed (627)
   Start at  11:01:43
   Duration  4.30s
```

All five polkadot tests pass. tsc --project .config/tsconfig.json --noEmit exits 0.

🤖 Agent-generated

## R2 tackle (ad66ad74)

**should-fix: empty-array bypass in signedExtensions guard**

The R1 guard used `payload.signedExtensions && payload.signedExtensions.length > 0` as the condition. A dApp passing `signedExtensions: []` makes `length > 0` false, so the entire guard short-circuits and AH bytes get appended to a payload that explicitly declared zero extensions - exactly the corruption the guard was meant to prevent.

Fix: changed to `payload.signedExtensions != null`. Any provided array, including empty, is now validated against the required ChargeAssetTxPayment/CheckMetadataHash extensions.

New boundary test: `signedExtensions: []` must throw, not pass through. Tests: 5 -> 6.

```
 RUN  v4.1.6

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  11:23:29
   Duration  340ms
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Asset Hub Polkadot network transactions with specialized signing requirements.
  * Enhanced swap fee tracking with detailed chain, token, and decimal information across all swap types.

* **Bug Fixes**
  * Improved swap fee chain resolution with automatic fallback when unmapped chains are encountered.

* **Tests**
  * Added comprehensive test suite for Asset Hub Polkadot payload construction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/550?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->