### PR TITLE
test(address): pin cosmos-family chainPublicKeys honoring

### DIFF
--- a/packages/sdk/tests/unit/tools/address/deriveAddressFromKeys.test.ts
+++ b/packages/sdk/tests/unit/tools/address/deriveAddressFromKeys.test.ts
@@ -290,5 +290,91 @@ describe('deriveAddressFromKeys', () => {
       ).rejects.toThrow(/Invalid chainPublicKeys entry for TerraClassic: pubkey must be non-empty/)
       expect(mockGetPublicKey).not.toHaveBeenCalled()
     })
+
+    // Cosmos-family chains (issue vultisig-sdk#613, mcp-ts#294 E2E discovery).
+    // These chains use BIP44 coin_type 118 with HARDENED derivation
+    // (m/44'/118'/0'/0/0), which cannot be re-walked from a pubkey alone — the
+    // MPC root + chaincode path produces the wrong address. Callers (mcp-ts
+    // execute_swap, agent-backend tool dispatch) MUST forward
+    // chainPublicKeys.<Chain> for these to work; we pin the contract here.
+    //
+    // The pubkey/address fixtures below are from a real on-chain account
+    // (cosmos1ky4k58aq…3xvy, account_number 2782851, 51 prior cosmoshub-4 txs),
+    // verified against the live LCD: the on-chain registered pubkey matches
+    // the chainPublicKeys.Cosmos value exactly. Same hardened key derives the
+    // bech32 for every cosmos-prefix family chain (different hrp per chain).
+    describe('cosmos-family chains', () => {
+      const cosmosHardenedPubkey = '029588aa44a9e3576f0db42de62fa69a528c5c61757284622ae436b9646e6cd513'
+      const cosmosFundedAddress = 'cosmos1ky4k58aq36yx6gvz34xcu2tzhhsvrewyxa3xvy'
+
+      it('uses chainPublicKeys[Cosmos] directly and returns funded cosmoshub-4 address', async () => {
+        mockDeriveAddress.mockReturnValueOnce(cosmosFundedAddress)
+        const result = await deriveAddressFromKeys({
+          chain: Chain.Cosmos,
+          ecdsaPublicKey: 'root_pubkey_hex',
+          hexChainCode: 'chain_code_hex',
+          chainPublicKeys: { [Chain.Cosmos]: cosmosHardenedPubkey },
+        })
+        expect(result).toEqual({ chain: Chain.Cosmos, address: cosmosFundedAddress })
+        expect(mockGetPublicKey).toHaveBeenCalledWith(
+          expect.objectContaining({
+            chain: Chain.Cosmos,
+            chainPublicKeys: { [Chain.Cosmos]: cosmosHardenedPubkey },
+          })
+        )
+      })
+
+      it('forwards chainPublicKeys[Osmosis] for osmosis-1 derivation', async () => {
+        const osmoHardenedPubkey = '029588aa44a9e3576f0db42de62fa69a528c5c61757284622ae436b9646e6cd513'
+        const osmoAddress = 'osmo1ky4k58aq36yx6gvz34xcu2tzhhsvrewywxzk6k'
+        mockDeriveAddress.mockReturnValueOnce(osmoAddress)
+        await deriveAddressFromKeys({
+          chain: Chain.Osmosis,
+          ecdsaPublicKey: 'root_pubkey_hex',
+          hexChainCode: 'chain_code_hex',
+          chainPublicKeys: { [Chain.Osmosis]: osmoHardenedPubkey },
+        })
+        expect(mockGetPublicKey).toHaveBeenCalledWith(
+          expect.objectContaining({
+            chain: Chain.Osmosis,
+            chainPublicKeys: { [Chain.Osmosis]: osmoHardenedPubkey },
+          })
+        )
+      })
+
+      it('forwards chainPublicKeys[Kujira] for kujira-1 derivation', async () => {
+        const kujiHardenedPubkey = '029588aa44a9e3576f0db42de62fa69a528c5c61757284622ae436b9646e6cd513'
+        const kujiAddress = 'kujira1ky4k58aq36yx6gvz34xcu2tzhhsvrewyh4n7pw'
+        mockDeriveAddress.mockReturnValueOnce(kujiAddress)
+        await deriveAddressFromKeys({
+          chain: Chain.Kujira,
+          ecdsaPublicKey: 'root_pubkey_hex',
+          hexChainCode: 'chain_code_hex',
+          chainPublicKeys: { [Chain.Kujira]: kujiHardenedPubkey },
+        })
+        expect(mockGetPublicKey).toHaveBeenCalledWith(
+          expect.objectContaining({
+            chain: Chain.Kujira,
+            chainPublicKeys: { [Chain.Kujira]: kujiHardenedPubkey },
+          })
+        )
+      })
+
+      it('Cosmos request with only Osmosis key supplied: map is NOT forwarded, BIP32 fallback runs', async () => {
+        // Each cosmos chain is its own entry in chainPublicKeys (unlike Terra↔TerraClassic
+        // which share coin_type 330). Cosmos↔Osmosis do NOT alias; a partial map for
+        // a sibling chain must not bleed into another chain's derivation.
+        mockDeriveAddress.mockReturnValueOnce('cosmos1bip32fallback')
+        await deriveAddressFromKeys({
+          chain: Chain.Cosmos,
+          ecdsaPublicKey: 'root_pubkey_hex',
+          hexChainCode: 'chain_code_hex',
+          chainPublicKeys: { [Chain.Osmosis]: '029588aa44a9e3576f0db42de62fa69a528c5c61757284622ae436b9646e6cd513' },
+        })
+        expect(mockGetPublicKey).toHaveBeenCalledWith(
+          expect.objectContaining({ chain: Chain.Cosmos, chainPublicKeys: undefined })
+        )
+      })
+    })
   })
 })


### PR DESCRIPTION
Closes #613.

## Summary

Pins the cosmos-family `chainPublicKeys` contract that `deriveAddressFromKeys` already supports on `main` but had **zero test coverage outside Terra**. Cosmos-family chains (CosmosHub/Osmosis/Kujira/Noble/Akash/Dydx/Sei/…) use BIP44 `coin_type 118` with HARDENED derivation; without forwarding `chainPublicKeys.<Chain>` from a KeyImport vault, callers get the wrong address and broadcasts fail `code 4: signature verification failed`.

## Real-world evidence

E2E sim test on 2026-05-31 against `vultisig/mcp-ts#294` (intra-Cosmos Skip routing) — a real seed-import vault holding 9.78 ATOM (`cosmos1ky4k58aq…3xvy`, account_number 2782851, 51 prior cosmoshub-4 txs):

| | |
|---|---|
| On-chain registered pubkey (base64) | `ApWIqkSp41dvDbQt5i+mmlKMXGF1coRiKuQ2uWRubNUT` |
| Same in hex | `029588aa44a9e3576f0db42de62fa69a528c5c61757284622ae436b9646e6cd513` |
| `chainPublicKeys.Cosmos` (what the app sends) | `029588aa44a9e3576f0db42de62fa69a528c5c61757284622ae436b9646e6cd513` ✅ exact match |
| HASH160 of that pubkey → bech32 'cosmos' | `cosmos1ky4k58aq36yx6gvz34xcu2tzhhsvrewyxa3xvy` ✅ matches on-chain |
| `@vultisig/sdk@0.22.3` (mcp-ts npm pin) `deriveAddressFromKeys` | `cosmos1h72383c8jzpgw88jrydyh6km4nh27ndx0gv6fr` ❌ wrong (chainPublicKeys argument silently dropped) |
| Current `main` `deriveAddressFromKeys` w/ same input | Returns the funded address ✅ (because PR #463 honoring exists) |

So the fix already exists upstream — this PR adds the regression test that should have caught the gap before the published 0.22.x line silently shipped without honoring chainPublicKeys.Cosmos.

## Changes

Extends `packages/sdk/tests/unit/tools/address/deriveAddressFromKeys.test.ts` with a `describe('cosmos-family chains')` block:

- **Cosmos**: `chainPublicKeys[Cosmos]` is forwarded → funded cosmoshub-4 address. Uses the real pubkey/address pair above so the contract has a lock against any future refactor that drops the per-chain pubkey forwarding.
- **Osmosis**: `chainPublicKeys[Osmosis]` forwarded for osmosis-1.
- **Kujira**: `chainPublicKeys[Kujira]` forwarded for kujira-1.
- **Negative — no cross-bleed**: a partial map with ONLY Osmosis key while deriving Cosmos must NOT cross-feed; the map is dropped and BIP32 fallback runs. This pins the absence of any Cosmos↔Osmosis aliasing (unlike Terra↔TerraClassic which legitimately share `coin_type 330`).

## Test results

```
Test Files  1 passed (1)
Tests       20 passed (20)  ← was 16, +4 cosmos cases
```

## Cross-refs

- vultisig-sdk#613 (this issue)
- vultisig/mcp-ts#294 (the E2E sim work that surfaced the regression)
- PR #463 (the original `chainPublicKeys` honoring code being pinned here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for address derivation across Cosmos-family chains (Cosmos, Osmosis, Kujira).
  * Added regression tests to ensure proper key forwarding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->