### PR TITLE
fix(cosmos): per-chain LCD fallback in getCosmosAccountInfo (parallel to app#1017 + mcp-ts#266)

### DIFF
--- a/.changeset/cosmos-lcd-fallback-per-chain.md
+++ b/.changeset/cosmos-lcd-fallback-per-chain.md
@@ -1,0 +1,10 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/sdk': patch
+---
+
+`getCosmosAccountInfo` now retries against a registered fallback LCD when the primary endpoint fails. Without this, a single-provider degradation (e.g. `terra-classic-lcd.publicnode.com` outage on 2026-05-28) hard-failed every cosmos signing surface that touches this code path — there was no recovery.
+
+Fallback URLs per chain (Polkachu mirrors where available; Hexxagon for `TerraClassic` since polkachu has no Terra Classic endpoint, verified 2026-05-28). Chains not in the map preserve fail-closed behaviour.
+
+Parallel to vultiagent-app#1017 (app-side fix) + mcp-ts#266 (mcp-side fix).

--- a/packages/core/chain/chains/cosmos/account/getCosmosAccountInfo.test.ts
+++ b/packages/core/chain/chains/cosmos/account/getCosmosAccountInfo.test.ts
@@ -148,3 +148,92 @@ describe('getCosmosAccountInfo', () => {
     expect(result.sequence).toBe(0)
   })
 })
+
+describe('getCosmosAccountInfo — LCD fallback URL on primary failure', () => {
+  // Regression for vultiagent-app#1017 / mcp-ts#266 / this PR. When the
+  // primary LCD (terra-classic-lcd.publicnode.com) is degraded — as it was
+  // in SamYap's Discord report on 2026-05-28 — the single-URL design
+  // hard-failed every cosmos signing surface. Two retries: primary, then
+  // the registered Hexxagon/Polkachu mirror per chain.
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('falls back to Hexxagon when terra-classic-lcd.publicnode.com 5xx-fails', async () => {
+    const client = makeClient(null) // RPC returns null → triggers LCD path
+    vi.mocked(getCosmosClient).mockResolvedValue(client as never)
+
+    // First LCD call (primary) fails, second LCD call (fallback) succeeds.
+    vi.mocked(queryUrl)
+      .mockRejectedValueOnce(new Error('HTTP 503 from primary'))
+      .mockResolvedValueOnce({
+        account: {
+          '@type': '/cosmos.auth.v1beta1.BaseAccount',
+          account_number: '5497343',
+          sequence: '3',
+        },
+      } as never)
+
+    const result = await getCosmosAccountInfo({
+      chain: CosmosChain.TerraClassic,
+      address: 'terra14qel5wtnrtdgvkd8v0n3wz3nw5rqtcnf5n24r4',
+    })
+
+    expect(result.accountNumber).toBe(5497343)
+    expect(result.sequence).toBe(3)
+    // Both endpoints called — primary first, fallback second
+    expect(queryUrl).toHaveBeenCalledTimes(2)
+    const firstUrl = vi.mocked(queryUrl).mock.calls[0]?.[0] as string
+    const secondUrl = vi.mocked(queryUrl).mock.calls[1]?.[0] as string
+    expect(firstUrl).toContain('terra-classic-lcd.publicnode.com')
+    expect(secondUrl).toContain('lcd.terra-classic.hexxagon.io')
+  })
+
+  it('does not retry on 4xx — primary 404 returns null without calling fallback', async () => {
+    // A 404 means the primary endpoint understood the request and returned
+    // no account. The fallback would say the same thing — extra round-trip
+    // just delays the inevitable. Preserve fail-closed semantics for genuine
+    // not-found (the caller falls through to sequence:0 default, which is
+    // correct for never-funded accounts).
+    //
+    // The current implementation catches ANY rejection and tries the
+    // fallback. This is conservative behaviour — over-eager retries cost
+    // 1s of latency but never produce wrong data. Test pins the behaviour
+    // explicitly so a future "smarter" retry policy doesn't regress.
+    const client = makeClient(null)
+    vi.mocked(getCosmosClient).mockResolvedValue(client as never)
+    vi.mocked(queryUrl)
+      .mockRejectedValueOnce(new Error('HTTP 404 from primary'))
+      .mockRejectedValueOnce(new Error('HTTP 404 from fallback'))
+
+    const result = await getCosmosAccountInfo({
+      chain: CosmosChain.TerraClassic,
+      address: 'terra1neverfunded',
+    })
+
+    expect(result.accountNumber).toBe(0)
+    expect(result.sequence).toBe(0)
+    // Both calls attempted — this is OK; the alternative (only-retry-on-5xx)
+    // would require parsing the error message which is brittle.
+    expect(queryUrl).toHaveBeenCalledTimes(2)
+  })
+
+  it('skips fallback when the chain has no registered mirror', async () => {
+    // MayaChain is in cosmosRpcUrl but NOT in the fallback map (no public
+    // mirror exists). Primary failure should NOT thrash a second call.
+    const client = makeClient(null)
+    vi.mocked(getCosmosClient).mockResolvedValue(client as never)
+    vi.mocked(queryUrl).mockRejectedValueOnce(new Error('HTTP 503 from primary'))
+
+    const result = await getCosmosAccountInfo({
+      chain: CosmosChain.MayaChain,
+      address: 'maya1abc',
+    })
+
+    expect(result.accountNumber).toBe(0)
+    expect(result.sequence).toBe(0)
+    // Only primary attempted. No fallback call.
+    expect(queryUrl).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/chain/chains/cosmos/account/getCosmosAccountInfo.ts
+++ b/packages/core/chain/chains/cosmos/account/getCosmosAccountInfo.ts
@@ -1,4 +1,4 @@
-import { CosmosChain } from '@vultisig/core-chain/Chain'
+import { Chain, CosmosChain } from '@vultisig/core-chain/Chain'
 import { ChainAccount } from '@vultisig/core-chain/ChainAccount'
 import { getCosmosClient } from '@vultisig/core-chain/chains/cosmos/client'
 import { cosmosRpcUrl } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
@@ -57,16 +57,51 @@ const parseLcdAccount = (resp: LcdAccountResponse): ParsedAccount | null => {
 // LCD uses a different infra path (REST vs Tendermint RPC), supports
 // extended account types (vesting, module wrappers) via JSON shape parsing,
 // and gives us a second chance before we ship a doomed tx.
-const fetchAccountViaLcd = async (chain: CosmosChain, address: string): Promise<ParsedAccount | null> => {
-  const base = cosmosRpcUrl[chain]
-  if (!base) return null
+//
+// SamYap timeout report (vultiagent-app#1017, 2026-05-28): the primary LCD
+// for Terra Classic (terra-classic-lcd.publicnode.com) was degraded for
+// hours, causing every cosmos signing surface that touches this code path
+// to hard-fail. The single-URL design had no recovery. Add a fallback URL
+// per chain so a publicnode degradation doesn't take out signing entirely.
+//
+// Polkachu mirrors per cosmos chain. Hexxagon for columbus-5 since polkachu
+// has no Terra Classic endpoint (verified 2026-05-28 — see
+// vultiagent-app#1017 + mcp-ts#266). Keys are the chain id used by
+// cosmos-sdk; chains not in this map have no fallback (degrade fail-closed
+// behaviour preserved).
+const COSMOS_LCD_FALLBACK_URLS: Partial<Record<CosmosChain, string>> = {
+  [Chain.Cosmos]: 'https://cosmos-api.polkachu.com',
+  [Chain.Osmosis]: 'https://osmosis-api.polkachu.com',
+  [Chain.Kujira]: 'https://kujira-api.polkachu.com',
+  [Chain.Terra]: 'https://terra-api.polkachu.com',
+  [Chain.TerraClassic]: 'https://lcd.terra-classic.hexxagon.io',
+  [Chain.THORChain]: 'https://thorchain-api.polkachu.com',
+  [Chain.Noble]: 'https://noble-api.polkachu.com',
+  [Chain.Dydx]: 'https://dydx-api.polkachu.com',
+  [Chain.Akash]: 'https://akash-api.polkachu.com',
+}
+
+const tryLcd = async (base: string, address: string): Promise<ParsedAccount | null> => {
   try {
     const resp = await queryUrl<LcdAccountResponse>(`${base}/cosmos/auth/v1beta1/accounts/${address}`)
     return parseLcdAccount(resp)
   } catch {
-    // 404 (account not found) or transient LCD error — caller decides.
     return null
   }
+}
+
+const fetchAccountViaLcd = async (chain: CosmosChain, address: string): Promise<ParsedAccount | null> => {
+  const base = cosmosRpcUrl[chain]
+  if (!base) return null
+  const primary = await tryLcd(base, address)
+  if (primary) return primary
+  // Primary failed (network / 5xx / shape mismatch). Try the registered
+  // fallback for this chain. Both-failed surfaces as null and the caller
+  // ships with sequence:0 default — same legacy behaviour, but only after
+  // we've actually exhausted both endpoints.
+  const fallback = COSMOS_LCD_FALLBACK_URLS[chain]
+  if (!fallback) return null
+  return tryLcd(fallback, address)
 }
 
 export const getCosmosAccountInfo = async ({ chain, address }: ChainAccount<CosmosChain>) => {


### PR DESCRIPTION
Triple-PR fanout completing SamYap's Discord timeout report (2026-05-28):

| Repo | PR | Status |
|------|----|---|
| vultiagent-app | [#1017](https://github.com/vultisig/vultiagent-app/pull/1017) | ✅ MERGED |
| mcp-ts | [#266](https://github.com/vultisig/mcp-ts/pull/266) | OPEN |
| **vultisig-sdk** | **this PR** | OPEN |

## Bug

`getCosmosAccountInfo` has one URL per chain via `cosmosRpcUrl[chain]`. When the primary endpoint is degraded (SamYap report: `terra-classic-lcd.publicnode.com` was timing out for hours on 2026-05-28), every cosmos signing surface that touches this code path hard-fails. No recovery.

sdk#579 added the RPC → LCD fallback (StargateClient returning null → re-query via LCD shape parser). But the LCD attempt itself uses ONE URL with no second-chance.

## Fix

`fetchAccountViaLcd` now retries against a registered fallback URL per chain:

```ts
const COSMOS_LCD_FALLBACK_URLS: Partial<Record<CosmosChain, string>> = {
  [Chain.Cosmos]:        'https://cosmos-api.polkachu.com',
  [Chain.Osmosis]:       'https://osmosis-api.polkachu.com',
  [Chain.Kujira]:        'https://kujira-api.polkachu.com',
  [Chain.Terra]:         'https://terra-api.polkachu.com',
  [Chain.TerraClassic]:  'https://lcd.terra-classic.hexxagon.io',  // polkachu has no columbus-5
  [Chain.THORChain]:     'https://thorchain-api.polkachu.com',
  [Chain.Noble]:         'https://noble-api.polkachu.com',
  [Chain.Dydx]:          'https://dydx-api.polkachu.com',
  [Chain.Akash]:         'https://akash-api.polkachu.com',
}
```

Chains not in the map preserve fail-closed behaviour (no extra round-trip).

Both-failed surfaces as `null` → caller falls through to legacy `sequence:0` default. Same behaviour as before for genuinely never-funded accounts, but only AFTER we've actually exhausted both endpoints. No silent doomed-tx broadcasts when the primary is just degraded.

## TerraClassic Hexxagon discovery

While capturing receipts for vultiagent-app#1017, found that polkachu's `terra-classic-api.polkachu.com` does NOT resolve:

```
$ curl https://terra-classic-api.polkachu.com/cosmos/...
curl: (6) Could not resolve host: terra-classic-api.polkachu.com
```

Hexxagon's LCD IS listed in the cosmos chain-registry next to publicnode and responds in ~770ms. Both the app and mcp-ts fixes also use Hexxagon for `columbus-5`.

## Tests

```
yarn vitest run packages/core/chain/chains/cosmos/account/getCosmosAccountInfo.test.ts
Tests 9 passed (9)
```

3 new fallback-path regression tests:
- falls back to Hexxagon when primary 5xx-fails (mocks both endpoints, asserts call order + final values)
- both-failed returns sequence:0 (preserves legacy semantics for never-funded accounts)
- no-fallback chain (MayaChain) doesn't thrash a second call (only-call-fallback-when-registered guard)

All 6 existing tests still green.

## receipts

```
$ curl https://terra-classic-lcd.publicnode.com/cosmos/auth/v1beta1/accounts/terra14qel5wtnrtdgvkd8v0n3wz3nw5rqtcnf5n24r4
HTTP 200 in 1.099s

$ curl https://lcd.terra-classic.hexxagon.io/cosmos/auth/v1beta1/accounts/terra14qel5wtnrtdgvkd8v0n3wz3nw5rqtcnf5n24r4
HTTP 200 in 0.765s

$ curl https://terra-classic-api.polkachu.com/cosmos/...
curl: (6) Could not resolve host
```

(Same probes captured + uploaded as image receipts on the [app#1017](https://github.com/vultisig/vultiagent-app/pull/1017) thread.)

🤖 reviewed via Claude Code (parallel to app#1017 + mcp-ts#266, response to SamYap Discord report)