### PR TITLE
fix(swap/swapkit): "no routes" → "amount too small" when pair is supported

### DIFF
--- a/.changeset/swapkit-amount-below-min.md
+++ b/.changeset/swapkit-amount-below-min.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/core-chain': patch
+---
+
+fix(swap/swapkit): reclassify noRoutesFound as "amount too small" when the pair is structurally supported - cross-checks the cached /providers snapshot so low-amount swaps (e.g. BCH->ETH) surface an actionable message instead of a misleading "no route" error

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -1400,6 +1400,16 @@
       "import": "./dist/swap/general/swapkit/SwapKitEnabledChains.js",
       "default": "./dist/swap/general/swapkit/SwapKitEnabledChains.js"
     },
+    "./swap/general/swapkit/SwapKitErrors": {
+      "types": "./dist/swap/general/swapkit/SwapKitErrors.d.ts",
+      "import": "./dist/swap/general/swapkit/SwapKitErrors.js",
+      "default": "./dist/swap/general/swapkit/SwapKitErrors.js"
+    },
+    "./swap/general/swapkit/SwapKitProviders": {
+      "types": "./dist/swap/general/swapkit/SwapKitProviders.d.ts",
+      "import": "./dist/swap/general/swapkit/SwapKitProviders.js",
+      "default": "./dist/swap/general/swapkit/SwapKitProviders.js"
+    },
     "./swap/keysign/getSwapDestinationAddress": {
       "types": "./dist/swap/keysign/getSwapDestinationAddress.d.ts",
       "import": "./dist/swap/keysign/getSwapDestinationAddress.js",

--- a/packages/core/chain/swap/general/swapkit/SwapKitErrors.ts
+++ b/packages/core/chain/swap/general/swapkit/SwapKitErrors.ts
@@ -1,0 +1,23 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+
+/** No SwapKit provider returned an eligible route for the requested swap. */
+export class SwapKitNoEligibleRoutesError extends Error {
+  constructor() {
+    super('SwapKit returned no eligible routes.')
+  }
+}
+
+/**
+ * The SwapKit pair is structurally supported (per the cached `/providers`
+ * snapshot) but no route was returned — i.e. the amount is below the provider
+ * minimum. Synthetic: never decoded from a SwapKit response, only raised by
+ * `getSwapKitQuote` after the pair cross-check. Mirrors vultisig-ios #4418.
+ */
+export class SwapKitAmountBelowMinimumError extends Error {
+  constructor(
+    readonly fromChain: Chain,
+    readonly toChain: Chain
+  ) {
+    super(`SwapKit amount below provider minimum for ${fromChain} -> ${toChain}.`)
+  }
+}

--- a/packages/core/chain/swap/general/swapkit/SwapKitProviders.test.ts
+++ b/packages/core/chain/swap/general/swapkit/SwapKitProviders.test.ts
@@ -22,6 +22,7 @@ describe('SwapKitProviders', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+    vi.useRealTimers()
   })
 
   describe('isSwapKitPairSupported', () => {
@@ -60,14 +61,14 @@ describe('SwapKitProviders', () => {
         'fetch',
         vi.fn(async () =>
           response([
-            { provider: 'MAYACHAIN_STREAMING', enabledChainIds: ['dash', '1'] },
+            { provider: 'MAYACHAIN_STREAMING', enabledChainIds: ['zcash', '1'] },
             { provider: 'NEAR', enabledChainIds: ['1'] },
           ])
         )
       )
 
-      // Dash -> ETH only co-enabled on MAYACHAIN_STREAMING, which is filtered out.
-      await expect(isSwapKitPairSupported({ from: Chain.Dash, to: Chain.Ethereum })).resolves.toBe(false)
+      // Zcash -> ETH only co-enabled on MAYACHAIN_STREAMING, which is filtered out.
+      await expect(isSwapKitPairSupported({ from: Chain.Zcash, to: Chain.Ethereum })).resolves.toBe(false)
     })
 
     it('fails open (returns true) when the providers snapshot is empty', async () => {
@@ -91,7 +92,9 @@ describe('SwapKitProviders', () => {
 
   describe('getSwapKitProviders', () => {
     it('caches the snapshot and does not refetch on the second call', async () => {
-      const fetchMock = vi.fn(async () => response([{ provider: 'NEAR', enabledChainIds: ['1', 'solana'] }]))
+      const fetchMock = vi.fn(async (_url: string) =>
+        response([{ provider: 'NEAR', enabledChainIds: ['1', 'solana'] }])
+      )
       vi.stubGlobal('fetch', fetchMock)
 
       await getSwapKitProviders()
@@ -110,6 +113,25 @@ describe('SwapKitProviders', () => {
       )
 
       await expect(getSwapKitProviders()).resolves.toEqual([])
+    })
+
+    it('fails open (returns []) when the providers request times out', async () => {
+      vi.useFakeTimers()
+      // Never resolves on its own; only the abort signal rejects it.
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(
+          (_url: string, init?: { signal?: AbortSignal }) =>
+            new Promise<Response>((_, reject) => {
+              init?.signal?.addEventListener('abort', () => reject(new Error('aborted')))
+            })
+        )
+      )
+
+      const providersPromise = getSwapKitProviders()
+      await vi.advanceTimersByTimeAsync(5_000)
+
+      await expect(providersPromise).resolves.toEqual([])
     })
   })
 })

--- a/packages/core/chain/swap/general/swapkit/SwapKitProviders.test.ts
+++ b/packages/core/chain/swap/general/swapkit/SwapKitProviders.test.ts
@@ -101,7 +101,7 @@ describe('SwapKitProviders', () => {
       await getSwapKitProviders()
 
       expect(fetchMock).toHaveBeenCalledTimes(1)
-      expect(fetchMock.mock.calls[0][0]).toBe(`${BASE_URL}/providers`)
+      expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/providers`, expect.any(Object))
     })
 
     it('returns an empty list (no throw) when the request fails', async () => {

--- a/packages/core/chain/swap/general/swapkit/SwapKitProviders.test.ts
+++ b/packages/core/chain/swap/general/swapkit/SwapKitProviders.test.ts
@@ -1,0 +1,115 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { configureSwapKit } from '@vultisig/core-chain/swap/general/swapkit/config'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getSwapKitProviders, isSwapKitPairSupported, resetSwapKitProvidersCache } from './SwapKitProviders'
+
+const response = (body: unknown, ok = true, status = 200) =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Bad Request',
+    json: vi.fn(async () => body),
+  }) as unknown as Response
+
+const BASE_URL = 'https://api.vultisig.com/swapkit-win'
+
+describe('SwapKitProviders', () => {
+  beforeEach(() => {
+    resetSwapKitProvidersCache()
+    configureSwapKit({ apiKey: undefined, baseUrl: BASE_URL })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('isSwapKitPairSupported', () => {
+    it('returns true when a single non-excluded provider enables both chains', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () =>
+          response([
+            { provider: 'NEAR', enabledChainIds: ['bitcoincash', '1', 'solana'] },
+            { provider: 'UNISWAP_V3', enabledChainIds: ['1', '42161'] },
+          ])
+        )
+      )
+
+      // BCH ('bitcoincash') -> ETH ('1') — NEAR enables both. This is the
+      // exact issue #3987 pair.
+      await expect(isSwapKitPairSupported({ from: Chain.BitcoinCash, to: Chain.Ethereum })).resolves.toBe(true)
+    })
+
+    it('returns false when the two chains are split across providers (no single provider has both)', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () =>
+          response([
+            { provider: 'GARDEN', enabledChainIds: ['bitcoincash'] },
+            { provider: 'UNISWAP_V3', enabledChainIds: ['1'] },
+          ])
+        )
+      )
+
+      await expect(isSwapKitPairSupported({ from: Chain.BitcoinCash, to: Chain.Ethereum })).resolves.toBe(false)
+    })
+
+    it('ignores excluded native providers when both chains are only enabled there', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () =>
+          response([
+            { provider: 'MAYACHAIN_STREAMING', enabledChainIds: ['dash', '1'] },
+            { provider: 'NEAR', enabledChainIds: ['1'] },
+          ])
+        )
+      )
+
+      // Dash -> ETH only co-enabled on MAYACHAIN_STREAMING, which is filtered out.
+      await expect(isSwapKitPairSupported({ from: Chain.Dash, to: Chain.Ethereum })).resolves.toBe(false)
+    })
+
+    it('fails open (returns true) when the providers snapshot is empty', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => response([]))
+      )
+
+      await expect(isSwapKitPairSupported({ from: Chain.BitcoinCash, to: Chain.Ethereum })).resolves.toBe(true)
+    })
+
+    it('fails open (returns true) when the providers request fails', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => response({}, false, 500))
+      )
+
+      await expect(isSwapKitPairSupported({ from: Chain.Solana, to: Chain.Ethereum })).resolves.toBe(true)
+    })
+  })
+
+  describe('getSwapKitProviders', () => {
+    it('caches the snapshot and does not refetch on the second call', async () => {
+      const fetchMock = vi.fn(async () => response([{ provider: 'NEAR', enabledChainIds: ['1', 'solana'] }]))
+      vi.stubGlobal('fetch', fetchMock)
+
+      await getSwapKitProviders()
+      await getSwapKitProviders()
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(fetchMock.mock.calls[0][0]).toBe(`${BASE_URL}/providers`)
+    })
+
+    it('returns an empty list (no throw) when the request fails', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => {
+          throw new Error('network down')
+        })
+      )
+
+      await expect(getSwapKitProviders()).resolves.toEqual([])
+    })
+  })
+})

--- a/packages/core/chain/swap/general/swapkit/SwapKitProviders.ts
+++ b/packages/core/chain/swap/general/swapkit/SwapKitProviders.ts
@@ -62,6 +62,11 @@ type ProvidersCache = {
 
 const PROVIDERS_CACHE_TTL_MS = 10 * 60 * 1000
 
+// Short timeout so a stalled /providers call fails open fast instead of dragging
+// out the no-route classification path (the outer findSwapQuote per-fetcher
+// timeout would also catch it, but much later).
+const PROVIDERS_FETCH_TIMEOUT_MS = 5_000
+
 let providersCache: ProvidersCache | null = null
 
 /** Test-only: clear the in-memory `/providers` snapshot. */
@@ -109,15 +114,23 @@ export const getSwapKitProviders = async (): Promise<SwapKitProviderInfo[]> => {
 
   const trimmedApiKey = apiKey?.trim()
   const result = await attempt(async () => {
-    const response = await fetch(`${baseUrl.replace(/\/$/, '')}/providers`, {
-      headers: trimmedApiKey ? { 'x-api-key': trimmedApiKey } : {},
-    })
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), PROVIDERS_FETCH_TIMEOUT_MS)
 
-    if (!response.ok) {
-      throw new Error(`SwapKit providers request failed (${response.status})`)
+    try {
+      const response = await fetch(`${baseUrl.replace(/\/$/, '')}/providers`, {
+        headers: trimmedApiKey ? { 'x-api-key': trimmedApiKey } : {},
+        signal: controller.signal,
+      })
+
+      if (!response.ok) {
+        throw new Error(`SwapKit providers request failed (${response.status})`)
+      }
+
+      return parseProviders(await response.json())
+    } finally {
+      clearTimeout(timeoutId)
     }
-
-    return parseProviders(await response.json())
   })
 
   if ('error' in result) {

--- a/packages/core/chain/swap/general/swapkit/SwapKitProviders.ts
+++ b/packages/core/chain/swap/general/swapkit/SwapKitProviders.ts
@@ -1,0 +1,165 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { getSwapKitConfig } from '@vultisig/core-chain/swap/general/swapkit/config'
+import { SwapKitEnabledChain, SwapKitSourceChain } from '@vultisig/core-chain/swap/general/swapkit/SwapKitEnabledChains'
+import { attempt } from '@vultisig/lib-utils/attempt'
+
+/**
+ * Providers handled by the dedicated native THORChain/MayaChain path, never via
+ * SwapKit aggregation. Filtered out of both route selection and the pair-support
+ * cross-check so a native-only provider can't make a pair look SwapKit-routable.
+ */
+export const swapKitExcludedProviders = new Set([
+  'THORCHAIN',
+  'THORCHAIN_STREAMING',
+  'MAYACHAIN',
+  'MAYACHAIN_STREAMING',
+])
+
+export const normalizeSwapKitProvider = (provider: string): string =>
+  provider.trim().toUpperCase().replace(/[-\s]/g, '_')
+
+/**
+ * Chain → SwapKit `enabledChainIds` token as returned by `/providers`. EVM chains
+ * use their numeric EVM chain id; non-EVM chains use SwapKit's named id. This is a
+ * DISTINCT id-space from `swapKitChainId` (the asset-prefix used in `/v3/quote`).
+ */
+const swapKitProviderChainId: Record<SwapKitEnabledChain, string> = {
+  [Chain.Ethereum]: '1',
+  [Chain.Arbitrum]: '42161',
+  [Chain.Avalanche]: '43114',
+  [Chain.Base]: '8453',
+  [Chain.BSC]: '56',
+  [Chain.Optimism]: '10',
+  [Chain.Polygon]: '137',
+  [Chain.Solana]: 'solana',
+  [Chain.Bitcoin]: 'bitcoin',
+  [Chain.BitcoinCash]: 'bitcoincash',
+  [Chain.Dogecoin]: 'dogecoin',
+  [Chain.Litecoin]: 'litecoin',
+  [Chain.Ripple]: 'ripple',
+  [Chain.Ton]: 'ton',
+  [Chain.Tron]: '728126428',
+  [Chain.Zcash]: 'zcash',
+  [Chain.Cardano]: 'cardano',
+  [Chain.Cosmos]: 'cosmos',
+  [Chain.Dash]: 'dash',
+  [Chain.Kujira]: 'kaiyo-1',
+  [Chain.MayaChain]: 'mayachain-mainnet-v1',
+  [Chain.Sui]: 'sui',
+  [Chain.THORChain]: 'thorchain-1',
+}
+
+export type SwapKitProviderInfo = {
+  provider: string
+  enabledChainIds: string[]
+}
+
+type ProvidersCache = {
+  baseUrl: string
+  providers: SwapKitProviderInfo[]
+  fetchedAt: number
+}
+
+const PROVIDERS_CACHE_TTL_MS = 10 * 60 * 1000
+
+let providersCache: ProvidersCache | null = null
+
+/** Test-only: clear the in-memory `/providers` snapshot. */
+export const resetSwapKitProvidersCache = () => {
+  providersCache = null
+}
+
+const parseProviders = (data: unknown): SwapKitProviderInfo[] => {
+  const list = Array.isArray(data) ? data : []
+
+  return list.flatMap(entry => {
+    if (typeof entry !== 'object' || entry === null) {
+      return []
+    }
+
+    const { provider, enabledChainIds } = entry as Record<string, unknown>
+    if (typeof provider !== 'string' || !Array.isArray(enabledChainIds)) {
+      return []
+    }
+
+    return [
+      {
+        provider,
+        enabledChainIds: enabledChainIds.filter((id): id is string => typeof id === 'string'),
+      },
+    ]
+  })
+}
+
+/**
+ * Fetches and caches SwapKit's `/providers` snapshot. The snapshot rarely changes
+ * and is only needed on the unhappy path, so a coarse TTL is enough. On any
+ * failure returns an empty list, which callers treat as "unknown" (fail-open).
+ */
+export const getSwapKitProviders = async (): Promise<SwapKitProviderInfo[]> => {
+  const { apiKey, baseUrl } = getSwapKitConfig()
+
+  if (
+    providersCache &&
+    providersCache.baseUrl === baseUrl &&
+    Date.now() - providersCache.fetchedAt < PROVIDERS_CACHE_TTL_MS
+  ) {
+    return providersCache.providers
+  }
+
+  const trimmedApiKey = apiKey?.trim()
+  const result = await attempt(async () => {
+    const response = await fetch(`${baseUrl.replace(/\/$/, '')}/providers`, {
+      headers: trimmedApiKey ? { 'x-api-key': trimmedApiKey } : {},
+    })
+
+    if (!response.ok) {
+      throw new Error(`SwapKit providers request failed (${response.status})`)
+    }
+
+    return parseProviders(await response.json())
+  })
+
+  if ('error' in result) {
+    return []
+  }
+
+  providersCache = { baseUrl, providers: result.data, fetchedAt: Date.now() }
+  return result.data
+}
+
+/**
+ * SwapKit collapses "amount below provider minimum" and "pair not supported" into
+ * the same `noRoutesFound` 404, so the envelope alone can't disambiguate them.
+ * Cross-check the cached `/providers` snapshot: if a single non-excluded provider
+ * enables BOTH chains, the pair is structurally supported, so a no-route result
+ * must be amount-related. Mirrors vultisig-ios #4418.
+ *
+ * Intersection on a SINGLE provider (not a union across providers): a provider
+ * that enables both chains is far likelier to actually route between them than
+ * two providers each covering one side. Fails open (returns `true`) when the
+ * snapshot is unavailable — degrading to "amount too small" beats a misleading
+ * "no route" message.
+ */
+export const isSwapKitPairSupported = async ({
+  from,
+  to,
+}: {
+  from: SwapKitSourceChain
+  to: SwapKitEnabledChain
+}): Promise<boolean> => {
+  const providers = await getSwapKitProviders()
+  if (providers.length === 0) {
+    return true
+  }
+
+  const fromId = swapKitProviderChainId[from]
+  const toId = swapKitProviderChainId[to]
+
+  return providers.some(
+    ({ provider, enabledChainIds }) =>
+      !swapKitExcludedProviders.has(normalizeSwapKitProvider(provider)) &&
+      enabledChainIds.includes(fromId) &&
+      enabledChainIds.includes(toId)
+  )
+}

--- a/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.test.ts
+++ b/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.test.ts
@@ -1,6 +1,11 @@
 import { Chain } from '@vultisig/core-chain/Chain'
 import { configureSwapKit, getSwapKitConfig } from '@vultisig/core-chain/swap/general/swapkit/config'
 import type { SwapKitSourceChain } from '@vultisig/core-chain/swap/general/swapkit/SwapKitEnabledChains'
+import {
+  SwapKitAmountBelowMinimumError,
+  SwapKitNoEligibleRoutesError,
+} from '@vultisig/core-chain/swap/general/swapkit/SwapKitErrors'
+import { resetSwapKitProvidersCache } from '@vultisig/core-chain/swap/general/swapkit/SwapKitProviders'
 import { networks, payments, Psbt } from 'bitcoinjs-lib'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -791,5 +796,51 @@ describe('getSwapKitQuote', () => {
         },
       },
     })
+  })
+
+  it('reclassifies noRoutesFound to an amount-below-minimum error when the pair is structurally supported (#4418)', async () => {
+    resetSwapKitProvidersCache()
+    const fetchMock = vi.fn(async (url: string) => {
+      if (typeof url === 'string' && url.endsWith('/providers')) {
+        return response([{ provider: 'NEAR', enabledChainIds: ['bitcoincash', '1'] }])
+      }
+      return response({ error: 'noRoutesFound', message: 'No routes found for BCH.BCH -> ETH.ETH' }, false, 404)
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+    configureSwapKit({ apiKey: undefined, baseUrl: 'https://api.vultisig.com/swapkit-win' })
+
+    // The issue #3987 pair: BCH -> ETH at a below-minimum amount. SwapKit only
+    // returns noRoutesFound (no providerErrors), but NEAR structurally supports
+    // the pair, so we surface an actionable amount error instead of "no route".
+    await expect(
+      getSwapKitQuote({
+        from: { chain: Chain.BitcoinCash, address: 'bitcoincash:qsource', ticker: 'BCH', decimals: 8 },
+        to: { chain: Chain.Ethereum, address: '0xdestination', ticker: 'ETH', decimals: 18 },
+        amount: 1_150_000n,
+      })
+    ).rejects.toBeInstanceOf(SwapKitAmountBelowMinimumError)
+  })
+
+  it('rethrows the no-eligible-routes error when the pair is not structurally supported', async () => {
+    resetSwapKitProvidersCache()
+    const fetchMock = vi.fn(async (url: string) => {
+      if (typeof url === 'string' && url.endsWith('/providers')) {
+        // No provider co-enables litecoin + ETH, so the pair is genuinely unsupported.
+        return response([{ provider: 'NEAR', enabledChainIds: ['1', 'solana'] }])
+      }
+      return response({ error: 'noRoutesFound' }, false, 404)
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+    configureSwapKit({ apiKey: undefined, baseUrl: 'https://api.vultisig.com/swapkit-win' })
+
+    await expect(
+      getSwapKitQuote({
+        from: { chain: Chain.Litecoin, address: 'ltc1qsource', ticker: 'LTC', decimals: 8 },
+        to: { chain: Chain.Ethereum, address: '0xdestination', ticker: 'ETH', decimals: 18 },
+        amount: 1000n,
+      })
+    ).rejects.toBeInstanceOf(SwapKitNoEligibleRoutesError)
   })
 })

--- a/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.ts
+++ b/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.ts
@@ -6,6 +6,15 @@ import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { GeneralSwapQuote, GeneralSwapTx } from '@vultisig/core-chain/swap/general/GeneralSwapQuote'
 import { getSwapKitConfig } from '@vultisig/core-chain/swap/general/swapkit/config'
 import { SwapKitEnabledChain, SwapKitSourceChain } from '@vultisig/core-chain/swap/general/swapkit/SwapKitEnabledChains'
+import {
+  SwapKitAmountBelowMinimumError,
+  SwapKitNoEligibleRoutesError,
+} from '@vultisig/core-chain/swap/general/swapkit/SwapKitErrors'
+import {
+  isSwapKitPairSupported,
+  normalizeSwapKitProvider,
+  swapKitExcludedProviders,
+} from '@vultisig/core-chain/swap/general/swapkit/SwapKitProviders'
 import { isOneOf } from '@vultisig/lib-utils/array/isOneOf'
 import { withoutUndefinedFields } from '@vultisig/lib-utils/record/withoutUndefinedFields'
 import { TransferDirection } from '@vultisig/lib-utils/TransferDirection'
@@ -79,8 +88,6 @@ const swapKitProviderQuoteAttempts: SwapKitProvider[][] = [
     'OPENOCEAN_V2',
   ],
 ]
-
-const swapKitExcludedProviders = new Set(['THORCHAIN', 'THORCHAIN_STREAMING', 'MAYACHAIN', 'MAYACHAIN_STREAMING'])
 
 const swapKitChainId: Record<SwapKitEnabledChain, string> = {
   [Chain.Arbitrum]: 'ARB',
@@ -181,14 +188,12 @@ const formatBasicUnitAmount = (amount: bigint, decimals: number): string => {
   return fraction ? `${sign}${whole.toString()}.${fraction}` : `${sign}${whole.toString()}`
 }
 
-const normalizeProvider = (provider: string) => provider.trim().toUpperCase().replace(/[-\s]/g, '_')
-
 const routeProviderNames = ({ providers, legs }: Pick<SwapKitQuoteRoute, 'providers' | 'legs'>): string[] => {
   const names = [...(providers ?? []), ...(legs ?? []).map(({ provider }) => provider)].filter(
     (provider): provider is string => !!provider
   )
 
-  return [...new Set(names.map(normalizeProvider))]
+  return [...new Set(names.map(normalizeSwapKitProvider))]
 }
 
 const isAllowedRoute = (route: SwapKitQuoteRoute) =>
@@ -690,7 +695,7 @@ const getBestSwapKitRoute = async (body: Record<string, unknown>, decimals: numb
     }
   }
 
-  throw new Error('SwapKit returned no eligible routes.')
+  throw new SwapKitNoEligibleRoutesError()
 }
 
 export const getSwapKitQuote = async ({
@@ -707,7 +712,22 @@ export const getSwapKitQuote = async ({
     slippage,
     affiliateFee: affiliateBps,
   }
-  const route = await getBestSwapKitRoute(quoteBody, to.decimals)
+  let route: SwapKitQuoteRoute
+  try {
+    route = await getBestSwapKitRoute(quoteBody, to.decimals)
+  } catch (error) {
+    // SwapKit's `noRoutesFound` 404 can't distinguish "amount below provider
+    // minimum" from "pair unsupported". When the pair IS structurally supported
+    // (per the /providers snapshot), reclassify so the form shows the actionable
+    // "amount too small" copy instead of a misleading "no route" error (#4418).
+    if (
+      error instanceof SwapKitNoEligibleRoutesError &&
+      (await isSwapKitPairSupported({ from: from.chain, to: to.chain }))
+    ) {
+      throw new SwapKitAmountBelowMinimumError(from.chain, to.chain)
+    }
+    throw error
+  }
 
   const swapResponse = await postSwapKit<SwapKitSwapResponse>(
     '/v3/swap',

--- a/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
@@ -5,6 +5,7 @@ import { getKyberSwapQuote } from '@vultisig/core-chain/swap/general/kyber/api/q
 import { getLifiSwapQuote } from '@vultisig/core-chain/swap/general/lifi/api/getLifiSwapQuote'
 import { getOneInchSwapQuote } from '@vultisig/core-chain/swap/general/oneInch/api/getOneInchSwapQuote'
 import { getSwapKitQuote } from '@vultisig/core-chain/swap/general/swapkit/api/getSwapKitQuote'
+import { SwapKitAmountBelowMinimumError } from '@vultisig/core-chain/swap/general/swapkit/SwapKitErrors'
 import { getNativeSwapQuote } from '@vultisig/core-chain/swap/native/api/getNativeSwapQuote'
 import { NativeSwapQuote } from '@vultisig/core-chain/swap/native/NativeSwapQuote'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -156,6 +157,18 @@ describe('findSwapQuote parallel selection', () => {
       throw new Error('Expected native quote')
     }
     expect(quote.quote.native.expected_amount_out).toBe('100')
+  })
+
+  it('reclassifies a SwapKit below-minimum rejection as "amount too small" (#4418)', async () => {
+    vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('skip kyber'))
+    vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('skip inch'))
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
+    vi.mocked(getNativeSwapQuote).mockRejectedValue(new Error('native unavailable'))
+    vi.mocked(getSwapKitQuote).mockRejectedValue(new SwapKitAmountBelowMinimumError(Chain.Ethereum, Chain.Ethereum))
+
+    await expect(findSwapQuote({ ...evmSameChainCoins, amount: 1n })).rejects.toThrow(
+      'Swap amount too small. Please increase the amount to proceed.'
+    )
   })
 
   it('does not let a malformed provider amount hide a succeeding one', async () => {

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -20,6 +20,7 @@ import {
   swapKitEnabledChains,
   swapKitSourceChains,
 } from '@vultisig/core-chain/swap/general/swapkit/SwapKitEnabledChains'
+import { SwapKitAmountBelowMinimumError } from '@vultisig/core-chain/swap/general/swapkit/SwapKitErrors'
 import { NativeSwapAffiliateConfig } from '@vultisig/core-chain/swap/native/api/affiliate'
 import { getNativeSwapQuote } from '@vultisig/core-chain/swap/native/api/getNativeSwapQuote'
 import { nativeSwapChains, nativeSwapEnabledChainsRecord } from '@vultisig/core-chain/swap/native/NativeSwapChain'
@@ -459,7 +460,14 @@ export const findSwapQuote = async ({
 
     const msg: string = result.reason instanceof Error ? result.reason.message : String(result.reason)
 
-    if (isInError(result.reason, 'dust threshold') || isInError(result.reason, 'amount less than')) {
+    // SwapKit raises this only after confirming the pair is structurally
+    // supported, so it is unambiguously an amount problem (#4418). Reuse the
+    // same copy as the THORChain dust-threshold path.
+    if (
+      result.reason instanceof SwapKitAmountBelowMinimumError ||
+      isInError(result.reason, 'dust threshold') ||
+      isInError(result.reason, 'amount less than')
+    ) {
       throw new SwapError(SwapErrorCode.AmountTooSmall, 'Swap amount too small. Please increase the amount to proceed.')
     }
 


### PR DESCRIPTION
## Summary
Fix https://github.com/vultisig/vultisig-windows/issues/3987
SwapKit's `/v3/quote` collapses **"amount below provider minimum"** and **"pair not supported"** into the same byte-identical `noRoutesFound` 404, so the SDK could not disambiguate them. As a result, a low-amount swap on a pair that clearly has routes at larger sizes surfaced a misleading **"No swap route found"** error instead of an actionable "amount too small" message.

This affects `clients/extension` + `clients/desktop` (shared `findSwapQuote` path) and is the SDK-side fix for `vultisig/vultisig-windows#3987`. Ports the approach from `vultisig/vultisig-ios#4418`.

## Empirical findings (live SwapKit proxy probe)

The previously-shipped below-minimum handling relied on `providerErrors` / `errorCode: BELOW_MINIMUM`. Probing the live proxy shows SwapKit does **not** emit those for the real cases — it returns a bare `noRoutesFound`:

| Pair | Below minimum | Above minimum |
|------|---------------|---------------|
| `BCH → ETH` (issue repro) | `404 noRoutesFound`, **no `providerErrors`** | `0.5 BCH` → `200` routes (NEAR) |
| `SOL → ETH.USDC` | `404 noRoutesFound`, **no `providerErrors`** | `0.3 SOL` → `200` routes (Chainflip) |

So widening the message classifier cannot help — there is no signal in the envelope to match.

## Approach (mirrors iOS #4418)

Cross-check the `/providers` snapshot we now cache: if a single **non-excluded** provider lists BOTH the source and destination chains in its `enabledChainIds`, the pair is structurally supported, so a no-route result must be amount-related. Re-classify it and reuse the existing "amount too small" copy.

- **`SwapKitProviders.ts`** — cached `/providers` fetch + `isSwapKitPairSupported({ from, to })` pure-logic predicate (intersection on a single provider, excluded native providers filtered out). Zero extra wire calls on the happy path; fails open when the snapshot is unavailable.
- **`SwapKitErrors.ts`** — `SwapKitNoEligibleRoutesError` (replaces the bare string throw) and the synthetic `SwapKitAmountBelowMinimumError` (raised only after the cache cross-check, never decoded from the envelope).
- **`getSwapKitQuote`** — on `SwapKitNoEligibleRoutesError`, ask the cache; if the pair is supported, throw `SwapKitAmountBelowMinimumError`, else rethrow the no-route error verbatim. Existing `providerErrors` below-minimum handling is unchanged.
- **`findSwapQuote`** — maps `SwapKitAmountBelowMinimumError` to the same `Swap amount too small. Please increase the amount to proceed.` copy already used by the THORChain dust-threshold path.

## False-positive scope

If every provider individually enables both chains but NO single provider co-enables them, a genuinely-unsupported pair would be classified as "amount too small". For NEAR-Intents' broad coverage this is effectively unreachable; degrading to "amount too small" over "no route" is still better UX, and the risk is the same one explicitly accepted in iOS #4418.

## Test plan

- [x] `yarn check` (shared-exports + typecheck + lint + knip + format) — clean
- [x] New unit tests pass (7 predicate/cache + 2 service reclassification + 1 findSwapQuote mapping); full affected suites green (51 passed)
- [x] Manual (app): `BCH→ETH` at sub-minimum amount shows "Swap amount too small. Please increase the amount to proceed." — see receipts below
- [x] Negative control: ATOM→ETH (no SwapKit provider covers ATOM) still shows "no swap route found" via CLI probe — not falsely reclassified

Fixes vultisig/vultisig-windows#3987

---

## Receipts

> Tested on local stack: SDK built from this branch (`fix/swapkit-no-routes-amount-too-small`) linked into mcp-ts via dist-file patch + local agent-backend (port 8087). All checks green as of 2026-05-28.

### A. Bash — SDK side

**A.1 Full test suite (837/837)**

```
 RUN  v4.1.6 /Users/gomes/Sites/vultisig-sdk

 Test Files  89 passed (89)
      Tests  837 passed (837)
   Start at  13:01:02
   Duration  3.25s (transform 2.70s, setup 0ms, import 14.29s, tests 2.30s)
```

**A.2 Targeted SwapKit tests (29/29)**

```
 RUN  v4.1.6 /Users/gomes/Sites/vultisig-sdk

 Test Files  2 passed (2)
      Tests  29 passed (29)
   Start at  13:01:10
   Duration  223ms
```

Files: `SwapKitProviders.test.ts` + `getSwapKitQuote.test.ts`

**A.3 Lint + typecheck**

```
$ yarn lint    -> (exit 0, no output)
$ yarn typecheck -> build success, no type errors
```

**A.4 Live `/providers` probe — `api.vultisig.com/swapkit-win`**

```
$ curl -sS "https://api.vultisig.com/swapkit-win/providers" | python3 -c "..."

Total providers: 12
BCH->ETH pair analysis:
  FOUND: NEAR co-enables BCH+ETH -> pair IS supported (25 chains)
LTC->ETH pair analysis:
  LTC not found in any non-excluded provider -> pair NOT supported -> no-route correct
MAYAN: 0 chains (listed but inactive, empty enabledChainIds[])
```

**A.5 Synthetic `isSwapKitPairSupported` demo (live `/providers` cross-check)**

```
=== SwapKit Pair Supported Demo ===
Using SwapKit proxy: https://api.vultisig.com/swapkit-win

Fetching https://api.vultisig.com/swapkit-win/providers...
Got 12 providers

=== Results ===
BCH -> ETH: supported = true
  Expected: true  (NEAR co-enables bitcoincash + 1)
  Error classification: "Swap amount too small. Please increase the amount to proceed."

LTC -> ETH: supported = false
  Expected: false (litecoin absent from all non-excluded providers)
  Error classification: "No swap route found."

Provider enabling BCH->ETH: NEAR
  Chain count: 25
LTC-enabled non-excluded providers: 0 (none)

PASS: BCH->ETH correctly classified as amount-too-small; LTC->ETH correctly classified as no-route
```

**A.6 CLI full-stack probe (local mcp-ts with PR branch SDK + agent-backend port 8087)**

BCH→ETH at 0.0001 BCH (positive case — pair supported, amount too small):
```
[tool] execute_swap ...
[SSE:tool_progress] output: {
  "error": "execute_swap: quote failed: Swap amount too small. Please increase the amount to proceed.",
  "status": "error"
}
```

ATOM→ETH at 1 ATOM (negative control — ATOM absent from all SwapKit providers):
```
[tool] execute_swap ...
[SSE:tool_progress] output: {
  "error": "execute_swap: no swap route found after trying SwapKit. If the amount is small, try a larger amount — cross-chain providers have per-pair minimums.",
  "status": "error"
}
```

ATOM routed via THORChain (native path, separate from SwapKit), not falsely reclassified as amount-too-small.

### B. Sim screenshots — iPhone 16e (iOS 18), vultiagent-app on local stack

**B.1 BCH→ETH at 0.0001 BCH — "amount too small" (positive case)**

App message: "swap 0.0001 BCH to ETH"
Agent runs `EXECUTE SWAP`, SwapKit returns `noRoutesFound`, SDK cross-checks `/providers` (NEAR co-enables BCH+ETH = pair supported), throws `SwapKitAmountBelowMinimumError`, `findSwapQuote` maps to `SwapError(AmountTooSmall, "Swap amount too small. Please increase the amount to proceed.")`, mcp-ts surfaces in the error card:

![bch-amount-too-small](https://i.imgur.com/nibkrjo.png)

**B.2 Both messages in chat — BCH error visible + ATOM follow-up**

![both-swap-messages](https://i.imgur.com/RJuIcmR.png)

The red error card reads: **"quote failed: Swap amount too small. Please increase the amount to proceed."** — the new copy from this PR.

**Notes on test setup:**
- SDK built from this branch (`yarn build:sdk`), dist files patched into mcp-ts `node_modules` for local testing. Production npm publish will follow standard SDK release flow (`changeset version` + `changeset publish`).
- The `.changeset/swapkit-amount-below-min.md` file added in `ccc7cfc1` ensures the version bump is captured.
- mcp-ts restored to npm-published SDK after testing (no permanent change to mcp-ts).