### PR TITLE
feat(notifications): optional appId on push registration for per-app routing

### DIFF
--- a/.changeset/push-app-id-routing.md
+++ b/.changeset/push-app-id-routing.md
@@ -1,0 +1,10 @@
+---
+'@vultisig/sdk': minor
+---
+
+Add optional `appId` to push device registration (`registerDevice`). Apps that
+share a vault with the regular wallet (e.g. Station, `money.terra.station`) can
+now register/unregister under their own bundle id, so the notification service
+routes their pushes to the correct app instead of the wallet that shares the
+vault. The field is optional and omitted by default, so existing wallet
+registrations are unchanged.

--- a/packages/sdk/src/services/PushNotificationService.ts
+++ b/packages/sdk/src/services/PushNotificationService.ts
@@ -75,6 +75,9 @@ export class PushNotificationService {
         party_name: opts.partyName,
         token: opts.token,
         device_type: toServerDeviceType(opts.deviceType),
+        // Only send app_id when supplied; omitting it preserves the server's
+        // wallet-default routing for existing (wallet) callers.
+        ...(opts.appId ? { app_id: opts.appId } : {}),
       }),
     })
 
@@ -82,12 +85,13 @@ export class PushNotificationService {
       throw new Error(`Failed to register device: ${response.status} ${response.statusText}`)
     }
 
-    // Persist locally
+    // Persist locally (incl. appId so unregister can scope to the same app)
     const registrations = await this.getRegistrations()
     registrations[opts.vaultId] = {
       vaultId: opts.vaultId,
       partyName: opts.partyName,
       registeredAt: Date.now(),
+      ...(opts.appId ? { appId: opts.appId } : {}),
     }
     await this.storage.set(STORAGE_KEY, registrations)
   }
@@ -110,6 +114,11 @@ export class PushNotificationService {
         body: JSON.stringify({
           vault_id: vaultId,
           party_name: reg.partyName,
+          // Scope the tokenless delete to the app this device registered under.
+          // The server defaults a missing app_id to the wallet bucket, so a
+          // non-wallet app (e.g. Station) must send it or its row is never
+          // removed. Wallet registrations have no appId and keep the default.
+          ...(reg.appId ? { app_id: reg.appId } : {}),
         }),
       })
       if (!response.ok) {
@@ -128,9 +137,18 @@ export class PushNotificationService {
   /**
    * Check if a vault is registered locally for push notifications.
    */
-  async isVaultRegistered(vaultId: string): Promise<boolean> {
+  async isVaultRegistered(vaultId: string, appId?: string): Promise<boolean> {
     const registrations = await this.getRegistrations()
-    return vaultId in registrations
+    const reg = registrations[vaultId]
+    if (!reg) return false
+    // Migration-aware: when the caller specifies the app it intends to register
+    // under, a local record stored under a different (or missing) appId counts
+    // as NOT registered, so the consumer's isVaultRegistered-gated
+    // registerDevice re-runs and moves the device onto the right app_id. A bare
+    // call (no appId) keeps the legacy "any local record counts" behaviour, so
+    // existing wallet callers are unchanged.
+    if (appId !== undefined && (reg.appId ?? '') !== appId) return false
+    return true
   }
 
   /**
@@ -161,6 +179,13 @@ export class PushNotificationService {
    * Note: The server deduplicates notifications per vault_id (30-second window).
    */
   async notifyVaultMembers(opts: NotifyVaultMembersOptions): Promise<void> {
+    // app_id is OPT-IN here and deliberately NOT inferred from local storage.
+    // notifyVaultMembers is the keysign-coordination path: it must reach every
+    // device on the vault regardless of which app each peer registered under.
+    // Auto-scoping to the sender's app would make mixed-version vaults (one
+    // signer migrated, another still wallet-default) miss keysign pushes. The
+    // app-scoped delivery that the leak fix needs is the SCHEDULED path, which
+    // goes through the agent-backend notifier, not this method.
     const response = await fetch(`${this.serverUrl}/notify`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -169,6 +194,8 @@ export class PushNotificationService {
         vault_name: opts.vaultName,
         local_party_id: opts.localPartyId,
         qr_code_data: opts.qrCodeData,
+        // Only target a specific app when the caller explicitly opts in.
+        ...(opts.appId ? { app_id: opts.appId } : {}),
       }),
     })
 

--- a/packages/sdk/src/types/notifications.ts
+++ b/packages/sdk/src/types/notifications.ts
@@ -17,6 +17,15 @@ export type RegisterDeviceOptions = {
   partyName: string
   token: PushToken
   deviceType: PushDeviceType
+  /**
+   * Bundle id of the app registering (e.g. "money.terra.station" for Station).
+   * The notification service routes pushes per app_id, so an app that shares a
+   * vault with the regular wallet must register its own appId to receive its
+   * pushes (and to avoid being delivered on the wallet's APNs topic). Optional:
+   * the regular wallet omits it and the server defaults to the wallet bundle id,
+   * so existing registrations are unchanged.
+   */
+  appId?: string
 }
 
 /** Options for sending a notification to vault members */
@@ -26,6 +35,12 @@ export type NotifyVaultMembersOptions = {
   localPartyId: string
   /** The keysign QR code data (session URL/payload) that other devices use to join signing */
   qrCodeData: string
+  /**
+   * Target app bundle id (see RegisterDeviceOptions.appId). When set, the
+   * notification service delivers only to that app's devices for the vault.
+   * Omit to keep the server's wallet-default routing.
+   */
+  appId?: string
 }
 
 /** Registration record persisted in SDK storage */
@@ -33,6 +48,9 @@ export type PushNotificationRegistration = {
   vaultId: string
   partyName: string
   registeredAt: number
+  /** App bundle id this device registered under (see RegisterDeviceOptions.appId).
+   *  Persisted so unregister can scope the server delete to the same app. */
+  appId?: string
 }
 
 /** Incoming push notification payload (from server push event) */


### PR DESCRIPTION
## what

Companion to [vultisig/notification#27](https://github.com/vultisig/notification/pull/27) (per-app notification routing) and the agent-backend notifier `app_id`. For the notification service to deliver a Station push to Station (instead of the wallet that shares the vault), the Station device must be **registered** under its own `app_id` (`money.terra.station`). This adds that capability to the SDK push service.

## how

- `RegisterDeviceOptions.appId` (optional) → sent as `app_id` on `/register`, and **persisted** in the local registration record.
- `unregisterVault()` sends the persisted `app_id` so the tokenless DELETE scopes to the same app (the server defaults a missing `app_id` to the wallet bucket, so a non-wallet app must send it).
- `isVaultRegistered(vaultId, appId?)` is **migration-aware**: when the caller passes the app it intends to register under, a local record stored under a different/missing `appId` counts as not-registered, so the consumer's `isVaultRegistered`-gated `registerDevice` re-runs and migrates existing opted-in devices onto their `app_id`.
- `notifyVaultMembers` gains an optional `appId` but it is **opt-in only** (see below).

All fields are optional and omitted by default → the regular wallet sends no `app_id`, the server keeps its wallet-default routing, and existing registrations are unchanged.

## design decisions (4 codex rounds)

- **`notifyVaultMembers` app_id is opt-in, NOT inferred from storage.** This is the keysign-coordination path: it must reach every device on a vault regardless of which app each peer registered under. Auto-scoping to the sender's app would make a mixed-version vault (one signer migrated, one still wallet-default) miss keysign pushes. The app-scoped delivery the leak fix needs is the **scheduled** path, which goes through the agent-backend notifier — not this method. (Codex oscillated on this; this is the deliberate resolution.)
- **No old-bucket orphan bookkeeping on migration.** The real notification service (#27) upserts `/register` on `(vault_id, party_name, token)` and updates `app_id` in place for the same token, so migrating wallet→station mutates the one row rather than orphaning a wallet-bucket row; a rotated token's stale row is 410-cleaned. No separate old-scope cleanup needed.

## rollout

Coordinated: this SDK change ships first, the Station app then passes `appId: "money.terra.station"` to `registerDevice`/`isVaultRegistered` (one-line consumer change), existing installs re-register on next launch (migration-aware gate), Station's APNs cert is provisioned, then `agent-backend` sets `NOTIFICATION_APP_ID`. Until the consumer passes `appId`, behaviour is identical to today.

## changeset

`@vultisig/sdk` minor (`.changeset/push-app-id-routing.md`).

## risk

Low. All additions are optional and wallet-default-preserving; the wallet path is byte-identical (no `app_id` sent). Note: local `yarn typecheck` not run in this worktree (yarn-workspace `node_modules` not installed in a fresh worktree); changes are additive optional fields + conditional spreads + one optional param — CI runs the full typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
