### PR TITLE
fix: add per-fetcher 30s timeout to findSwapQuote

### DIFF
--- a/.changeset/swap-per-fetcher-timeout.md
+++ b/.changeset/swap-per-fetcher-timeout.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/core-chain': patch
+---
+
+add 30s per-fetcher timeout guard to findSwapQuote — a hanging provider no longer stalls the whole allSettled fan-out

--- a/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
@@ -6,7 +6,7 @@ import { getOneInchSwapQuote } from '@vultisig/core-chain/swap/general/oneInch/a
 import { getSwapKitQuote } from '@vultisig/core-chain/swap/general/swapkit/api/getSwapKitQuote'
 import { getNativeSwapQuote } from '@vultisig/core-chain/swap/native/api/getNativeSwapQuote'
 import { NativeSwapQuote } from '@vultisig/core-chain/swap/native/NativeSwapQuote'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { findSwapQuote } from './findSwapQuote'
 
@@ -581,5 +581,57 @@ describe('findSwapQuote THOR/Maya bias (paaao directive 2026-05-22)', () => {
       throw new Error('Expected Maya native quote to win via bias on Arbitrum')
     }
     expect(quote.quote.native.swapChain).toBe(Chain.MayaChain)
+  })
+})
+
+describe('findSwapQuote per-fetcher timeout guard (issue #412)', () => {
+  beforeEach(() => {
+    vi.mocked(getKyberSwapQuote).mockReset()
+    vi.mocked(getOneInchSwapQuote).mockReset()
+    vi.mocked(getLifiSwapQuote).mockReset()
+    vi.mocked(getSwapKitQuote).mockReset()
+    vi.mocked(getNativeSwapQuote).mockReset()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not stall when one provider hangs - the other providers still resolve', async () => {
+    // KyberSwap hangs forever; the other providers resolve quickly.
+    vi.mocked(getKyberSwapQuote).mockReturnValue(new Promise(() => undefined))
+    vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('skip inch'))
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
+    vi.mocked(getSwapKitQuote).mockResolvedValue(minimalGeneralQuote('1000000', 'swapkit'))
+    vi.mocked(getNativeSwapQuote).mockRejectedValue(new Error('native unavailable'))
+
+    const resultPromise = findSwapQuote({ ...evmSameChainCoins, amount: 1n })
+
+    // Advance past the 30s per-fetcher timeout so the hanging provider is rejected.
+    await vi.runAllTimersAsync()
+
+    const quote = await resultPromise
+
+    expect('general' in quote.quote).toBe(true)
+    if (!('general' in quote.quote)) {
+      throw new Error('Expected SwapKit quote')
+    }
+    expect(quote.quote.general.provider).toBe('swapkit')
+  })
+
+  it('rejects with no-route error when every provider hangs', async () => {
+    vi.mocked(getKyberSwapQuote).mockReturnValue(new Promise(() => undefined))
+    vi.mocked(getOneInchSwapQuote).mockReturnValue(new Promise(() => undefined))
+    vi.mocked(getLifiSwapQuote).mockReturnValue(new Promise(() => undefined))
+    vi.mocked(getSwapKitQuote).mockReturnValue(new Promise(() => undefined))
+    vi.mocked(getNativeSwapQuote).mockReturnValue(new Promise(() => undefined))
+
+    const resultPromise = findSwapQuote({ ...evmSameChainCoins, amount: 1n })
+    await vi.runAllTimersAsync()
+
+    await expect(resultPromise).rejects.toThrow(
+      'No swap route found after trying KyberSwap, 1inch, LiFi, SwapKit, THORChain, MayaChain.'
+    )
   })
 })

--- a/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
@@ -628,10 +628,12 @@ describe('findSwapQuote per-fetcher timeout guard (issue #412)', () => {
     vi.mocked(getNativeSwapQuote).mockReturnValue(new Promise(() => undefined))
 
     const resultPromise = findSwapQuote({ ...evmSameChainCoins, amount: 1n })
-    await vi.runAllTimersAsync()
-
-    await expect(resultPromise).rejects.toThrow(
+    // Register the rejection handler BEFORE advancing timers - avoids an
+    // unhandled-rejection when the promise rejects mid-tick after runAllTimersAsync.
+    const assertion = expect(resultPromise).rejects.toThrow(
       'No swap route found after trying KyberSwap, 1inch, LiFi, SwapKit, THORChain, MayaChain.'
     )
+    await vi.runAllTimersAsync()
+    await assertion
   })
 })

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -99,13 +99,15 @@ const isNativeProvider = (name: SwapQuoteProviderName): name is NativeProviderNa
 
 const QUOTE_FETCH_TIMEOUT_MS = 30_000
 
-const withTimeout = <T>(p: Promise<T>, ms: number): Promise<T> =>
-  Promise.race([
-    p,
-    new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error(`swap quote fetch timed out after ${ms}ms`)), ms)
-    ),
-  ])
+const withTimeout = <T>(p: Promise<T>, ms: number): Promise<T> => {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => reject(new Error(`swap quote fetch timed out after ${ms}ms`)), ms)
+  })
+  return Promise.race([p, timeoutPromise]).finally(() => {
+    clearTimeout(timeoutId)
+  })
+}
 
 /**
  * Declared preference order for AGGREGATOR ties — when two aggregators return

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -97,6 +97,16 @@ const nativeProviderNamesSet = new Set<SwapQuoteProviderName>(nativeProviderName
 
 const isNativeProvider = (name: SwapQuoteProviderName): name is NativeProviderName => nativeProviderNamesSet.has(name)
 
+const QUOTE_FETCH_TIMEOUT_MS = 30_000
+
+const withTimeout = <T>(p: Promise<T>, ms: number): Promise<T> =>
+  Promise.race([
+    p,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`swap quote fetch timed out after ${ms}ms`)), ms)
+    ),
+  ])
+
 /**
  * Declared preference order for AGGREGATOR ties — when two aggregators return
  * identical `outputAmount`, the earlier entry wins. This makes the tie-break
@@ -368,7 +378,7 @@ export const findSwapQuote = async ({
 
   const settled = await Promise.allSettled(
     fetchers.map(async (fetcher): Promise<RankedSwapQuote> => {
-      const quote = await fetcher.fetch()
+      const quote = await withTimeout(fetcher.fetch(), QUOTE_FETCH_TIMEOUT_MS)
       return {
         quote,
         outputAmount: getComparableOutputAmount(quote, to),


### PR DESCRIPTION
closes #412

a hanging swap provider previously blocked the entire `Promise.allSettled` fan-out for up to the network timeout of that one provider. every other quote was also delayed (or never returned).

**fix**: wrap each `fetcher.fetch()` call with `withTimeout(p, 30_000)` - a `Promise.race` against a 30s `setTimeout` rejection. the other providers still race and the best available quote wins as normal.

**tests**: two new cases in `findSwapQuote.selection.test.ts` under `describe('findSwapQuote per-fetcher timeout guard')` using `vi.useFakeTimers()`:
- one hanging provider, rest succeed - SwapKit still wins
- all providers hang - rejects with the normal no-route error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 30-second timeout guard per swap quote provider to prevent unresponsive providers from blocking the overall swap quote retrieval process. The system now gracefully handles hanging providers and continues fetching quotes from other available sources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/591?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->