### PR TITLE
feat(mpc): env-gated diag logging for relay-decrypt ghash tag investigation

### DIFF
--- a/.changeset/mpc-diag-relay-logging.md
+++ b/.changeset/mpc-diag-relay-logging.md
@@ -1,0 +1,13 @@
+---
+'@vultisig/core-mpc': patch
+---
+
+feat(mpc): env-gated diagnostic logging for relay-decrypt ghash tag investigation
+
+Adds non-default-on diagnostic logging to `fromMpcServerMessage` and the
+`receiveMessages` keysign relay loop, gated on `VULTISIG_DIAG_MPC_RELAY=1`.
+Logs envelope shape (`body_len`, `decoded_len`, `nonce_hex`, first 32 bytes
+of ciphertext) plus a `key_fingerprint` (sha256-truncated of decoded key
+bytes, NOT raw key material) for cross-node correlation of the persistent
+"aes/gcm: invalid ghash tag" failures. Behavior unchanged when the env flag
+is absent.

--- a/.changeset/polkadot-asset-hub-tron-memo.md
+++ b/.changeset/polkadot-asset-hub-tron-memo.md
@@ -1,0 +1,16 @@
+---
+'@vultisig/core-chain': minor
+'@vultisig/core-mpc': patch
+'@vultisig/sdk': minor
+---
+
+## New
+
+- Polkadot Asset Hub USDT (asset_id 1984) + USDC (asset_id 1337) token registry (#562)
+- Polkadot `pallet_assets.Account` balance resolver for Asset Hub tokens - replaces placeholder 0n guard (#563)
+- Tron native send `data` field (proto field 12) for THORChain memos + exchange deposit memos; `BuildTronSendOptions` and `BuildTrc20TransferOptions` gain optional `data?: Uint8Array` field (#559)
+
+## Fixed
+
+- Tron TRC-20 fee estimate now subtracts sender's available energy before charging TRX (#556)
+- Tron native send free bandwidth check prevents spurious fee charge when bandwidth is available (#555)

--- a/.config/eslint.config.mjs
+++ b/.config/eslint.config.mjs
@@ -50,6 +50,10 @@ export default [
       // WASM files copied by build tools
       '**/public/wallet-core.js',
       '**/public/wallet-core.wasm',
+      // Metro symlink+exports shim — CommonJS module.exports required so
+      // Metro's resolver can pick it up at runtime. Source lint rules don't
+      // apply; this is build-tool plumbing, not application source.
+      'packages/sdk/react-native.js',
     ],
   },
   ...fixupConfigRules(

--- a/package.json
+++ b/package.json
@@ -189,6 +189,8 @@
     "readable-stream": "3.6.2",
     "@noble/hashes": "1.8.0",
     "@lifi/sdk/@solana/web3.js": "1.98.4",
-    "@cosmjs/encoding/@scure/base": "1.2.6"
+    "@cosmjs/encoding/@scure/base": "1.2.6",
+    "tmp@npm:^0.0.33": "0.2.6",
+    "tmp@npm:^0.2.0": "0.2.6"
   }
 }

--- a/packages/core/mpc/keysign/index.ts
+++ b/packages/core/mpc/keysign/index.ts
@@ -147,6 +147,21 @@ export const keysign = async ({
         continue
       }
 
+      // Diagnostic logging for "aes/gcm: invalid ghash tag" investigation.
+      // Enable via VULTISIG_DIAG_MPC_RELAY=1. Remove once root-cause is confirmed.
+      if (process.env.VULTISIG_DIAG_MPC_RELAY === '1') {
+        console.log(
+          '[DIAG-MPC-INBOUND]',
+          JSON.stringify({
+            from: msg.from,
+            to: msg.to,
+            session_id: msg.session_id,
+            body_len: msg.body?.length ?? null,
+            message_id: messageId,
+          })
+        )
+      }
+
       const accepted = session.inputMessage(fromMpcServerMessage(msg.body, hexEncryptionKey))
       if (accepted) {
         processedMessages[cacheKey] = true

--- a/packages/core/mpc/message/server.test.ts
+++ b/packages/core/mpc/message/server.test.ts
@@ -4,6 +4,7 @@ describe('mpc server message encoding', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
     vi.resetModules()
+    delete process.env.VULTISIG_DIAG_MPC_RELAY
   })
 
   it('round-trips when globalThis.Buffer is undefined (browser-like)', async () => {
@@ -19,5 +20,41 @@ describe('mpc server message encoding', () => {
     const decoded = fromMpcServerMessage(encoded, hexEncryptionKey)
 
     expect(new Uint8Array(decoded)).toEqual(body)
+  })
+
+  it('does not call console.log when VULTISIG_DIAG_MPC_RELAY is unset', async () => {
+    delete process.env.VULTISIG_DIAG_MPC_RELAY
+    vi.resetModules()
+
+    const consoleSpy = vi.spyOn(console, 'log')
+    const { fromMpcServerMessage, toMpcServerMessage } = await import('./server')
+
+    const hexEncryptionKey = 'b'.repeat(64)
+    const body = new Uint8Array([0x01, 0x02, 0x03])
+
+    const encoded = toMpcServerMessage(body, hexEncryptionKey)
+    fromMpcServerMessage(encoded, hexEncryptionKey)
+
+    expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('[DIAG-MPC-RELAY]'), expect.anything())
+    consoleSpy.mockRestore()
+  })
+
+  it('calls console.log with expected fields when VULTISIG_DIAG_MPC_RELAY=1', async () => {
+    process.env.VULTISIG_DIAG_MPC_RELAY = '1'
+    vi.resetModules()
+
+    const consoleSpy = vi.spyOn(console, 'log')
+    const { fromMpcServerMessage, toMpcServerMessage } = await import('./server')
+
+    const hexEncryptionKey = 'c'.repeat(64)
+    const body = new Uint8Array([0xca, 0xfe, 0xba, 0xbe])
+
+    const encoded = toMpcServerMessage(body, hexEncryptionKey)
+    fromMpcServerMessage(encoded, hexEncryptionKey)
+
+    expect(consoleSpy).toHaveBeenCalledWith('[DIAG-MPC-RELAY]', expect.stringMatching(/"body_len":\d+/))
+    expect(consoleSpy).toHaveBeenCalledWith('[DIAG-MPC-RELAY]', expect.stringMatching(/"nonce_hex":"[0-9a-f]{24}"/))
+    expect(consoleSpy).toHaveBeenCalledWith('[DIAG-MPC-RELAY]', expect.stringMatching(/"key_first16":"[0-9a-f]{16}"/))
+    consoleSpy.mockRestore()
   })
 })

--- a/packages/core/mpc/message/server.test.ts
+++ b/packages/core/mpc/message/server.test.ts
@@ -54,7 +54,13 @@ describe('mpc server message encoding', () => {
 
     expect(consoleSpy).toHaveBeenCalledWith('[DIAG-MPC-RELAY]', expect.stringMatching(/"body_len":\d+/))
     expect(consoleSpy).toHaveBeenCalledWith('[DIAG-MPC-RELAY]', expect.stringMatching(/"nonce_hex":"[0-9a-f]{24}"/))
-    expect(consoleSpy).toHaveBeenCalledWith('[DIAG-MPC-RELAY]', expect.stringMatching(/"key_first16":"[0-9a-f]{16}"/))
+    // key_fingerprint is a sha256-truncated digest, not key bits — never logs raw key material.
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[DIAG-MPC-RELAY]',
+      expect.stringMatching(/"key_fingerprint":"[0-9a-f]{16}"/)
+    )
+    // Negative: never log the raw key prefix shape (key_first16 was the pre-fix logger).
+    expect(consoleSpy).not.toHaveBeenCalledWith('[DIAG-MPC-RELAY]', expect.stringMatching(/"key_first16":/))
     consoleSpy.mockRestore()
   })
 })

--- a/packages/core/mpc/message/server.test.ts
+++ b/packages/core/mpc/message/server.test.ts
@@ -54,13 +54,40 @@ describe('mpc server message encoding', () => {
 
     expect(consoleSpy).toHaveBeenCalledWith('[DIAG-MPC-RELAY]', expect.stringMatching(/"body_len":\d+/))
     expect(consoleSpy).toHaveBeenCalledWith('[DIAG-MPC-RELAY]', expect.stringMatching(/"nonce_hex":"[0-9a-f]{24}"/))
-    // key_fingerprint is a sha256-truncated digest, not key bits — never logs raw key material.
+    // key_fingerprint is a sha256-truncated digest of DECODED key bytes, not
+    // hex text or raw key material. Hex-text hashing would split the same key
+    // into two fingerprints based on caller-side casing.
     expect(consoleSpy).toHaveBeenCalledWith(
       '[DIAG-MPC-RELAY]',
       expect.stringMatching(/"key_fingerprint":"[0-9a-f]{16}"/)
     )
     // Negative: never log the raw key prefix shape (key_first16 was the pre-fix logger).
     expect(consoleSpy).not.toHaveBeenCalledWith('[DIAG-MPC-RELAY]', expect.stringMatching(/"key_first16":/))
+    consoleSpy.mockRestore()
+  })
+
+  it('key_fingerprint is stable across uppercase/lowercase hex variants of the same key', async () => {
+    process.env.VULTISIG_DIAG_MPC_RELAY = '1'
+    vi.resetModules()
+
+    const consoleSpy = vi.spyOn(console, 'log')
+    const { fromMpcServerMessage, toMpcServerMessage } = await import('./server')
+
+    const lowerKey = 'c'.repeat(64)
+    const upperKey = 'C'.repeat(64)
+    const body = new Uint8Array([0xca, 0xfe])
+
+    const encoded = toMpcServerMessage(body, lowerKey)
+    fromMpcServerMessage(encoded, lowerKey)
+    fromMpcServerMessage(encoded, upperKey)
+
+    const calls = consoleSpy.mock.calls.filter(c => c[0] === '[DIAG-MPC-RELAY]')
+    const fingerprints = calls.map(c => {
+      const parsed = JSON.parse(c[1] as string)
+      return parsed.key_fingerprint as string
+    })
+    expect(fingerprints).toHaveLength(2)
+    expect(fingerprints[0]).toBe(fingerprints[1])
     consoleSpy.mockRestore()
   })
 })

--- a/packages/core/mpc/message/server.ts
+++ b/packages/core/mpc/message/server.ts
@@ -16,9 +16,13 @@ export const fromMpcServerMessage = (body: string, hexEncryptionKey: string) => 
   // No behavior change — only logs body/key signature shapes when the env flag is set.
   // Enable via VULTISIG_DIAG_MPC_RELAY=1. Remove once root-cause is confirmed.
   //
-  // key_fingerprint is a sha256-truncated digest of the relay key, NOT any
-  // bits of the key itself. Identifies which key is in use across nodes for
-  // cross-node correlation without putting key material in logs.
+  // key_fingerprint is a sha256-truncated digest of the relay key's DECODED
+  // bytes (NOT the hex string), so the fingerprint is stable across
+  // upper/lower-case hex inputs - `0xABCD...` and `0xabcd...` map to the same
+  // 32 bytes of key material and must produce the same fingerprint for
+  // cross-node correlation. Hashing the hex string would split the same key
+  // into two distinct fingerprints based on caller-side casing. No key bits
+  // reach the log either way.
   if (process.env.VULTISIG_DIAG_MPC_RELAY === '1') {
     console.log(
       '[DIAG-MPC-RELAY]',
@@ -27,7 +31,7 @@ export const fromMpcServerMessage = (body: string, hexEncryptionKey: string) => 
         decoded_len: encryptedBuf.length,
         nonce_hex: encryptedBuf.subarray(0, 12).toString('hex'),
         first32_hex: encryptedBuf.toString('hex').slice(0, 64),
-        key_fingerprint: createHash('sha256').update(hexEncryptionKey).digest('hex').slice(0, 16),
+        key_fingerprint: createHash('sha256').update(Buffer.from(hexEncryptionKey, 'hex')).digest('hex').slice(0, 16),
       })
     )
   }

--- a/packages/core/mpc/message/server.ts
+++ b/packages/core/mpc/message/server.ts
@@ -5,14 +5,32 @@ import { decryptWithAesGcm } from '@vultisig/lib-utils/encryption/aesGcm/decrypt
 import { encryptWithAesGcm } from '@vultisig/lib-utils/encryption/aesGcm/encryptWithAesGcm'
 import { encryptedEncoding, plainTextEncoding } from '@vultisig/lib-utils/encryption/config'
 
-export const fromMpcServerMessage = (body: string, hexEncryptionKey: string) =>
-  Buffer.from(
+export const fromMpcServerMessage = (body: string, hexEncryptionKey: string) => {
+  // Diagnostic logging for "aes/gcm: invalid ghash tag" investigation.
+  // No behavior change — only logs body/key signature shapes when the env flag is set.
+  // Enable via VULTISIG_DIAG_MPC_RELAY=1. Remove once root-cause is confirmed.
+  if (process.env.VULTISIG_DIAG_MPC_RELAY === '1') {
+    const decoded = Buffer.from(body, encryptedEncoding)
+    console.log(
+      '[DIAG-MPC-RELAY]',
+      JSON.stringify({
+        body_len: body.length,
+        decoded_len: decoded.length,
+        nonce_hex: decoded.subarray(0, 12).toString('hex'),
+        first32_hex: decoded.toString('hex').slice(0, 64),
+        key_first16: hexEncryptionKey.slice(0, 16),
+      })
+    )
+  }
+
+  return Buffer.from(
     decryptWithAesGcm({
       key: Buffer.from(hexEncryptionKey, 'hex'),
       value: Buffer.from(body, encryptedEncoding),
     }).toString(plainTextEncoding),
     'base64'
   )
+}
 
 export const toMpcServerMessage = (body: Uint8Array, hexEncryptionKey: string) =>
   encryptWithAesGcm({

--- a/packages/core/mpc/message/server.ts
+++ b/packages/core/mpc/message/server.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto'
 import { Buffer } from 'buffer'
 
 import { base64Encode } from '@vultisig/lib-utils/base64Encode'
@@ -6,19 +7,27 @@ import { encryptWithAesGcm } from '@vultisig/lib-utils/encryption/aesGcm/encrypt
 import { encryptedEncoding, plainTextEncoding } from '@vultisig/lib-utils/encryption/config'
 
 export const fromMpcServerMessage = (body: string, hexEncryptionKey: string) => {
+  // Decode once so the diag log and the decrypt path observe identical bytes
+  // and any decode failure attributes to a single site (cleaner stack trace
+  // for the ghash investigation).
+  const encryptedBuf = Buffer.from(body, encryptedEncoding)
+
   // Diagnostic logging for "aes/gcm: invalid ghash tag" investigation.
   // No behavior change — only logs body/key signature shapes when the env flag is set.
   // Enable via VULTISIG_DIAG_MPC_RELAY=1. Remove once root-cause is confirmed.
+  //
+  // key_fingerprint is a sha256-truncated digest of the relay key, NOT any
+  // bits of the key itself. Identifies which key is in use across nodes for
+  // cross-node correlation without putting key material in logs.
   if (process.env.VULTISIG_DIAG_MPC_RELAY === '1') {
-    const decoded = Buffer.from(body, encryptedEncoding)
     console.log(
       '[DIAG-MPC-RELAY]',
       JSON.stringify({
         body_len: body.length,
-        decoded_len: decoded.length,
-        nonce_hex: decoded.subarray(0, 12).toString('hex'),
-        first32_hex: decoded.toString('hex').slice(0, 64),
-        key_first16: hexEncryptionKey.slice(0, 16),
+        decoded_len: encryptedBuf.length,
+        nonce_hex: encryptedBuf.subarray(0, 12).toString('hex'),
+        first32_hex: encryptedBuf.toString('hex').slice(0, 64),
+        key_fingerprint: createHash('sha256').update(hexEncryptionKey).digest('hex').slice(0, 16),
       })
     )
   }
@@ -26,7 +35,7 @@ export const fromMpcServerMessage = (body: string, hexEncryptionKey: string) => 
   return Buffer.from(
     decryptWithAesGcm({
       key: Buffer.from(hexEncryptionKey, 'hex'),
-      value: Buffer.from(body, encryptedEncoding),
+      value: encryptedBuf,
     }).toString(plainTextEncoding),
     'base64'
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -16953,13 +16953,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"os-tmpdir@npm:~1.0.2":
-  version: 1.0.2
-  resolution: "os-tmpdir@npm:1.0.2"
-  checksum: 10c0/f438450224f8e2687605a8dd318f0db694b6293c5d835ae509a69e97c8de38b6994645337e5577f5001115470414638978cc49da1cdcc25106dad8738dc69990
-  languageName: node
-  linkType: hard
-
 "outdent@npm:^0.5.0":
   version: 0.5.0
   resolution: "outdent@npm:0.5.0"
@@ -20653,19 +20646,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:^0.0.33":
-  version: 0.0.33
-  resolution: "tmp@npm:0.0.33"
-  dependencies:
-    os-tmpdir: "npm:~1.0.2"
-  checksum: 10c0/69863947b8c29cabad43fe0ce65cec5bb4b481d15d4b4b21e036b060b3edbf3bc7a5541de1bacb437bb3f7c4538f669752627fdf9b4aaf034cebd172ba373408
-  languageName: node
-  linkType: hard
-
-"tmp@npm:^0.2.0":
-  version: 0.2.5
-  resolution: "tmp@npm:0.2.5"
-  checksum: 10c0/cee5bb7d674bb4ba3ab3f3841c2ca7e46daeb2109eec395c1ec7329a91d52fcb21032b79ac25161a37b2565c4858fefab927af9735926a113ef7bac9091a6e0e
+"tmp@npm:0.2.6":
+  version: 0.2.6
+  resolution: "tmp@npm:0.2.6"
+  checksum: 10c0/fa5b9bfbe60f70904aba5c96b4970e9158d99867891302d10320fe35eee1e45f42946fded4cf5c8514baa087bebee44419029b7deb227da05a68b5205a12d8ab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## what

Adds env-gated diagnostic logging in `@vultisig/sdk` DKLS keysign relay-decrypt path. NO behavior change when the flag is unset. When set, logs body/key/nonce shapes that pinpoint the source of "aes/gcm: invalid ghash tag" errors reported by Pan (Discord 12:52 today) + NakYot (14:28).

## why

Two deep spikes + one sim repro attempt converged on: bug is in `fromMpcServerMessage` relay-decrypt path, wire format and KDF wire-compatible analytically, need device-level byte capture to identify the actual failure mode. Local repro blocked (no test vault can start a successful keysign with VultiServer).

Shipping this lets us capture the bytes in real failed sessions and root-cause the bug.

## how

- Env flag: `VULTISIG_DIAG_MPC_RELAY=1` enables. Default off.
- `packages/core/mpc/message/server.ts` - logs before `decryptWithAesGcm`: `body_len`, `decoded_len`, `nonce_hex`, `first32_hex`, `key_first16`
- `packages/core/mpc/keysign/index.ts` - logs in `processInbound` loop before `inputMessage`: `from`, `to`, `session_id`, `body_len`, `message_id`
- No new deps. Uses `process.env` directly, consistent with `cosigner.ts` convention.

## receipts

- Unit test: logging is OFF by default (no `console.log` spy fires without flag)
- Unit test: logging fires with `VULTISIG_DIAG_MPC_RELAY=1`, correct fields present (`body_len`, `nonce_hex`, `key_first16`)
- 3/3 `server.test.ts` tests pass, CI will confirm

No sim receipt applicable - purely observability, no user-visible surface.

## risk

Low. Pure addition gated by env flag. Default-off matches current behavior exactly. No new deps. The `key_first16` slice exposes only the first 8 bytes of the hex-encoded key (16 chars = 8 bytes of the 32-byte key) - enough to correlate mismatches without leaking the full key.

## followup

Once we capture the bytes in a real failure (Pan / NakYot / any new report), root-cause + ship the actual fix and revert this diag. The companion vultiagent-app wiring (`EXPO_PUBLIC_VULTISIG_DIAG_MPC_RELAY=1` in staging env) is deferred until this SDK PR lands + publishes.

🤖 Agent-generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Polkadot Asset Hub USDT and USDC tokens
  * Added Tron native send memo data support

* **Bug Fixes**
  * Fixed Tron TRC-20 fee estimation to properly account for sender's available energy
  * Resolved spurious fee charges when bandwidth is available on Tron

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/577?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->