### PR TITLE
fix: release SDK after core package updates

### DIFF
--- a/.changeset/brave-sdk-psbt-release.md
+++ b/.changeset/brave-sdk-psbt-release.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+Publish the SDK bundle with the latest SwapKit Bitcoin PSBT signing path from `@vultisig/core-chain` and `@vultisig/core-mpc`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       should_publish: ${{ steps.version.outputs.should_publish }}
+      should_tag_release: ${{ steps.version.outputs.should_tag_release }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
@@ -73,6 +74,7 @@ jobs:
           )
 
           SHOULD_PUBLISH=false
+          SHOULD_TAG_RELEASE=false
 
           for PKG_PATH in "${PACKAGES[@]}"; do
             PKG_NAME=$(node -p "require('./${PKG_PATH}/package.json').name")
@@ -83,6 +85,9 @@ jobs:
 
             if [ "$PKG_LOCAL" != "$PKG_NPM" ]; then
               SHOULD_PUBLISH=true
+              if [ "$PKG_NAME" = "@vultisig/sdk" ]; then
+                SHOULD_TAG_RELEASE=true
+              fi
             fi
           done
 
@@ -93,6 +98,7 @@ jobs:
             echo "Unpublished packages found, proceeding with publish"
             echo "should_publish=true" >> $GITHUB_OUTPUT
           fi
+          echo "should_tag_release=$SHOULD_TAG_RELEASE" >> $GITHUB_OUTPUT
 
       - name: Upload SDK dist
         uses: actions/upload-artifact@v7
@@ -260,8 +266,8 @@ jobs:
   # ============ JOB 4: Tag + GitHub Release ============
   tag-and-release:
     name: Tag & GitHub Release
-    needs: [build, test]
-    if: needs.build.outputs.should_publish == 'true'
+    needs: [build, test, publish]
+    if: needs.build.outputs.should_tag_release == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -271,9 +277,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
       - name: Create and push tag
+        id: tag
         run: |
-          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
-            echo "Tag v$VERSION already exists, skipping tag creation"
+          if git ls-remote --exit-code --tags origin "refs/tags/v$VERSION" >/dev/null 2>&1; then
+            echo "Remote tag v$VERSION already exists, skipping tag creation"
             exit 0
           fi
           git config user.name "github-actions[bot]"
@@ -281,7 +288,19 @@ jobs:
           git tag -a "v$VERSION" -m "Release v$VERSION"
           git push origin "v$VERSION"
 
+      - name: Check existing GitHub Release
+        id: github_release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "v$VERSION" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create GitHub Release
+        if: steps.github_release.outputs.exists != 'true'
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v2
         with:
           tag_name: v${{ env.VERSION }}
@@ -291,13 +310,15 @@ jobs:
 
   # ============ JOB 5: Deploy Vercel ============
   deploy-vercel:
-    needs: [build, test]
+    needs: [build, test, publish]
+    if: needs.build.outputs.should_tag_release == 'true'
     uses: ./.github/workflows/deploy-vercel.yml
     secrets: inherit
 
   # ============ JOB 6: Sync Docs ============
   sync-docs:
-    needs: [build, test]
+    needs: [build, test, publish]
+    if: needs.build.outputs.should_tag_release == 'true'
     uses: ./.github/workflows/sync-docs.yml
     with:
       version: ${{ needs.build.outputs.version }}
@@ -305,14 +326,15 @@ jobs:
 
   # ============ JOB 7: Sync Skills ============
   sync-skills:
-    needs: [build, test]
+    needs: [build, test, publish]
+    if: needs.build.outputs.should_tag_release == 'true'
     uses: ./.github/workflows/sync-skills.yml
     secrets: inherit
 
   # ============ JOB 8: Discord Notify ============
   notify:
     needs: [build, test, publish, tag-and-release, deploy-vercel, sync-docs, sync-skills]
-    if: always() && needs.build.outputs.should_publish == 'true'
+    if: always() && needs.build.outputs.should_tag_release == 'true'
     uses: ./.github/workflows/notify-discord.yml
     with:
       version: ${{ needs.build.outputs.version }}


### PR DESCRIPTION
## Summary
- add a missing changeset so the SwapKit Bitcoin PSBT fix is published in a fresh `@vultisig/sdk` release (`1.2.2`) and linked CLI release
- only create the SDK GitHub tag/release when `@vultisig/sdk` itself is newly published
- wait for npm publish to succeed before creating GitHub tags/releases or running post-publish side jobs

## Root cause
PR #588 changed `@vultisig/core-chain` and `@vultisig/core-mpc`, and PR #589 published those two packages. It did not publish `@vultisig/sdk`, because the changeset only listed the core packages. The release workflow still tried to create a GitHub tag from the SDK version (`v1.2.1`), which already existed from PR #581, so the workflow failed even though the core package npm publish completed.

The npm page screenshot is correct: `@vultisig/sdk@1.2.1` was last published on 2026-05-27, and it does not contain the new SwapKit PSBT code path. This PR queues the missing SDK release.

## Verification
- `npm view @vultisig/sdk@1.2.1 time dist-tags --json` confirms latest SDK is still `1.2.1` from 2026-05-27
- downloaded `@vultisig/sdk@1.2.1` tarball and confirmed `verifySwapKitBitcoinPsbtOutputs`, `swapkitSignBitcoin`, and `buildSignBitcoinFromPsbt` are absent from SDK dist
- `npm view @vultisig/core-chain@2.3.2` and `npm view @vultisig/core-mpc@1.2.23` confirm those core packages were published by the failed run
- `yarn changeset status --verbose` shows pending patch bumps for `@vultisig/sdk@1.2.2` and `@vultisig/cli@1.2.2`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated SDK package with improved Bitcoin PSBT signing functionality using the latest SwapKit signing implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-sdk/pull/594?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->