### PR TITLE
fix(swap): surface THORChain/MayaChain below-min as actionable error

### DIFF
--- a/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
@@ -393,6 +393,86 @@ describe('findSwapQuote parallel selection', () => {
       })
     ).rejects.toThrow('Swap amount too small. Please increase the amount to proceed.')
   })
+
+  // #604 — THORChain/MayaChain below-min wordings that slipped through the old
+  // allowlist and produced the generic "No swap route found" message instead.
+
+  it('#604: THORChain "swap amount is less than the minimum" surfaces as AmountTooSmall, not generic no-route', async () => {
+    vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('kyber fail'))
+    vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('inch fail'))
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('lifi fail'))
+    vi.mocked(getSwapKitQuote).mockRejectedValue(new Error('swapkit fail'))
+    vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) => {
+      if (swapChain === Chain.THORChain) {
+        throw new Error('swap amount is less than the minimum')
+      }
+      throw new Error('maya fail')
+    })
+
+    await expect(
+      findSwapQuote({
+        ...evmSameChainCoins,
+        amount: 1n,
+      })
+    ).rejects.toThrow('Swap amount too small. Please increase the amount to proceed.')
+  })
+
+  it('#604: THORChain "outbound amount does not meet requirements" surfaces as below-minimum, not generic no-route', async () => {
+    vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('kyber fail'))
+    vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('inch fail'))
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('lifi fail'))
+    vi.mocked(getSwapKitQuote).mockRejectedValue(new Error('swapkit fail'))
+    vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) => {
+      if (swapChain === Chain.THORChain) {
+        throw new Error('outbound amount does not meet requirements')
+      }
+      throw new Error('maya fail')
+    })
+
+    await expect(
+      findSwapQuote({
+        ...evmSameChainCoins,
+        amount: 1n,
+      })
+    ).rejects.toThrow('Amount below the minimum required by a swap provider.')
+  })
+
+  it('#604: MayaChain "amount is less than minimum" surfaces as AmountTooSmall, not generic no-route', async () => {
+    vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('kyber fail'))
+    vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('inch fail'))
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('lifi fail'))
+    vi.mocked(getSwapKitQuote).mockRejectedValue(new Error('swapkit fail'))
+    vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) => {
+      if (swapChain === Chain.THORChain) {
+        throw new Error('thor fail')
+      }
+      // MayaChain variant of the same wording
+      throw new Error('amount is less than minimum')
+    })
+
+    await expect(
+      findSwapQuote({
+        ...evmSameChainCoins,
+        amount: 1n,
+      })
+    ).rejects.toThrow('Swap amount too small. Please increase the amount to proceed.')
+  })
+
+  it('#604: true no-route (unsupported pair) still shows the generic provider-list message', async () => {
+    // All providers reject with generic non-amount errors → AllProvidersFailed
+    vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('unsupported pair'))
+    vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('unsupported pair'))
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('unsupported pair'))
+    vi.mocked(getSwapKitQuote).mockRejectedValue(new Error('unsupported pair'))
+    vi.mocked(getNativeSwapQuote).mockRejectedValue(new Error('unsupported pair'))
+
+    await expect(
+      findSwapQuote({
+        ...evmSameChainCoins,
+        amount: 1n,
+      })
+    ).rejects.toThrow('No swap route found after trying KyberSwap, 1inch, LiFi, SwapKit, THORChain, MayaChain.')
+  })
 })
 
 describe('findSwapQuote THOR/Maya bias (paaao directive 2026-05-22)', () => {

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -446,7 +446,11 @@ export const findSwapQuote = async ({
       lower.includes('minimum amount') ||
       lower.includes('min amount') ||
       lower.includes('amount too small') ||
-      lower.includes('below the minimum')
+      lower.includes('below the minimum') ||
+      // THORChain/MayaChain: "swap amount is less than the minimum"
+      lower.includes('less than the minimum') ||
+      // THORChain/MayaChain: "outbound amount does not meet requirements"
+      lower.includes('does not meet requirements')
     )
   }
 
@@ -463,10 +467,13 @@ export const findSwapQuote = async ({
     // SwapKit raises this only after confirming the pair is structurally
     // supported, so it is unambiguously an amount problem (#4418). Reuse the
     // same copy as the THORChain dust-threshold path.
+    // `'amount is less than'` covers THORChain's "amount is less than X" wording
+    // (distinct from `'amount less than'` which misses the "is").
     if (
       result.reason instanceof SwapKitAmountBelowMinimumError ||
       isInError(result.reason, 'dust threshold') ||
-      isInError(result.reason, 'amount less than')
+      isInError(result.reason, 'amount less than') ||
+      isInError(result.reason, 'amount is less than')
     ) {
       throw new SwapError(SwapErrorCode.AmountTooSmall, 'Swap amount too small. Please increase the amount to proceed.')
     }


### PR DESCRIPTION
## Summary

Fixes a UX bug where small cross-chain swaps (e.g. ETH→BTC ~\$2.81) that fail because the amount is below provider minimums show the misleading generic message:

> Error - No swap route found after trying THORChain, MayaChain, SwapKit.

instead of an actionable "amount too small" error.

**Root cause:** The substring allowlist in `findSwapQuote` (`isBelowMinimumMsg`) and the `isInError` early-exit did not cover the exact wordings that THORChain and MayaChain actually return for sub-minimum amounts:

| Provider error string | Old behaviour | Fixed behaviour |
|---|---|---|
| `"swap amount is less than the minimum"` | fell through → generic no-route | `AmountTooSmall` |
| `"outbound amount does not meet requirements"` | fell through → generic no-route | `AmountBelowMinimum` |
| `"amount is less than X"` | fell through (note: old check was `"amount less than"`, missing "is") | `AmountTooSmall` |

**Fix:** Two-line addition to `findSwapQuote.ts`:

1. `isBelowMinimumMsg` gains `'less than the minimum'` and `'does not meet requirements'`
2. The `isInError` early-exit gains `'amount is less than'` (companion to the existing `'amount less than'`)

No behaviour change for any other provider or error path.

## Reproduction

On `main` (before fix):
```
// THORChain returns: "swap amount is less than the minimum"
// → isBelowMinimumMsg() = false  (no pattern match)
// → isInError('amount less than') = false  ("amount IS less than" ≠ "amount less than")
// → falls through to AllProvidersFailed → "No swap route found after trying …"
```

After fix:
```
// THORChain returns: "swap amount is less than the minimum"
// → isInError('amount is less than') = true  → AmountTooSmall
// → "Swap amount too small. Please increase the amount to proceed."
```

## receipts

```
$ cd /tmp/sdk-fix-604 && yarn test:core 2>&1 | tail -3
Test Files  90 passed (90)
      Tests  855 passed (855)
Duration  17.29s
```

4 new tests added in `findSwapQuote.selection.test.ts`:
- `#604: THORChain "swap amount is less than the minimum" surfaces as AmountTooSmall`
- `#604: THORChain "outbound amount does not meet requirements" surfaces as below-minimum`
- `#604: MayaChain "amount is less than minimum" surfaces as AmountTooSmall`
- `#604: true no-route (unsupported pair) still shows the generic provider-list message`

**Before:** `"No swap route found after trying THORChain, MayaChain, SwapKit."`
**After:** `"Swap amount too small. Please increase the amount to proceed."` (or `"Amount below the minimum required by a swap provider. <provider raw msg>"`)

closes #604

🤖 Agent-generated