### PR TITLE
Fix SwapKit BTC PSBT keysign payloads

### DIFF
--- a/.changeset/gold-btc-psbt.md
+++ b/.changeset/gold-btc-psbt.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/core-mpc': patch
+---
+
+Request built SwapKit Bitcoin transfer transactions and route PSBT payloads through the SignBitcoin hashing and compilation path.

--- a/.changeset/gold-btc-psbt.md
+++ b/.changeset/gold-btc-psbt.md
@@ -3,4 +3,4 @@
 '@vultisig/core-mpc': patch
 ---
 
-Request built SwapKit Bitcoin transfer transactions and route PSBT payloads through the SignBitcoin hashing and compilation path.
+Enable pre-built SwapKit Bitcoin PSBT transactions and route payloads through the SignBitcoin hashing and compilation path.

--- a/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.test.ts
+++ b/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.test.ts
@@ -21,7 +21,6 @@ const textEncoder = new TextEncoder()
 type TransferSourceFixture = readonly [string, SwapKitSourceChain, string, number, string, string]
 
 const transferSourceFixtures: TransferSourceFixture[] = [
-  ['Bitcoin', Chain.Bitcoin, 'BTC', 8, 'bc1qsource', 'bc1qdeposit'],
   ['Litecoin', Chain.Litecoin, 'LTC', 8, 'ltc1qsource', 'Ldeposit'],
   ['Dogecoin', Chain.Dogecoin, 'DOGE', 8, 'Dsource', 'Ddeposit'],
   ['Bitcoin Cash', Chain.BitcoinCash, 'BCH', 8, 'bitcoincash:qsource', 'bitcoincash:qdeposit'],
@@ -257,35 +256,34 @@ describe('getSwapKitQuote', () => {
   })
 
   it('maps SwapKit transfer tx metadata into QR payload fields', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi
-        .fn()
-        .mockResolvedValueOnce(
-          response({
-            routes: [
-              {
-                routeId: 'psbt-route',
-                providers: ['CHAINFLIP'],
-                expectedBuyAmount: '0.01',
-              },
-            ],
-          })
-        )
-        .mockResolvedValueOnce(
-          response({
-            expectedBuyAmount: '0.009',
-            providers: ['CHAINFLIP'],
-            targetAddress: 'bc1qdeposit',
-            inboundAddress: 'bc1qinbound',
-            tx: 'cHNidA==',
-            meta: {
-              txType: 'PSBT',
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        response({
+          routes: [
+            {
+              routeId: 'psbt-route',
+              providers: ['CHAINFLIP'],
+              expectedBuyAmount: '0.01',
             },
-            swapId: 'swapkit-id',
-          })
-        )
-    )
+          ],
+        })
+      )
+      .mockResolvedValueOnce(
+        response({
+          expectedBuyAmount: '0.009',
+          providers: ['CHAINFLIP'],
+          targetAddress: 'bc1qdeposit',
+          inboundAddress: 'bc1qinbound',
+          tx: 'cHNidA==',
+          meta: {
+            txType: 'PSBT',
+          },
+          swapId: 'swapkit-id',
+        })
+      )
+
+    vi.stubGlobal('fetch', fetchMock)
     configureSwapKit({ apiKey: undefined })
 
     const quote = await getSwapKitQuote({
@@ -304,6 +302,13 @@ describe('getSwapKitQuote', () => {
       amount: 100_000n,
     })
 
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toMatchObject({
+      routeId: 'psbt-route',
+      sourceAddress: 'bc1qsource',
+      destinationAddress: '0xdestination',
+      disableBalanceCheck: true,
+    })
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body).disableBuildTx).toBeUndefined()
     expect(quote.tx).toEqual({
       transfer: {
         to: 'bc1qdeposit',

--- a/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.ts
+++ b/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.ts
@@ -683,7 +683,7 @@ export const getSwapKitQuote = async ({
       sourceAddress: from.address,
       destinationAddress: to.address,
       disableBalanceCheck: true,
-      disableBuildTx: shouldUseTransferTx(from.chain) ? true : undefined,
+      disableBuildTx: shouldUseTransferTx(from.chain) && from.chain !== Chain.Bitcoin ? true : undefined,
     })
   )
 

--- a/packages/core/mpc/keysign/swap/build.transfer.test.ts
+++ b/packages/core/mpc/keysign/swap/build.transfer.test.ts
@@ -1,7 +1,9 @@
+import { Buffer } from 'buffer'
 import { create, fromBinary, toBinary } from '@bufbuild/protobuf'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { SwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
 import { KeysignPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { networks, payments, Psbt } from 'bitcoinjs-lib'
 import { describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
@@ -39,8 +41,30 @@ const publicKey = {
   data: () => new Uint8Array([1, 2, 3]),
 } as never
 
+const TEST_PUBKEY = Buffer.from('0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798', 'hex')
+
+const makeBitcoinPsbtFixture = () => {
+  const p2wpkh = payments.p2wpkh({ pubkey: TEST_PUBKEY, network: networks.bitcoin })
+  const psbt = new Psbt({ network: networks.bitcoin })
+
+  psbt.addInput({
+    hash: 'aa'.repeat(32),
+    index: 0,
+    witnessUtxo: { script: Buffer.from(p2wpkh.output!), value: 100_000n },
+  })
+  psbt.addOutput({
+    address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+    value: 90_000n,
+  })
+
+  return {
+    address: p2wpkh.address!,
+    payload: psbt.toBuffer(),
+  }
+}
+
 describe('buildSwapKeysignPayload transfer routes', () => {
-  it('builds swapkitSwapPayload for UTXO source (Chainflip, no memo)', async () => {
+  it('rejects Bitcoin SwapKit transfer routes without PSBT data', async () => {
     mocks.getChainSpecific.mockResolvedValueOnce({
       case: 'utxoSpecific',
       value: { byteFee: '10', sendMaxAmount: false },
@@ -63,10 +87,62 @@ describe('buildSwapKeysignPayload transfer routes', () => {
       },
     }
 
+    await expect(
+      buildSwapKeysignPayload({
+        fromCoin: {
+          chain: Chain.Bitcoin,
+          address: 'bc1qsource',
+          ticker: 'BTC',
+          decimals: 8,
+        },
+        toCoin: {
+          chain: Chain.Ethereum,
+          address: '0xdestination',
+          ticker: 'ETH',
+          decimals: 18,
+        },
+        amount: 0.006,
+        swapQuote,
+        vaultId: 'vault-id',
+        localPartyId: 'local-party',
+        fromPublicKey: publicKey,
+        toPublicKey: publicKey,
+        libType: 'DKLS',
+        walletCore: {} as never,
+      })
+    ).rejects.toThrow('SwapKit Bitcoin transfer routes must include PSBT txType and txPayload.')
+  })
+
+  it('builds SwapKit Bitcoin PSBT payload and SignBitcoin data', async () => {
+    mocks.getChainSpecific.mockResolvedValueOnce({
+      case: 'utxoSpecific',
+      value: { byteFee: '10', sendMaxAmount: false },
+    })
+    const psbt = makeBitcoinPsbtFixture()
+
+    const swapQuote: SwapQuote = {
+      discounts: [],
+      quote: {
+        general: {
+          dstAmount: '1800000000000000000',
+          provider: 'swapkit',
+          routeProvider: 'CHAINFLIP',
+          tx: {
+            transfer: {
+              to: 'bc1qchainflipdeposit',
+              amount: 600_000n,
+              txType: 'PSBT',
+              txPayload: psbt.payload,
+            },
+          },
+        },
+      },
+    }
+
     const payload = await buildSwapKeysignPayload({
       fromCoin: {
         chain: Chain.Bitcoin,
-        address: 'bc1qsource',
+        address: psbt.address,
         ticker: 'BTC',
         decimals: 8,
       },
@@ -94,7 +170,14 @@ describe('buildSwapKeysignPayload transfer routes', () => {
       expect(payload.swapPayload.value.fromAmount).toBe('600000')
       expect(payload.swapPayload.value.targetAddress).toBe('bc1qchainflipdeposit')
       expect(payload.swapPayload.value.subProvider).toBe('CHAINFLIP')
-      expect(payload.swapPayload.value.txPayload).toEqual(new Uint8Array())
+      expect(payload.swapPayload.value.txType).toBe('PSBT')
+      expect(payload.swapPayload.value.txPayload).toEqual(psbt.payload)
+    }
+    expect(payload.signData.case).toBe('signBitcoin')
+    if (payload.signData.case === 'signBitcoin') {
+      expect(payload.signData.value.inputs).toHaveLength(1)
+      expect(payload.signData.value.outputs).toHaveLength(1)
+      expect(payload.signData.value.inputs[0].isOurs).toBe(true)
     }
 
     const roundtrip = fromBinary(

--- a/packages/core/mpc/keysign/swap/build.ts
+++ b/packages/core/mpc/keysign/swap/build.ts
@@ -1,7 +1,9 @@
 import { Buffer } from 'buffer'
 import { create } from '@bufbuild/protobuf'
+import { buildSignBitcoinFromPsbt } from '@vultisig/core-chain/chains/utxo/tx/buildSignBitcoinFromPsbt'
 import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
 import { toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'
+import { Chain } from '@vultisig/core-chain/Chain'
 import { isChainOfKind } from '@vultisig/core-chain/ChainKind'
 import { getErc20Allowance } from '@vultisig/core-chain/chains/evm/erc20/getErc20Allowance'
 import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
@@ -30,6 +32,7 @@ import { SwapKitSwapPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keys
 import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
 import { WalletCore } from '@trustwallet/wallet-core'
 import { PublicKey } from '@trustwallet/wallet-core/dist/src/wallet-core'
+import { Psbt } from 'bitcoinjs-lib'
 
 export type BuildSwapKeysignPayloadInput = {
   fromCoin: AccountCoin
@@ -45,6 +48,31 @@ export type BuildSwapKeysignPayloadInput = {
 }
 
 type TransferSwapTx = Extract<GeneralSwapTx, { transfer: unknown }>['transfer']
+
+const isSwapKitBitcoinPsbt = (fromCoin: AccountCoin, transfer: TransferSwapTx) =>
+  fromCoin.chain === Chain.Bitcoin && transfer.txType?.toUpperCase() === 'PSBT'
+
+const getSwapKitBitcoinSignData = (fromCoin: AccountCoin, transfer: TransferSwapTx): KeysignPayload['signData'] => {
+  if (fromCoin.chain !== Chain.Bitcoin) {
+    return { case: undefined }
+  }
+
+  if (!isSwapKitBitcoinPsbt(fromCoin, transfer)) {
+    throw new Error('SwapKit Bitcoin transfer routes must include PSBT txType and txPayload.')
+  }
+
+  if (!transfer.txPayload?.length) {
+    throw new Error('SwapKit Bitcoin PSBT payload is empty.')
+  }
+
+  return {
+    case: 'signBitcoin',
+    value: buildSignBitcoinFromPsbt({
+      psbt: Psbt.fromBuffer(Buffer.from(transfer.txPayload)),
+      senderAddress: fromCoin.address,
+    }),
+  }
+}
 
 /**
  * Builds a KeysignPayload for a swap transaction.
@@ -124,6 +152,8 @@ export const buildSwapKeysignPayload = async ({
       })
 
       if (quote.provider === 'swapkit' && transfer) {
+        keysignPayload.signData = getSwapKitBitcoinSignData(fromCoin, transfer)
+
         return {
           case: 'swapkitSwapPayload',
           value: create(SwapKitSwapPayloadSchema, {

--- a/packages/core/mpc/package.json
+++ b/packages/core/mpc/package.json
@@ -797,6 +797,11 @@
       "import": "./dist/tx/signature/generateSignature.js",
       "default": "./dist/tx/signature/generateSignature.js"
     },
+    "./tx/swapkitSignBitcoin": {
+      "types": "./dist/tx/swapkitSignBitcoin.d.ts",
+      "import": "./dist/tx/swapkitSignBitcoin.js",
+      "default": "./dist/tx/swapkitSignBitcoin.js"
+    },
     "./types/plugin/constraint_pb": {
       "types": "./dist/types/plugin/constraint_pb.d.ts",
       "import": "./dist/types/plugin/constraint_pb.js",

--- a/packages/core/mpc/tx/compile/compileSignBitcoinTx.test.ts
+++ b/packages/core/mpc/tx/compile/compileSignBitcoinTx.test.ts
@@ -14,6 +14,7 @@
  * expects from MPC (`KeysignSignature.der_signature`).
  */
 import { Buffer } from 'buffer'
+import { create } from '@bufbuild/protobuf'
 import { describe, expect, it, beforeAll } from 'vitest'
 import { Psbt, payments, networks } from 'bitcoinjs-lib'
 import * as ecc from 'tiny-secp256k1'
@@ -25,6 +26,11 @@ import { getTwPublicKeyType } from '@vultisig/core-chain/publicKey/tw/getTwPubli
 
 import { encodeDERSignature } from '../../derSignature'
 import { computePreSigningHashes } from '../../keysign/signingInputs/resolvers/bitcoin/sighash'
+import { CoinSchema } from '../../types/vultisig/keysign/v1/coin_pb'
+import { KeysignPayloadSchema } from '../../types/vultisig/keysign/v1/keysign_message_pb'
+import { SwapKitSwapPayloadSchema } from '../../types/vultisig/keysign/v1/swapkit_swap_payload_pb'
+import { getPreSigningHashes } from '../preSigningHashes'
+import { compileTx } from './compileTx'
 import { compileSignBitcoinTx } from './compileSignBitcoinTx'
 
 const TEST_PUBKEY = Buffer.from('0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798', 'hex')
@@ -105,5 +111,118 @@ describe('compileSignBitcoinTx', () => {
 
     expect(compiledRaw.toString('hex')).toBe(EXPECTED_BITCOINJS_RAW_TX)
     expect(compiledRaw.equals(expected)).toBe(true)
+  })
+
+  it('routes SwapKit PSBT payloads through the SignBitcoin hash and compile path', () => {
+    const privKey = new Uint8Array(32)
+    privKey[31] = 1
+
+    const p2wpkh = payments.p2wpkh({ pubkey: TEST_PUBKEY, network: networks.bitcoin })
+    const psbt = new Psbt({ network: networks.bitcoin })
+    psbt.addInput({
+      hash: 'aa'.repeat(32),
+      index: 0,
+      witnessUtxo: { script: Buffer.from(p2wpkh.output!), value: 100000n },
+    })
+    psbt.addOutput({
+      address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+      value: 90000n,
+    })
+
+    const keysignPayload = create(KeysignPayloadSchema, {
+      coin: create(CoinSchema, {
+        chain: Chain.Bitcoin,
+        ticker: 'BTC',
+        address: p2wpkh.address!,
+        decimals: 8,
+      }),
+      swapPayload: {
+        case: 'swapkitSwapPayload',
+        value: create(SwapKitSwapPayloadSchema, {
+          txType: 'PSBT',
+          txPayload: psbt.toBuffer(),
+        }),
+      },
+    })
+
+    const [hash] = getPreSigningHashes({
+      walletCore,
+      chain: Chain.Bitcoin,
+      txInputData: new Uint8Array(),
+      keysignPayload,
+    })
+    const hashHex = Buffer.from(hash).toString('hex')
+    const compact = ecc.sign(hash, privKey)
+    const der = encodeDERSignature(compact.subarray(0, 32), compact.subarray(32, 64))
+
+    const twPublicKey = walletCore.PublicKey.createWithData(
+      new Uint8Array(TEST_PUBKEY),
+      getTwPublicKeyType({ walletCore, chain: Chain.Bitcoin })
+    )
+
+    const compiled = compileTx({
+      publicKey: twPublicKey,
+      txInputData: new Uint8Array(),
+      signatures: {
+        [hashHex]: {
+          msg: '',
+          r: '',
+          s: '',
+          der_signature: Buffer.from(der).toString('hex'),
+        },
+      },
+      chain: Chain.Bitcoin,
+      walletCore,
+      keysignPayload,
+    })
+
+    const decoded = TW.Bitcoin.Proto.SigningOutput.decode(compiled)
+
+    expect(Buffer.from(decoded.encoded).toString('hex')).toBe(EXPECTED_BITCOINJS_RAW_TX)
+  })
+
+  it('returns SwapKit PSBT hashes sorted to match iOS co-signing', () => {
+    const p2wpkh = payments.p2wpkh({ pubkey: TEST_PUBKEY, network: networks.bitcoin })
+    const psbt = new Psbt({ network: networks.bitcoin })
+    psbt.addInput({
+      hash: 'aa'.repeat(32),
+      index: 0,
+      witnessUtxo: { script: Buffer.from(p2wpkh.output!), value: 100000n },
+    })
+    psbt.addInput({
+      hash: 'bb'.repeat(32),
+      index: 1,
+      witnessUtxo: { script: Buffer.from(p2wpkh.output!), value: 200000n },
+    })
+    psbt.addOutput({
+      address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+      value: 250000n,
+    })
+
+    const keysignPayload = create(KeysignPayloadSchema, {
+      coin: create(CoinSchema, {
+        chain: Chain.Bitcoin,
+        ticker: 'BTC',
+        address: p2wpkh.address!,
+        decimals: 8,
+      }),
+      swapPayload: {
+        case: 'swapkitSwapPayload',
+        value: create(SwapKitSwapPayloadSchema, {
+          txType: 'PSBT',
+          txPayload: psbt.toBuffer(),
+        }),
+      },
+    })
+
+    const hashes = getPreSigningHashes({
+      walletCore,
+      chain: Chain.Bitcoin,
+      txInputData: new Uint8Array(),
+      keysignPayload,
+    }).map(hash => Buffer.from(hash).toString('hex'))
+
+    expect(hashes).toHaveLength(2)
+    expect(hashes).toEqual([...hashes].sort())
   })
 })

--- a/packages/core/mpc/tx/compile/compileTx.ts
+++ b/packages/core/mpc/tx/compile/compileTx.ts
@@ -18,6 +18,7 @@ import { decodeBittensorTxInput } from '../../keysign/signingInputs/resolvers/bi
 import { KeysignPayload, KeysignPayloadSchema } from '../../types/vultisig/keysign/v1/keysign_message_pb'
 import { getPreSigningHashes } from '../preSigningHashes'
 import { generateSignature } from '../signature/generateSignature'
+import { getSwapKitSignBitcoin } from '../swapkitSignBitcoin'
 import { compileSignBitcoinTx } from './compileSignBitcoinTx'
 
 type Input = {
@@ -37,12 +38,14 @@ export const compileTx = ({
   walletCore,
   keysignPayload,
 }: Input) => {
+  const signBitcoin = keysignPayload ? getSwapKitSignBitcoin(keysignPayload) : undefined
+
   // PSBT signing: build raw signed tx from SignBitcoin fields + MPC signatures
-  if (keysignPayload?.signData.case === 'signBitcoin') {
+  if (signBitcoin) {
     if (!publicKey) {
       throw new Error('publicKey is required for SignBitcoin compilation')
     }
-    return compileSignBitcoinTx(keysignPayload.signData.value, keysignSignatures, publicKey)
+    return compileSignBitcoinTx(signBitcoin, keysignSignatures, publicKey)
   }
 
   if (chain === Chain.QBTC) {

--- a/packages/core/mpc/tx/preSigningHashes/index.ts
+++ b/packages/core/mpc/tx/preSigningHashes/index.ts
@@ -10,6 +10,7 @@ import { WalletCore } from '@trustwallet/wallet-core'
 import { getBlockchainSpecificValue } from '../../keysign/chainSpecific/KeysignChainSpecific'
 import { getPreSigningOutput } from '../../keysign/preSigningOutput'
 import { KeysignPayload, KeysignPayloadSchema } from '../../types/vultisig/keysign/v1/keysign_message_pb'
+import { getSwapKitSignBitcoin } from '../swapkitSignBitcoin'
 
 type Input = {
   walletCore: WalletCore
@@ -18,10 +19,15 @@ type Input = {
   keysignPayload?: KeysignPayload
 }
 
+const sortHashes = (hashes: Uint8Array[]): Uint8Array[] =>
+  [...hashes].sort((one, another) => Buffer.from(one).compare(Buffer.from(another)))
+
 export const getPreSigningHashes = ({ walletCore, txInputData, chain, keysignPayload }: Input) => {
+  const signBitcoin = keysignPayload ? getSwapKitSignBitcoin(keysignPayload) : undefined
+
   // PSBT signing: compute BIP-143 sighashes directly from structured data
-  if (keysignPayload?.signData.case === 'signBitcoin') {
-    return computePreSigningHashes(keysignPayload.signData.value)
+  if (signBitcoin) {
+    return sortHashes(computePreSigningHashes(signBitcoin))
   }
 
   if (chain === Chain.QBTC) {

--- a/packages/core/mpc/tx/swapkitSignBitcoin.ts
+++ b/packages/core/mpc/tx/swapkitSignBitcoin.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { buildSignBitcoinFromPsbt } from '@vultisig/core-chain/chains/utxo/tx/buildSignBitcoinFromPsbt'
 import { Psbt } from 'bitcoinjs-lib'

--- a/packages/core/mpc/tx/swapkitSignBitcoin.ts
+++ b/packages/core/mpc/tx/swapkitSignBitcoin.ts
@@ -1,0 +1,34 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { buildSignBitcoinFromPsbt } from '@vultisig/core-chain/chains/utxo/tx/buildSignBitcoinFromPsbt'
+import { Psbt } from 'bitcoinjs-lib'
+
+import { KeysignPayload } from '../types/vultisig/keysign/v1/keysign_message_pb'
+import { SignBitcoin } from '../types/vultisig/keysign/v1/wasm_execute_contract_payload_pb'
+
+export const getSwapKitSignBitcoin = (keysignPayload: KeysignPayload): SignBitcoin | undefined => {
+  if (keysignPayload.signData.case === 'signBitcoin') {
+    return keysignPayload.signData.value
+  }
+
+  const { coin, swapPayload } = keysignPayload
+
+  if (
+    !coin ||
+    coin.chain !== Chain.Bitcoin ||
+    swapPayload.case !== 'swapkitSwapPayload' ||
+    swapPayload.value.txType.toUpperCase() !== 'PSBT'
+  ) {
+    return undefined
+  }
+
+  const txPayload = swapPayload.value.txPayload
+
+  if (txPayload.length === 0) {
+    throw new Error('SwapKit Bitcoin PSBT payload is empty.')
+  }
+
+  return buildSignBitcoinFromPsbt({
+    psbt: Psbt.fromBuffer(Buffer.from(txPayload)),
+    senderAddress: coin.address,
+  })
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled use of pre-built SwapKit Bitcoin PSBT transactions and routing through the Bitcoin signing path for swap flows.

* **Bug Fixes**
  * Adjusted swap quoting so build-disabled flag is not set for Bitcoin transfer routes, preventing unnecessary build suppression.
  * Made PSBT compilation and signing handling more robust and deterministic.

* **Tests**
  * Added/updated tests to verify PSBT-based swap flows, compilation output, and deterministic pre-signing hash ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/588?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->