### PR TITLE
chore(sdk): patch changeset to publish latest core-chain bundle (unblock consumer SDK rollout)

### DIFF
--- a/.changeset/sdk-publish-roll-core-features.md
+++ b/.changeset/sdk-publish-roll-core-features.md
@@ -1,0 +1,11 @@
+---
+'@vultisig/sdk': patch
+---
+
+Republish the `@vultisig/sdk` bundle so consumers (mcp-ts, vultiagent-app) pick up the latest `@vultisig/core-chain` features that landed without an `@vultisig/sdk` changeset:
+
+- `resolveTokenPriceId(chain, denomOrAddress?)` helper for registry-driven token price resolution ([#587](https://github.com/vultisig/vultisig-sdk/pull/587))
+- LiFi stable-pair slippage tuning ([changeset](.changeset/lifi-stable-pair-slippage.md))
+- Plus any other pending `@vultisig/core-chain` minors that have been merged without a corresponding sdk-package changeset.
+
+Pure repackage — no consumer-facing API change; the bundle just embeds the latest core-chain dist.


### PR DESCRIPTION
The recent core-chain landings ([sdk#587 resolveTokenPriceId](https://github.com/vultisig/vultisig-sdk/pull/587), [sdk#592 LiFi stable slippage](https://github.com/vultisig/vultisig-sdk/pull/592), upcoming sdk#584/#593/#596) added `@vultisig/core-chain` changesets but no `@vultisig/sdk` changeset. The changesets-action only versions packages that have explicit changesets — so the public `@vultisig/sdk` npm package stays on **1.3.1** while internal core-chain is freshly bumped on every `chore: version packages` PR.

Consumers (mcp-ts, vultiagent-app) pin `@vultisig/sdk`, not core-chain. Without an sdk-package changeset, the new core-chain features can't reach them via `npm install @vultisig/sdk@latest`.

This single-line patch changeset forces the next `chore: version packages` PR to republish `@vultisig/sdk` so the bundle ships the latest core-chain dist. Pure repackage — no consumer-facing API change.

## Followup convention

Pair every core-chain-touching PR with a one-line `@vultisig/sdk` patch changeset so the bundle stays in lockstep going forward.

## receipts

no runtime changes (single changeset file added)