### PR TITLE
fix(tron): check free bandwidth before charging native trx send fee

### DIFF
--- a/packages/core/mpc/keysign/chainSpecific/resolvers/tron/index.test.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/tron/index.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for getTronChainSpecific — native TRX fee estimation with
+ * free-bandwidth awareness.
+ *
+ * Tron grants ~1500 free bandwidth/day per account; a native TRX transfer
+ * costs ~300 bytes. Users whose bandwidth isn't exhausted should see 0n fee,
+ * not the 800k sun worst-case shown previously (R2 audit finding #3).
+ *
+ * Logic mirrors iOS TronService.swift lines 160-175.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Mocks — must be at top level for vi.mock hoisting
+// ---------------------------------------------------------------------------
+
+vi.mock('@vultisig/core-chain/chains/tron/getTronBlockInfo', () => ({
+  getTronBlockInfo: vi.fn().mockResolvedValue({
+    timestamp: 1_716_000_000_000,
+    expiration: 1_716_000_060_000,
+    blockHeaderTimestamp: 1_716_000_000_000,
+    blockHeaderNumber: 99_000_000,
+    blockHeaderVersion: 30,
+    blockHeaderTxTrieRoot: new Uint8Array(32),
+    blockHeaderParentHash: new Uint8Array(32),
+    blockHeaderWitnessAddress: new Uint8Array(21),
+  }),
+}))
+
+vi.mock('@vultisig/core-chain/chains/tron/resources/getTronAccountResources', () => ({
+  getTronAccountResources: vi.fn(),
+}))
+
+// isFeeCoin returns true for the native TRX coin (no contractAddress / id)
+vi.mock('@vultisig/core-chain/coin/utils/isFeeCoin', () => ({
+  isFeeCoin: vi.fn((coin: any) => !coin.id),
+}))
+
+import { getTronAccountResources } from '@vultisig/core-chain/chains/tron/resources/getTronAccountResources'
+import { getTronChainSpecific } from './index.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTrxPayload(fromAddress = 'TFromAddress123') {
+  return {
+    toAmount: '1000000',
+    toAddress: 'TToAddress456',
+    coin: {
+      chain: 'tron' as any,
+      address: fromAddress,
+      ticker: 'TRX',
+      decimals: 6,
+      // no id => isFeeCoin returns true
+    },
+  } as any
+}
+
+function makeBandwidthResources(available: number) {
+  return {
+    bandwidth: { available, total: 1500, used: 1500 - available },
+    energy: { available: 0, total: 0, used: 0 },
+    frozenForBandwidthSun: 0n,
+    frozenForEnergySun: 0n,
+    unfreezingEntries: [],
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('getTronChainSpecific — native TRX bandwidth fee check', () => {
+  beforeEach(() => {
+    vi.mocked(getTronAccountResources).mockReset()
+  })
+
+  it('returns 0n fee when sender has ample free bandwidth (happy path)', async () => {
+    // Fresh account: 1500 free bandwidth, none used
+    vi.mocked(getTronAccountResources).mockResolvedValue(makeBandwidthResources(1500))
+
+    const result = await getTronChainSpecific({
+      keysignPayload: makeTrxPayload(),
+      walletCore: {} as any,
+      thirdPartyGasLimitEstimation: undefined,
+      expiration: undefined,
+      timestamp: undefined,
+      refBlockBytesHex: undefined,
+      refBlockHashHex: undefined,
+    })
+
+    expect(result.gasEstimation).toBe(0n)
+  })
+
+  it('returns 800_000n when bandwidth is fully exhausted', async () => {
+    // 1500/1500 used, 0 staked => available = 0
+    vi.mocked(getTronAccountResources).mockResolvedValue(makeBandwidthResources(0))
+
+    const result = await getTronChainSpecific({
+      keysignPayload: makeTrxPayload(),
+      walletCore: {} as any,
+      thirdPartyGasLimitEstimation: undefined,
+      expiration: undefined,
+      timestamp: undefined,
+      refBlockBytesHex: undefined,
+      refBlockHashHex: undefined,
+    })
+
+    expect(result.gasEstimation).toBe(800_000n)
+  })
+
+  it('returns 800_000n when available bandwidth is below 300-byte threshold', async () => {
+    // 200 bytes available — not enough for a ~300 byte native transfer
+    vi.mocked(getTronAccountResources).mockResolvedValue(makeBandwidthResources(200))
+
+    const result = await getTronChainSpecific({
+      keysignPayload: makeTrxPayload(),
+      walletCore: {} as any,
+      thirdPartyGasLimitEstimation: undefined,
+      expiration: undefined,
+      timestamp: undefined,
+      refBlockBytesHex: undefined,
+      refBlockHashHex: undefined,
+    })
+
+    expect(result.gasEstimation).toBe(800_000n)
+  })
+
+  it('falls back to 800_000n gracefully when resource RPC throws', async () => {
+    vi.mocked(getTronAccountResources).mockRejectedValue(new Error('503 Service Unavailable'))
+
+    const result = await getTronChainSpecific({
+      keysignPayload: makeTrxPayload(),
+      walletCore: {} as any,
+      thirdPartyGasLimitEstimation: undefined,
+      expiration: undefined,
+      timestamp: undefined,
+      refBlockBytesHex: undefined,
+      refBlockHashHex: undefined,
+    })
+
+    // Graceful degradation: don't block the send, use worst-case fee
+    expect(result.gasEstimation).toBe(800_000n)
+  })
+
+  it('honours thirdPartyGasLimitEstimation when provided, skipping bandwidth check', async () => {
+    vi.mocked(getTronAccountResources).mockResolvedValue(makeBandwidthResources(1500))
+
+    const result = await getTronChainSpecific({
+      keysignPayload: makeTrxPayload(),
+      walletCore: {} as any,
+      thirdPartyGasLimitEstimation: 1_234_567n,
+      expiration: undefined,
+      timestamp: undefined,
+      refBlockBytesHex: undefined,
+      refBlockHashHex: undefined,
+    })
+
+    expect(result.gasEstimation).toBe(1_234_567n)
+    expect(getTronAccountResources).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/tron/index.test.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/tron/index.test.ts
@@ -144,6 +144,23 @@ describe('getTronChainSpecific — native TRX bandwidth fee check', () => {
     expect(result.gasEstimation).toBe(800_000n)
   })
 
+  it('returns 0n fee when available bandwidth exactly equals the threshold (boundary: available === 300)', async () => {
+    // The check is `>= BYTES_PER_NATIVE_TRX_TX`, so exactly 300 must be free.
+    vi.mocked(getTronAccountResources).mockResolvedValue(makeBandwidthResources(300))
+
+    const result = await getTronChainSpecific({
+      keysignPayload: makeTrxPayload(),
+      walletCore: {} as any,
+      thirdPartyGasLimitEstimation: undefined,
+      expiration: undefined,
+      timestamp: undefined,
+      refBlockBytesHex: undefined,
+      refBlockHashHex: undefined,
+    })
+
+    expect(result.gasEstimation).toBe(0n)
+  })
+
   it('honours thirdPartyGasLimitEstimation when provided, skipping bandwidth check', async () => {
     vi.mocked(getTronAccountResources).mockResolvedValue(makeBandwidthResources(1500))
 

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/tron/index.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/tron/index.ts
@@ -9,9 +9,10 @@ import { getKeysignCoin } from '../../../utils/getKeysignCoin'
 import { GetChainSpecificResolver } from '../../resolver'
 import { getTrc20TransferFee } from './fee'
 
-// Conservative worst-case fee when sender has exhausted bandwidth. Tron's
-// dynamic fee schedule charges ~1000 sun/bandwidth-point; a native transfer
-// consumes ~267-345 points, but the fee can spike — 800k sun gives margin.
+// Worst-case fee when sender has exhausted bandwidth. A native TRX transfer
+// is ~267-345 bytes on-wire (signed size); at 1000 sun/byte that's ~267k-345k
+// sun. 800_000n keeps the pre-existing margin (~2.4× the median signed size)
+// and guards against governance-driven bandwidth price hikes.
 const NATIVE_TRX_SEND_FEE_FALLBACK = 800_000n
 
 // Native TRX transfer is ~270-345 bytes; use 300 as the threshold (mirrors iOS BYTES_PER_COIN_TX)

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/tron/index.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/tron/index.ts
@@ -1,5 +1,6 @@
 import { create } from '@bufbuild/protobuf'
 import { getTronBlockInfo } from '@vultisig/core-chain/chains/tron/getTronBlockInfo'
+import { getTronAccountResources } from '@vultisig/core-chain/chains/tron/resources/getTronAccountResources'
 import { isFeeCoin } from '@vultisig/core-chain/coin/utils/isFeeCoin'
 import { TronSpecificSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
 
@@ -8,7 +9,24 @@ import { getKeysignCoin } from '../../../utils/getKeysignCoin'
 import { GetChainSpecificResolver } from '../../resolver'
 import { getTrc20TransferFee } from './fee'
 
-const nativeTronSendFee = 800000n
+// Worst-case fee when sender has exhausted bandwidth (300 bytes * 1000 sun/byte)
+const NATIVE_TRX_SEND_FEE_FALLBACK = 800_000n
+
+// Native TRX transfer is ~270-345 bytes; use 300 as the threshold (mirrors iOS BYTES_PER_COIN_TX)
+const BYTES_PER_NATIVE_TRX_TX = 300
+
+const getNativeTronSendFee = async (fromAddress: string): Promise<bigint> => {
+  try {
+    const resources = await getTronAccountResources(fromAddress)
+    if (resources.bandwidth.available >= BYTES_PER_NATIVE_TRX_TX) {
+      return 0n
+    }
+    return NATIVE_TRX_SEND_FEE_FALLBACK
+  } catch {
+    // RPC error — don't block the send, fall back to worst-case estimate
+    return NATIVE_TRX_SEND_FEE_FALLBACK
+  }
+}
 
 export const getTronChainSpecific: GetChainSpecificResolver<'tronSpecific'> = async ({
   keysignPayload,
@@ -32,7 +50,7 @@ export const getTronChainSpecific: GetChainSpecificResolver<'tronSpecific'> = as
       return thirdPartyGasLimitEstimation
     }
     if (isFeeCoin(coin)) {
-      return nativeTronSendFee
+      return getNativeTronSendFee(coin.address)
     }
 
     return getTrc20TransferFee({

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/tron/index.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/tron/index.ts
@@ -9,7 +9,9 @@ import { getKeysignCoin } from '../../../utils/getKeysignCoin'
 import { GetChainSpecificResolver } from '../../resolver'
 import { getTrc20TransferFee } from './fee'
 
-// Worst-case fee when sender has exhausted bandwidth (300 bytes * 1000 sun/byte)
+// Conservative worst-case fee when sender has exhausted bandwidth. Tron's
+// dynamic fee schedule charges ~1000 sun/bandwidth-point; a native transfer
+// consumes ~267-345 points, but the fee can spike — 800k sun gives margin.
 const NATIVE_TRX_SEND_FEE_FALLBACK = 800_000n
 
 // Native TRX transfer is ~270-345 bytes; use 300 as the threshold (mirrors iOS BYTES_PER_COIN_TX)


### PR DESCRIPTION
## what

`getTronChainSpecific` always returned a hardcoded `800_000` sun (0.8 TRX) as the native TRX send fee regardless of the sender's actual bandwidth state.

Tron grants every account ~1500 free bandwidth per day. A native TRX transfer costs ~300 bytes. Any user who hadn't sent a tx that day was seeing a fee that was a straight-up lie - the transfer would actually cost nothing in bandwidth.

R2 audit finding #3 (2026-05-25).

## how

- Added `getNativeTronSendFee(fromAddress)` which fetches account resources via `getTronAccountResources` (already exists in `packages/core/chain`) and checks `bandwidth.available >= 300`
- If sufficient bandwidth: returns `0n` (free)
- If insufficient bandwidth: returns `800_000n` worst-case fallback
- If the resource RPC throws for any reason: graceful `800_000n` fallback (never blocks the send)

This mirrors iOS `TronService.swift` lines 160-175 (`getBandwidthFeeDiscount` + `BYTES_PER_COIN_TX` check) so UX is now consistent between platforms.

## ios reference

`VultisigApp/Blockchain/Tron/Service/TronService.swift`:
```swift
// line 160-175
private func getBandwidthFeeDiscount(isNativeToken: Bool, availableBandwidth: Int64) async throws -> BigInt {
    let feeBandwidthRequired = isNativeToken ? Self.BYTES_PER_COIN_TX : Self.BYTES_PER_CONTRACT_TX
    ...
    switch (isNativeToken, availableBandwidth >= feeBandwidthRequired) {
    case (true, true):
        return BigInt.zero  // <-- free!
    ...
    case (true, false):
        return BigInt(feeBandwidthRequired * bandwidthPrice)
    }
}
```

## tests (5 total)

- bandwidth-rich account (1500 available) -> `0n` fee
- fully exhausted bandwidth (0 available) -> `800_000n`
- partial bandwidth below threshold (200 < 300) -> `800_000n`
- resource RPC throws -> graceful `800_000n` fallback
- `thirdPartyGasLimitEstimation` provided -> bypass bandwidth check entirely

All 642 core tests pass.

## risk

Low - isolated to native TRX send fee display. TRC20 path untouched. Fails safe (worst-case hardcoded fee) on RPC error.

🤖 Agent-generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * TRON (TRX) native fee estimation is now dynamic and based on real-time account bandwidth availability, providing more accurate transaction fees.

* **Tests**
  * Added comprehensive test coverage for TRON fee estimation scenarios, including bandwidth availability and fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/555?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->