### PR TITLE
feat(terra-recovery): add derivationOverrides to deriveAddressFromKeys and VaultIdentity (L1)

### DIFF
--- a/packages/core/mpc/vault/Vault.ts
+++ b/packages/core/mpc/vault/Vault.ts
@@ -32,6 +32,12 @@ export type Vault = {
   keyShareMldsa?: string
   /** Zcash Sapling key material (legacy / storage). */
   saplingExtras?: string
+  /**
+   * Per-chain BIP32 path overrides for recovery wallets.
+   * An empty string (`""`) means literal root: use the ECDSA root key directly
+   * with no derivation hop. Required for Fast Vault MPC recovery vaults.
+   */
+  derivationOverrides?: Partial<Record<Chain, string>>
 }
 
 export const getVaultId = (vault: Vault): string => vault.publicKeys.ecdsa

--- a/packages/sdk/src/tools/address/deriveAddressFromKeys.ts
+++ b/packages/sdk/src/tools/address/deriveAddressFromKeys.ts
@@ -21,6 +21,23 @@ type DeriveAddressFromKeysInput = {
    * non-hardened BIP32 fallback is used unchanged — existing callers are unaffected.
    */
   chainPublicKeys?: Partial<Record<Chain, string>>
+  /**
+   * Per-chain BIP32 path overrides.  An empty string (`""`) means "literal root":
+   * use the ECDSA root public key directly with no BIP32 derivation.
+   *
+   * Required for Fast Vault MPC recovery wallets whose keysign session was
+   * executed at the root key (no derivation hop), producing an address of the
+   * form `bech32(prefix, hash160(ecdsaRootPubKey))`.
+   *
+   * Behaviour:
+   * - `""` → the root `ecdsaPublicKey` is injected as a synthetic `chainPublicKeys`
+   *   entry for the requested chain, bypassing BIP32 derivation entirely.
+   * - Non-empty strings are reserved for future path-override support and are
+   *   currently ignored (the standard derivation path is used).
+   * - Takes precedence over `chainPublicKeys` for the same chain when both are
+   *   provided (the synthetic injection wins).
+   */
+  derivationOverrides?: Partial<Record<Chain, string>>
 }
 
 type DeriveAddressFromKeysResult = {
@@ -63,13 +80,45 @@ export const deriveAddressFromKeys = async (
     )
   }
 
+  // Resolve derivationOverrides: an empty-string override means "literal root" —
+  // use the ECDSA root pubkey directly with no BIP32 derivation hop.
+  // We implement this by injecting a synthetic chainPublicKeys entry so the
+  // existing chainPublicKeys path handles the bypass transparently.
+  // derivationOverrides takes precedence over chainPublicKeys for the same chain.
+  const effectiveChainPublicKeys: Partial<Record<Chain, string>> | undefined = (() => {
+    // Determine if a literal-root override applies for the requested chain.
+    // The override map may key on either the exact chain OR its Terra/TerraClassic alias.
+    const directOverride = input.derivationOverrides?.[input.chain]
+    const aliasOverride =
+      input.chain === Chain.TerraClassic
+        ? input.derivationOverrides?.[Chain.Terra]
+        : input.chain === Chain.Terra
+          ? input.derivationOverrides?.[Chain.TerraClassic]
+          : undefined
+    const activeOverride = directOverride ?? aliasOverride
+
+    if (activeOverride === '') {
+      // Literal-root override: use the ECDSA root key as the pre-derived pubkey.
+      // ecdsaPublicKey is guaranteed non-empty by the guard at the top of this function.
+      const rootKey = input.ecdsaPublicKey!
+      const synthetic: Partial<Record<Chain, string>> = {
+        ...input.chainPublicKeys,
+        [input.chain]: rootKey,
+      }
+      return synthetic
+    }
+    // Non-empty override strings are reserved for future use; fall through to
+    // standard chainPublicKeys resolution.
+    return input.chainPublicKeys
+  })()
+
   // Terra and TerraClassic share BIP44 coin_type 330 and the same hardened-derived pubkey.
   // Mirror the alias from addressDerivation.ts so callers only need to supply one direction.
   // We also filter the map to only include the requested chain: getPublicKey treats any
   // non-empty map as authoritative and throws "Chain public key not found" when the chain
   // is absent, so we must not forward a partial map for an unrelated chain.
   const resolvedChainPublicKeys: Partial<Record<Chain, string>> | undefined = (() => {
-    const keys = input.chainPublicKeys
+    const keys = effectiveChainPublicKeys
     if (!keys) return undefined
 
     // Validate all present entries before any alias logic.

--- a/packages/sdk/src/tools/prep/types.ts
+++ b/packages/sdk/src/tools/prep/types.ts
@@ -22,6 +22,12 @@ export type VaultIdentity = {
   libType: KeysignLibType
   publicKeyMldsa?: string
   chainPublicKeys?: Partial<Record<Chain, string>>
+  /**
+   * Per-chain BIP32 path overrides forwarded from the vault model.
+   * An empty string (`""`) means literal root (no derivation hop).
+   * Used when building keysign payloads for recovery wallets.
+   */
+  derivationOverrides?: Partial<Record<Chain, string>>
 }
 
 /**
@@ -37,4 +43,5 @@ export const vaultDataToIdentity = (vault: CoreVault): VaultIdentity => ({
   libType: vault.libType,
   publicKeyMldsa: vault.publicKeyMldsa,
   chainPublicKeys: vault.chainPublicKeys,
+  derivationOverrides: vault.derivationOverrides,
 })

--- a/packages/sdk/tests/unit/tools/address/deriveAddressFromKeys.test.ts
+++ b/packages/sdk/tests/unit/tools/address/deriveAddressFromKeys.test.ts
@@ -291,4 +291,134 @@ describe('deriveAddressFromKeys', () => {
       expect(mockGetPublicKey).not.toHaveBeenCalled()
     })
   })
+
+  describe('derivationOverrides — literal-root recovery path', () => {
+    // BIP32 test vector 1 master-level ECDSA public key (no derivation).
+    // Pinned test vector from the Terra wrong-derivation recovery spec:
+    //   rootPubKey = 0339a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c2
+    //   override   = { Terra: "" }
+    //   expected   = terra1x3ppj0smkuy3d6g525sh9n2w9k7fm7q3k0tgd9
+    const ROOT_PUBKEY = '0339a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c2'
+    const RECOVERY_ADDRESS = 'terra1x3ppj0smkuy3d6g525sh9n2w9k7fm7q3k0tgd9'
+    const CHAIN_CODE = '873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d508'
+
+    it('empty-string override injects root pubkey as synthetic chainPublicKeys entry', async () => {
+      mockDeriveAddress.mockReturnValueOnce(RECOVERY_ADDRESS)
+      const result = await deriveAddressFromKeys({
+        chain: Chain.Terra,
+        ecdsaPublicKey: ROOT_PUBKEY,
+        hexChainCode: CHAIN_CODE,
+        derivationOverrides: { [Chain.Terra]: '' },
+      })
+      expect(result).toEqual({ chain: Chain.Terra, address: RECOVERY_ADDRESS })
+      // The root pubkey must be forwarded as-is — no BIP32 derivation
+      expect(mockGetPublicKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chain: Chain.Terra,
+          chainPublicKeys: expect.objectContaining({
+            [Chain.Terra]: ROOT_PUBKEY,
+          }),
+        })
+      )
+    })
+
+    it('override on Terra also resolves when querying TerraClassic (alias)', async () => {
+      mockDeriveAddress.mockReturnValueOnce(RECOVERY_ADDRESS)
+      await deriveAddressFromKeys({
+        chain: Chain.TerraClassic,
+        ecdsaPublicKey: ROOT_PUBKEY,
+        hexChainCode: CHAIN_CODE,
+        derivationOverrides: { [Chain.Terra]: '' },
+      })
+      // TerraClassic query honours the Terra override via alias
+      expect(mockGetPublicKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chain: Chain.TerraClassic,
+          chainPublicKeys: expect.objectContaining({
+            [Chain.TerraClassic]: ROOT_PUBKEY,
+          }),
+        })
+      )
+    })
+
+    it('override on TerraClassic resolves when querying Terra (reverse alias)', async () => {
+      mockDeriveAddress.mockReturnValueOnce(RECOVERY_ADDRESS)
+      await deriveAddressFromKeys({
+        chain: Chain.Terra,
+        ecdsaPublicKey: ROOT_PUBKEY,
+        hexChainCode: CHAIN_CODE,
+        derivationOverrides: { [Chain.TerraClassic]: '' },
+      })
+      expect(mockGetPublicKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chain: Chain.Terra,
+          chainPublicKeys: expect.objectContaining({
+            [Chain.Terra]: ROOT_PUBKEY,
+          }),
+        })
+      )
+    })
+
+    it('derivationOverrides takes precedence over chainPublicKeys for the same chain', async () => {
+      const hardenedPubkey = '03c7721fa4760e081f7ae3b192084467528603ebdf84ebf3d86addc86d5bcdc31b'
+      mockDeriveAddress.mockReturnValueOnce(RECOVERY_ADDRESS)
+      await deriveAddressFromKeys({
+        chain: Chain.Terra,
+        ecdsaPublicKey: ROOT_PUBKEY,
+        hexChainCode: CHAIN_CODE,
+        chainPublicKeys: { [Chain.Terra]: hardenedPubkey },
+        derivationOverrides: { [Chain.Terra]: '' },
+      })
+      // The root pubkey (from derivationOverrides) wins over the hardened key (from chainPublicKeys)
+      expect(mockGetPublicKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chainPublicKeys: expect.objectContaining({
+            [Chain.Terra]: ROOT_PUBKEY,
+          }),
+        })
+      )
+    })
+
+    it('non-empty override string is ignored; standard derivation runs', async () => {
+      await deriveAddressFromKeys({
+        chain: Chain.Ethereum,
+        ecdsaPublicKey: ROOT_PUBKEY,
+        hexChainCode: CHAIN_CODE,
+        derivationOverrides: { [Chain.Ethereum]: "m/44'/60'/0'/0/0" },
+      })
+      // Non-empty override string is reserved for future use; chainPublicKeys stays undefined
+      expect(mockGetPublicKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chainPublicKeys: undefined,
+        })
+      )
+    })
+
+    it('override for an unrelated chain does not affect the requested chain', async () => {
+      await deriveAddressFromKeys({
+        chain: Chain.Ethereum,
+        ecdsaPublicKey: ROOT_PUBKEY,
+        hexChainCode: CHAIN_CODE,
+        derivationOverrides: { [Chain.Terra]: '' },
+      })
+      // Ethereum is not in derivationOverrides — standard BIP32 derivation must run
+      expect(mockGetPublicKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chain: Chain.Ethereum,
+          chainPublicKeys: undefined,
+        })
+      )
+    })
+
+    it('absent derivationOverrides leaves existing behaviour unchanged', async () => {
+      await deriveAddressFromKeys({
+        chain: Chain.Ethereum,
+        ecdsaPublicKey: ROOT_PUBKEY,
+        hexChainCode: CHAIN_CODE,
+      })
+      expect(mockGetPublicKey).toHaveBeenCalledWith(
+        expect.objectContaining({ chainPublicKeys: undefined })
+      )
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Agent-side companion to va#974 (Terra wrong-derivation MPC recovery), L1 of 4.

- **`packages/sdk/src/tools/address/deriveAddressFromKeys.ts`** — adds `derivationOverrides?: Partial<Record<Chain, string>>` input field. An empty-string value (`""`) means literal root: injects the ECDSA root pubkey as a synthetic `chainPublicKeys` entry, bypassing BIP32 derivation entirely. Terra ↔ TerraClassic aliasing applies to override lookup. Takes precedence over `chainPublicKeys` for the same chain.
- **`packages/sdk/src/tools/prep/types.ts`** — adds `derivationOverrides` to `VaultIdentity` and maps it in `vaultDataToIdentity`
- **`packages/core/mpc/vault/Vault.ts`** — adds `derivationOverrides` to the `Vault` type for downstream storage serialization

## Pinned test vector

The unit tests verify the injection logic at the mock level. E2E verification (real WalletCore hash160 → bech32) is covered by the funded E2E tests:
- rootPubKey: `0339a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c2`
- `derivationOverrides: { Terra: "" }` → root key passed directly to `getPublicKey`

## Dependency chain

| Layer | Repo | Status |
|-------|------|--------|
| **L1** | **vultisig-sdk** | **this PR** |
| L2 | mcp-ts | PR #239 (type-cast until this merges) |
| L3 | agent-backend | PR #767 |
| L4 | vultiagent-app | merged (9cf7a626) |

## Test plan

- [x] `vitest run tests/unit` — 1459/1459 pass (104 test files)
- [x] `tsc --noEmit --skipLibCheck` — clean
- [x] 7 new unit tests for `derivationOverrides` covering: empty-string injection, Terra/TerraClassic alias both directions, precedence over `chainPublicKeys`, non-empty string passthrough (no-op), unrelated chain isolation, absent field (no regression)

🤖 Agent-generated