### PR TITLE
fix(tron): subtract sender's available energy from trc-20 fee estimate

### DIFF
--- a/packages/core/mpc/keysign/chainSpecific/resolvers/tron/fee.test.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/tron/fee.test.ts
@@ -1,14 +1,48 @@
+/**
+ * Tests for getTrc20TransferFee — correct endpoint, negative energy guard,
+ * and sender's staked energy subtraction before computing the fee.
+ *
+ * Mirrors iOS TronService.swift:117-126 intent.
+ */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
   queryUrl: vi.fn(),
 }))
 
+vi.mock('@vultisig/core-chain/chains/tron/resources/getTronAccountResources', () => ({
+  getTronAccountResources: vi.fn(),
+}))
+
+vi.mock('./energyPrice', () => ({
+  getEnergyPrice: vi.fn(),
+}))
+
 import { OtherChain } from '@vultisig/core-chain/Chain'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+import { getTronAccountResources } from '@vultisig/core-chain/chains/tron/resources/getTronAccountResources'
+import { getEnergyPrice } from './energyPrice'
 import { getTrc20TransferFee } from './fee'
 
 const mockQueryUrl = vi.mocked(queryUrl)
+const mockGetTronAccountResources = vi.mocked(getTronAccountResources)
+const mockGetEnergyPrice = vi.mocked(getEnergyPrice)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ENERGY_PRICE = 280n
+
+function makeResources(available: number) {
+  return {
+    bandwidth: { available: 5000, total: 5000, used: 0 },
+    energy: { available, total: available, used: 0 },
+    frozenForBandwidthSun: 0n,
+    frozenForEnergySun: 0n,
+    unfreezingEntries: [],
+  }
+}
 
 const coin = {
   address: 'TJDENsfBJs4RFETt1X1W8wMDc8M5XnJhd',
@@ -16,25 +50,44 @@ const coin = {
   chain: OtherChain.Tron,
 }
 
+const baseInput = {
+  coin,
+  amount: 1_000_000n,
+  receiver: 'TJDENsfBJs4RFETt1X1W8wMDc8M5XnJhd',
+}
+
+// triggerconstantcontract response: 65k energy_used, 0 penalty (active destination)
+const CONTRACT_ENERGY_USED = 65_000
+const CONTRACT_ENERGY_PENALTY = 0
+const TOTAL_ENERGY = BigInt(CONTRACT_ENERGY_USED + CONTRACT_ENERGY_PENALTY)
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
 describe('getTrc20TransferFee', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockGetEnergyPrice.mockResolvedValue(ENERGY_PRICE)
+    // default: no staked energy
+    mockGetTronAccountResources.mockResolvedValue(makeResources(0))
   })
 
   it('calls /wallet/triggerconstantcontract, not /walletsolidity/...', async () => {
     mockQueryUrl.mockResolvedValue({ energy_used: 100, energy_penalty: 0 })
 
-    await getTrc20TransferFee({ coin, amount: 1_000_000n, receiver: 'TJDENsfBJs4RFETt1X1W8wMDc8M5XnJhd' })
+    await getTrc20TransferFee(baseInput)
 
     const calledUrl = mockQueryUrl.mock.calls[0][0] as string
     expect(calledUrl).toMatch(/\/wallet\/triggerconstantcontract$/)
     expect(calledUrl).not.toMatch(/walletsolidity/)
   })
 
-  it('returns (energy_used + energy_penalty) * 280n as fee', async () => {
+  it('returns (energy_used + energy_penalty) * energyPrice as fee when no staked energy', async () => {
     mockQueryUrl.mockResolvedValue({ energy_used: 30000, energy_penalty: 5000 })
+    mockGetTronAccountResources.mockResolvedValue(makeResources(0))
 
-    const fee = await getTrc20TransferFee({ coin, amount: 1_000_000n, receiver: 'TJDENsfBJs4RFETt1X1W8wMDc8M5XnJhd' })
+    const fee = await getTrc20TransferFee(baseInput)
 
     // (30000 + 5000) * 280 = 9_800_000
     expect(fee).toBe(9_800_000n)
@@ -43,7 +96,7 @@ describe('getTrc20TransferFee', () => {
   it('defaults missing energy fields to 0', async () => {
     mockQueryUrl.mockResolvedValue({})
 
-    const fee = await getTrc20TransferFee({ coin, amount: 1_000_000n, receiver: 'TJDENsfBJs4RFETt1X1W8wMDc8M5XnJhd' })
+    const fee = await getTrc20TransferFee(baseInput)
 
     expect(fee).toBe(0n)
   })
@@ -51,23 +104,83 @@ describe('getTrc20TransferFee', () => {
   it('propagates queryUrl errors (throw-bubbling contract)', async () => {
     mockQueryUrl.mockRejectedValue(new Error('network error'))
 
-    await expect(
-      getTrc20TransferFee({ coin, amount: 1_000_000n, receiver: 'TJDENsfBJs4RFETt1X1W8wMDc8M5XnJhd' })
-    ).rejects.toThrow('network error')
+    await expect(getTrc20TransferFee(baseInput)).rejects.toThrow('network error')
   })
 
   it('clamps negative energy_used / energy_penalty totals to 0n (avoids negative feeLimit broadcast reject)', async () => {
     // TronGrid edge cases can return negative values. Without clamping, the
     // negative bigint flows as `gasEstimation` into protobuf `feeLimit` via
     // `Long.fromString(gasEstimation.toString())`, encoding a negative int64
-    // which TronGrid rejects at broadcast. Send-service path has a similar
-    // guard at sdk/src/chains/tron/tx.ts:391; this mirrors it for the MPC
-    // keysign path.
+    // which TronGrid rejects at broadcast.
     mockQueryUrl.mockResolvedValue({ energy_used: -5000, energy_penalty: -1000 })
 
-    const fee = await getTrc20TransferFee({ coin, amount: 1_000_000n, receiver: 'TJDENsfBJs4RFETt1X1W8wMDc8M5XnJhd' })
+    const fee = await getTrc20TransferFee(baseInput)
 
     // (-5000 + -1000) = -6000n -> clamp to 0n -> no broadcast reject
     expect(fee).toBe(0n)
+  })
+
+  describe('staked energy subtraction', () => {
+    beforeEach(() => {
+      mockQueryUrl.mockResolvedValue({
+        energy_used: CONTRACT_ENERGY_USED,
+        energy_penalty: CONTRACT_ENERGY_PENALTY,
+      })
+    })
+
+    it('returns 0 when sender has more staked energy than needed (fully covered)', async () => {
+      mockGetTronAccountResources.mockResolvedValue(makeResources(100_000))
+
+      const fee = await getTrc20TransferFee(baseInput)
+
+      expect(fee).toBe(0n)
+    })
+
+    it('returns 0 when sender has exactly the energy needed (boundary)', async () => {
+      mockGetTronAccountResources.mockResolvedValue(makeResources(65_000))
+
+      const fee = await getTrc20TransferFee(baseInput)
+
+      expect(fee).toBe(0n)
+    })
+
+    it('returns partial burn when sender has less energy than needed', async () => {
+      mockGetTronAccountResources.mockResolvedValue(makeResources(30_000))
+
+      const fee = await getTrc20TransferFee(baseInput)
+
+      // only 35_000 energy needs to be burned
+      expect(fee).toBe(35_000n * ENERGY_PRICE)
+    })
+
+    it('returns full burn when sender has zero staked energy', async () => {
+      mockGetTronAccountResources.mockResolvedValue(makeResources(0))
+
+      const fee = await getTrc20TransferFee(baseInput)
+
+      expect(fee).toBe(TOTAL_ENERGY * ENERGY_PRICE)
+    })
+
+    it('falls back to full burn when resources fetch throws (no crash)', async () => {
+      mockGetTronAccountResources.mockRejectedValue(new Error('network error'))
+
+      const fee = await getTrc20TransferFee(baseInput)
+
+      // worst-case — same as before the fix
+      expect(fee).toBe(TOTAL_ENERGY * ENERGY_PRICE)
+    })
+
+    it('accounts for energy_penalty in the total energy needed', async () => {
+      mockQueryUrl.mockResolvedValue({
+        energy_used: 65_000,
+        energy_penalty: 10_000,
+      })
+      // 50k available, 75k needed -> 25k burned
+      mockGetTronAccountResources.mockResolvedValue(makeResources(50_000))
+
+      const fee = await getTrc20TransferFee(baseInput)
+
+      expect(fee).toBe(25_000n * ENERGY_PRICE)
+    })
   })
 })

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/tron/fee.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/tron/fee.ts
@@ -1,5 +1,6 @@
 import { Buffer } from 'buffer'
 import { AccountCoinKey } from '@vultisig/core-chain/coin/AccountCoin'
+import { getTronAccountResources } from '@vultisig/core-chain/chains/tron/resources/getTronAccountResources'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 import base58 from 'bs58'
 
@@ -55,6 +56,7 @@ export const getTrc20TransferFee = async ({ coin, receiver, amount }: GetTrc20Tr
   const energyUsed = responseData.energy_used ?? 0
   const energyPenalty = responseData.energy_penalty ?? 0
   const totalEnergy = BigInt(energyUsed) + BigInt(energyPenalty)
+
   // Clamp negative totals to 0. TronGrid edge cases can return negative energy
   // values which, multiplied by energyPrice, produce a negative int64 in the
   // protobuf feeLimit field via `Long.fromString(gasEstimation.toString())`.
@@ -64,8 +66,25 @@ export const getTrc20TransferFee = async ({ coin, receiver, amount }: GetTrc20Tr
   if (totalEnergy <= 0n) {
     return 0n
   }
+
+  // Subtract sender's available staked energy before computing the burn cost.
+  // Mirrors iOS TronService.swift:117-126 intent — falls back to worst-case on
+  // fetch failure so fee is never under-estimated.
+  let energyToBurn = totalEnergy
+  try {
+    const resources = await getTronAccountResources(coin.address)
+    const availableEnergy = BigInt(resources.energy.available)
+    if (availableEnergy >= totalEnergy) {
+      energyToBurn = 0n
+    } else if (availableEnergy > 0n) {
+      energyToBurn = totalEnergy - availableEnergy
+    }
+  } catch (err) {
+    console.warn('[tron] failed to fetch account energy resources, falling back to worst-case fee', err)
+  }
+
   const energyPrice = await getEnergyPrice()
-  const totalSun = totalEnergy * energyPrice
+  const totalSun = energyToBurn * energyPrice
 
   return totalSun
 }


### PR DESCRIPTION
## what

`getTrc20TransferFee` always returned worst-case energy cost regardless of whether the sender had staked TRX. A user with 100k staked TRX (-> 100k energy) would see an ~18 TRX fee preview for a USDT transfer when the actual on-chain cost is 0 — energy fully covers it.

This is audit gap #4 from the R2 review (2026-05-25).

## fix

Before multiplying `totalEnergy * energyPrice`, we now fetch the sender's available staked energy via `getTronAccountResources` and subtract it:

- `availableEnergy >= totalEnergy` -> fee is 0 (fully covered)
- `0 < availableEnergy < totalEnergy` -> only burn the delta
- `availableEnergy == 0` -> full burn (same as before)
- resources fetch throws -> fall back to worst-case, no crash

Mirrors iOS parity: `TronService.swift:117-126`.

## tests

6 new unit tests covering:
- full cover (>= energy needed) -> 0n
- boundary (exactly energy needed) -> 0n
- partial cover -> `(totalEnergy - available) * 280n`
- zero energy -> full burn
- resources fetch throws -> full burn, no crash
- `energy_penalty` included in total (not just `energy_used`)

```
Test Files  74 passed (74)
Tests  648 passed (648)  (+6 new)
```

## ios parity

`~/Sites/vultisig-ios/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift:117-126`

```swift
let accountResource = try await apiService.getAccountResource(address: coin.address)
let availableEnergy = accountResource.EnergyLimit - accountResource.EnergyUsed

let energyRequired = isDestinationActive ? 65000 : 130000

if availableEnergy >= energyRequired {
    transactionFee = BigInt(1_000_000)
} else {
    transactionFee = isDestinationActive ? BigInt(18_000_000) : BigInt(36_000_000)
}
```

Note: iOS uses hardcoded 65k/130k thresholds whereas the SDK simulates via `triggerconstantcontract` for an exact energy figure. The subtraction logic is identical in intent.

## receipts

BE-only change - no UI surface affected. No sim receipts required.

🤖 Agent-generated

---

**SDK vs iOS accuracy note:** iOS uses a hardcoded 65k/130k threshold giving a binary 0 vs 18 TRX outcome. The SDK uses `triggerconstantcontract` simulation for the exact required energy and computes a proportional sun amount — strictly more accurate for partial-coverage cases.