### PR TITLE
Guard SwapKit BTC PSBT destination outputs

### DIFF
--- a/.changeset/gold-btc-psbt.md
+++ b/.changeset/gold-btc-psbt.md
@@ -3,4 +3,4 @@
 '@vultisig/core-mpc': patch
 ---
 
-Enable pre-built SwapKit Bitcoin PSBT transactions and route payloads through the SignBitcoin hashing and compilation path.
+Enable pre-built SwapKit Bitcoin PSBT transactions, verify their destination outputs, and route payloads through the SignBitcoin hashing and compilation path.

--- a/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.test.ts
+++ b/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.test.ts
@@ -1,6 +1,7 @@
 import { Chain } from '@vultisig/core-chain/Chain'
 import { configureSwapKit, getSwapKitConfig } from '@vultisig/core-chain/swap/general/swapkit/config'
 import type { SwapKitSourceChain } from '@vultisig/core-chain/swap/general/swapkit/SwapKitEnabledChains'
+import { networks, payments, Psbt } from 'bitcoinjs-lib'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { getSwapKitQuote } from './getSwapKitQuote'
@@ -17,6 +18,29 @@ const response = (body: unknown, ok = true, status = 200) => {
 }
 
 const textEncoder = new TextEncoder()
+const TEST_PUBKEY = Buffer.from('0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798', 'hex')
+const BTC_RECIPIENT_ADDRESS = 'bc1q0ht9tyks4vh7p5p904t340cr9nvahy7u3re7zg'
+
+const makeBitcoinPsbtPayload = (outputValue: bigint) => {
+  const p2wpkh = payments.p2wpkh({ pubkey: TEST_PUBKEY, network: networks.bitcoin })
+  const psbt = new Psbt({ network: networks.bitcoin })
+
+  psbt.addInput({
+    hash: 'aa'.repeat(32),
+    index: 0,
+    witnessUtxo: { script: Buffer.from(p2wpkh.output!), value: 110_000n },
+  })
+  psbt.addOutput({
+    address: BTC_RECIPIENT_ADDRESS,
+    value: outputValue,
+  })
+
+  return {
+    sourceAddress: p2wpkh.address!,
+    targetAddress: BTC_RECIPIENT_ADDRESS,
+    payload: psbt.toBuffer(),
+  }
+}
 
 type TransferSourceFixture = readonly [string, SwapKitSourceChain, string, number, string, string]
 
@@ -256,6 +280,7 @@ describe('getSwapKitQuote', () => {
   })
 
   it('maps SwapKit transfer tx metadata into QR payload fields', async () => {
+    const psbt = makeBitcoinPsbtPayload(99_999n)
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(
@@ -273,9 +298,10 @@ describe('getSwapKitQuote', () => {
         response({
           expectedBuyAmount: '0.009',
           providers: ['CHAINFLIP'],
-          targetAddress: 'bc1qdeposit',
+          targetAddress: psbt.targetAddress,
           inboundAddress: 'bc1qinbound',
-          tx: 'cHNidA==',
+          depositAmount: '0.001',
+          tx: Buffer.from(psbt.payload).toString('base64'),
           meta: {
             txType: 'PSBT',
           },
@@ -289,7 +315,7 @@ describe('getSwapKitQuote', () => {
     const quote = await getSwapKitQuote({
       from: {
         chain: Chain.Bitcoin,
-        address: 'bc1qsource',
+        address: psbt.sourceAddress,
         ticker: 'BTC',
         decimals: 8,
       },
@@ -304,17 +330,17 @@ describe('getSwapKitQuote', () => {
 
     expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toMatchObject({
       routeId: 'psbt-route',
-      sourceAddress: 'bc1qsource',
+      sourceAddress: psbt.sourceAddress,
       destinationAddress: '0xdestination',
       disableBalanceCheck: true,
     })
     expect(JSON.parse(fetchMock.mock.calls[1][1].body).disableBuildTx).toBeUndefined()
     expect(quote.tx).toEqual({
       transfer: {
-        to: 'bc1qdeposit',
-        amount: 100_000n,
+        to: psbt.targetAddress,
+        amount: 99_999n,
         txType: 'PSBT',
-        txPayload: textEncoder.encode('psbt'),
+        txPayload: psbt.payload,
         inboundAddress: 'bc1qinbound',
         swapId: 'swapkit-id',
       },

--- a/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.ts
+++ b/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.ts
@@ -9,6 +9,7 @@ import { SwapKitEnabledChain, SwapKitSourceChain } from '@vultisig/core-chain/sw
 import { isOneOf } from '@vultisig/lib-utils/array/isOneOf'
 import { withoutUndefinedFields } from '@vultisig/lib-utils/record/withoutUndefinedFields'
 import { TransferDirection } from '@vultisig/lib-utils/TransferDirection'
+import { address as btcAddress, networks, Psbt } from 'bitcoinjs-lib'
 
 type Input = Record<TransferDirection, AccountCoin<SwapKitEnabledChain>> & {
   from: AccountCoin<SwapKitSourceChain>
@@ -480,6 +481,31 @@ const encodeSwapKitTxPayload = (tx: unknown, txType?: string): Uint8Array => {
   return textEncoder.encode(stringifyCanonicalJson(tx))
 }
 
+const getBitcoinPsbtDestinationAmount = ({
+  txPayload,
+  senderAddress,
+  targetAddress,
+}: {
+  txPayload: Uint8Array
+  senderAddress: string
+  targetAddress: string
+}): bigint | undefined => {
+  try {
+    const psbt = Psbt.fromBuffer(Buffer.from(txPayload))
+    const senderScript = Buffer.from(btcAddress.toOutputScript(senderAddress, networks.bitcoin))
+    const targetScript = Buffer.from(btcAddress.toOutputScript(targetAddress, networks.bitcoin))
+    const destinationOutputs = psbt.txOutputs.filter(({ script }) => {
+      const outputScript = Buffer.from(script)
+
+      return !outputScript.equals(senderScript) && outputScript.equals(targetScript)
+    })
+
+    return destinationOutputs.length === 1 ? BigInt(destinationOutputs[0].value) : undefined
+  } catch {
+    return undefined
+  }
+}
+
 const buildTransferTx = (
   response: SwapKitSwapResponse,
   from: AccountCoin<SwapKitSourceChain>,
@@ -491,16 +517,23 @@ const buildTransferTx = (
     throw new Error('SwapKit transfer route did not return a target address.')
   }
 
+  const txType = response.meta?.txType
+  const txPayload = response.tx ? encodeSwapKitTxPayload(response.tx, txType) : undefined
+  const psbtDestinationAmount =
+    from.chain === Chain.Bitcoin && txType?.toUpperCase() === 'PSBT' && txPayload?.length
+      ? getBitcoinPsbtDestinationAmount({
+          txPayload,
+          senderAddress: from.address,
+          targetAddress: to,
+        })
+      : undefined
+
   const transfer = {
     to,
-    amount: getTransferAmount(response, amount, from.decimals),
+    amount: psbtDestinationAmount ?? getTransferAmount(response, amount, from.decimals),
     ...(response.memo ? { memo: response.memo } : {}),
-    ...(response.meta?.txType ? { txType: response.meta.txType } : {}),
-    ...(response.tx
-      ? {
-          txPayload: encodeSwapKitTxPayload(response.tx, response.meta?.txType),
-        }
-      : {}),
+    ...(txType ? { txType } : {}),
+    ...(response.tx ? { txPayload } : {}),
     ...(response.inboundAddress ? { inboundAddress: response.inboundAddress } : {}),
     ...(response.swapId ? { swapId: response.swapId } : {}),
   }

--- a/packages/core/mpc/keysign/swap/build.transfer.test.ts
+++ b/packages/core/mpc/keysign/swap/build.transfer.test.ts
@@ -77,7 +77,7 @@ const makeBitcoinPsbtFixture = ({
 
   return {
     address: p2wpkh.address!,
-    recipientAddress: RECIPIENT_ADDRESS,
+    recipientAddress: outputAddress ?? RECIPIENT_ADDRESS,
     payload: psbt.toBuffer(),
   }
 }

--- a/packages/core/mpc/keysign/swap/build.transfer.test.ts
+++ b/packages/core/mpc/keysign/swap/build.transfer.test.ts
@@ -42,8 +42,20 @@ const publicKey = {
 } as never
 
 const TEST_PUBKEY = Buffer.from('0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798', 'hex')
+const RECIPIENT_ADDRESS = 'bc1q0ht9tyks4vh7p5p904t340cr9nvahy7u3re7zg'
+const EXTRA_RECIPIENT_ADDRESS = '1BoatSLRHtKNngkdXEeobR76b53LETtpyT'
 
-const makeBitcoinPsbtFixture = () => {
+const makeBitcoinPsbtFixture = ({
+  outputValue = 90_000n,
+  outputAddress,
+  extraOutputAddress,
+  extraOutputValue,
+}: {
+  outputValue?: bigint
+  outputAddress?: string
+  extraOutputAddress?: string
+  extraOutputValue?: bigint
+} = {}) => {
   const p2wpkh = payments.p2wpkh({ pubkey: TEST_PUBKEY, network: networks.bitcoin })
   const psbt = new Psbt({ network: networks.bitcoin })
 
@@ -53,12 +65,19 @@ const makeBitcoinPsbtFixture = () => {
     witnessUtxo: { script: Buffer.from(p2wpkh.output!), value: 100_000n },
   })
   psbt.addOutput({
-    address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
-    value: 90_000n,
+    address: outputAddress ?? RECIPIENT_ADDRESS,
+    value: outputValue,
   })
+  if (extraOutputAddress && extraOutputValue !== undefined) {
+    psbt.addOutput({
+      address: extraOutputAddress,
+      value: extraOutputValue,
+    })
+  }
 
   return {
     address: p2wpkh.address!,
+    recipientAddress: RECIPIENT_ADDRESS,
     payload: psbt.toBuffer(),
   }
 }
@@ -129,8 +148,8 @@ describe('buildSwapKeysignPayload transfer routes', () => {
           routeProvider: 'CHAINFLIP',
           tx: {
             transfer: {
-              to: 'bc1qchainflipdeposit',
-              amount: 600_000n,
+              to: psbt.recipientAddress,
+              amount: 90_000n,
               txType: 'PSBT',
               txPayload: psbt.payload,
             },
@@ -162,13 +181,13 @@ describe('buildSwapKeysignPayload transfer routes', () => {
       walletCore: {} as never,
     })
 
-    expect(payload.toAddress).toBe('bc1qchainflipdeposit')
-    expect(payload.toAmount).toBe('600000')
+    expect(payload.toAddress).toBe(psbt.recipientAddress)
+    expect(payload.toAmount).toBe('90000')
     expect(payload.memo).toBeUndefined()
     expect(payload.swapPayload.case).toBe('swapkitSwapPayload')
     if (payload.swapPayload.case === 'swapkitSwapPayload') {
-      expect(payload.swapPayload.value.fromAmount).toBe('600000')
-      expect(payload.swapPayload.value.targetAddress).toBe('bc1qchainflipdeposit')
+      expect(payload.swapPayload.value.fromAmount).toBe('90000')
+      expect(payload.swapPayload.value.targetAddress).toBe(psbt.recipientAddress)
       expect(payload.swapPayload.value.subProvider).toBe('CHAINFLIP')
       expect(payload.swapPayload.value.txType).toBe('PSBT')
       expect(payload.swapPayload.value.txPayload).toEqual(psbt.payload)
@@ -191,8 +210,168 @@ describe('buildSwapKeysignPayload transfer routes', () => {
     )
     expect(roundtrip.swapPayload.case).toBe('swapkitSwapPayload')
     if (roundtrip.swapPayload.case === 'swapkitSwapPayload') {
-      expect(roundtrip.swapPayload.value.targetAddress).toBe('bc1qchainflipdeposit')
+      expect(roundtrip.swapPayload.value.targetAddress).toBe(psbt.recipientAddress)
     }
+  })
+
+  it('rejects SwapKit Bitcoin PSBTs that pay a different address than the quote', async () => {
+    mocks.getChainSpecific.mockResolvedValueOnce({
+      case: 'utxoSpecific',
+      value: { byteFee: '10', sendMaxAmount: false },
+    })
+    const psbt = makeBitcoinPsbtFixture()
+
+    const swapQuote: SwapQuote = {
+      discounts: [],
+      quote: {
+        general: {
+          dstAmount: '1800000000000000000',
+          provider: 'swapkit',
+          routeProvider: 'CHAINFLIP',
+          tx: {
+            transfer: {
+              to: EXTRA_RECIPIENT_ADDRESS,
+              amount: 90_000n,
+              txType: 'PSBT',
+              txPayload: psbt.payload,
+            },
+          },
+        },
+      },
+    }
+
+    await expect(
+      buildSwapKeysignPayload({
+        fromCoin: {
+          chain: Chain.Bitcoin,
+          address: psbt.address,
+          ticker: 'BTC',
+          decimals: 8,
+        },
+        toCoin: {
+          chain: Chain.Ethereum,
+          address: '0xdestination',
+          ticker: 'ETH',
+          decimals: 18,
+        },
+        amount: 0.0009,
+        swapQuote,
+        vaultId: 'vault-id',
+        localPartyId: 'local-party',
+        fromPublicKey: publicKey,
+        toPublicKey: publicKey,
+        libType: 'DKLS',
+        walletCore: {} as never,
+      })
+    ).rejects.toThrow('value-bearing non-change output')
+  })
+
+  it('rejects SwapKit Bitcoin PSBTs whose non-change amount differs from the quote', async () => {
+    mocks.getChainSpecific.mockResolvedValueOnce({
+      case: 'utxoSpecific',
+      value: { byteFee: '10', sendMaxAmount: false },
+    })
+    const psbt = makeBitcoinPsbtFixture()
+
+    const swapQuote: SwapQuote = {
+      discounts: [],
+      quote: {
+        general: {
+          dstAmount: '1800000000000000000',
+          provider: 'swapkit',
+          routeProvider: 'CHAINFLIP',
+          tx: {
+            transfer: {
+              to: psbt.recipientAddress,
+              amount: 80_000n,
+              txType: 'PSBT',
+              txPayload: psbt.payload,
+            },
+          },
+        },
+      },
+    }
+
+    await expect(
+      buildSwapKeysignPayload({
+        fromCoin: {
+          chain: Chain.Bitcoin,
+          address: psbt.address,
+          ticker: 'BTC',
+          decimals: 8,
+        },
+        toCoin: {
+          chain: Chain.Ethereum,
+          address: '0xdestination',
+          ticker: 'ETH',
+          decimals: 18,
+        },
+        amount: 0.0008,
+        swapQuote,
+        vaultId: 'vault-id',
+        localPartyId: 'local-party',
+        fromPublicKey: publicKey,
+        toPublicKey: publicKey,
+        libType: 'DKLS',
+        walletCore: {} as never,
+      })
+    ).rejects.toThrow('non-change outputs sum to 90000, but expected 80000')
+  })
+
+  it('rejects SwapKit Bitcoin PSBTs with a hidden value-bearing non-change output', async () => {
+    mocks.getChainSpecific.mockResolvedValueOnce({
+      case: 'utxoSpecific',
+      value: { byteFee: '10', sendMaxAmount: false },
+    })
+    const psbt = makeBitcoinPsbtFixture({
+      outputValue: 50_000n,
+      extraOutputAddress: EXTRA_RECIPIENT_ADDRESS,
+      extraOutputValue: 40_000n,
+    })
+
+    const swapQuote: SwapQuote = {
+      discounts: [],
+      quote: {
+        general: {
+          dstAmount: '1800000000000000000',
+          provider: 'swapkit',
+          routeProvider: 'CHAINFLIP',
+          tx: {
+            transfer: {
+              to: psbt.recipientAddress,
+              amount: 90_000n,
+              txType: 'PSBT',
+              txPayload: psbt.payload,
+            },
+          },
+        },
+      },
+    }
+
+    await expect(
+      buildSwapKeysignPayload({
+        fromCoin: {
+          chain: Chain.Bitcoin,
+          address: psbt.address,
+          ticker: 'BTC',
+          decimals: 8,
+        },
+        toCoin: {
+          chain: Chain.Ethereum,
+          address: '0xdestination',
+          ticker: 'ETH',
+          decimals: 18,
+        },
+        amount: 0.0009,
+        swapQuote,
+        vaultId: 'vault-id',
+        localPartyId: 'local-party',
+        fromPublicKey: publicKey,
+        toPublicKey: publicKey,
+        libType: 'DKLS',
+        walletCore: {} as never,
+      })
+    ).rejects.toThrow('value-bearing non-change output')
   })
 
   it('builds a normal source-chain send payload for SwapKit transfer tx variants', async () => {

--- a/packages/core/mpc/keysign/swap/build.ts
+++ b/packages/core/mpc/keysign/swap/build.ts
@@ -19,6 +19,7 @@ import { refineKeysignUtxo } from '@vultisig/core-mpc/keysign/refine/utxo'
 import { CommKeysignSwapPayload } from '@vultisig/core-mpc/keysign/swap/KeysignSwapPayload'
 import { getKeysignUtxoInfo } from '@vultisig/core-mpc/keysign/utxo/getKeysignUtxoInfo'
 import { KeysignLibType } from '@vultisig/core-mpc/mpcLib'
+import { verifySwapKitBitcoinPsbtOutputs } from '@vultisig/core-mpc/tx/swapkitSignBitcoin'
 import { toCommCoin } from '@vultisig/core-mpc/types/utils/commCoin'
 import {
   OneInchQuoteSchema,
@@ -65,12 +66,21 @@ const getSwapKitBitcoinSignData = (fromCoin: AccountCoin, transfer: TransferSwap
     throw new Error('SwapKit Bitcoin PSBT payload is empty.')
   }
 
+  const signBitcoin = buildSignBitcoinFromPsbt({
+    psbt: Psbt.fromBuffer(Buffer.from(transfer.txPayload)),
+    senderAddress: fromCoin.address,
+  })
+
+  verifySwapKitBitcoinPsbtOutputs({
+    signBitcoin,
+    senderAddress: fromCoin.address,
+    expectedToAddress: transfer.to,
+    expectedToAmount: transfer.amount,
+  })
+
   return {
     case: 'signBitcoin',
-    value: buildSignBitcoinFromPsbt({
-      psbt: Psbt.fromBuffer(Buffer.from(transfer.txPayload)),
-      senderAddress: fromCoin.address,
-    }),
+    value: signBitcoin,
   }
 }
 

--- a/packages/core/mpc/tx/compile/compileSignBitcoinTx.test.ts
+++ b/packages/core/mpc/tx/compile/compileSignBitcoinTx.test.ts
@@ -34,8 +34,9 @@ import { compileTx } from './compileTx'
 import { compileSignBitcoinTx } from './compileSignBitcoinTx'
 
 const TEST_PUBKEY = Buffer.from('0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798', 'hex')
+const RECIPIENT_ADDRESS = 'bc1q0ht9tyks4vh7p5p904t340cr9nvahy7u3re7zg'
 const EXPECTED_BITCOINJS_RAW_TX =
-  '02000000000101aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000ffffffff01905f010000000000160014751e76e8199196d454941c45d1b3a323f1433bd60247304402204f69fe236b040aa999563dd909273ee088df86e6e1c0c46a083399384c02fc12022038870510658d27312b253380b3b2bbfb1b5db4423399561a3e5737e1540f825b01210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179800000000'
+  '02000000000101aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000ffffffff01905f0100000000001600147dd65592d0ab2fe0d0257d571abf032cd9db93dc02483045022100cf5ed8951fc872ce1ec2021f76de2d191494c78f9ace2901c0ba41e9292bdd5d022018801adb6683ff7d68d0ccd02ecb001169f5f22c3ae0c2b3748bdad457fa649801210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179800000000'
 
 describe('compileSignBitcoinTx', () => {
   let walletCore: WalletCore
@@ -56,7 +57,7 @@ describe('compileSignBitcoinTx', () => {
       witnessUtxo: { script: Buffer.from(p2wpkh.output!), value: 100000n },
     })
     psbt.addOutput({
-      address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+      address: RECIPIENT_ADDRESS,
       value: 90000n,
     })
 
@@ -99,7 +100,7 @@ describe('compileSignBitcoinTx', () => {
       witnessUtxo: { script: Buffer.from(p2wpkh.output!), value: 100000n },
     })
     psbtRef.addOutput({
-      address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+      address: RECIPIENT_ADDRESS,
       value: 90000n,
     })
     await psbtRef.signInputAsync(0, {
@@ -125,7 +126,7 @@ describe('compileSignBitcoinTx', () => {
       witnessUtxo: { script: Buffer.from(p2wpkh.output!), value: 100000n },
     })
     psbt.addOutput({
-      address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+      address: RECIPIENT_ADDRESS,
       value: 90000n,
     })
 
@@ -136,6 +137,8 @@ describe('compileSignBitcoinTx', () => {
         address: p2wpkh.address!,
         decimals: 8,
       }),
+      toAddress: RECIPIENT_ADDRESS,
+      toAmount: '90000',
       swapPayload: {
         case: 'swapkitSwapPayload',
         value: create(SwapKitSwapPayloadSchema, {
@@ -181,7 +184,7 @@ describe('compileSignBitcoinTx', () => {
     expect(Buffer.from(decoded.encoded).toString('hex')).toBe(EXPECTED_BITCOINJS_RAW_TX)
   })
 
-  it('returns SwapKit PSBT hashes sorted to match iOS co-signing', () => {
+  it('returns SwapKit PSBT hashes in deterministic sorted ceremony order', () => {
     const p2wpkh = payments.p2wpkh({ pubkey: TEST_PUBKEY, network: networks.bitcoin })
     const psbt = new Psbt({ network: networks.bitcoin })
     psbt.addInput({
@@ -195,7 +198,7 @@ describe('compileSignBitcoinTx', () => {
       witnessUtxo: { script: Buffer.from(p2wpkh.output!), value: 200000n },
     })
     psbt.addOutput({
-      address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+      address: RECIPIENT_ADDRESS,
       value: 250000n,
     })
 
@@ -206,6 +209,8 @@ describe('compileSignBitcoinTx', () => {
         address: p2wpkh.address!,
         decimals: 8,
       }),
+      toAddress: RECIPIENT_ADDRESS,
+      toAmount: '250000',
       swapPayload: {
         case: 'swapkitSwapPayload',
         value: create(SwapKitSwapPayloadSchema, {
@@ -224,5 +229,46 @@ describe('compileSignBitcoinTx', () => {
 
     expect(hashes).toHaveLength(2)
     expect(hashes).toEqual([...hashes].sort())
+  })
+
+  it('rejects SwapKit PSBT payloads without a quoted amount', () => {
+    const p2wpkh = payments.p2wpkh({ pubkey: TEST_PUBKEY, network: networks.bitcoin })
+    const psbt = new Psbt({ network: networks.bitcoin })
+    psbt.addInput({
+      hash: 'aa'.repeat(32),
+      index: 0,
+      witnessUtxo: { script: Buffer.from(p2wpkh.output!), value: 100000n },
+    })
+    psbt.addOutput({
+      address: RECIPIENT_ADDRESS,
+      value: 90000n,
+    })
+
+    const keysignPayload = create(KeysignPayloadSchema, {
+      coin: create(CoinSchema, {
+        chain: Chain.Bitcoin,
+        ticker: 'BTC',
+        address: p2wpkh.address!,
+        decimals: 8,
+      }),
+      toAddress: RECIPIENT_ADDRESS,
+      toAmount: '',
+      swapPayload: {
+        case: 'swapkitSwapPayload',
+        value: create(SwapKitSwapPayloadSchema, {
+          txType: 'PSBT',
+          txPayload: psbt.toBuffer(),
+        }),
+      },
+    })
+
+    expect(() =>
+      getPreSigningHashes({
+        walletCore,
+        chain: Chain.Bitcoin,
+        txInputData: new Uint8Array(),
+        keysignPayload,
+      })
+    ).toThrow('expected amount is invalid')
   })
 })

--- a/packages/core/mpc/tx/preSigningHashes/index.ts
+++ b/packages/core/mpc/tx/preSigningHashes/index.ts
@@ -25,7 +25,9 @@ const sortHashes = (hashes: Uint8Array[]): Uint8Array[] =>
 export const getPreSigningHashes = ({ walletCore, txInputData, chain, keysignPayload }: Input) => {
   const signBitcoin = keysignPayload ? getSwapKitSignBitcoin(keysignPayload) : undefined
 
-  // PSBT signing: compute BIP-143 sighashes directly from structured data
+  // PSBT signing: compute BIP-143 sighashes directly from structured data.
+  // Sort the public ceremony hashes for deterministic cross-platform order;
+  // final PSBT assembly still maps signatures by hash and preserves input order.
   if (signBitcoin) {
     return sortHashes(computePreSigningHashes(signBitcoin))
   }

--- a/packages/core/mpc/tx/swapkitSignBitcoin.ts
+++ b/packages/core/mpc/tx/swapkitSignBitcoin.ts
@@ -1,35 +1,149 @@
 import { Buffer } from 'buffer'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { buildSignBitcoinFromPsbt } from '@vultisig/core-chain/chains/utxo/tx/buildSignBitcoinFromPsbt'
-import { Psbt } from 'bitcoinjs-lib'
+import { address as btcAddress, networks, Psbt } from 'bitcoinjs-lib'
 
 import { KeysignPayload } from '../types/vultisig/keysign/v1/keysign_message_pb'
+import { SwapKitSwapPayload } from '../types/vultisig/keysign/v1/swapkit_swap_payload_pb'
 import { SignBitcoin } from '../types/vultisig/keysign/v1/wasm_execute_contract_payload_pb'
 
-export const getSwapKitSignBitcoin = (keysignPayload: KeysignPayload): SignBitcoin | undefined => {
-  if (keysignPayload.signData.case === 'signBitcoin') {
-    return keysignPayload.signData.value
+type VerifySwapKitBitcoinPsbtOutputsInput = {
+  signBitcoin: SignBitcoin
+  senderAddress: string
+  expectedToAddress: string
+  expectedToAmount: string | bigint
+}
+
+const getScriptPubKeyForAddress = (address: string, label: string): Buffer => {
+  if (!address) {
+    throw new Error(`SwapKit Bitcoin PSBT ${label} address is empty.`)
   }
 
-  const { coin, swapPayload } = keysignPayload
+  try {
+    return Buffer.from(btcAddress.toOutputScript(address, networks.bitcoin))
+  } catch {
+    throw new Error(`SwapKit Bitcoin PSBT ${label} address is invalid: ${address}`)
+  }
+}
 
-  if (
-    !coin ||
-    coin.chain !== Chain.Bitcoin ||
-    swapPayload.case !== 'swapkitSwapPayload' ||
-    swapPayload.value.txType.toUpperCase() !== 'PSBT'
-  ) {
+const parseExpectedAmount = (amount: string | bigint): bigint => {
+  if (typeof amount === 'string' && !/^\d+$/.test(amount)) {
+    throw new Error(`SwapKit Bitcoin PSBT expected amount is invalid: ${amount}`)
+  }
+
+  try {
+    const value = typeof amount === 'bigint' ? amount : BigInt(amount)
+    if (value < 0n) {
+      throw new Error('negative')
+    }
+    return value
+  } catch {
+    throw new Error(`SwapKit Bitcoin PSBT expected amount is invalid: ${amount}`)
+  }
+}
+
+const getOutputScript = (scriptPubKey: string, index: number): Buffer => {
+  if (!/^(?:[0-9a-f]{2})+$/iu.test(scriptPubKey)) {
+    throw new Error(`SwapKit Bitcoin PSBT output #${index} has an invalid scriptPubKey.`)
+  }
+
+  return Buffer.from(scriptPubKey, 'hex')
+}
+
+export const verifySwapKitBitcoinPsbtOutputs = ({
+  signBitcoin,
+  senderAddress,
+  expectedToAddress,
+  expectedToAmount,
+}: VerifySwapKitBitcoinPsbtOutputsInput) => {
+  const expectedDestinationScript = getScriptPubKeyForAddress(expectedToAddress, 'destination')
+  const expectedChangeScript = getScriptPubKeyForAddress(senderAddress, 'sender')
+  const expectedAmount = parseExpectedAmount(expectedToAmount)
+
+  const outputs = signBitcoin.outputs.map((output, index) => ({
+    output,
+    script: getOutputScript(output.scriptPubKey, index),
+  }))
+
+  outputs.forEach(({ output, script }, index) => {
+    const derivedIsChange = script.equals(expectedChangeScript)
+    if (output.isChange !== derivedIsChange) {
+      throw new Error(
+        `SwapKit Bitcoin PSBT output #${index} has isChange=${output.isChange}, ` +
+          `but its scriptPubKey ${derivedIsChange ? 'does' : 'does not'} pay back to the sender.`
+      )
+    }
+  })
+
+  const nonChangeOutputs = outputs.filter(({ output }) => !output.isChange)
+  const nonChangeAmount = nonChangeOutputs.reduce((sum, { output }) => sum + output.amount, 0n)
+
+  if (nonChangeAmount !== expectedAmount) {
+    throw new Error(
+      `SwapKit Bitcoin PSBT non-change outputs sum to ${nonChangeAmount}, ` + `but expected ${expectedAmount}.`
+    )
+  }
+
+  const destinationMatches = nonChangeOutputs.map(({ output, script }) => ({
+    amount: output.amount,
+    matches: script.equals(expectedDestinationScript),
+  }))
+
+  if (destinationMatches.some(({ amount, matches }) => amount > 0n && !matches)) {
+    throw new Error(
+      'SwapKit Bitcoin PSBT contains a value-bearing non-change output that is not the quoted destination.'
+    )
+  }
+
+  const destinationMatchCount = destinationMatches.filter(({ matches }) => matches).length
+  if (destinationMatchCount !== 1) {
+    throw new Error(
+      `SwapKit Bitcoin PSBT must contain exactly one non-change output paying to ${expectedToAddress}, ` +
+        `but found ${destinationMatchCount}.`
+    )
+  }
+}
+
+const getSwapKitBitcoinPsbtPayload = (keysignPayload: KeysignPayload): SwapKitSwapPayload | undefined => {
+  if (keysignPayload.coin?.chain !== Chain.Bitcoin || keysignPayload.swapPayload.case !== 'swapkitSwapPayload') {
     return undefined
   }
 
-  const txPayload = swapPayload.value.txPayload
+  const swapKitPayload = keysignPayload.swapPayload.value
+  return swapKitPayload.txType.toUpperCase() === 'PSBT' ? swapKitPayload : undefined
+}
 
-  if (txPayload.length === 0) {
-    throw new Error('SwapKit Bitcoin PSBT payload is empty.')
+export const getSwapKitSignBitcoin = (keysignPayload: KeysignPayload): SignBitcoin | undefined => {
+  let signBitcoin: SignBitcoin | undefined
+  const swapKitBitcoinPsbtPayload = getSwapKitBitcoinPsbtPayload(keysignPayload)
+
+  if (keysignPayload.signData.case === 'signBitcoin') {
+    signBitcoin = keysignPayload.signData.value
+  } else if (swapKitBitcoinPsbtPayload) {
+    const txPayload = swapKitBitcoinPsbtPayload.txPayload
+
+    if (txPayload.length === 0) {
+      throw new Error('SwapKit Bitcoin PSBT payload is empty.')
+    }
+
+    signBitcoin = buildSignBitcoinFromPsbt({
+      psbt: Psbt.fromBuffer(Buffer.from(txPayload)),
+      senderAddress: keysignPayload.coin?.address ?? '',
+    })
   }
 
-  return buildSignBitcoinFromPsbt({
-    psbt: Psbt.fromBuffer(Buffer.from(txPayload)),
-    senderAddress: coin.address,
-  })
+  if (!signBitcoin) {
+    return undefined
+  }
+
+  if (swapKitBitcoinPsbtPayload) {
+    verifySwapKitBitcoinPsbtOutputs({
+      signBitcoin,
+      senderAddress: keysignPayload.coin?.address ?? '',
+      expectedToAddress: keysignPayload.toAddress,
+      expectedToAmount: keysignPayload.toAmount,
+    })
+  }
+
+  return signBitcoin
 }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SwapKit Bitcoin PSBTs are now validated: destination address and amount must match the quote; PSBTs with unexpected value-bearing outputs or mismatched sums are rejected.

* **Tests**
  * Expanded coverage for PSBT scenarios, including matching/mismatching addresses, amounts, and hidden extra outputs.

* **Behavior**
  * SwapKit Bitcoin PSBT payloads are validated and processed through the Bitcoin signing/verification flow before signing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/590?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->