### PR TITLE
feat(sdk): add getSwapExplorerUrl helper for swap-provider tx links (#426)

### DIFF
--- a/.changeset/get-swap-explorer-url.md
+++ b/.changeset/get-swap-explorer-url.md
@@ -1,0 +1,14 @@
+---
+'@vultisig/core-chain': minor
+'@vultisig/sdk': minor
+---
+
+Add `getSwapExplorerUrl` helper for swap-provider tx links (#426).
+
+Tx history surfaces (vultisig-windows, vultiagent-app, future RN SDK) now have a single source of truth for "View on Explorer" URLs that point to the swap **provider's** scanner — `scan.li.fi`, `orb.helius.dev` for LI.FI Solana settlement, `runescan.io` for THORChain, and the MayaChain explorer — instead of every consumer reimplementing the routing and most defaulting to the source-chain explorer (which hides cross-chain routes from users).
+
+- New: `getSwapExplorerUrl({ provider, txHash, fromChain })` in `@vultisig/core-chain/swap/utils/getSwapExplorerUrl`
+- New: `Vultisig.getSwapExplorerUrl(provider, txHash, fromChain)` static method for parity with `getTxExplorerUrl`
+- For `1inch` / `kyber` / `swapkit`, falls back to the source-chain explorer (no public per-tx aggregator page)
+- Mirrors iOS `ExplorerLinkBuilder.swift` and Android `ExplorerLinkRepository.getSwapProgressLink`
+- Pure URL builder, no new deps

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -1480,6 +1480,11 @@
       "import": "./dist/swap/SwapFee.js",
       "default": "./dist/swap/SwapFee.js"
     },
+    "./swap/utils/getSwapExplorerUrl": {
+      "types": "./dist/swap/utils/getSwapExplorerUrl/index.d.ts",
+      "import": "./dist/swap/utils/getSwapExplorerUrl/index.js",
+      "default": "./dist/swap/utils/getSwapExplorerUrl/index.js"
+    },
     "./tw/signingOutput": {
       "types": "./dist/tw/signingOutput.d.ts",
       "import": "./dist/tw/signingOutput.js",

--- a/packages/core/chain/swap/general/GeneralSwapQuote.ts
+++ b/packages/core/chain/swap/general/GeneralSwapQuote.ts
@@ -57,6 +57,16 @@ export type GeneralSwapTx =
       }
     }
 
+/**
+ * Quote returned by an EVM/Solana general-purpose swap aggregator.
+ *
+ * Consumers building a "View on Explorer" link should call
+ * `getSwapExplorerUrl({ provider, txHash, fromChain })` from
+ * `@vultisig/core-chain/swap/utils/getSwapExplorerUrl` instead of routing
+ * by hand — the helper covers the LI.FI / Helius scanners and falls back to
+ * the source-chain explorer for `1inch` / `kyber` / `swapkit` (none of which
+ * expose a per-tx aggregator page).
+ */
 export type GeneralSwapQuote = {
   dstAmount: string
   provider: GeneralSwapProvider

--- a/packages/core/chain/swap/utils/getSwapExplorerUrl/index.test.ts
+++ b/packages/core/chain/swap/utils/getSwapExplorerUrl/index.test.ts
@@ -1,0 +1,142 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { describe, expect, it } from 'vitest'
+
+import { getSwapExplorerUrl, swapExplorerProviders } from './index'
+
+// Realistic-shape txHashes (length and case match what each chain emits).
+const EVM_TX_HASH = '0x9f8c2b1a4d3e5f6a7b8c9d0e1f2a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c'
+const THOR_TX_HASH_NO_PREFIX = 'F1E2D3C4B5A6978869DECABFE1F2A3B4C5D6E7F8091A2B3C4D5E6F708192A3B4'
+const MAYA_TX_HASH_NO_PREFIX = '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF'
+const SOL_TX_HASH = '5sN4Gd1cYpkqXf9PJ2vk3aHe8mLZbT9rsQwYjVtNcXkA6zBeLgFmHqWdYbCnRsVtUxKpJ8MzTwQhPgRfNlEd'
+
+describe('getSwapExplorerUrl', () => {
+  describe('li.fi', () => {
+    it('uses scan.li.fi for EVM source chains and keeps the raw hash (incl. 0x)', () => {
+      expect(
+        getSwapExplorerUrl({
+          provider: 'li.fi',
+          txHash: EVM_TX_HASH,
+          fromChain: Chain.Ethereum,
+        })
+      ).toBe(`https://scan.li.fi/tx/${EVM_TX_HASH}`)
+
+      expect(
+        getSwapExplorerUrl({
+          provider: 'li.fi',
+          txHash: EVM_TX_HASH,
+          fromChain: Chain.Arbitrum,
+        })
+      ).toBe(`https://scan.li.fi/tx/${EVM_TX_HASH}`)
+    })
+
+    it('routes Solana cross-chain settlement to Helius (LI.FI has no per-tx page)', () => {
+      expect(
+        getSwapExplorerUrl({
+          provider: 'li.fi',
+          txHash: SOL_TX_HASH,
+          fromChain: Chain.Solana,
+        })
+      ).toBe(`https://orb.helius.dev/tx/${SOL_TX_HASH}`)
+    })
+  })
+
+  describe('thorchain', () => {
+    it('strips a 0x prefix before composing the runescan URL', () => {
+      expect(
+        getSwapExplorerUrl({
+          provider: 'thorchain',
+          txHash: `0x${THOR_TX_HASH_NO_PREFIX}`,
+          fromChain: Chain.THORChain,
+        })
+      ).toBe(`https://runescan.io/tx/${THOR_TX_HASH_NO_PREFIX}`)
+    })
+
+    it('leaves a hash that has no 0x prefix unchanged', () => {
+      expect(
+        getSwapExplorerUrl({
+          provider: 'thorchain',
+          txHash: THOR_TX_HASH_NO_PREFIX,
+          fromChain: Chain.Bitcoin,
+        })
+      ).toBe(`https://runescan.io/tx/${THOR_TX_HASH_NO_PREFIX}`)
+    })
+
+    it('strips a capitalised 0X prefix the same way', () => {
+      expect(
+        getSwapExplorerUrl({
+          provider: 'thorchain',
+          txHash: `0X${THOR_TX_HASH_NO_PREFIX}`,
+          fromChain: Chain.Ethereum,
+        })
+      ).toBe(`https://runescan.io/tx/${THOR_TX_HASH_NO_PREFIX}`)
+    })
+  })
+
+  describe('mayachain', () => {
+    it('strips a 0x prefix before composing the mayachain explorer URL', () => {
+      expect(
+        getSwapExplorerUrl({
+          provider: 'mayachain',
+          txHash: `0x${MAYA_TX_HASH_NO_PREFIX}`,
+          fromChain: Chain.MayaChain,
+        })
+      ).toBe(`https://www.explorer.mayachain.info/tx/${MAYA_TX_HASH_NO_PREFIX}`)
+    })
+
+    it('leaves a hash that has no 0x prefix unchanged', () => {
+      expect(
+        getSwapExplorerUrl({
+          provider: 'mayachain',
+          txHash: MAYA_TX_HASH_NO_PREFIX,
+          fromChain: Chain.Dash,
+        })
+      ).toBe(`https://www.explorer.mayachain.info/tx/${MAYA_TX_HASH_NO_PREFIX}`)
+    })
+  })
+
+  describe('aggregators without a per-tx scanner', () => {
+    it('1inch falls back to the source-chain block explorer', () => {
+      expect(
+        getSwapExplorerUrl({
+          provider: '1inch',
+          txHash: EVM_TX_HASH,
+          fromChain: Chain.Ethereum,
+        })
+      ).toBe(`https://etherscan.io/tx/${EVM_TX_HASH}`)
+
+      expect(
+        getSwapExplorerUrl({
+          provider: '1inch',
+          txHash: EVM_TX_HASH,
+          fromChain: Chain.Polygon,
+        })
+      ).toBe(`https://polygonscan.com/tx/${EVM_TX_HASH}`)
+    })
+
+    it('kyber falls back to the source-chain block explorer', () => {
+      expect(
+        getSwapExplorerUrl({
+          provider: 'kyber',
+          txHash: EVM_TX_HASH,
+          fromChain: Chain.Base,
+        })
+      ).toBe(`https://basescan.org/tx/${EVM_TX_HASH}`)
+    })
+
+    it('swapkit falls back to the source-chain block explorer', () => {
+      expect(
+        getSwapExplorerUrl({
+          provider: 'swapkit',
+          txHash: SOL_TX_HASH,
+          fromChain: Chain.Solana,
+        })
+      ).toBe(`https://solscan.io/tx/${SOL_TX_HASH}`)
+    })
+  })
+
+  it('exposes every provider via swapExplorerProviders', () => {
+    expect([...swapExplorerProviders].sort()).toEqual(
+      ['1inch', 'kyber', 'li.fi', 'mayachain', 'swapkit', 'thorchain'].sort()
+    )
+  })
+})

--- a/packages/core/chain/swap/utils/getSwapExplorerUrl/index.ts
+++ b/packages/core/chain/swap/utils/getSwapExplorerUrl/index.ts
@@ -1,0 +1,69 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { getBlockExplorerUrl } from '@vultisig/core-chain/utils/getBlockExplorerUrl'
+
+/**
+ * Swap-provider scanners covered by `getSwapExplorerUrl`.
+ *
+ * - `li.fi` → scan.li.fi (or orb.helius.dev for Solana settlement)
+ * - `thorchain` / `mayachain` → native chain scanner
+ * - `1inch`, `kyber`, `swapkit` → no per-tx aggregator page; fall back to source-chain explorer
+ *
+ * Keep this union in sync with iOS `ExplorerLinkBuilder.swift` and Android
+ * `ExplorerLinkRepository.getSwapProgressLink`.
+ */
+export const swapExplorerProviders = ['1inch', 'kyber', 'li.fi', 'mayachain', 'swapkit', 'thorchain'] as const
+
+export type SwapExplorerProvider = (typeof swapExplorerProviders)[number]
+
+export type GetSwapExplorerUrlInput = {
+  provider: SwapExplorerProvider
+  txHash: string
+  /**
+   * The chain the tx was broadcast on. Used both for source-chain fallback and
+   * for the Solana-settlement branch on `li.fi` (where the LI.FI scanner has
+   * no per-tx page).
+   */
+  fromChain: Chain
+}
+
+const stripHexPrefix = (value: string): string =>
+  value.startsWith('0x') || value.startsWith('0X') ? value.slice(2) : value
+
+/**
+ * Resolve the canonical "view on explorer" URL for a swap-provider transaction.
+ *
+ * Mirrors iOS `ExplorerLinkBuilder.swift` and Android `ExplorerLinkRepository.getSwapProgressLink`
+ * so every consumer (vultisig-windows, vultiagent-app, future RN SDK) routes
+ * tx-history links to the same scanner.
+ *
+ * For aggregators without a public per-tx page (`1inch`, `kyber`, `swapkit`),
+ * the source-chain explorer is returned so the row never renders as a dead link.
+ */
+export const getSwapExplorerUrl = ({ provider, txHash, fromChain }: GetSwapExplorerUrlInput): string => {
+  switch (provider) {
+    case 'li.fi':
+      // LI.FI's scanner has no per-tx page for Solana cross-chain settlement;
+      // Helius is the canonical view there.
+      if (fromChain === Chain.Solana) {
+        return `https://orb.helius.dev/tx/${txHash}`
+      }
+      return `https://scan.li.fi/tx/${txHash}`
+    case 'thorchain':
+      return `https://runescan.io/tx/${stripHexPrefix(txHash)}`
+    case 'mayachain':
+      return `https://www.explorer.mayachain.info/tx/${stripHexPrefix(txHash)}`
+    case '1inch':
+    case 'kyber':
+    case 'swapkit':
+      // No public aggregator scanner. Source-chain explorer keeps the link
+      // useful (Etherscan / Solscan / etc.) without fabricating a URL.
+      return getBlockExplorerUrl({ chain: fromChain, entity: 'tx', value: txHash })
+    default: {
+      // Compile-time guard: if `swapExplorerProviders` grows without a matching
+      // case here, TS narrows `provider` to `never` and fails the build. The
+      // runtime throw covers the (impossible-by-types) JS-caller path.
+      const _exhaustive: never = provider
+      throw new Error(`Unknown swap explorer provider: ${String(_exhaustive)}`)
+    }
+  }
+}

--- a/packages/sdk/src/Vultisig.ts
+++ b/packages/sdk/src/Vultisig.ts
@@ -6,6 +6,7 @@ import { knownTokens, knownTokensIndex } from '@vultisig/core-chain/coin/knownTo
 import { getCoinPrices as coreCoinPrices } from '@vultisig/core-chain/coin/price/getCoinPrices'
 import { getCoinPricesWithChange as coreCoinPricesWithChange } from '@vultisig/core-chain/coin/price/getCoinPricesWithChange'
 import { scanSiteWithBlockaid } from '@vultisig/core-chain/security/blockaid/site'
+import { getSwapExplorerUrl, type SwapExplorerProvider } from '@vultisig/core-chain/swap/utils/getSwapExplorerUrl'
 import { getBlockExplorerUrl } from '@vultisig/core-chain/utils/getBlockExplorerUrl'
 import { isValidAddress } from '@vultisig/core-chain/utils/isValidAddress'
 import { vaultContainerFromString } from '@vultisig/core-mpc/vault/utils/vaultContainerFromString'
@@ -1113,6 +1114,27 @@ export class Vultisig extends UniversalEventEmitter<SdkEvents> {
    */
   static getAddressExplorerUrl(chain: Chain, address: string): string {
     return getBlockExplorerUrl({ chain, entity: 'address', value: address })
+  }
+
+  /**
+   * Get the canonical "view on explorer" URL for a swap-provider transaction.
+   *
+   * Routes to the aggregator's scanner where one exists (LI.FI / Helius for
+   * Solana settlement, Runescan for THORChain, the MayaChain explorer for
+   * MayaChain) and falls back to the source-chain explorer for `1inch`,
+   * `kyber`, and `swapkit` — none of which expose a per-tx aggregator page.
+   *
+   * Mirrors iOS `ExplorerLinkBuilder.swift` and Android
+   * `ExplorerLinkRepository.getSwapProgressLink` so every Vultisig client
+   * routes tx-history links to the same scanner.
+   *
+   * @param provider - The swap provider that executed the trade
+   * @param txHash - The on-chain transaction hash (with or without 0x prefix)
+   * @param fromChain - The chain the tx was broadcast on
+   * @returns The provider-specific explorer URL
+   */
+  static getSwapExplorerUrl(provider: SwapExplorerProvider, txHash: string, fromChain: Chain): string {
+    return getSwapExplorerUrl({ provider, txHash, fromChain })
   }
 
   /**

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -180,6 +180,12 @@ export type {
 // Swap type guards
 export { isAccountCoin, isSimpleCoinInput, KeysignPayloadSchema } from './types'
 
+// Swap explorer URL helper (parity with iOS ExplorerLinkBuilder /
+// Android ExplorerLinkRepository.getSwapProgressLink). Use this instead of
+// chain-only explorer URLs when rendering swap tx history.
+export type { GetSwapExplorerUrlInput, SwapExplorerProvider } from '@vultisig/core-chain/swap/utils/getSwapExplorerUrl'
+export { getSwapExplorerUrl, swapExplorerProviders } from '@vultisig/core-chain/swap/utils/getSwapExplorerUrl'
+
 // ============================================================================
 // PUBLIC API - Seedphrase & Multi-Device Vault Creation
 // ============================================================================


### PR DESCRIPTION
Closes #426.

## Summary

Tx history surfaces (vultisig-windows, vultiagent-app, future RN SDK) need a "View on Explorer" URL that points to the swap **provider's** scanner — `scan.li.fi`, `orb.helius.dev` for LI.FI Solana settlement, `runescan.io` for THORChain, the MayaChain explorer for MayaChain — instead of the source-chain explorer, which hides cross-chain routes from users.

Today the SDK exposes only chain-explorer URLs (`Vultisig.getTxExplorerUrl(chain, txHash)`, `getBlockExplorerUrl`). `GeneralSwapQuote` carries `provider: '1inch' | 'li.fi' | 'kyber' | 'swapkit'` but no explorer field, so every consumer reimplements the routing — and most default to chain explorers.

This PR adds a single helper that mirrors iOS `ExplorerLinkBuilder.swift` and Android `ExplorerLinkRepository.getSwapProgressLink`, plus a `Vultisig.getSwapExplorerUrl` static for parity with `getTxExplorerUrl`.

```ts
import { getSwapExplorerUrl } from '@vultisig/sdk'
//      or
import { Vultisig } from '@vultisig/sdk'

Vultisig.getSwapExplorerUrl('li.fi', txHash, Chain.Ethereum)
// → https://scan.li.fi/tx/{txHash}

Vultisig.getSwapExplorerUrl('li.fi', txHash, Chain.Solana)
// → https://orb.helius.dev/tx/{txHash}

Vultisig.getSwapExplorerUrl('thorchain', '0xABC...', Chain.Bitcoin)
// → https://runescan.io/tx/ABC...   (0x stripped)
```

## Provider coverage

| Provider   | fromChain   | URL                                            | Test |
| ---------- | ----------- | ---------------------------------------------- | ---- |
| `li.fi`    | EVM         | `https://scan.li.fi/tx/{txHash}`               | pass |
| `li.fi`    | `Solana`    | `https://orb.helius.dev/tx/{txHash}`           | pass |
| `thorchain`| any         | `https://runescan.io/tx/{stripped}`            | pass |
| `mayachain`| any         | `https://www.explorer.mayachain.info/tx/{stripped}` | pass |
| `1inch`    | any EVM     | source-chain explorer via `getBlockExplorerUrl`| pass |
| `kyber`    | any EVM     | source-chain explorer via `getBlockExplorerUrl`| pass |
| `swapkit`  | any         | source-chain explorer via `getBlockExplorerUrl`| pass |

`stripped` = `txHash.replace(/^0[xX]/, '')` — both THORChain and MayaChain serve uppercase hex without an `0x` prefix.

## API surface

```ts
// packages/core/chain/swap/utils/getSwapExplorerUrl/index.ts
export const swapExplorerProviders = ['1inch', 'kyber', 'li.fi', 'mayachain', 'swapkit', 'thorchain'] as const
export type SwapExplorerProvider = (typeof swapExplorerProviders)[number]

export type GetSwapExplorerUrlInput = {
  provider: SwapExplorerProvider
  txHash: string
  fromChain: Chain
}

export const getSwapExplorerUrl = (input: GetSwapExplorerUrlInput): string
```

Re-exported from `@vultisig/sdk` (`getSwapExplorerUrl`, `swapExplorerProviders`, `SwapExplorerProvider`, `GetSwapExplorerUrlInput`) and surfaced on the static `Vultisig` class as `Vultisig.getSwapExplorerUrl(provider, txHash, fromChain)`.

Updated `GeneralSwapQuote.ts` JSDoc to point consumers at this helper instead of building URLs by hand (per acceptance criteria).

## Acceptance criteria (from #426)

- [x] `getSwapExplorerUrl` helper + unit tests covering each provider × (EVM, Solana) matrix
- [x] Re-exported on `Vultisig` static class for parity with `getTxExplorerUrl`
- [x] No new deps; pure URL builder
- [x] Update `packages/core/chain/swap/general/GeneralSwapQuote.ts` JSDoc

## Tests

```
$ yarn test:core --run packages/core/chain/swap/utils/getSwapExplorerUrl
 Test Files  1 passed (1)
      Tests  11 passed (11)

$ yarn test:core
 Test Files  82 passed (82)
      Tests  728 passed (728)

$ yarn workspace @vultisig/sdk test
 Test Files  104 passed (104)
      Tests  1452 passed (1452)
```

Also: `yarn typecheck` exits 0, `yarn lint` on all touched files exits 0, `yarn format:check` clean.

## Related

- vultisig-windows tx history bug (separate issue) — will consume this
- vultisig-android tx history bug (separate issue) — Kotlin already has equivalent in `ExplorerLinkRepository.getSwapProgressLink`
- vultisig-ios reference: `ExplorerLinkBuilder.swift`
- vultiagent-app `TxStatusCard.tsx` (separate issue) — will consume this

🤖 Agent-generated — vultisig-ops

## receipts

Generated 2026-05-28 from an isolated worktree at PR head `31d66b4c` (`feat/get-swap-explorer-url-426`), `yarn install --frozen-lockfile`, vitest v4.1.6.

### Unit tests (11/11 pass)

```
$ yarn test:core --run packages/core/chain/swap/utils/getSwapExplorerUrl --reporter=verbose

 ✓ getSwapExplorerUrl > li.fi > uses scan.li.fi for EVM source chains and keeps the raw hash (incl. 0x)
 ✓ getSwapExplorerUrl > li.fi > routes Solana cross-chain settlement to Helius (LI.FI has no per-tx page)
 ✓ getSwapExplorerUrl > thorchain > strips a 0x prefix before composing the runescan URL
 ✓ getSwapExplorerUrl > thorchain > leaves a hash that has no 0x prefix unchanged
 ✓ getSwapExplorerUrl > thorchain > strips a capitalised 0X prefix the same way
 ✓ getSwapExplorerUrl > mayachain > strips a 0x prefix before composing the mayachain explorer URL
 ✓ getSwapExplorerUrl > mayachain > leaves a hash that has no 0x prefix unchanged
 ✓ getSwapExplorerUrl > aggregators without a per-tx scanner > 1inch falls back to the source-chain block explorer
 ✓ getSwapExplorerUrl > aggregators without a per-tx scanner > kyber falls back to the source-chain block explorer
 ✓ getSwapExplorerUrl > aggregators without a per-tx scanner > swapkit falls back to the source-chain block explorer
 ✓ getSwapExplorerUrl > exposes every provider via swapExplorerProviders

 Test Files  1 passed (1)
      Tests  11 passed (11)
```

### Actual helper output per provider

Captured by calling `getSwapExplorerUrl(...)` at runtime for each provider/chain combo and printing the returned string (throwaway harness, removed after capture — working tree stayed clean). The THORChain/MayaChain rows feed a real `0x`-prefixed uppercase hash to prove the strip path:

| Provider / chain | Input `txHash` | Returned URL |
| --- | --- | --- |
| `li.fi` + Ethereum (EVM) | `0x9f8c2b1a4d3e…92a3b4c` | `https://scan.li.fi/tx/0x9f8c2b1a4d3e…92a3b4c` |
| `li.fi` + Solana | `5sN4Gd1cYpkq…hPgRfNlEd` | `https://orb.helius.dev/tx/5sN4Gd1cYpkq…hPgRfNlEd` |
| `thorchain` + Bitcoin | `0xF1E2D3C4B5A6…192A3B4` | `https://runescan.io/tx/F1E2D3C4B5A6…192A3B4` (0x stripped) |
| `mayachain` + Dash | `0xF1E2D3C4B5A6…192A3B4` | `https://www.explorer.mayachain.info/tx/F1E2D3C4B5A6…192A3B4` (0x stripped) |
| `1inch` + Ethereum | `0x9f8c2b1a4d3e…92a3b4c` | `https://etherscan.io/tx/0x9f8c2b1a4d3e…92a3b4c` |
| `kyber` + Base | `0x9f8c2b1a4d3e…92a3b4c` | `https://basescan.org/tx/0x9f8c2b1a4d3e…92a3b4c` |
| `swapkit` + Solana | `5sN4Gd1cYpkq…hPgRfNlEd` | `https://solscan.io/tx/5sN4Gd1cYpkq…hPgRfNlEd` |

Raw harness stdout:

```
RECEIPT | li.fi + Ethereum (EVM)
RECEIPT |   input.txHash = 0x9f8c2b1a4d3e5f6a7b8c9d0e1f2a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c
RECEIPT |   returned     = https://scan.li.fi/tx/0x9f8c2b1a4d3e5f6a7b8c9d0e1f2a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c
RECEIPT | li.fi + Solana
RECEIPT |   input.txHash = 5sN4Gd1cYpkqXf9PJ2vk3aHe8mLZbT9rsQwYjVtNcXkA6zBeLgFmHqWdYbCnRsVtUxKpJ8MzTwQhPgRfNlEd
RECEIPT |   returned     = https://orb.helius.dev/tx/5sN4Gd1cYpkqXf9PJ2vk3aHe8mLZbT9rsQwYjVtNcXkA6zBeLgFmHqWdYbCnRsVtUxKpJ8MzTwQhPgRfNlEd
RECEIPT | thorchain + Bitcoin (0x-prefixed input → stripped)
RECEIPT |   input.txHash = 0xF1E2D3C4B5A6978869DECABFE1F2A3B4C5D6E7F8091A2B3C4D5E6F708192A3B4
RECEIPT |   returned     = https://runescan.io/tx/F1E2D3C4B5A6978869DECABFE1F2A3B4C5D6E7F8091A2B3C4D5E6F708192A3B4
RECEIPT | mayachain + Dash (0x-prefixed input → stripped)
RECEIPT |   input.txHash = 0xF1E2D3C4B5A6978869DECABFE1F2A3B4C5D6E7F8091A2B3C4D5E6F708192A3B4
RECEIPT |   returned     = https://www.explorer.mayachain.info/tx/F1E2D3C4B5A6978869DECABFE1F2A3B4C5D6E7F8091A2B3C4D5E6F708192A3B4
RECEIPT | 1inch + Ethereum
RECEIPT |   input.txHash = 0x9f8c2b1a4d3e5f6a7b8c9d0e1f2a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c
RECEIPT |   returned     = https://etherscan.io/tx/0x9f8c2b1a4d3e5f6a7b8c9d0e1f2a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c
RECEIPT | kyber + Base
RECEIPT |   input.txHash = 0x9f8c2b1a4d3e5f6a7b8c9d0e1f2a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c
RECEIPT |   returned     = https://basescan.org/tx/0x9f8c2b1a4d3e5f6a7b8c9d0e1f2a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c
RECEIPT | swapkit + Solana
RECEIPT |   input.txHash = 5sN4Gd1cYpkqXf9PJ2vk3aHe8mLZbT9rsQwYjVtNcXkA6zBeLgFmHqWdYbCnRsVtUxKpJ8MzTwQhPgRfNlEd
RECEIPT |   returned     = https://solscan.io/tx/5sN4Gd1cYpkqXf9PJ2vk3aHe8mLZbT9rsQwYjVtNcXkA6zBeLgFmHqWdYbCnRsVtUxKpJ8MzTwQhPgRfNlEd
```

### Explorer domains live

`curl -sI` (HEAD) against each base domain the helper composes URLs for. The four swap-specific scanners this PR introduces all resolve:

```
200  https://scan.li.fi/                      # li.fi EVM
308  https://orb.helius.dev/                  # li.fi Solana settlement (redirect → app)
200  https://runescan.io/                     # thorchain
200  https://www.explorer.mayachain.info/     # mayachain
200  https://basescan.org/                    # kyber fallback (Base)
000  https://etherscan.io/                    # 1inch fallback — anti-bot edge drops HEAD/GET; domain is live in-browser
403  https://solscan.io/                      # swapkit fallback — Cloudflare 403 on non-browser; domain is live in-browser
```

`etherscan.io` and `solscan.io` are long-standing, widely-used explorers; the `000`/`403` are their anti-bot edge protection rejecting a non-browser client (HEAD and GET both blocked even with a browser UA), not dead domains. The new swap-routing surface — scan.li.fi, orb.helius.dev, runescan.io, explorer.mayachain.info — all return 2xx/3xx.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generate canonical “View on Explorer” links for swap transactions, routing to provider-specific explorers (LI.FI with Solana settlement support, THORChain, MayaChain) and falling back to source-chain explorers for some aggregators.
  * Exposed helper via the SDK and as a static convenience method for easy use.

* **Tests**
  * Added test coverage validating provider-specific URL behavior and fallbacks.

* **Documentation**
  * Updated inline documentation to recommend using the new helper for swap transaction links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/585?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->