### PR TITLE
fix: lifi per-pair slippage - 0.3% stable, 1% volatile

### DIFF
--- a/.changeset/lifi-stable-pair-slippage.md
+++ b/.changeset/lifi-stable-pair-slippage.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/core-chain': patch
+---
+
+lifi: tighten slippage to 0.3% for stablecoin pairs (USDC/USDT/DAI/...), keep 1% for volatile pairs

--- a/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.slippage.test.ts
+++ b/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.slippage.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { isStablePair, STABLE_TICKERS } from './getLifiSwapQuote'
+
+const coin = (ticker: string) => ({ ticker })
+
+describe('getLifiSwapQuote stable-pair slippage selection (issue #524)', () => {
+  it('STABLE_TICKERS contains the canonical stable set', () => {
+    for (const ticker of ['USDC', 'USDT', 'DAI', 'BUSD', 'TUSD', 'FRAX', 'USDP', 'GUSD', 'LUSD', 'USDD', 'FDUSD', 'PYUSD']) {
+      expect(STABLE_TICKERS.has(ticker)).toBe(true)
+    }
+  })
+
+  it('isStablePair returns true for USDC/USDT', () => {
+    expect(isStablePair(coin('USDC'), coin('USDT'))).toBe(true)
+  })
+
+  it('isStablePair returns true for DAI/USDC', () => {
+    expect(isStablePair(coin('DAI'), coin('USDC'))).toBe(true)
+  })
+
+  it('isStablePair returns true for FRAX/USDT', () => {
+    expect(isStablePair(coin('FRAX'), coin('USDT'))).toBe(true)
+  })
+
+  it('isStablePair returns false for ETH/USDC (volatile/stable mix)', () => {
+    expect(isStablePair(coin('ETH'), coin('USDC'))).toBe(false)
+  })
+
+  it('isStablePair returns false for SOL/USDT (volatile/stable mix)', () => {
+    expect(isStablePair(coin('SOL'), coin('USDT'))).toBe(false)
+  })
+
+  it('isStablePair returns false for ETH/BTC (volatile pair)', () => {
+    expect(isStablePair(coin('ETH'), coin('BTC'))).toBe(false)
+  })
+
+  it('isStablePair handles case-insensitive tickers', () => {
+    expect(isStablePair(coin('usdc'), coin('usdt'))).toBe(true)
+  })
+
+  it('isStablePair returns false when ticker is absent', () => {
+    const noTicker = {}
+    expect(isStablePair(noTicker, coin('USDT'))).toBe(false)
+  })
+})

--- a/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.slippage.test.ts
+++ b/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.slippage.test.ts
@@ -6,7 +6,20 @@ const coin = (ticker: string) => ({ ticker })
 
 describe('getLifiSwapQuote stable-pair slippage selection (issue #524)', () => {
   it('STABLE_TICKERS contains the canonical stable set', () => {
-    for (const ticker of ['USDC', 'USDT', 'DAI', 'BUSD', 'TUSD', 'FRAX', 'USDP', 'GUSD', 'LUSD', 'USDD', 'FDUSD', 'PYUSD']) {
+    for (const ticker of [
+      'USDC',
+      'USDT',
+      'DAI',
+      'BUSD',
+      'TUSD',
+      'FRAX',
+      'USDP',
+      'GUSD',
+      'LUSD',
+      'USDD',
+      'FDUSD',
+      'PYUSD',
+    ]) {
       expect(STABLE_TICKERS.has(ticker)).toBe(true)
     }
   })

--- a/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
+++ b/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
@@ -14,10 +14,36 @@ import { AccountCoinKey } from '../../../../coin/AccountCoin'
 import { GeneralSwapQuote } from '../../GeneralSwapQuote'
 import { injectSolanaAtaIfMissing } from './injectSolanaAtaIfMissing'
 
-type Input = Record<TransferDirection, AccountCoinKey<LifiSwapEnabledChain>> & {
+type Input = Record<TransferDirection, AccountCoinKey<LifiSwapEnabledChain> & { ticker?: string }> & {
   amount: bigint
   affiliateBps?: number
 }
+
+// Stable-pair detection: tickers that commonly trade within a tight peg.
+// DAI is included because on most DEXs DAI/USDC depth is comparable to
+// USDC/USDT and the 0.3% ceiling is still safe headroom for MPC latency.
+/** @internal exported for unit tests only */
+export const STABLE_TICKERS: ReadonlySet<string> = new Set([
+  'USDC',
+  'USDT',
+  'DAI',
+  'BUSD',
+  'TUSD',
+  'FRAX',
+  'USDP',
+  'GUSD',
+  'LUSD',
+  'USDD',
+  'FDUSD',
+  'PYUSD',
+])
+
+const isStableTicker = (ticker: string | undefined): boolean =>
+  ticker !== undefined && STABLE_TICKERS.has(ticker.toUpperCase())
+
+/** @internal exported for unit tests only */
+export const isStablePair = (from: { ticker?: string }, to: { ticker?: string }): boolean =>
+  isStableTicker(from.ticker) && isStableTicker(to.ticker)
 
 const setupLifi = memoize(() => {
   createConfig({
@@ -68,7 +94,15 @@ const setupLifi = memoize(() => {
 // through the resolver, tracked at vultisig/vultisig-sdk#NEW — TODO
 // open) lands as a clean diff rather than reshaping the function
 // body. Codex Round 1b review feedback (vultisig-sdk#513 r1).
+//
+// Two tiers (vultisig-sdk#524):
+// - stable pairs (USDC/USDT/DAI/...): 0.3% — well above typical
+//   concentrated-liquidity spread (0.02-0.05%) but avoids the 1%
+//   MEV surface on tight-peg operations.
+// - volatile pairs: 1% — covers MPC ceremony latency (30-90s) where
+//   price can move >0.5% on thin pairs. See full rationale above.
 const DEFAULT_LIFI_SLIPPAGE_TOLERANCE = 0.01
+const STABLE_PAIR_LIFI_SLIPPAGE_TOLERANCE = 0.003
 
 // Combined affiliate + slippage ceiling. Defensive guard so a high
 // affiliateBps + the 1% slippage don't silently combine into a >3%
@@ -112,12 +146,16 @@ export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: In
   const [fromToken, toToken] = [transfer.from, transfer.to].map(({ id, chain }) => id ?? chainFeeCoin[chain].ticker)
   const [fromAddress, toAddress] = [transfer.from, transfer.to].map(({ address }) => address)
 
+  const slippage = isStablePair(transfer.from, transfer.to)
+    ? STABLE_PAIR_LIFI_SLIPPAGE_TOLERANCE
+    : DEFAULT_LIFI_SLIPPAGE_TOLERANCE
+
   // Defensive: log when affiliate + slippage combined cost crosses the
   // 3% ceiling. Today affiliateBps is typically 0 and slippage is 1%,
   // so 100bps total — well under the ceiling — but a future bump to
   // affiliateBps shouldn't silently combine into a >3% effective cost
   // on the user without anyone noticing. NeOMakinG #513 r1.
-  const combinedCostBps = (affiliateBps ?? 0) + DEFAULT_LIFI_SLIPPAGE_TOLERANCE * 10000
+  const combinedCostBps = (affiliateBps ?? 0) + slippage * 10000
   if (combinedCostBps > MAX_COMBINED_COST_BPS) {
     console.warn(
       `[getLifiSwapQuote] affiliate + slippage combined cost exceeds ${MAX_COMBINED_COST_BPS}bps: ${combinedCostBps}bps`
@@ -133,7 +171,7 @@ export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: In
     fromAddress,
     toAddress,
     fee: affiliateBps ? affiliateBps / 10000 : undefined,
-    slippage: DEFAULT_LIFI_SLIPPAGE_TOLERANCE,
+    slippage,
   })
 
   const { transactionRequest, estimate } = quote


### PR DESCRIPTION
closes #524

stablecoin pairs (USDC/USDT, DAI/USDC, FRAX/USDT, etc.) now use **0.3% slippage** instead of 1%. volatile pairs keep 1%.

**why**: concentrated-liquidity AMMs on stable pairs (Orca on Solana, Curve on EVM) trade within 0.02-0.05% spread. the old 1% ceiling creates unnecessary MEV surface on what should be tight-peg operations. 0.3% is still ~6x the typical spread - more than enough headroom for MPC ceremony latency (30-90s).

**detection**: `isStablePair(from, to)` checks both tickers against a `STABLE_TICKERS` set. tickers flow in from `findSwapQuote` via the `AccountCoin` spread (already includes `.ticker`). volatile pairs (ETH/USDC, SOL/anything) use the existing 1% path unchanged.

**stable set**: USDC, USDT, DAI, BUSD, TUSD, FRAX, USDP, GUSD, LUSD, USDD, FDUSD, PYUSD.

**tests**: `getLifiSwapQuote.slippage.test.ts` - 9 unit tests for `isStablePair` and `STABLE_TICKERS`, covering stable pairs, volatile pairs, mixed pairs, case-insensitivity, and missing ticker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Fixed swap quote hangs by adding 30-second timeout protection per provider, preventing unresponsive providers from blocking quote retrieval.
- Optimized swap efficiency on stablecoin pairs: reduced slippage tolerance to 0.3% for stable pairs (USDC/USDT/DAI) while maintaining 1% for volatile assets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/592?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->