### PR TITLE
feat(polkadot): pallet_assets.account balance resolver for asset hub tokens

### DIFF
--- a/packages/core/chain/chains/polkadot/client.ts
+++ b/packages/core/chain/chains/polkadot/client.ts
@@ -7,6 +7,11 @@ export const polkadotRpcUrl = `${rootApiUrl}/dot/`
 // Asset Hub (parachain 1000) — home of pallet_assets USDT/USDC
 export const assetHubRpcUrl = `${rootApiUrl}/dot-ah/`
 
+/**
+ * Returns the Polkadot RELAY CHAIN client (NOT Asset Hub).
+ * For Asset Hub queries (e.g. pallet_assets), use assetHubRpcUrl directly
+ * via the getAssetHubTokenBalance resolver instead.
+ */
 export const getPolkadotClient = memoizeAsync(() => {
   const provider = new HttpProvider(polkadotRpcUrl)
   return ApiPromise.create({ provider })

--- a/packages/core/chain/chains/polkadot/client.ts
+++ b/packages/core/chain/chains/polkadot/client.ts
@@ -4,6 +4,9 @@ import { memoizeAsync } from '@vultisig/lib-utils/memoizeAsync'
 
 export const polkadotRpcUrl = `${rootApiUrl}/dot/`
 
+// Asset Hub (parachain 1000) — home of pallet_assets USDT/USDC
+export const assetHubRpcUrl = `${rootApiUrl}/dot-ah/`
+
 export const getPolkadotClient = memoizeAsync(() => {
   const provider = new HttpProvider(polkadotRpcUrl)
   return ApiPromise.create({ provider })

--- a/packages/core/chain/coin/balance/resolvers/polkadot.test.ts
+++ b/packages/core/chain/coin/balance/resolvers/polkadot.test.ts
@@ -9,52 +9,133 @@ vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
 
 import { getPolkadotCoinBalance } from './polkadot'
 
-// A valid Polkadot SS58 address (Alice, network prefix 0).
+// Alice's Polkadot SS58 address (network prefix 0) and its 32-byte public key.
+// Public key: d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
 const VALID_DOT_ADDRESS = '15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5'
 
-describe('getPolkadotCoinBalance — interim token guard (PR A / #562)', () => {
-  // PR A adds USDT (id=1984) + USDC (id=1337) to knownTokens.
-  // PR B (TBD) will wire pallet_assets.Account queries for those assets.
-  // Until PR B lands the resolver must return 0n for any coin with an id
-  // rather than returning the native DOT System.Account free balance —
-  // which would show the user a misleading DOT balance under a USDT row.
+// Storage key verification (computed offline via @polkadot/util-crypto + @noble/hashes):
+//
+//   twox128("Assets")  = 682a59d51ab9e48a8c8cc418ff9708d2
+//   twox128("Account") = b99d880ec681799c0cf30e8886371da9
+//   le_u32(1984)       = c0070000
+//   blake2_128(le_u32(1984)) = a319d0e87221ca1ee751c1529f201522
+//   blake2_128(alice_pubkey) = de1e86a9a8c739864cf3cc5ec2bea59f
+//
+//   USDT key = 0x682a59d51ab9e48a8c8cc418ff9708d2
+//              b99d880ec681799c0cf30e8886371da9
+//              a319d0e87221ca1ee751c1529f201522c0070000
+//              de1e86a9a8c739864cf3cc5ec2bea59f
+//              d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
+//   (202 chars total including "0x" prefix)
 
+describe('getPolkadotCoinBalance — pallet_assets.Account (Asset Hub tokens)', () => {
   beforeEach(() => {
     queryUrlMock.mockReset()
   })
 
-  it('returns 0n for USDT (asset_id=1984) without hitting RPC', async () => {
+  it('fetches USDT balance (asset_id=1984) from Asset Hub pallet_assets', async () => {
+    // AssetAccount SCALE: balance(u128 LE) + status(Liquid=0x00) + reason(Consumer=0x01)
+    // balance = 1_000_000 (1 USDT at 6 decimals) = 0x0F4240
+    // LE 16 bytes: 40 42 0f 00 00 00 00 00 00 00 00 00 00 00 00 00
+    const fakeAssetAccountHex = '0x' + '40420f00000000000000000000000000' + '00' + '01'
+    queryUrlMock.mockResolvedValue({ result: fakeAssetAccountHex })
+
     const balance = await getPolkadotCoinBalance({
       chain: Chain.Polkadot,
       address: VALID_DOT_ADDRESS,
-      id: '1984', // TODO(PR B): wire pallet_assets.Account query here
+      id: '1984',
+    })
+
+    expect(balance).toBe(1_000_000n)
+    expect(queryUrlMock).toHaveBeenCalledTimes(1)
+
+    // Verify it called Asset Hub (not relay chain) with the correct storage key.
+    const call = queryUrlMock.mock.calls[0]
+    const url: string = call[0]
+    expect(url).toContain('dot-ah')
+
+    const storageKey: string = call[1].body.params[0]
+    // key must start with twox128("Assets") + twox128("Account")
+    expect(storageKey.startsWith('0x682a59d51ab9e48a8c8cc418ff9708d2b99d880ec681799c0cf30e8886371da9')).toBe(true)
+    // full key for USDT + Alice — verified offline via @polkadot/util-crypto
+    expect(storageKey).toBe(
+      '0x682a59d51ab9e48a8c8cc418ff9708d2b99d880ec681799c0cf30e8886371da9' +
+        'a319d0e87221ca1ee751c1529f201522c0070000' +
+        'de1e86a9a8c739864cf3cc5ec2bea59f' +
+        'd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d'
+    )
+    expect(storageKey).toHaveLength(202)
+  })
+
+  it('fetches USDC balance (asset_id=1337) from Asset Hub pallet_assets', async () => {
+    // balance = 500_000 (0.5 USDC at 6 decimals)
+    // 500_000 = 0x7A120, LE 16 bytes: 20 a1 07 00 00...
+    const fakeAssetAccountHex = '0x' + '20a10700000000000000000000000000' + '00' + '01'
+    queryUrlMock.mockResolvedValue({ result: fakeAssetAccountHex })
+
+    const balance = await getPolkadotCoinBalance({
+      chain: Chain.Polkadot,
+      address: VALID_DOT_ADDRESS,
+      id: '1337',
+    })
+
+    expect(balance).toBe(500_000n)
+    expect(queryUrlMock).toHaveBeenCalledTimes(1)
+
+    // Key must contain le_u32(1337) = 39050000 in the asset segment
+    const storageKey: string = queryUrlMock.mock.calls[0][1].body.params[0]
+    expect(storageKey).toContain('39050000') // le_u32(1337)
+    expect(storageKey).toHaveLength(202)
+  })
+
+  it('returns 0n when the account has no entry for that asset (null RPC response)', async () => {
+    queryUrlMock.mockResolvedValue({ result: null })
+
+    const balance = await getPolkadotCoinBalance({
+      chain: Chain.Polkadot,
+      address: VALID_DOT_ADDRESS,
+      id: '1984',
     })
 
     expect(balance).toBe(0n)
-    // RPC must NOT be called — guard must short-circuit before any network I/O
+    expect(queryUrlMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws on malformed SCALE response (too short to contain u128)', async () => {
+    // 30 hex chars = 15 bytes — not enough for u128 (needs 32 hex chars)
+    queryUrlMock.mockResolvedValue({ result: '0x' + 'aa'.repeat(15) })
+
+    await expect(
+      getPolkadotCoinBalance({
+        chain: Chain.Polkadot,
+        address: VALID_DOT_ADDRESS,
+        id: '1984',
+      })
+    ).rejects.toThrow(/unexpected storage response/)
+  })
+
+  it('throws on non-numeric asset_id', async () => {
+    await expect(
+      getPolkadotCoinBalance({
+        chain: Chain.Polkadot,
+        address: VALID_DOT_ADDRESS,
+        id: 'not-a-number',
+      })
+    ).rejects.toThrow(/Invalid Asset Hub asset_id/)
+
     expect(queryUrlMock).not.toHaveBeenCalled()
   })
 
-  it('returns 0n for USDC (asset_id=1337) without hitting RPC', async () => {
-    const balance = await getPolkadotCoinBalance({
-      chain: Chain.Polkadot,
-      address: VALID_DOT_ADDRESS,
-      id: '1337', // TODO(PR B): wire pallet_assets.Account query here
-    })
+  it('propagates Asset Hub RPC errors', async () => {
+    queryUrlMock.mockResolvedValue({ error: { code: -32000, message: 'storage error' } })
 
-    expect(balance).toBe(0n)
-    expect(queryUrlMock).not.toHaveBeenCalled()
-  })
-
-  it('returns 0n for any non-empty id (generic guard coverage)', async () => {
-    const balance = await getPolkadotCoinBalance({
-      chain: Chain.Polkadot,
-      address: VALID_DOT_ADDRESS,
-      id: '9999',
-    })
-
-    expect(balance).toBe(0n)
-    expect(queryUrlMock).not.toHaveBeenCalled()
+    await expect(
+      getPolkadotCoinBalance({
+        chain: Chain.Polkadot,
+        address: VALID_DOT_ADDRESS,
+        id: '1984',
+      })
+    ).rejects.toThrow(/pallet_assets RPC error/)
   })
 })
 
@@ -63,16 +144,12 @@ describe('getPolkadotCoinBalance — native DOT path (no id)', () => {
     queryUrlMock.mockReset()
   })
 
-  it('queries RPC for native DOT (no id present)', async () => {
+  it('queries relay chain RPC for native DOT (no id present)', async () => {
     // SCALE-encoded AccountInfo with free balance = 1_000_000_000_000n (1 DOT)
     // Layout: nonce(u32=0) + consumers(u32=0) + providers(u32=1) + sufficients(u32=0)
     //         + free(u128) + reserved(u128) + frozen(u128) + flags(u128)
     // free = 1_000_000_000_000 = 0x000000E8D4A51000 LE-encoded in 16 bytes:
     //   LE bytes: 00 10 A5 D4 E8 00 00 00 00 00 00 00 00 00 00 00
-    // Full hex (nonce+consumers+providers+sufficients = 00000000 00000000 01000000 00000000):
-    //   0x 00000000 00000000 01000000 00000000
-    //      0010A5D4E8000000000000000000000000  (free, 16 bytes LE)
-    //      + 3 more u128 zero fields (reserved, frozen, flags)
     const freeLE = '0010A5D4E8000000000000000000000000'
     const fakeResult =
       '0x' +
@@ -93,9 +170,17 @@ describe('getPolkadotCoinBalance — native DOT path (no id)', () => {
       // no id — native DOT
     })
 
-    // Should have called the RPC
     expect(queryUrlMock).toHaveBeenCalledTimes(1)
-    // Balance should be 1 DOT = 1_000_000_000_000 planck
+
+    // Must call the relay chain, not Asset Hub
+    const url: string = queryUrlMock.mock.calls[0][0]
+    expect(url).not.toContain('dot-ah')
+    expect(url).toContain('/dot/')
+
+    // Must use System.Account prefix, not Assets.Account
+    const storageKey: string = queryUrlMock.mock.calls[0][1].body.params[0]
+    expect(storageKey.startsWith('0x26aa394eea5630e07c48ae0c9558cef7')).toBe(true)
+
     expect(balance).toBe(1_000_000_000_000n)
   })
 

--- a/packages/core/chain/coin/balance/resolvers/polkadot.test.ts
+++ b/packages/core/chain/coin/balance/resolvers/polkadot.test.ts
@@ -162,6 +162,40 @@ describe('getPolkadotCoinBalance — pallet_assets.Account (Asset Hub tokens)', 
     expect(queryUrlMock).not.toHaveBeenCalled()
   })
 
+  it('accepts asset_id=0 (valid lower u32 boundary) and returns 0n when account has no entry', async () => {
+    // le_u32(0) = 00000000. Some system chains use asset_id=0.
+    queryUrlMock.mockResolvedValue({ result: null })
+
+    const balance = await getPolkadotCoinBalance({
+      chain: Chain.Polkadot,
+      address: VALID_DOT_ADDRESS,
+      id: '0',
+    })
+
+    expect(balance).toBe(0n)
+    // Verify the storage key includes the le_u32(0) asset segment (8 hex chars of '0')
+    const calledKey = queryUrlMock.mock.calls[0]?.[1]?.body?.params?.[0] as string
+    expect(calledKey).toBeDefined()
+    // le_u32(0) = 00000000 — must appear somewhere in the storage key after the prefix hash
+    expect(calledKey).toContain('00000000')
+  })
+
+  it('scientific-notation asset_id (1.984e3) is accepted — Number() evaluates to integer 1984', async () => {
+    // Number('1.984e3') === 1984 which is a valid integer. Document this
+    // accepted-but-non-canonical form so future callers know the contract.
+    // In practice coin.id only comes from knownTokens which always uses plain
+    // decimal strings ('1984', '1337') so this path is never hit in production.
+    queryUrlMock.mockResolvedValue({ result: null })
+
+    const balance = await getPolkadotCoinBalance({
+      chain: Chain.Polkadot,
+      address: VALID_DOT_ADDRESS,
+      id: '1.984e3',
+    })
+
+    expect(balance).toBe(0n)
+  })
+
   it('propagates Asset Hub RPC errors', async () => {
     queryUrlMock.mockResolvedValue({ error: { code: -32000, message: 'storage error' } })
 

--- a/packages/core/chain/coin/balance/resolvers/polkadot.test.ts
+++ b/packages/core/chain/coin/balance/resolvers/polkadot.test.ts
@@ -121,7 +121,43 @@ describe('getPolkadotCoinBalance — pallet_assets.Account (Asset Hub tokens)', 
         address: VALID_DOT_ADDRESS,
         id: 'not-a-number',
       })
-    ).rejects.toThrow(/Invalid Asset Hub asset_id/)
+    ).rejects.toThrow(/Invalid Polkadot asset_id/)
+
+    expect(queryUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('throws on fractional asset_id (1984.5 would silently truncate with parseInt)', async () => {
+    await expect(
+      getPolkadotCoinBalance({
+        chain: Chain.Polkadot,
+        address: VALID_DOT_ADDRESS,
+        id: '1984.5',
+      })
+    ).rejects.toThrow(/Invalid Polkadot asset_id/)
+
+    expect(queryUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('throws on asset_id that overflows u32 (4294967296 = 0x100000000)', async () => {
+    await expect(
+      getPolkadotCoinBalance({
+        chain: Chain.Polkadot,
+        address: VALID_DOT_ADDRESS,
+        id: '4294967296',
+      })
+    ).rejects.toThrow(/Invalid Polkadot asset_id/)
+
+    expect(queryUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('throws on negative asset_id', async () => {
+    await expect(
+      getPolkadotCoinBalance({
+        chain: Chain.Polkadot,
+        address: VALID_DOT_ADDRESS,
+        id: '-1',
+      })
+    ).rejects.toThrow(/Invalid Polkadot asset_id/)
 
     expect(queryUrlMock).not.toHaveBeenCalled()
   })
@@ -150,7 +186,7 @@ describe('getPolkadotCoinBalance — native DOT path (no id)', () => {
     //         + free(u128) + reserved(u128) + frozen(u128) + flags(u128)
     // free = 1_000_000_000_000 = 0x000000E8D4A51000 LE-encoded in 16 bytes:
     //   LE bytes: 00 10 A5 D4 E8 00 00 00 00 00 00 00 00 00 00 00
-    const freeLE = '0010A5D4E8000000000000000000000000'
+    const freeLE = '0010a5d4e80000000000000000000000'
     const fakeResult =
       '0x' +
       '00000000' + // nonce

--- a/packages/core/chain/coin/balance/resolvers/polkadot.ts
+++ b/packages/core/chain/coin/balance/resolvers/polkadot.ts
@@ -5,7 +5,7 @@
 // Bittensor revert that originally broke this resolver.
 import { blake2b } from '@noble/hashes/blake2b'
 import { bytesToHex } from '@noble/hashes/utils'
-import { polkadotRpcUrl } from '@vultisig/core-chain/chains/polkadot/client'
+import { assetHubRpcUrl, polkadotRpcUrl } from '@vultisig/core-chain/chains/polkadot/client'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 import bs58 from 'bs58'
 
@@ -20,6 +20,11 @@ type RpcResponse<T> = {
 
 // twox128("System") ++ twox128("Account") — well-known Substrate storage prefix
 const systemAccountPrefix = '0x26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da9'
+
+// twox128("Assets") ++ twox128("Account") — pallet_assets.Account on Asset Hub
+// Computed via xxhashAsHex('Assets', 128) + xxhashAsHex('Account', 128) from @polkadot/util-crypto.
+// Hardcoded to avoid pulling @polkadot/util-crypto (BN.js double-bundle crash).
+const assetsAccountPrefix = '0x682a59d51ab9e48a8c8cc418ff9708d2b99d880ec681799c0cf30e8886371da9'
 
 const polkadotSs58Prefix = 0
 const ss58AddressByteLength = 35
@@ -51,17 +56,70 @@ const decodePolkadotPublicKey = (address: string): Uint8Array => {
   return payload.subarray(1)
 }
 
-export const getPolkadotCoinBalance: CoinBalanceResolver = async input => {
-  // PR A (#562) registers USDT (id=1984) + USDC (id=1337) in knownTokens.
-  // PR B (TBD) will wire pallet_assets.Account storage queries for those assets.
-  // Until PR B lands, bail early for any non-native coin to avoid returning the
-  // DOT System.Account free balance for a USDT/USDC row — that would show the
-  // user a misleading DOT balance under a USDT token entry.
-  if (input.id) {
-    return BigInt(0)
+// Storage key: assetsAccountPrefix
+//   + blake2_128_concat(le_u32(assetId))   — 16-byte hash + 4-byte raw
+//   + blake2_128_concat(accountId_32bytes)  — 16-byte hash + 32-byte raw
+// Total: 32 + 20 + 48 = 100 bytes → 202 hex chars with "0x" prefix.
+//
+// Response is SCALE-encoded AssetAccount; only the first 16 bytes matter:
+//   balance: u128 LE — 0 (or null response) means the account doesn't hold that asset.
+const getAssetHubTokenBalance = async (assetIdStr: string, pubkey: Uint8Array): Promise<bigint> => {
+  const assetId = parseInt(assetIdStr, 10)
+  if (!Number.isInteger(assetId) || assetId <= 0) {
+    throw new Error(`Invalid Asset Hub asset_id: ${assetIdStr}`)
   }
 
+  const assetIdLE = new Uint8Array(4)
+  new DataView(assetIdLE.buffer).setUint32(0, assetId, true)
+
+  const assetIdHashHex = bytesToHex(blake2b(assetIdLE, { dkLen: 16 }))
+  const assetIdHex = bytesToHex(assetIdLE)
+  const accountHashHex = bytesToHex(blake2b(pubkey, { dkLen: 16 }))
+  const accountHex = bytesToHex(pubkey)
+
+  const storageKey = assetsAccountPrefix + assetIdHashHex + assetIdHex + accountHashHex + accountHex
+
+  const response = await queryUrl<RpcResponse<string | null>>(assetHubRpcUrl, {
+    body: {
+      jsonrpc: '2.0',
+      method: 'state_getStorage',
+      params: [storageKey],
+      id: 1,
+    },
+  })
+
+  if (response.error) {
+    throw new Error(`Asset Hub pallet_assets RPC error: ${response.error.message ?? `code ${response.error.code}`}`)
+  }
+
+  // Null result means the account has no entry for this asset — balance is 0.
+  const result = response.result
+  if (!result) return 0n
+
+  // AssetAccount SCALE layout: balance(u128=16 bytes LE) + status(u8) + reason(enum) + extra
+  // We only need the first 16 bytes for balance.
+  const hex = result.startsWith('0x') ? result.slice(2) : result
+  if (hex.length < 32 || !/^[0-9a-fA-F]+$/.test(hex)) {
+    throw new Error(`Asset Hub pallet_assets: unexpected storage response: ${result}`)
+  }
+  const balanceHex = hex.slice(0, 32)
+
+  const leBytes = balanceHex.match(/.{2}/g)
+  if (!leBytes) {
+    throw new Error(`Asset Hub pallet_assets: failed to parse balance hex: ${balanceHex}`)
+  }
+  return BigInt('0x' + leBytes.reverse().join(''))
+}
+
+export const getPolkadotCoinBalance: CoinBalanceResolver = async input => {
   const pubkey = decodePolkadotPublicKey(input.address)
+
+  // Non-native coins (USDT id=1984, USDC id=1337, etc.) live on Asset Hub.
+  // Query pallet_assets.Account storage instead of System.Account.
+  if (input.id) {
+    return getAssetHubTokenBalance(input.id, pubkey)
+  }
+
   const hash = bytesToHex(blake2b(pubkey, { dkLen: 16 }))
   const accountId = bytesToHex(pubkey)
   const storageKey = systemAccountPrefix + hash + accountId

--- a/packages/core/chain/coin/balance/resolvers/polkadot.ts
+++ b/packages/core/chain/coin/balance/resolvers/polkadot.ts
@@ -97,9 +97,10 @@ const getAssetHubTokenBalance = async (assetIdStr: string, pubkey: Uint8Array): 
   if (!result) return 0n
 
   // AssetAccount SCALE layout: balance(u128=16 bytes LE) + status(u8) + reason(enum) + extra
-  // We only need the first 16 bytes for balance.
+  // We return the raw u128 balance regardless of account status (Liquid/Frozen/Blocked).
+  // Freeze checks are a spend-path concern; balance display should reflect total holdings.
   const hex = result.startsWith('0x') ? result.slice(2) : result
-  if (hex.length < 32 || !/^[0-9a-fA-F]+$/.test(hex)) {
+  if (hex.length < 32 || hex.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(hex)) {
     throw new Error(`Asset Hub pallet_assets: unexpected storage response: ${result}`)
   }
   const balanceHex = hex.slice(0, 32)

--- a/packages/core/chain/coin/balance/resolvers/polkadot.ts
+++ b/packages/core/chain/coin/balance/resolvers/polkadot.ts
@@ -64,9 +64,9 @@ const decodePolkadotPublicKey = (address: string): Uint8Array => {
 // Response is SCALE-encoded AssetAccount; only the first 16 bytes matter:
 //   balance: u128 LE — 0 (or null response) means the account doesn't hold that asset.
 const getAssetHubTokenBalance = async (assetIdStr: string, pubkey: Uint8Array): Promise<bigint> => {
-  const assetId = parseInt(assetIdStr, 10)
-  if (!Number.isInteger(assetId) || assetId <= 0) {
-    throw new Error(`Invalid Asset Hub asset_id: ${assetIdStr}`)
+  const assetId = Number(assetIdStr)
+  if (!Number.isInteger(assetId) || assetId < 0 || assetId > 0xffffffff) {
+    throw new Error(`Invalid Polkadot asset_id: ${assetIdStr}`)
   }
 
   const assetIdLE = new Uint8Array(4)


### PR DESCRIPTION
closes vultisig/vultisig-sdk#562 (depends on it - stacked on top)

## what

PR A (#562) registered USDT (asset_id=1984) and USDC (asset_id=1337) in knownTokens, but left an interim guard in the balance resolver (`if (input.id) return 0n`) to prevent the resolver from returning the DOT relay-chain balance under a USDT token row.

This PR (B) wires the real query: `pallet_assets.Account` storage on Asset Hub (parachain 1000), so USDT/USDC holders see their actual balance.

## how

### storage key encoding (Substrate spec)

```
twox128("Assets")              // 16 bytes - module hash
+ twox128("Account")           // 16 bytes - storage item hash
+ blake2_128_concat(le_u32(asset_id))  // 16 + 4 bytes
+ blake2_128_concat(account_id_32)     // 16 + 32 bytes
```

Total: 100 bytes = 202 hex chars with `0x` prefix.

`twox128` hashes are hardcoded constants (same pattern as the existing `systemAccountPrefix`) to avoid pulling `@polkadot/util-crypto` — that package's BN.js dep double-bundles in browser/extension builds and crashes at module init (see comment in polkadot.ts for the full story).

`blake2_128` uses `@noble/hashes/blake2b` with `dkLen: 16` — already in the tree.

### response decoding

The response is a SCALE-encoded `AssetAccount`. Only the first 16 bytes matter: `balance: u128` LE. Null response = account has no entry for that asset = 0n.

### Asset Hub RPC

Added `assetHubRpcUrl = ${rootApiUrl}/dot-ah/` to `polkadot/client.ts`. Token queries go there; native DOT relay-chain queries still use the existing `polkadotRpcUrl = ${rootApiUrl}/dot/`.

## storage key verification

USDT (asset_id=1984) + Alice pubkey (`d43593c...`):

```
twox128("Assets")  = 682a59d51ab9e48a8c8cc418ff9708d2
twox128("Account") = b99d880ec681799c0cf30e8886371da9
le_u32(1984)       = c0070000
blake2_128(le_u32(1984))  = a319d0e87221ca1ee751c1529f201522
blake2_128(alice_pubkey)  = de1e86a9a8c739864cf3cc5ec2bea59f

full key = 0x682a59d51ab9e48a8c8cc418ff9708d2
             b99d880ec681799c0cf30e8886371da9
             a319d0e87221ca1ee751c1529f201522c0070000
             de1e86a9a8c739864cf3cc5ec2bea59f
             d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
           (202 chars - matches Substrate spec)
```

Verified against `@polkadot/util-crypto` (`xxhashAsHex` + `blake2AsHex`) offline, and cross-checked that `@noble/hashes/blake2b` with `dkLen: 16` produces identical output.

USDC (asset_id=1337) similarly verified (`le_u32(1337)=39050000`).

## tests (8 total, replaces 5 interim-guard tests)

| test | what it covers |
|---|---|
| USDT balance fetch | correct balance decode + storage key shape + `dot-ah` URL |
| USDC balance fetch | correct balance decode + `le_u32(1337)` in key |
| missing account (null) | → 0n |
| malformed SCALE response | → throws `unexpected storage response` |
| non-numeric asset_id | → throws `Invalid Asset Hub asset_id` (no RPC call) |
| Asset Hub RPC error | → propagates error |
| native DOT: relay chain URL | confirms `dot-ah` NOT used, `System.Account` prefix used |
| native DOT: null account | → 0n |

## stacking note

This PR is based on `feat_register_asset_hub_usdt_usdc` (#562). Review/merge order: #562 first, then this.

## risk

Low - isolated to the Polkadot balance resolver. Native DOT path unchanged (confirmed by tests checking URL + storage key prefix). No other chain touched.

no-receipts-required (pure resolver + no user-facing surface change, SDK-level only)

🤖 Agent-generated