### PR TITLE
Fixing base64 parsing issue

### DIFF
--- a/packages/sdk/src/utils/parseKeygenQR.ts
+++ b/packages/sdk/src/utils/parseKeygenQR.ts
@@ -133,8 +133,12 @@ export async function parseKeygenQR(qrPayload: string): Promise<ParsedKeygenQR> 
     throw new Error('Invalid QR payload: missing jsonData parameter')
   }
 
+  // URLSearchParams decodes '+' as space per application/x-www-form-urlencoded spec.
+  // Base64 data legitimately contains '+' characters, so restore them.
+  const base64Safe = jsonData.replace(/ /g, '+')
+
   // URL decode and decompress
-  const decodedData = decodeURIComponent(jsonData)
+  const decodedData = decodeURIComponent(base64Safe)
   const binaryData = await decompressData(decodedData)
 
   // Parse protobuf

--- a/packages/sdk/tests/unit/utils/parseKeygenQR.base64Encoding.test.ts
+++ b/packages/sdk/tests/unit/utils/parseKeygenQR.base64Encoding.test.ts
@@ -22,7 +22,6 @@ const validKeygenBinary = toBinary(
 
 // Track what base64 data was written to the mock FS
 let writtenBase64: string | null = null
-let callMainCalled = false
 
 const mockSevenZip = {
   FS: {
@@ -37,10 +36,7 @@ const mockSevenZip = {
     }),
     unlink: vi.fn(),
   },
-  callMain: vi.fn(() => {
-    callMainCalled = true
-    return 0
-  }),
+  callMain: vi.fn(() => 0),
 }
 
 vi.mock('@vultisig/core-mpc/compression/getSevenZip', () => ({
@@ -50,7 +46,6 @@ vi.mock('@vultisig/core-mpc/compression/getSevenZip', () => ({
 describe('parseKeygenQR — base64 encoding with + characters', () => {
   beforeEach(() => {
     writtenBase64 = null
-    callMainCalled = false
     vi.clearAllMocks()
   })
 

--- a/packages/sdk/tests/unit/utils/parseKeygenQR.base64Encoding.test.ts
+++ b/packages/sdk/tests/unit/utils/parseKeygenQR.base64Encoding.test.ts
@@ -1,0 +1,104 @@
+import { create, toBinary } from '@bufbuild/protobuf'
+import { KeygenMessageSchema } from '@vultisig/core-mpc/types/vultisig/keygen/v1/keygen_message_pb'
+import { LibType } from '@vultisig/core-mpc/types/vultisig/keygen/v1/lib_type_message_pb'
+import { describe, expect, it, vi } from 'vitest'
+
+import { parseKeygenQR } from '../../../src/utils/parseKeygenQR'
+
+/** Minimal valid KeygenMessage; decompress is mocked to return this payload. */
+const validKeygenBinary = toBinary(
+  KeygenMessageSchema,
+  create(KeygenMessageSchema, {
+    sessionId: 'sess-encoding-test',
+    hexChainCode: 'cc'.repeat(32),
+    serviceName: 'initiator-party',
+    encryptionKeyHex: 'ee'.repeat(32),
+    useVultisigRelay: true,
+    vaultName: 'Encoding Test Vault',
+    libType: LibType.DKLS,
+    chains: [],
+  })
+)
+
+// Track what base64 data was written to the mock FS
+let writtenBase64: string | null = null
+let callMainCalled = false
+
+const mockSevenZip = {
+  FS: {
+    writeFile: vi.fn((filename: string, data: Uint8Array) => {
+      writtenBase64 = Buffer.from(data).toString()
+    }),
+    readFile: vi.fn((filename: string) => {
+      if (filename === 'data.bin' || filename === 'compressed') {
+        return validKeygenBinary
+      }
+      throw new Error(`unexpected read: ${filename}`)
+    }),
+    unlink: vi.fn(),
+  },
+  callMain: vi.fn(() => {
+    callMainCalled = true
+    return 0
+  }),
+}
+
+vi.mock('@vultisig/core-mpc/compression/getSevenZip', () => ({
+  getSevenZip: vi.fn(async () => mockSevenZip),
+}))
+
+describe('parseKeygenQR — base64 encoding with + characters', () => {
+  beforeEach(() => {
+    writtenBase64 = null
+    callMainCalled = false
+    vi.clearAllMocks()
+  })
+
+  it('handles jsonData with raw + signs (not URL-encoded)', async () => {
+    // Base64 data that contains + characters: "hello+world/=="
+    // When placed in a URL query param without encoding, URLSearchParams
+    // will decode + as space, corrupting the base64.
+    const base64WithPlus = 'aGVsbG8rd29ybGQv'
+    const qrPayload = `vultisig://?type=NewVault&tssType=Keygen&jsonData=${base64WithPlus}`
+
+    await parseKeygenQR(qrPayload)
+
+    // The fix should restore + from space before calling decompressData
+    // Verify the mock FS received correct base64 (with + intact)
+    expect(writtenBase64).toBe('hello+world/')
+  })
+
+  it('handles jsonData with URL-encoded + signs (%2B)', async () => {
+    // Properly URL-encoded: + becomes %2B
+    const base64Encoded = 'aGVsbG8lMkJ3b3JsZC8%3D'
+    const qrPayload = `vultisig://?type=NewVault&tssType=Keygen&jsonData=${base64Encoded}`
+
+    await parseKeygenQR(qrPayload)
+
+    // decodeURIComponent(%2B) → +, so FS should get correct base64
+    expect(writtenBase64).toBe('hello+world/=')
+  })
+
+  it('handles jsonData with both + and / characters (standard base64)', async () => {
+    // Standard base64 often has both + and / chars
+    // "abc+def/ghi=" → base64 "YWJjK2RlZi9naGk="
+    const base64Standard = 'YWJjK2RlZi9naGk%3D'
+    const qrPayload = `vultisig://?type=NewVault&tssType=Keygen&jsonData=${base64Standard}`
+
+    await parseKeygenQR(qrPayload)
+
+    // Verify the correct base64 reaches the decompressor
+    expect(writtenBase64).toBe('abc+def/ghi=')
+  })
+
+  it('still parses core protobuf fields when + encoding is used', async () => {
+    const base64Simple = 'YWFh' // base64 of "aaa" (no + chars)
+    const qrPayload = `vultisig://?type=NewVault&tssType=Keygen&jsonData=${base64Simple}`
+
+    const parsed = await parseKeygenQR(qrPayload)
+
+    expect(parsed.sessionId).toBe('sess-encoding-test')
+    expect(parsed.libType).toBe('DKLS')
+    expect(parsed.vaultName).toBe('Encoding Test Vault')
+  })
+})

--- a/packages/sdk/tests/unit/utils/parseKeygenQR.base64Encoding.test.ts
+++ b/packages/sdk/tests/unit/utils/parseKeygenQR.base64Encoding.test.ts
@@ -55,40 +55,42 @@ describe('parseKeygenQR — base64 encoding with + characters', () => {
   })
 
   it('handles jsonData with raw + signs (not URL-encoded)', async () => {
-    // Base64 data that contains + characters: "hello+world/=="
-    // When placed in a URL query param without encoding, URLSearchParams
-    // will decode + as space, corrupting the base64.
-    const base64WithPlus = 'aGVsbG8rd29ybGQv'
+    // 'ICA+' is a base64 string that literally contains '+'.
+    // URLSearchParams decodes '+' as space per the form-urlencoded spec,
+    // so placing this raw in the query string produces 'ICA ' (corrupted).
+    // The fix must restore the space back to '+' before decoding.
+    const base64WithPlus = 'ICA+'
     const qrPayload = `vultisig://?type=NewVault&tssType=Keygen&jsonData=${base64WithPlus}`
 
     await parseKeygenQR(qrPayload)
 
-    // The fix should restore + from space before calling decompressData
-    // Verify the mock FS received correct base64 (with + intact)
-    expect(writtenBase64).toBe('hello+world/')
+    // Buffer.from('ICA+', 'base64') decodes to bytes [32, 32, 62] -> '  >'
+    // If the fix is absent, writtenBase64 would be '  ' (only 2 bytes from 'ICA ')
+    expect(writtenBase64).toBe('  >')
   })
 
-  it('handles jsonData with URL-encoded + signs (%2B)', async () => {
-    // Properly URL-encoded: + becomes %2B
-    const base64Encoded = 'aGVsbG8lMkJ3b3JsZC8%3D'
+  it('handles jsonData with URL-encoded = signs (%3D)', async () => {
+    // base64 of 'hello+world/=' with padding encoded as %3D
+    // URLSearchParams decodes %3D back to =, no + corruption in this path
+    const base64Encoded = 'aGVsbG8rd29ybGQvPQ%3D%3D'
     const qrPayload = `vultisig://?type=NewVault&tssType=Keygen&jsonData=${base64Encoded}`
 
     await parseKeygenQR(qrPayload)
 
-    // decodeURIComponent(%2B) → +, so FS should get correct base64
+    // Buffer.from('aGVsbG8rd29ybGQvPQ==', 'base64') = 'hello+world/='
     expect(writtenBase64).toBe('hello+world/=')
   })
 
   it('handles jsonData with both + and / characters (standard base64)', async () => {
     // Standard base64 often has both + and / chars
-    // "abc+def/ghi=" → base64 "YWJjK2RlZi9naGk="
+    // 'YWJjK2RlZi9naGk=' is base64 for 'abc+def/ghi' (no trailing =)
     const base64Standard = 'YWJjK2RlZi9naGk%3D'
     const qrPayload = `vultisig://?type=NewVault&tssType=Keygen&jsonData=${base64Standard}`
 
     await parseKeygenQR(qrPayload)
 
-    // Verify the correct base64 reaches the decompressor
-    expect(writtenBase64).toBe('abc+def/ghi=')
+    // Buffer.from('YWJjK2RlZi9naGk=', 'base64') = 'abc+def/ghi'
+    expect(writtenBase64).toBe('abc+def/ghi')
   })
 
   it('still parses core protobuf fields when + encoding is used', async () => {


### PR DESCRIPTION
## Description

Fixes the QR code + / space encoding mismatch between CLI and desktop/mobile vault creation. When a SecureVault QR payload contains + characters in its base64-encoded jsonData query parameter, URLSearchParams decodes them as spaces per the URL spec, corrupting the XZ-compressed protobuf data before decompression. The decompression then fails with "Data Error: compressed" / "premature EOF".

This affects CLI-to-CLI vault joining and CLI-to-desktop-app vault joining. Phone apps likely side-step this because they use a different parsing path.

**Root cause:**

In parseKeygenQR():

```javascript
const params = new URLSearchParams(urlParts[1])
const jsonData = params.get('jsonData')
```

Standard base64 uses + as a valid character. URLSearchParams.get() decodes + as space. The subsequent decodeURIComponent() only handles %XX and does not restore +. The corrupted base64 decodes to wrong binary data, and 7z WASM fails.

Conversely, when + is properly URL-encoded as %2B, the round-trip works: URLSearchParams preserves %2B, then decodeURIComponent converts to +. The root problem is that the QR payload generator emits raw + characters without URL-encoding them.

**What was changed:**

packages/sdk/src/utils/parseKeygenQR.ts — Added one line after extracting jsonData:

```javascript
const base64Safe = jsonData.replace(/ /g, '+')
```


This is safe because spaces are never valid in base64, so any space after URL parsing must have been a + sign that was incorrectly decoded.

Both raw + and URL-encoded %2B inputs now produce the correct decoded base64.

**Test file added:**
packages/sdk/tests/unit/utils/parseKeygenQR.base64Encoding.test.ts

**Which feature affected:**
- [X] Create vault (Secure / Fast)

**Checklist:**
- [X] Self-review of code
- [X] Commented hard-to-understand areas
- [X] No new warnings
- [X] Tests added

**Additional context:**
The fix was discovered by tracing a failing vultisig join secure command. URL-encoding + as %2B in the QR payload allowed the join to succeed, confirming the root cause. A secondary approach would be to URL-encode the jsonData at generation time, but the parse-time fix was chosen because it's defensive (handles both encoded and un-encoded payloads).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed QR parsing so base64 payloads preserve "+" characters (preventing corruption during decoding), restoring reliable decompression and data integrity.

* **Tests**
  * Added unit tests covering QR base64 decoding scenarios, including inputs with raw "+" characters and URL-encoded padding, to ensure correct handling of edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->