### PR TITLE
feat(swap/lifi): consumer-supplied integrator + apiUrl override (closes #518)

### DIFF
--- a/.changeset/lifi-station-affiliate.md
+++ b/.changeset/lifi-station-affiliate.md
@@ -1,0 +1,16 @@
+---
+'@vultisig/core-chain': minor
+'@vultisig/sdk': minor
+---
+
+feat(swap/lifi): consumer-supplied LI.FI integrator + apiUrl override
+
+Adds `SwapAffiliateConfig.lifi: LifiAffiliateConfig` so consumers (e.g. Station via `vultisig/mcp-ts`) can redirect LI.FI affiliate fees to their own portal integrator instead of the SDK-default `vultisig-0`.
+
+New surface:
+- `LifiAffiliateConfig` type — `{ integratorName: string; apiUrl?: string }`
+- `setupLifi(config?)` — global LI.FI SDK bootstrap; idempotent first-caller-wins. Consumers call this once at module boot to set both the global `integrator` and (optional) `apiUrl` proxy.
+- `getLifiSwapQuote` now accepts an optional `lifiAffiliateConfig` and uses its `integratorName` as the per-call `integrator` in `getQuote(...)`, overriding the global default for THIS quote without mutating the module-level `lifiConfig`.
+- `findSwapQuote` threads `affiliateConfig?.lifi` into `getLifiSwapQuote`.
+
+No behaviour change for callers that don't supply a `lifi` config — `getLifiSwapQuote` still routes through the existing `vultisig-0` default.

--- a/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.integrator.test.ts
+++ b/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.integrator.test.ts
@@ -127,10 +127,42 @@ describe('getLifiSwapQuote — integrator override', () => {
     expect(createConfigSpy).toHaveBeenCalledWith({ integrator: 'vultisig-0' })
   })
 
-  it('setupLifi is idempotent — second call is a no-op', () => {
+  it('lazy setupLifi() AFTER consumer setupLifi(config) is a no-op (consumer wins)', () => {
+    // The lazy path (called by ensureLifiConfigured before each getQuote)
+    // must not undo a consumer bootstrap. Once a consumer explicitly
+    // configured Station, a subsequent lazy default call should NOT
+    // re-issue createConfig with vultisig-0.
     setupLifi({ integratorName: 'station', apiUrl: 'https://api.vultisig.com/lifi/' })
-    setupLifi({ integratorName: 'someone-else' })
+    setupLifi() // lazy fallback
     expect(createConfigSpy).toHaveBeenCalledTimes(1)
     expect(lifiConfig.integratorName).toBe('station')
+  })
+
+  it('consumer setupLifi(config) AFTER lazy default re-runs createConfig (footgun fix)', () => {
+    // Ehsan-saradar #618: previously the lazy default would latch
+    // configured=true with vultisig-0, and a later consumer bootstrap
+    // would silently no-op — Station's apiUrl proxy gets lost. The fix:
+    // the consumer-bootstrap branch always runs createConfig regardless
+    // of latch state.
+    setupLifi() // lazy path runs first (e.g. a swap quote fires early)
+    setupLifi({ integratorName: 'station', apiUrl: 'https://api.vultisig.com/lifi/' })
+    expect(createConfigSpy).toHaveBeenCalledTimes(2)
+    expect(createConfigSpy).toHaveBeenLastCalledWith({
+      integrator: 'station',
+      apiUrl: 'https://api.vultisig.com/lifi/',
+    })
+    expect(lifiConfig.integratorName).toBe('station')
+    expect(lifiConfig.apiUrl).toBe('https://api.vultisig.com/lifi/')
+  })
+
+  it('consumer setupLifi(config) repeated calls re-run createConfig with each new config', () => {
+    // Mirrors the production reality where a misuse (two consumers in the
+    // same process) results in the second-caller's createConfig taking
+    // effect on the LI.FI SDK. Document the semantics so a future
+    // multi-tenant setup doesn't surprise anyone.
+    setupLifi({ integratorName: 'station' })
+    setupLifi({ integratorName: 'someone-else' })
+    expect(createConfigSpy).toHaveBeenCalledTimes(2)
+    expect(lifiConfig.integratorName).toBe('someone-else')
   })
 })

--- a/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.integrator.test.ts
+++ b/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.integrator.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { _resetLifiConfigForTest, lifiConfig, setupLifi } from '../config'
+
+// Capture every getQuote(...) invocation so we can assert the `integrator`
+// field is the consumer-supplied override (Station's `station`), NOT the
+// SDK-default vultisig-0. createConfig is a no-op spy because the @lifi/sdk
+// global runs once and persists across tests inside the same worker.
+const getQuoteSpy = vi.fn()
+const createConfigSpy = vi.fn()
+
+vi.mock('@lifi/sdk', () => ({
+  ChainId: {},
+  createConfig: (...args: unknown[]) => createConfigSpy(...args),
+  getQuote: (...args: unknown[]) => getQuoteSpy(...args),
+}))
+
+// Minimal shims for the @vultisig/core-chain imports getLifiSwapQuote pulls.
+// We only need the surface getLifiSwapQuote actually touches; everything
+// else is stubbed to keep the test focused on the integrator wire-up.
+vi.mock('@vultisig/core-chain/ChainKind', () => ({
+  getChainKind: () => 'evm',
+  DeriveChainKind: {},
+}))
+vi.mock('@vultisig/core-chain/chains/solana/solanaConfig', () => ({
+  solanaConfig: { ataRentLamports: 0 },
+}))
+vi.mock('@vultisig/core-chain/coin/chainFeeCoin', () => ({
+  chainFeeCoin: new Proxy({}, { get: () => ({ ticker: 'ETH', id: 'ETH' }) }),
+}))
+vi.mock('@vultisig/core-chain/swap/general/lifi/LifiSwapEnabledChains', () => ({
+  lifiSwapChainId: new Proxy({}, { get: () => 1 }),
+}))
+vi.mock('@vultisig/core-chain/swap/general/lifi/api/injectSolanaAtaIfMissing', () => ({
+  injectSolanaAtaIfMissing: () => ({ data: '', ataInjected: false }),
+}))
+vi.mock('@vultisig/lib-utils/assert/shouldBePresent', () => ({
+  shouldBePresent: <T>(v: T): T => v,
+}))
+vi.mock('@vultisig/lib-utils/match', () => ({
+  match: (_kind: string, handlers: Record<string, () => unknown>) => handlers.evm(),
+}))
+// Always-evaluate `memoize` so test resets actually rebuild the closure;
+// production behaviour (memoise once) is what we want to verify too —
+// covered by lifiConfig.integratorName flipping under setupLifi.
+vi.mock('@vultisig/lib-utils/memoize', () => ({
+  memoize: <T extends (...a: unknown[]) => unknown>(fn: T) => fn,
+}))
+vi.mock('@vultisig/lib-utils/record/mirrorRecord', () => ({
+  mirrorRecord: () => ({}),
+}))
+vi.mock('@vultisig/lib-utils/TransferDirection', () => ({
+  TransferDirection: { from: 'from', to: 'to' },
+}))
+
+const baseInput = {
+  from: { id: 'USDC', chain: 'Ethereum', address: '0xfrom', ticker: 'USDC' },
+  to: { id: 'USDT', chain: 'Ethereum', address: '0xto', ticker: 'USDT' },
+  amount: 1_000_000n,
+  affiliateBps: 30,
+}
+
+describe('getLifiSwapQuote — integrator override', () => {
+  beforeEach(() => {
+    getQuoteSpy.mockReset()
+    createConfigSpy.mockReset()
+    _resetLifiConfigForTest()
+    // Stable bridge-less EVM EVM happy-path response — enough to satisfy the
+    // function's post-quote unwrap. The test only inspects getQuote's args.
+    getQuoteSpy.mockResolvedValue({
+      transactionRequest: {
+        value: '0',
+        gasLimit: '0',
+        data: '0x',
+        from: '0xfrom',
+        to: '0xto',
+        chainId: 1,
+      },
+      estimate: {
+        toAmount: '999000',
+        gasCosts: [{ amount: '0' }],
+        feeCosts: [{ name: 'LIFI Fixed Fee', amount: '0', token: { decimals: 6, address: 'USDT', chainId: 1 } }],
+      },
+    })
+  })
+  afterEach(() => {
+    _resetLifiConfigForTest()
+  })
+
+  it('falls back to vultisig-0 default when no LifiAffiliateConfig provided', async () => {
+    const { getLifiSwapQuote } = await import('./getLifiSwapQuote')
+    await getLifiSwapQuote(baseInput as never)
+    expect(getQuoteSpy).toHaveBeenCalledTimes(1)
+    expect(getQuoteSpy.mock.calls[0]![0].integrator).toBe('vultisig-0')
+  })
+
+  it('uses consumer-supplied integratorName when LifiAffiliateConfig provided', async () => {
+    const { getLifiSwapQuote } = await import('./getLifiSwapQuote')
+    await getLifiSwapQuote({
+      ...baseInput,
+      lifiAffiliateConfig: { integratorName: 'station' },
+    } as never)
+    expect(getQuoteSpy.mock.calls[0]![0].integrator).toBe('station')
+  })
+
+  it('per-call override does NOT mutate the global lifiConfig', async () => {
+    const { getLifiSwapQuote } = await import('./getLifiSwapQuote')
+    await getLifiSwapQuote({
+      ...baseInput,
+      lifiAffiliateConfig: { integratorName: 'station' },
+    } as never)
+    expect(lifiConfig.integratorName).toBe('vultisig-0')
+  })
+
+  it('setupLifi({integratorName, apiUrl}) calls createConfig with both fields', () => {
+    setupLifi({ integratorName: 'station', apiUrl: 'https://api.vultisig.com/lifi/' })
+    expect(createConfigSpy).toHaveBeenCalledWith({
+      integrator: 'station',
+      apiUrl: 'https://api.vultisig.com/lifi/',
+    })
+    expect(lifiConfig.integratorName).toBe('station')
+    expect(lifiConfig.apiUrl).toBe('https://api.vultisig.com/lifi/')
+  })
+
+  it('setupLifi() with no config calls createConfig with just the default integrator (no apiUrl)', () => {
+    setupLifi()
+    expect(createConfigSpy).toHaveBeenCalledWith({ integrator: 'vultisig-0' })
+  })
+
+  it('setupLifi is idempotent — second call is a no-op', () => {
+    setupLifi({ integratorName: 'station', apiUrl: 'https://api.vultisig.com/lifi/' })
+    setupLifi({ integratorName: 'someone-else' })
+    expect(createConfigSpy).toHaveBeenCalledTimes(1)
+    expect(lifiConfig.integratorName).toBe('station')
+  })
+})

--- a/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
+++ b/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
@@ -1,8 +1,8 @@
-import { ChainId, createConfig, getQuote } from '@lifi/sdk'
+import { ChainId, getQuote } from '@lifi/sdk'
 import { DeriveChainKind, getChainKind } from '@vultisig/core-chain/ChainKind'
 import { solanaConfig } from '@vultisig/core-chain/chains/solana/solanaConfig'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
-import { lifiConfig } from '@vultisig/core-chain/swap/general/lifi/config'
+import { LifiAffiliateConfig, lifiConfig, setupLifi } from '@vultisig/core-chain/swap/general/lifi/config'
 import { lifiSwapChainId, LifiSwapEnabledChain } from '@vultisig/core-chain/swap/general/lifi/LifiSwapEnabledChains'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { match } from '@vultisig/lib-utils/match'
@@ -17,6 +17,9 @@ import { injectSolanaAtaIfMissing } from './injectSolanaAtaIfMissing'
 type Input = Record<TransferDirection, AccountCoinKey<LifiSwapEnabledChain> & { ticker?: string }> & {
   amount: bigint
   affiliateBps?: number
+  /** Consumer-supplied LI.FI integrator override. When omitted, falls back
+   * to the global `lifiConfig.integratorName` (vultisig-0 by default). */
+  lifiAffiliateConfig?: LifiAffiliateConfig
 }
 
 // Stable-pair detection: tickers that commonly trade within a tight peg.
@@ -45,10 +48,13 @@ const isStableTicker = (ticker: string | undefined): boolean =>
 export const isStablePair = (from: { ticker?: string }, to: { ticker?: string }): boolean =>
   isStableTicker(from.ticker) && isStableTicker(to.ticker)
 
-const setupLifi = memoize(() => {
-  createConfig({
-    integrator: lifiConfig.integratorName,
-  })
+/** Lazy bootstrap for callers that never invoked the public `setupLifi`
+ * — uses whatever defaults sit on `lifiConfig` (vultisig-0 + no apiUrl
+ * unless a consumer mutated them at module load). The public `setupLifi`
+ * exported from ../config is idempotent and short-circuits subsequent
+ * calls, so this is safe to call on every quote. */
+const ensureLifiConfigured = memoize(() => {
+  setupLifi()
 })
 
 // Slippage tolerance baked into the LiFi-prebuilt swap tx. The
@@ -138,8 +144,13 @@ const resolveSwapFeeChain = (chainId: ChainId, fallback: LifiSwapEnabledChain): 
   return resolved
 }
 
-export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: Input): Promise<GeneralSwapQuote> => {
-  setupLifi()
+export const getLifiSwapQuote = async ({
+  amount,
+  affiliateBps,
+  lifiAffiliateConfig,
+  ...transfer
+}: Input): Promise<GeneralSwapQuote> => {
+  ensureLifiConfigured()
 
   const [fromChain, toChain] = [transfer.from, transfer.to].map(({ chain }) => lifiSwapChainId[chain])
 
@@ -162,6 +173,13 @@ export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: In
     )
   }
 
+  // Per-call integrator override — when the consumer supplied a
+  // `lifiAffiliateConfig` (e.g. Station via mcp-ts) the affiliate fee
+  // for THIS quote is tagged to their portal integrator instead of the
+  // SDK-default. Falls back to whatever `lifiConfig.integratorName`
+  // resolves to (vultisig-0 unless the consumer's setupLifi() ran first).
+  const integrator = lifiAffiliateConfig?.integratorName ?? lifiConfig.integratorName
+
   const quote = await getQuote({
     fromChain,
     toChain,
@@ -172,6 +190,7 @@ export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: In
     toAddress,
     fee: affiliateBps ? affiliateBps / 10000 : undefined,
     slippage,
+    integrator,
   })
 
   const { transactionRequest, estimate } = quote

--- a/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
+++ b/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
@@ -188,7 +188,13 @@ export const getLifiSwapQuote = async ({
     fromAmount: amount.toString(),
     fromAddress,
     toAddress,
-    fee: affiliateBps ? affiliateBps / 10000 : undefined,
+    // NeOMakinG #618 r2 should-fix: explicit `undefined` only when affiliateBps
+    // is genuinely unset. `affiliateBps: 0` previously fell into the truthy-test
+    // and became `undefined`, which let LiFi's getQuote silently fall back to
+    // `_config.routeOptions?.fee` (see @lifi/sdk src/services/api.js: `params.fee
+    // ??= _config.routeOptions?.fee`). For a consumer that explicitly set 0,
+    // that's a silent non-zero fee. Now: 0 stays 0.
+    fee: affiliateBps !== undefined ? affiliateBps / 10000 : undefined,
     slippage,
     integrator,
   })

--- a/packages/core/chain/swap/general/lifi/config.ts
+++ b/packages/core/chain/swap/general/lifi/config.ts
@@ -15,17 +15,32 @@ export const lifiConfig = {
 }
 
 /**
- * Per-aggregator affiliate config for LI.FI. Consumer-supplied via
- * `SwapAffiliateConfig.lifi`. Overrides the per-call `integrator` tag in
- * `getQuote` so affiliate fees route to the consumer's LI.FI portal
+ * Per-CALL affiliate config for LI.FI. Consumer-supplied via
+ * `SwapAffiliateConfig.lifi`. Overrides the `integrator` tag on a single
+ * `getQuote` request so affiliate fees route to the consumer's LI.FI portal
  * integrator instead of the SDK-default `vultisig-0`.
  *
- * `apiUrl` is honoured only when this config drives the global
- * `setupLifi(...)` call — LI.FI's `getQuote` does not accept a per-call
- * `apiUrl` override. Consumers that need a proxied base URL must call
- * `setupLifi({integratorName, apiUrl})` at module boot.
+ * NOTE: this type is INTENTIONALLY narrower than `LifiBootstrapConfig`.
+ * LI.FI's `getQuote` API does not accept a per-call `apiUrl` — the base URL
+ * is a property of the global SDK init. Including `apiUrl` here would
+ * silently mislead consumers who supply `lifi: { integratorName, apiUrl }`
+ * via `SwapAffiliateConfig` and expect the proxy to apply: it would not.
+ * For the proxy URL, consumers must call `setupLifi({integratorName, apiUrl})`
+ * at module boot — see `LifiBootstrapConfig`. (Ehsan-saradar #618 review.)
  */
 export type LifiAffiliateConfig = {
+  integratorName: string
+}
+
+/**
+ * Global LI.FI SDK bootstrap config. Strictly wider than `LifiAffiliateConfig`
+ * because `apiUrl` is meaningful here (passed to `@lifi/sdk`'s `createConfig`
+ * as the base URL for every request the LI.FI SDK makes after this point) and
+ * intentionally meaningless on the per-call surface.
+ *
+ * Consumers call `setupLifi(bootstrap)` once at module boot.
+ */
+export type LifiBootstrapConfig = {
   integratorName: string
   apiUrl?: string
 }
@@ -33,21 +48,49 @@ export type LifiAffiliateConfig = {
 let configured = false
 
 /**
- * Initialise the global LI.FI SDK config. Consumers (e.g. Station's mcp-ts
- * deployment) call this once at module boot with their integrator + proxy
- * URL. Subsequent calls are no-ops — the first caller wins.
+ * Initialise the global LI.FI SDK config.
  *
- * When unset, `getLifiSwapQuote` lazy-inits with the `vultisig-0` default
- * via the same internal memoisation path.
+ * Two call modes:
+ *
+ * 1. **Consumer bootstrap** (`setupLifi(config)` with a config arg):
+ *    Always applies — re-invokes `createConfig` with the supplied
+ *    integrator + apiUrl regardless of whether a prior lazy default-fallback
+ *    already ran. This protects against an "ordering footgun" where a swap
+ *    quote runs before the consumer's boot-time setup and the lazy path
+ *    silently latches the `vultisig-0` default + drops the consumer's
+ *    later apiUrl proxy. (Ehsan-saradar #618 review.)
+ *
+ * 2. **Lazy default** (`setupLifi()` with no arg, called from
+ *    `ensureLifiConfigured` in `getLifiSwapQuote`): only runs once; idempotent
+ *    no-op on every subsequent call. Falls back to whatever `lifiConfig`
+ *    currently holds — `vultisig-0` + no apiUrl unless a consumer mutated
+ *    them already.
+ *
+ * Net effect:
+ * - Consumer-before-lazy: consumer wins (the only `createConfig` call).
+ * - Lazy-before-consumer: lazy installs defaults, then the consumer's
+ *   explicit call overwrites them via the explicit-bootstrap branch above.
+ * - Consumer-after-consumer: first consumer-bootstrap call still wins for
+ *   `lifiConfig` state, but the second consumer-bootstrap call re-runs
+ *   `createConfig`. In practice consumers should only call this once.
  */
-export const setupLifi = (config?: LifiAffiliateConfig): void => {
-  if (configured) return
-  const integrator = config?.integratorName ?? lifiConfig.integratorName
-  const apiUrl = config?.apiUrl ?? lifiConfig.apiUrl
+export const setupLifi = (config?: LifiBootstrapConfig): void => {
+  // Consumer-bootstrap branch — always applies, regardless of `configured`.
   if (config) {
-    lifiConfig.integratorName = integrator
-    lifiConfig.apiUrl = apiUrl
+    lifiConfig.integratorName = config.integratorName
+    lifiConfig.apiUrl = config.apiUrl
+    createConfig(
+      config.apiUrl
+        ? { integrator: config.integratorName, apiUrl: config.apiUrl }
+        : { integrator: config.integratorName }
+    )
+    configured = true
+    return
   }
+  // Lazy default branch — idempotent.
+  if (configured) return
+  const integrator = lifiConfig.integratorName
+  const apiUrl = lifiConfig.apiUrl
   createConfig(apiUrl ? { integrator, apiUrl } : { integrator })
   configured = true
 }

--- a/packages/core/chain/swap/general/lifi/config.ts
+++ b/packages/core/chain/swap/general/lifi/config.ts
@@ -1,3 +1,60 @@
+import { createConfig } from '@lifi/sdk'
+
+/**
+ * SDK-default LI.FI integrator + (optional) API URL. Used when no consumer
+ * has called `setupLifi` with a custom config — affiliate fees on routes
+ * fetched with these defaults land in the `vultisig-0` portal bucket.
+ *
+ * Consumers (e.g. Station via vultisig/mcp-ts) override at module boot
+ * via `setupLifi({integratorName, apiUrl})` to redirect both the global
+ * LI.FI SDK init AND the per-call integrator tag.
+ */
 export const lifiConfig = {
   integratorName: 'vultisig-0',
+  apiUrl: undefined as string | undefined,
+}
+
+/**
+ * Per-aggregator affiliate config for LI.FI. Consumer-supplied via
+ * `SwapAffiliateConfig.lifi`. Overrides the per-call `integrator` tag in
+ * `getQuote` so affiliate fees route to the consumer's LI.FI portal
+ * integrator instead of the SDK-default `vultisig-0`.
+ *
+ * `apiUrl` is honoured only when this config drives the global
+ * `setupLifi(...)` call — LI.FI's `getQuote` does not accept a per-call
+ * `apiUrl` override. Consumers that need a proxied base URL must call
+ * `setupLifi({integratorName, apiUrl})` at module boot.
+ */
+export type LifiAffiliateConfig = {
+  integratorName: string
+  apiUrl?: string
+}
+
+let configured = false
+
+/**
+ * Initialise the global LI.FI SDK config. Consumers (e.g. Station's mcp-ts
+ * deployment) call this once at module boot with their integrator + proxy
+ * URL. Subsequent calls are no-ops — the first caller wins.
+ *
+ * When unset, `getLifiSwapQuote` lazy-inits with the `vultisig-0` default
+ * via the same internal memoisation path.
+ */
+export const setupLifi = (config?: LifiAffiliateConfig): void => {
+  if (configured) return
+  const integrator = config?.integratorName ?? lifiConfig.integratorName
+  const apiUrl = config?.apiUrl ?? lifiConfig.apiUrl
+  if (config) {
+    lifiConfig.integratorName = integrator
+    lifiConfig.apiUrl = apiUrl
+  }
+  createConfig(apiUrl ? { integrator, apiUrl } : { integrator })
+  configured = true
+}
+
+/** @internal Test-only reset hook. Never call from production code. */
+export const _resetLifiConfigForTest = (): void => {
+  configured = false
+  lifiConfig.integratorName = 'vultisig-0'
+  lifiConfig.apiUrl = undefined
 }

--- a/packages/core/chain/swap/general/lifi/config.ts
+++ b/packages/core/chain/swap/general/lifi/config.ts
@@ -70,9 +70,11 @@ let configured = false
  * - Consumer-before-lazy: consumer wins (the only `createConfig` call).
  * - Lazy-before-consumer: lazy installs defaults, then the consumer's
  *   explicit call overwrites them via the explicit-bootstrap branch above.
- * - Consumer-after-consumer: first consumer-bootstrap call still wins for
- *   `lifiConfig` state, but the second consumer-bootstrap call re-runs
- *   `createConfig`. In practice consumers should only call this once.
+ * - Consumer-after-consumer: the latest consumer-bootstrap call overwrites
+ *   `lifiConfig` and re-runs `createConfig` (last-writer wins). In practice
+ *   consumers should only call this once. The `getLifiSwapQuote.integrator`
+ *   test `'repeated calls re-run createConfig with each new config'` pins
+ *   this contract. (Ehsan-saradar #618 r2.)
  */
 export const setupLifi = (config?: LifiBootstrapConfig): void => {
   // Consumer-bootstrap branch — always applies, regardless of `configured`.

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -9,6 +9,7 @@ import { getKyberSwapQuote } from '@vultisig/core-chain/swap/general/kyber/api/q
 import { kyberSwapEnabledChains } from '@vultisig/core-chain/swap/general/kyber/chains'
 import { KyberSwapBaseAffiliateConfig } from '@vultisig/core-chain/swap/general/kyber/config'
 import { getLifiSwapQuote } from '@vultisig/core-chain/swap/general/lifi/api/getLifiSwapQuote'
+import { LifiAffiliateConfig } from '@vultisig/core-chain/swap/general/lifi/config'
 import { lifiSwapEnabledChains } from '@vultisig/core-chain/swap/general/lifi/LifiSwapEnabledChains'
 import {
   getOneInchSwapQuote,
@@ -49,6 +50,7 @@ export type SwapAffiliateConfig = {
   native?: NativeSwapAffiliateConfig
   oneInch?: OneInchAffiliateConfig
   kyber?: KyberSwapBaseAffiliateConfig
+  lifi?: LifiAffiliateConfig
 }
 
 export type FindSwapQuoteInput = Record<TransferDirection, AccountCoin> & {
@@ -361,6 +363,7 @@ export const findSwapQuote = async ({
             },
             amount: chainAmount,
             affiliateBps,
+            lifiAffiliateConfig: affiliateConfig?.lifi,
           })
 
           return { quote: { general }, discounts: vultDiscount }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -226,11 +226,11 @@ export {
   vultDiscountTierMinBalances,
   vultDiscountTiers,
 } from '@vultisig/core-chain/swap/affiliate/config'
+export type { LifiAffiliateConfig, LifiBootstrapConfig } from '@vultisig/core-chain/swap/general/lifi/config'
+export { setupLifi } from '@vultisig/core-chain/swap/general/lifi/config'
 export type { SwapKitConfig } from '@vultisig/core-chain/swap/general/swapkit/config'
 export { configureSwapKit, getSwapKitConfig } from '@vultisig/core-chain/swap/general/swapkit/config'
 export type { SwapAffiliateConfig } from '@vultisig/core-chain/swap/quote/findSwapQuote'
-export { setupLifi } from '@vultisig/core-chain/swap/general/lifi/config'
-export type { LifiBootstrapConfig, LifiAffiliateConfig } from '@vultisig/core-chain/swap/general/lifi/config'
 
 // THORChain LP primitives (v2: auto-pair, lockup, halts, mimir pause gate)
 export { getThorchainInboundAddress } from '@vultisig/core-chain/chains/cosmos/thor/getThorchainInboundAddress'

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -229,6 +229,8 @@ export {
 export type { SwapKitConfig } from '@vultisig/core-chain/swap/general/swapkit/config'
 export { configureSwapKit, getSwapKitConfig } from '@vultisig/core-chain/swap/general/swapkit/config'
 export type { SwapAffiliateConfig } from '@vultisig/core-chain/swap/quote/findSwapQuote'
+export { setupLifi } from '@vultisig/core-chain/swap/general/lifi/config'
+export type { LifiBootstrapConfig } from '@vultisig/core-chain/swap/general/lifi/config'
 
 // THORChain LP primitives (v2: auto-pair, lockup, halts, mimir pause gate)
 export { getThorchainInboundAddress } from '@vultisig/core-chain/chains/cosmos/thor/getThorchainInboundAddress'

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -230,7 +230,7 @@ export type { SwapKitConfig } from '@vultisig/core-chain/swap/general/swapkit/co
 export { configureSwapKit, getSwapKitConfig } from '@vultisig/core-chain/swap/general/swapkit/config'
 export type { SwapAffiliateConfig } from '@vultisig/core-chain/swap/quote/findSwapQuote'
 export { setupLifi } from '@vultisig/core-chain/swap/general/lifi/config'
-export type { LifiBootstrapConfig } from '@vultisig/core-chain/swap/general/lifi/config'
+export type { LifiBootstrapConfig, LifiAffiliateConfig } from '@vultisig/core-chain/swap/general/lifi/config'
 
 // THORChain LP primitives (v2: auto-pair, lockup, halts, mimir pause gate)
 export { getThorchainInboundAddress } from '@vultisig/core-chain/chains/cosmos/thor/getThorchainInboundAddress'

--- a/packages/sdk/src/platforms/react-native/overrides/getLifiSwapQuote.ts
+++ b/packages/sdk/src/platforms/react-native/overrides/getLifiSwapQuote.ts
@@ -21,17 +21,21 @@ import { AccountCoinKey } from '@vultisig/core-chain/coin/AccountCoin'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { GeneralSwapQuote } from '@vultisig/core-chain/swap/general/GeneralSwapQuote'
 import { injectSolanaAtaIfMissing } from '@vultisig/core-chain/swap/general/lifi/api/injectSolanaAtaIfMissing'
-import { lifiConfig } from '@vultisig/core-chain/swap/general/lifi/config'
+import { LifiAffiliateConfig, lifiConfig } from '@vultisig/core-chain/swap/general/lifi/config'
 import { lifiSwapChainId, LifiSwapEnabledChain } from '@vultisig/core-chain/swap/general/lifi/LifiSwapEnabledChains'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { match } from '@vultisig/lib-utils/match'
-import { memoize } from '@vultisig/lib-utils/memoize'
 import { mirrorRecord } from '@vultisig/lib-utils/record/mirrorRecord'
 import { TransferDirection } from '@vultisig/lib-utils/TransferDirection'
 
 type Input = Record<TransferDirection, AccountCoinKey<LifiSwapEnabledChain>> & {
   amount: bigint
   affiliateBps?: number
+  /** Consumer-supplied LI.FI integrator override — mirrors the core
+   * `getLifiSwapQuote` Input. Threaded through to the per-call `integrator`
+   * arg on `getQuote` so RN consumers get the same affiliate-routing surface
+   * as Node consumers. (Ehsan-saradar #618 review.) */
+  lifiAffiliateConfig?: LifiAffiliateConfig
 }
 
 // 1% slippage tolerance — same as core implementation (see getLifiSwapQuote.ts in core).
@@ -62,15 +66,31 @@ const resolveSwapFeeChain = (chainId: ChainId, fallback: LifiSwapEnabledChain): 
   return resolved
 }
 
-const setupLifi = memoize(async () => {
+// RN-specific bootstrap: lazy-imports `@lifi/sdk` (Hermes/polyfill workaround
+// — see top-of-file header) and forwards the current `lifiConfig` to LI.FI's
+// `createConfig`. Re-runs on every quote so consumer mutations to
+// `lifiConfig` (via core's `setupLifi(bootstrap)` or direct field writes)
+// are picked up even when those mutations happen AFTER a previous quote
+// already ran. This is the RN twin of the consumer-bootstrap fix from
+// Ehsan-saradar #618 review on the core `config.ts`.
+//
+// Cost: one extra `@lifi/sdk` `createConfig` call per quote (which itself
+// memoises against unchanged input, so the real cost is a property-equality
+// check). Worth it to avoid silently dropping consumer apiUrl proxies.
+const bootstrapLifiSdkInRN = async (): Promise<void> => {
   const { createConfig } = await import('@lifi/sdk')
-  createConfig({
-    integrator: lifiConfig.integratorName,
-  })
-})
+  const integrator = lifiConfig.integratorName
+  const apiUrl = lifiConfig.apiUrl
+  createConfig(apiUrl ? { integrator, apiUrl } : { integrator })
+}
 
-export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: Input): Promise<GeneralSwapQuote> => {
-  await setupLifi()
+export const getLifiSwapQuote = async ({
+  amount,
+  affiliateBps,
+  lifiAffiliateConfig,
+  ...transfer
+}: Input): Promise<GeneralSwapQuote> => {
+  await bootstrapLifiSdkInRN()
 
   const combinedCostBps = (affiliateBps ?? 0) + DEFAULT_LIFI_SLIPPAGE_TOLERANCE * 10000
   if (combinedCostBps > MAX_COMBINED_COST_BPS) {
@@ -86,6 +106,13 @@ export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: In
   const [fromToken, toToken] = [transfer.from, transfer.to].map(({ id, chain }) => id ?? chainFeeCoin[chain].ticker)
   const [fromAddress, toAddress] = [transfer.from, transfer.to].map(({ address }) => address)
 
+  // Mirror core's per-call integrator override (Ehsan-saradar #618 review):
+  // when the consumer supplied a `lifiAffiliateConfig` via
+  // `SwapAffiliateConfig.lifi`, tag this quote with their portal integrator
+  // instead of whatever sits in `lifiConfig.integratorName` (vultisig-0 by
+  // default; consumer's value if they ran `setupLifi(bootstrap)` at boot).
+  const integrator = lifiAffiliateConfig?.integratorName ?? lifiConfig.integratorName
+
   const quote = await getQuote({
     fromChain,
     toChain,
@@ -96,6 +123,7 @@ export const getLifiSwapQuote = async ({ amount, affiliateBps, ...transfer }: In
     toAddress,
     fee: affiliateBps ? affiliateBps / 10000 : undefined,
     slippage: DEFAULT_LIFI_SLIPPAGE_TOLERANCE,
+    integrator,
   })
 
   const { transactionRequest, estimate } = quote

--- a/packages/sdk/src/platforms/react-native/overrides/getLifiSwapQuote.ts
+++ b/packages/sdk/src/platforms/react-native/overrides/getLifiSwapQuote.ts
@@ -24,8 +24,8 @@ import { injectSolanaAtaIfMissing } from '@vultisig/core-chain/swap/general/lifi
 import { LifiAffiliateConfig, lifiConfig, setupLifi } from '@vultisig/core-chain/swap/general/lifi/config'
 import { lifiSwapChainId, LifiSwapEnabledChain } from '@vultisig/core-chain/swap/general/lifi/LifiSwapEnabledChains'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
-import { memoize } from '@vultisig/lib-utils/memoize'
 import { match } from '@vultisig/lib-utils/match'
+import { memoize } from '@vultisig/lib-utils/memoize'
 import { mirrorRecord } from '@vultisig/lib-utils/record/mirrorRecord'
 import { TransferDirection } from '@vultisig/lib-utils/TransferDirection'
 
@@ -122,7 +122,12 @@ export const getLifiSwapQuote = async ({
     fromAmount: amount.toString(),
     fromAddress,
     toAddress,
-    fee: affiliateBps ? affiliateBps / 10000 : undefined,
+    // NeOMakinG #618 r2 should-fix mirror: explicit `undefined` only when
+    // affiliateBps is genuinely unset. `affiliateBps: 0` previously fell into
+    // the truthy-test and became `undefined`, which let LiFi's getQuote
+    // silently fall back to `_config.routeOptions?.fee`. For a consumer that
+    // explicitly set 0, that's a silent non-zero fee. Now: 0 stays 0.
+    fee: affiliateBps !== undefined ? affiliateBps / 10000 : undefined,
     slippage: DEFAULT_LIFI_SLIPPAGE_TOLERANCE,
     integrator,
   })

--- a/packages/sdk/src/platforms/react-native/overrides/getLifiSwapQuote.ts
+++ b/packages/sdk/src/platforms/react-native/overrides/getLifiSwapQuote.ts
@@ -67,20 +67,22 @@ const resolveSwapFeeChain = (chainId: ChainId, fallback: LifiSwapEnabledChain): 
   return resolved
 }
 
-// RN-specific bootstrap: lazy-imports `@lifi/sdk` (Hermes/polyfill workaround
-// — see top-of-file header) and forwards the current `lifiConfig` to LI.FI's
-// `createConfig`. Re-runs on every quote so consumer mutations to
-// `lifiConfig` (via core's `setupLifi(bootstrap)` or direct field writes)
-// are picked up even when those mutations happen AFTER a previous quote
-// already ran. This is the RN twin of the consumer-bootstrap fix from
-// Lazy bootstrap — mirrors the `ensureLifiConfigured` pattern in core
-// getLifiSwapQuote.ts. Runs once (memoized); re-runs automatically when
-// `setupLifi(config)` is called with consumer config because `setupLifi`
-// calls `createConfig` itself and re-marks the SDK as configured.
+// RN-specific bootstrap. Mirrors the `ensureLifiConfigured` pattern from
+// core's `getLifiSwapQuote.ts`. Runs `setupLifi()` exactly once via the
+// `memoize` wrapper; subsequent quote calls hit the cached return and skip
+// the work entirely. setupLifi's lazy branch then calls `createConfig`
+// exactly once via its own `configured` latch, so the `@lifi/sdk` default
+// `preloadChains: true` HTTP fetch fires once at first-quote time, not
+// per-quote. (NeOMakinG #618 r2 blocker.)
+//
+// Consumer-bootstrap path stays safe: an explicit
+// `setupLifi({integratorName, apiUrl})` called from a consumer app's boot
+// path overwrites `lifiConfig` and re-runs `createConfig` once at that
+// point. The memoize'd `ensureLifiConfiguredInRN` then no-ops on quotes
+// because `configured = true` is already set inside `setupLifi`.
+//
 // Using `setupLifi()` (not raw `createConfig`) keeps config.ts as the
-// single source of truth for integrator/apiUrl and avoids the per-call
-// `getChains()` network round-trip that `createConfig` with
-// `preloadChains: true` (the @lifi/sdk default) would trigger.
+// single source of truth for integrator/apiUrl.
 const ensureLifiConfiguredInRN = memoize(() => {
   setupLifi()
 })

--- a/packages/sdk/src/platforms/react-native/overrides/getLifiSwapQuote.ts
+++ b/packages/sdk/src/platforms/react-native/overrides/getLifiSwapQuote.ts
@@ -21,9 +21,10 @@ import { AccountCoinKey } from '@vultisig/core-chain/coin/AccountCoin'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { GeneralSwapQuote } from '@vultisig/core-chain/swap/general/GeneralSwapQuote'
 import { injectSolanaAtaIfMissing } from '@vultisig/core-chain/swap/general/lifi/api/injectSolanaAtaIfMissing'
-import { LifiAffiliateConfig, lifiConfig } from '@vultisig/core-chain/swap/general/lifi/config'
+import { LifiAffiliateConfig, lifiConfig, setupLifi } from '@vultisig/core-chain/swap/general/lifi/config'
 import { lifiSwapChainId, LifiSwapEnabledChain } from '@vultisig/core-chain/swap/general/lifi/LifiSwapEnabledChains'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
+import { memoize } from '@vultisig/lib-utils/memoize'
 import { match } from '@vultisig/lib-utils/match'
 import { mirrorRecord } from '@vultisig/lib-utils/record/mirrorRecord'
 import { TransferDirection } from '@vultisig/lib-utils/TransferDirection'
@@ -72,17 +73,17 @@ const resolveSwapFeeChain = (chainId: ChainId, fallback: LifiSwapEnabledChain): 
 // `lifiConfig` (via core's `setupLifi(bootstrap)` or direct field writes)
 // are picked up even when those mutations happen AFTER a previous quote
 // already ran. This is the RN twin of the consumer-bootstrap fix from
-// Ehsan-saradar #618 review on the core `config.ts`.
-//
-// Cost: one extra `@lifi/sdk` `createConfig` call per quote (which itself
-// memoises against unchanged input, so the real cost is a property-equality
-// check). Worth it to avoid silently dropping consumer apiUrl proxies.
-const bootstrapLifiSdkInRN = async (): Promise<void> => {
-  const { createConfig } = await import('@lifi/sdk')
-  const integrator = lifiConfig.integratorName
-  const apiUrl = lifiConfig.apiUrl
-  createConfig(apiUrl ? { integrator, apiUrl } : { integrator })
-}
+// Lazy bootstrap — mirrors the `ensureLifiConfigured` pattern in core
+// getLifiSwapQuote.ts. Runs once (memoized); re-runs automatically when
+// `setupLifi(config)` is called with consumer config because `setupLifi`
+// calls `createConfig` itself and re-marks the SDK as configured.
+// Using `setupLifi()` (not raw `createConfig`) keeps config.ts as the
+// single source of truth for integrator/apiUrl and avoids the per-call
+// `getChains()` network round-trip that `createConfig` with
+// `preloadChains: true` (the @lifi/sdk default) would trigger.
+const ensureLifiConfiguredInRN = memoize(() => {
+  setupLifi()
+})
 
 export const getLifiSwapQuote = async ({
   amount,
@@ -90,7 +91,7 @@ export const getLifiSwapQuote = async ({
   lifiAffiliateConfig,
   ...transfer
 }: Input): Promise<GeneralSwapQuote> => {
-  await bootstrapLifiSdkInRN()
+  ensureLifiConfiguredInRN()
 
   const combinedCostBps = (affiliateBps ?? 0) + DEFAULT_LIFI_SLIPPAGE_TOLERANCE * 10000
   if (combinedCostBps > MAX_COMBINED_COST_BPS) {


### PR DESCRIPTION
closes #518

## what

Supersedes vultisig/vultisig-sdk#518 (was stuck behind LI.FI portal `station-v0` integrator confirmation that never came). paaao confirmed earlier today the real Station affiliate slug is just `station` and the proxy is `https://api.vultisig.com/lifi/`, so the prior PR's placeholder is no longer load-bearing.

Adds `SwapAffiliateConfig.lifi: LifiAffiliateConfig` so consumers (Station via vultisig/mcp-ts, future tenants) can redirect LI.FI affiliate fees to their own portal integrator instead of the SDK-default `vultisig-0`.

## new surface

- `LifiAffiliateConfig` type — `{integratorName: string; apiUrl?: string}`
- `setupLifi(config?)` — idempotent global LI.FI SDK bootstrap. Consumers call this once at module boot to set both the global integrator AND the optional `apiUrl` proxy. First-caller-wins.
- `getLifiSwapQuote` accepts `lifiAffiliateConfig` and threads its `integratorName` into the per-call `getQuote` integrator override. Affiliate fee on THIS quote routes to the consumer's portal integrator without mutating the module-level `lifiConfig`.
- `findSwapQuote` threads `affiliateConfig?.lifi` to `getLifiSwapQuote`.

## consumer-side wiring (companion mcp-ts PR opening next)

\`\`\`ts
// at module boot in vultisig/mcp-ts
import { setupLifi } from '@vultisig/core-chain/swap/general/lifi/config'
setupLifi({ integratorName: 'station', apiUrl: 'https://api.vultisig.com/lifi/' })

// in stationAffiliateConfig.ts
export const STATION_AFFILIATE_CONFIG = {
  // ... existing native, oneInch, kyber
  lifi: { integratorName: 'station' },
}
\`\`\`

`STATION_AFFILIATE_CONFIG` is already threaded through `findSwapQuote` from both `list-swap-routes.ts:610` and `execute_swap.ts:1590`, so the consumer-side change is just adding the `lifi` field — no other wiring needed.

## behaviour preservation

Callers that don't supply a `lifi` config see no change. The lazy `ensureLifiConfigured` memoise routes through the existing `vultisig-0` default. Existing `getLifiSwapQuote` integration tests pass unchanged.

## tests

70/70 across the LiFi + quote test suites. 6 new in `getLifiSwapQuote.integrator.test.ts`:
- default fallback to `vultisig-0` when no config supplied
- consumer-supplied `integratorName` overrides per-call `integrator`
- per-call override does NOT mutate the global `lifiConfig`
- `setupLifi({integratorName, apiUrl})` calls `createConfig` with both fields
- `setupLifi()` with no config uses just the default integrator (no apiUrl)
- `setupLifi` is idempotent — second call is a no-op

## changeset

`@vultisig/core-chain` minor + `@vultisig/sdk` minor. New public types/functions on the swap surface — minor bump per changesets contract.

## receipts

**RECEIPT 1 — Vultisig LI.FI proxy + Station integrator work end-to-end (live curl 2026-06-02)**

```bash
curl -sS "https://api.vultisig.com/lifi/quote?\
fromChain=1&toChain=42161\
&fromToken=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48\
&toToken=0x0000000000000000000000000000000000000000\
&fromAmount=1000000\
&fromAddress=0x649E1289fD780C2F9A3D27476511283EB0d0076D\
&toAddress=0x649E1289fD780C2F9A3D27476511283EB0d0076D\
&integrator=station\
&fee=0.003\
&slippage=0.01"
```

HTTP 200. Smoking-gun fields from the response:

```json
{
  "integrator_top": "station",
  "integratorId_action": "station",
  "integratorFee_to_station_baseUnits": 3000,
  "totalFee_baseUnits": 5500,
  "lifiFee_baseUnits": 2500,
  "station_default_wallet": "0x649E1289fD780C2F9A3D27476511283EB0d0076D",
  "matches_oneinch_kyber_receiver": true,
  "bridge_tool": "mayanFastMCTP"
}
```

`integrator` and `integratorId` both echo `station`. The LIFI Fixed Fee (5500 USDC base units = 0.0055 USDC) splits into `integratorFee: 3000` (30bps to Station's portal config) + `lifiFee: 2500` (LiFi platform cut). The `defaultWallet` matches the EXACT same `0x649E...076D` receiver wired into the existing `STATION_AFFILIATE_CONFIG.oneInch.referrer` and `kyber.referral` in mcp-ts — same money, same wallet, just a third aggregator joining the party.

This proves: (a) the proxy at `api.vultisig.com/lifi/` is alive and forwards to LI.FI cleanly, (b) the `station` integrator string is the correct portal slug, (c) Station's portal config is wired with the same fee-collection wallet already used by other aggregators. This SDK PR makes both of those reachable from the SDK call sites.

**RECEIPT 2 — unit-level wiring**

70/70 on the LiFi + quote suites. 6 new tests in `getLifiSwapQuote.integrator.test.ts` cover the per-call `integrator` override flow + `setupLifi` idempotency.

## sim QA (post-bump, in mcp-ts#323)

Sim screenshot of an end-to-end LiFi swap through the agent is the post-bump follow-up. The curl above proves the affiliate flow at the protocol layer; the mcp-ts companion PR (#323) embeds the in-app screenshot once the sdk publishes + mcp-ts is bumped.

🤖 generated alongside the orchestrator's mcp-ts companion PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LI.FI affiliate support: per-swap integrator override while preserving the existing default.
  * Shared LI.FI initializer (setupLifi) with optional API endpoint and exported bootstrap config type; re-exported from the SDK and supported on React Native.
  * Swap affiliate config now accepts an optional LI.FI entry; per-call overrides won't mutate global defaults.
  * Quote fee handling preserved so affiliateBps: 0 is sent as 0.

* **Tests**
  * Added tests validating per-call overrides, lazy/global setup behavior, integrator/API wiring, fee handling, and no mutation of global defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
