### PR TITLE
Drop native swap priority for banded routing

### DIFF
--- a/.changeset/banded-swap-routing.md
+++ b/.changeset/banded-swap-routing.md
@@ -1,0 +1,7 @@
+---
+"@vultisig/core-chain": patch
+"@vultisig/sdk": patch
+"@vultisig/cli": patch
+---
+
+Select swap quotes with a 1% provider preference band instead of hard native priority.

--- a/packages/core/chain/swap/quote/__tests__/findSwapQuote.cowswap.test.ts
+++ b/packages/core/chain/swap/quote/__tests__/findSwapQuote.cowswap.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { aggregatorPreferenceOrder } from '../findSwapQuote'
+import { providerPreferenceOrder } from '../findSwapQuote'
 
 // Phase 2 (#471 / #584 / #3930) — CowSwap is now wired as a live fetcher in
 // `findSwapQuote`: the consumer pipeline can rebuild the order's EIP-712 digest,
@@ -9,12 +9,12 @@ import { aggregatorPreferenceOrder } from '../findSwapQuote'
 // regression is caught here, not by a user.
 
 describe('CowSwap — Phase 2 invariants (#471 / #584 / #3930)', () => {
-  it('aggregatorPreferenceOrder includes CowSwap', () => {
-    expect(aggregatorPreferenceOrder.includes('CowSwap')).toBe(true)
+  it('providerPreferenceOrder includes CowSwap', () => {
+    expect(providerPreferenceOrder.includes('CowSwap')).toBe(true)
   })
 
   it('ranks CowSwap first — MEV-protected, gas-less fills win exact-output ties', () => {
-    expect(aggregatorPreferenceOrder[0]).toBe('CowSwap')
+    expect(providerPreferenceOrder[0]).toBe('CowSwap')
   })
 
   it('cowswap module is importable and the Phase 2 helpers exist', async () => {

--- a/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
@@ -588,6 +588,8 @@ describe('findSwapQuote banded provider preference (issue #605)', () => {
     vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('skip kyber'))
     vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('skip inch'))
     vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
+    // Regression for reversing the paaao 2026-05-22 hard THOR priority directive:
+    // under the old rule, THORChain won even when SwapKit was 10% better.
     // SwapKit: gross output 1_100_000 (10% higher than THORChain).
     vi.mocked(getSwapKitQuote).mockResolvedValue(minimalGeneralQuote('1100000', 'swapkit'))
     // THORChain native: comparable 1_000_000. SwapKit is outside the 1% band, so rate wins.

--- a/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
@@ -61,7 +61,7 @@ const evmSameChainCoins = {
   },
 } as const
 
-function minimalGeneralQuote(dstAmount: string, provider: 'kyber' | '1inch' | 'swapkit'): GeneralSwapQuote {
+function minimalGeneralQuote(dstAmount: string, provider: 'kyber' | '1inch' | 'swapkit' | 'li.fi'): GeneralSwapQuote {
   const base = {
     dstAmount,
     tx: {
@@ -260,12 +260,10 @@ describe('findSwapQuote parallel selection', () => {
     expect(quote.quote.general.provider).toBe('kyber')
   })
 
-  it('tie-break: 1inch wins over SwapKit on equal output by declared preference', async () => {
-    // 1inch is ranked 2nd, SwapKit is ranked 4th in aggregatorPreferenceOrder.
-    // On an equal-output tie, 1inch must win regardless of fetcher array order
-    // (which is determined dynamically by shouldPreferGeneralSwap). This
-    // exercises the declared-preference tie-break introduced in #521 r3 to
-    // replace the previous implicit index-based tie-break. (NeO should-fix.)
+  it('tie-break: SwapKit wins over 1inch on equal output by declared provider preference', async () => {
+    // SwapKit now sits above the EVM aggregators in providerPreferenceOrder.
+    // On an equal-output tie, it must win regardless of fetcher array order
+    // (which is determined dynamically by shouldPreferGeneralSwap).
     vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('skip kyber'))
     vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
     vi.mocked(getNativeSwapQuote).mockRejectedValue(new Error('skip native'))
@@ -281,7 +279,7 @@ describe('findSwapQuote parallel selection', () => {
     if (!('general' in quote.quote)) {
       throw new Error('Expected general quote')
     }
-    expect(quote.quote.general.provider).toBe('1inch')
+    expect(quote.quote.general.provider).toBe('swapkit')
   })
 
   it('when all providers fail, reports every attempted provider', async () => {
@@ -542,7 +540,7 @@ describe('findSwapQuote parallel selection', () => {
   })
 })
 
-describe('findSwapQuote THOR/Maya bias (paaao directive 2026-05-22)', () => {
+describe('findSwapQuote banded provider preference (issue #605)', () => {
   beforeEach(() => {
     vi.mocked(getCowSwapQuote).mockReset()
     vi.mocked(getCowSwapQuote).mockRejectedValue(new Error('skip cowswap'))
@@ -561,13 +559,13 @@ describe('findSwapQuote THOR/Maya bias (paaao directive 2026-05-22)', () => {
   // value = raw / 10^(8 - 6) = raw / 100. So to make THOR comparable-output ≈ X
   // (in 6 decimals), set native expected_amount_out = X * 100.
 
-  it('prefers direct THORChain when SwapKit is better by 2% (inside 5% bias)', async () => {
+  it('same-chain ERC20 route picks SwapKit over THORChain when SwapKit is more than 1% better', async () => {
     vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('skip kyber'))
     vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('skip inch'))
     vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
     // SwapKit: gross output 1_020_000 (in 6 dec).
     vi.mocked(getSwapKitQuote).mockResolvedValue(minimalGeneralQuote('1020000', 'swapkit'))
-    // THORChain native: comparable 1_000_000 (raw 100_000_000 in 8-dec). 1.96% lower → inside bias.
+    // THORChain native: comparable 1_000_000 (raw 100_000_000 in 8-dec). 1.96% lower -> outside band.
     vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) => {
       if (swapChain === Chain.THORChain) {
         return minimalNativeQuote(swapChain, '100000000')
@@ -580,20 +578,19 @@ describe('findSwapQuote THOR/Maya bias (paaao directive 2026-05-22)', () => {
       amount: 1n,
     })
 
-    if (!('native' in quote.quote)) {
-      throw new Error('Expected native THORChain quote to win via bias')
+    if (!('general' in quote.quote)) {
+      throw new Error('Expected SwapKit quote to win by rate outside the band')
     }
-    expect(quote.quote.native.swapChain).toBe(Chain.THORChain)
-    expect(quote.quote.native.expected_amount_out).toBe('100000000')
+    expect(quote.quote.general.provider).toBe('swapkit')
   })
 
-  it('prefers THORChain over SwapKit even when SwapKit is 10% better (hard priority, no output comparison)', async () => {
+  it('outside band: the better-rate provider wins regardless of preference order', async () => {
     vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('skip kyber'))
     vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('skip inch'))
     vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
     // SwapKit: gross output 1_100_000 (10% higher than THORChain).
     vi.mocked(getSwapKitQuote).mockResolvedValue(minimalGeneralQuote('1100000', 'swapkit'))
-    // THORChain native: comparable 1_000_000. Hard priority means THOR still wins.
+    // THORChain native: comparable 1_000_000. SwapKit is outside the 1% band, so rate wins.
     vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) => {
       if (swapChain === Chain.THORChain) {
         return minimalNativeQuote(swapChain, '100000000')
@@ -606,10 +603,10 @@ describe('findSwapQuote THOR/Maya bias (paaao directive 2026-05-22)', () => {
       amount: 1n,
     })
 
-    if (!('native' in quote.quote)) {
-      throw new Error('Expected THORChain to win via hard priority regardless of SwapKit output')
+    if (!('general' in quote.quote)) {
+      throw new Error('Expected SwapKit quote to win by rate outside the band')
     }
-    expect(quote.quote.native.swapChain).toBe(Chain.THORChain)
+    expect(quote.quote.general.provider).toBe('swapkit')
   })
 
   it('only SwapKit available → SwapKit wins (no native bias applies)', async () => {
@@ -653,7 +650,7 @@ describe('findSwapQuote THOR/Maya bias (paaao directive 2026-05-22)', () => {
     expect(quote.quote.native.swapChain).toBe(Chain.THORChain)
   })
 
-  it('SwapKit ties THORChain on output → THORChain wins via bias (Δ=0 is within any bias)', async () => {
+  it('SwapKit ties THORChain on output -> THORChain wins by provider preference', async () => {
     vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('skip kyber'))
     vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('skip inch'))
     vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
@@ -672,11 +669,9 @@ describe('findSwapQuote THOR/Maya bias (paaao directive 2026-05-22)', () => {
       amount: 1n,
     })
 
-    // On an exact tie, the EVM-EVM same-chain path puts general first, so
-    // tie-break makes SwapKit the initial `best`. But THORChain is within bias
-    // (Δ=0) so it should be selected by the bias step.
+    // On an exact tie, THORChain is within the band and outranks SwapKit.
     if (!('native' in quote.quote)) {
-      throw new Error('Expected THORChain native quote to win on tie via bias')
+      throw new Error('Expected THORChain native quote to win on tie by provider preference')
     }
     expect(quote.quote.native.swapChain).toBe(Chain.THORChain)
   })
@@ -713,7 +708,7 @@ describe('findSwapQuote THOR/Maya bias (paaao directive 2026-05-22)', () => {
     expect(quote.quote.native.expected_amount_out).toBe('120000000')
   })
 
-  it('MayaChain also benefits from the bias when it is the only native option', async () => {
+  it('near-tie: MayaChain wins when SwapKit is within the 1% band', async () => {
     // Use Arbitrum ↔ Arbitrum: Maya supports Arbitrum (per nativeSwapEnabledChainsRecord),
     // SwapKit supports Arbitrum as well. THORChain does NOT support Arbitrum.
     const arbCoins = {
@@ -736,8 +731,8 @@ describe('findSwapQuote THOR/Maya bias (paaao directive 2026-05-22)', () => {
     vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('skip kyber'))
     vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('skip inch'))
     vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
-    // SwapKit better by ~2%.
-    vi.mocked(getSwapKitQuote).mockResolvedValue(minimalGeneralQuote('1020000', 'swapkit'))
+    // SwapKit better by 0.5%, within the 1% band.
+    vi.mocked(getSwapKitQuote).mockResolvedValue(minimalGeneralQuote('1005000', 'swapkit'))
     // Maya native: 8-dec canonical → 1_000_000 comparable.
     vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) => {
       if (swapChain === Chain.MayaChain) {
@@ -752,9 +747,28 @@ describe('findSwapQuote THOR/Maya bias (paaao directive 2026-05-22)', () => {
     })
 
     if (!('native' in quote.quote)) {
-      throw new Error('Expected Maya native quote to win via bias on Arbitrum')
+      throw new Error('Expected Maya native quote to win by provider preference on Arbitrum')
     }
     expect(quote.quote.native.swapChain).toBe(Chain.MayaChain)
+  })
+
+  it('near-tie: SwapKit beats LiFi when within the 1% band', async () => {
+    vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('skip kyber'))
+    vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('skip inch'))
+    vi.mocked(getNativeSwapQuote).mockRejectedValue(new Error('skip native'))
+    // LiFi has the best output, but SwapKit is only 0.5% lower and ranks higher.
+    vi.mocked(getLifiSwapQuote).mockResolvedValue(minimalGeneralQuote('1005000', 'li.fi'))
+    vi.mocked(getSwapKitQuote).mockResolvedValue(minimalGeneralQuote('1000000', 'swapkit'))
+
+    const quote = await findSwapQuote({
+      ...evmSameChainCoins,
+      amount: 1n,
+    })
+
+    if (!('general' in quote.quote)) {
+      throw new Error('Expected general quote')
+    }
+    expect(quote.quote.general.provider).toBe('swapkit')
   })
 })
 

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -73,40 +73,6 @@ type RankedSwapQuote = {
   providerName: SwapQuoteProviderName
 }
 
-/**
- * Hard native priority: when any direct THORChain or MayaChain route is available,
- * it is always preferred over any aggregator (SwapKit, LiFi, etc.) regardless of
- * gross output. When both THOR and Maya succeed, the one with the higher comparable
- * output wins; among aggregator-only results the normal output ranking applies.
- *
- * Rationale (paaao, 2026-05-22): for L1 swaps that native protocols serve directly,
- * the protocol-aligned route is always preferred. Direct routes capture full
- * vultisig affiliate revenue and avoid the aggregator fee skim; the protocol is
- * the moat. Mirrors the priority-first-success pattern in vultisig-ios's
- * `SwapService.fetchQuote` + `Coin+Swaps.swapProviders`.
- */
-
-/**
- * Native swap providers — direct on-chain protocols (no aggregator layer).
- *
- * Adding a new native protocol (e.g. Chainflip-direct in the future) requires:
- *   1. Adding its name to `SwapQuoteProviderName` above
- *   2. Adding it here so `isNativeProvider` recognises it for hard-priority
- *      selection in `selectBestEligibleQuote`
- *   3. Wiring its fetcher into `getNativeFetchers`
- *
- * The `satisfies` clause gives compile-time safety against typos, but the
- * semantic mapping (which providers count as "native") still lives in this
- * file and must be kept aligned with the protocol's actual integration mode.
- */
-const nativeProviderNames = ['THORChain', 'MayaChain'] as const satisfies readonly SwapQuoteProviderName[]
-
-type NativeProviderName = (typeof nativeProviderNames)[number]
-
-const nativeProviderNamesSet = new Set<SwapQuoteProviderName>(nativeProviderNames)
-
-const isNativeProvider = (name: SwapQuoteProviderName): name is NativeProviderName => nativeProviderNamesSet.has(name)
-
 const QUOTE_FETCH_TIMEOUT_MS = 30_000
 
 const withTimeout = <T>(p: Promise<T>, ms: number): Promise<T> => {
@@ -120,37 +86,43 @@ const withTimeout = <T>(p: Promise<T>, ms: number): Promise<T> => {
 }
 
 /**
- * Declared preference order for AGGREGATOR ties — when two aggregators return
- * identical `outputAmount`, the earlier entry wins. This makes the tie-break
- * explicit (the previous implementation tied via `fetchers[]` array index,
- * which was determined dynamically by `shouldPreferGeneralSwap` and therefore
- * harder to reason about). Native providers (THORChain/MayaChain) bypass this
- * because they have hard priority over aggregators regardless of output.
- *
- * Order rationale: KyberSwap and 1inch typically surface the best on-chain
- * liquidity for EVM-only swaps; LiFi covers the broader cross-chain matrix;
- * SwapKit is the catch-all fallback. Adjust as data changes.
+ * Declared preference order for economically equivalent quotes. Quotes are
+ * first ranked by comparable net output across all providers. Providers within
+ * `SWAP_QUOTE_PREFERENCE_BAND_BPS` of the best output are then selected by this
+ * order, so users stay close to the best rate while near-ties prefer CowSwap,
+ * native routes, and SwapKit economics.
  *
  * @internal Exported for unit-test introspection only.
  */
-export const aggregatorPreferenceOrder: readonly SwapQuoteProviderName[] = [
+export const providerPreferenceOrder: readonly SwapQuoteProviderName[] = [
   // CowSwap is slotted FIRST: its solver-driven RFQ fills are MEV-protected and
   // gas-less, so on an exact-output tie it is the preferred route. It only
   // competes for same-chain ERC-20 EVM pairs (see fetcher registration below);
   // for every other pair it simply isn't in the candidate set.
   'CowSwap',
+  'THORChain',
+  'MayaChain',
+  'SwapKit',
   'KyberSwap',
   '1inch',
   'LiFi',
-  'SwapKit',
 ] as const
 
-const aggregatorPreferenceIndex = new Map<SwapQuoteProviderName, number>(
-  aggregatorPreferenceOrder.map((name, idx) => [name, idx])
+/** @deprecated Use `providerPreferenceOrder`. */
+export const aggregatorPreferenceOrder = providerPreferenceOrder
+
+const providerPreferenceIndex = new Map<SwapQuoteProviderName, number>(
+  providerPreferenceOrder.map((name, idx) => [name, idx])
 )
 
-const getAggregatorPreferenceRank = (name: SwapQuoteProviderName): number =>
-  aggregatorPreferenceIndex.get(name) ?? Number.POSITIVE_INFINITY
+const getProviderPreferenceRank = (name: SwapQuoteProviderName): number =>
+  providerPreferenceIndex.get(name) ?? Number.POSITIVE_INFINITY
+
+const SWAP_QUOTE_PREFERENCE_BAND_BPS = 100n
+const BPS_DENOMINATOR = 10_000n
+
+const isWithinPreferenceBand = (outputAmount: bigint, bestOutputAmount: bigint): boolean =>
+  outputAmount * BPS_DENOMINATOR >= bestOutputAmount * (BPS_DENOMINATOR - SWAP_QUOTE_PREFERENCE_BAND_BPS)
 
 /** Re-base an integer amount from `fromDecimals` fixed-point to `toDecimals`. */
 function rebaseDecimals(value: bigint, fromDecimals: number, toDecimals: number): bigint {
@@ -185,44 +157,44 @@ function getComparableOutputAmount(q: SwapQuote, to: AccountCoin): bigint {
 }
 
 function selectBestEligibleQuote(settled: PromiseSettledResult<RankedSwapQuote>[]): SwapQuote | null {
-  let bestNative: RankedSwapQuote | null = null
-  let bestAggregator: RankedSwapQuote | null = null
-  let bestAggregatorPreferenceRank = Number.POSITIVE_INFINITY
+  const candidates: RankedSwapQuote[] = []
 
   for (let i = 0; i < settled.length; i++) {
     const result = settled[i]
-    if (result.status !== 'fulfilled') {
-      continue
-    }
-    const candidate = result.value
-
-    if (isNativeProvider(candidate.providerName)) {
-      // Among natives (THOR + Maya), prefer higher output.
-      if (bestNative === null || candidate.outputAmount > bestNative.outputAmount) {
-        bestNative = candidate
-      }
-    } else {
-      // Tie-break by declared aggregator preference (lower rank wins). This
-      // replaces the previous index-based tie-break, which was determined
-      // dynamically by `shouldPreferGeneralSwap` and therefore harder to
-      // reason about. The declared order lives in `aggregatorPreferenceOrder`
-      // above. (#521 r3 — NeO should-fix.)
-      const candidateRank = getAggregatorPreferenceRank(candidate.providerName)
-      if (
-        bestAggregator === null ||
-        candidate.outputAmount > bestAggregator.outputAmount ||
-        (candidate.outputAmount === bestAggregator.outputAmount && candidateRank < bestAggregatorPreferenceRank)
-      ) {
-        bestAggregator = candidate
-        bestAggregatorPreferenceRank = candidateRank
-      }
+    if (result.status === 'fulfilled') {
+      candidates.push(result.value)
     }
   }
 
-  // Hard THORChain/Maya priority: if any native route exists, always prefer it
-  // over any aggregator route. Mirrors vultisig-ios's priority-first-success
-  // pattern. No output comparison between native and aggregator.
-  return (bestNative ?? bestAggregator)?.quote ?? null
+  if (candidates.length === 0) {
+    return null
+  }
+
+  const bestOutputAmount = candidates.reduce(
+    (best, candidate) => (candidate.outputAmount > best ? candidate.outputAmount : best),
+    candidates[0].outputAmount
+  )
+
+  let selected: RankedSwapQuote | null = null
+  let selectedPreferenceRank = Number.POSITIVE_INFINITY
+
+  for (const candidate of candidates) {
+    if (!isWithinPreferenceBand(candidate.outputAmount, bestOutputAmount)) {
+      continue
+    }
+
+    const candidatePreferenceRank = getProviderPreferenceRank(candidate.providerName)
+    if (
+      selected === null ||
+      candidatePreferenceRank < selectedPreferenceRank ||
+      (candidatePreferenceRank === selectedPreferenceRank && candidate.outputAmount > selected.outputAmount)
+    ) {
+      selected = candidate
+      selectedPreferenceRank = candidatePreferenceRank
+    }
+  }
+
+  return selected?.quote ?? null
 }
 
 export const findSwapQuote = async ({

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -118,6 +118,10 @@ const providerPreferenceIndex = new Map<SwapQuoteProviderName, number>(
 const getProviderPreferenceRank = (name: SwapQuoteProviderName): number =>
   providerPreferenceIndex.get(name) ?? Number.POSITIVE_INFINITY
 
+/**
+ * Tuning point for issue #605's banded routing rule. 100 bps = 1%.
+ * Adjust this when product wants a wider or narrower provider-preference band.
+ */
 const SWAP_QUOTE_PREFERENCE_BAND_BPS = 100n
 const BPS_DENOMINATOR = 10_000n
 


### PR DESCRIPTION
Closes #605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Swap quote selection now uses a 1% provider-preference band—quotes within 1% are decided by provider preference rather than a hard native priority.
  * Tie-break outcomes updated to reflect banded rules (examples: SwapKit vs THORChain, SwapKit vs LiFi, MayaChain near-ties).
  * CowSwap is excluded from Phase 1 provider preferences.

* **Chores**
  * Patch version bumps for core packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->