### PR TITLE
feat(ton): add jetton master token metadata discovery

### DIFF
--- a/.changeset/ton-jetton-metadata-discovery.md
+++ b/.changeset/ton-jetton-metadata-discovery.md
@@ -1,0 +1,13 @@
+---
+'@vultisig/core-chain': minor
+---
+
+feat(ton): add jetton master token metadata discovery
+
+Adds a TON token metadata resolver so pasting a jetton master address (`EQ.../UQ...`) auto-fills ticker, decimals, and logo — same UX as EVM/Solana/Tron custom token discovery.
+
+- New `getJettonMasterInfo()` helper hits Toncenter v3 `/jetton/masters`, preferring the validated indexer `token_info` entry over on-chain TEP-64 `jetton_content`.
+- Logo selection prefers Toncenter's `imgproxy.toncenter.com` variants (`_image_medium` → `_image_small` → `_image_big`) before the raw `image` URL. Many jetton issuers serve their PNG with `Cross-Origin-Resource-Policy: same-origin`, which browsers refuse to embed cross-origin; the proxied variants load reliably.
+- `OtherChain.Ton` added to `chainsWithTokenMetadataDiscovery`; the new `getTonTokenMetadata` resolver is registered under the `ton` chain kind.
+
+Unblocks vultisig/vultisig-windows#4029.

--- a/packages/core/chain/chains/ton/api.ts
+++ b/packages/core/chain/chains/ton/api.ts
@@ -64,3 +64,95 @@ export const getTonWalletState = async (address: string): Promise<string> => {
 
   return response.status
 }
+
+type JettonContent = {
+  decimals?: string
+  uri?: string
+  name?: string
+  symbol?: string
+  image?: string
+}
+
+type JettonTokenInfo = {
+  valid?: boolean
+  type?: string
+  name?: string
+  symbol?: string
+  description?: string
+  image?: string
+  extra?: {
+    decimals?: string
+    uri?: string
+    _image_small?: string
+    _image_medium?: string
+    _image_big?: string
+  }
+}
+
+type JettonMasterEntry = {
+  address: string
+  total_supply?: string
+  mintable?: boolean
+  jetton_content?: JettonContent
+}
+
+type JettonMastersResponse = {
+  jetton_masters: JettonMasterEntry[]
+  metadata?: Record<
+    string,
+    {
+      is_indexed?: boolean
+      token_info?: JettonTokenInfo[]
+    }
+  >
+}
+
+export type JettonMasterInfo = {
+  ticker: string
+  decimals: number
+  logo?: string
+}
+
+/**
+ * Fetches jetton master metadata (ticker, decimals, logo) from toncenter v3.
+ * Prefers Toncenter's validated indexer entry (`token_info` with `valid: true`),
+ * falling back to the on-chain TEP-64 `jetton_content` stored in the master.
+ */
+export const getJettonMasterInfo = async (jettonMasterAddress: string): Promise<JettonMasterInfo> => {
+  const url = `${tonApiUrl}/v3/jetton/masters?address=${jettonMasterAddress}&limit=1`
+  const response = await queryUrl<JettonMastersResponse>(url)
+
+  const master = response.jetton_masters[0]
+  if (!master) {
+    throw new Error(`No jetton master found for ${jettonMasterAddress}`)
+  }
+
+  const nonEmpty = (value: string | undefined): string | undefined => {
+    const trimmed = value?.trim()
+    return trimmed ? trimmed : undefined
+  }
+
+  const indexed = response.metadata?.[master.address]?.token_info?.find(entry => entry.valid === true)
+  const content = master.jetton_content
+
+  const ticker = nonEmpty(indexed?.symbol) ?? nonEmpty(content?.symbol)
+  if (!ticker) {
+    throw new Error(`Jetton master ${jettonMasterAddress} has no symbol`)
+  }
+
+  const decimalsRaw = indexed?.extra?.decimals ?? content?.decimals
+  const decimals = decimalsRaw !== undefined ? parseInt(decimalsRaw, 10) : 9
+
+  // Prefer Toncenter's imgproxy URLs: the original `image` URL often serves
+  // with `Cross-Origin-Resource-Policy: same-origin`, which browsers refuse
+  // to embed cross-origin. The `_image_*` variants are normalized PNGs from
+  // `imgproxy.toncenter.com` and load reliably in extension/desktop pages.
+  const logo =
+    nonEmpty(indexed?.extra?._image_medium) ??
+    nonEmpty(indexed?.extra?._image_small) ??
+    nonEmpty(indexed?.extra?._image_big) ??
+    nonEmpty(indexed?.image) ??
+    nonEmpty(content?.image)
+
+  return { ticker, decimals, logo }
+}

--- a/packages/core/chain/chains/ton/api.ts
+++ b/packages/core/chain/chains/ton/api.ts
@@ -119,7 +119,7 @@ export type JettonMasterInfo = {
  * falling back to the on-chain TEP-64 `jetton_content` stored in the master.
  */
 export const getJettonMasterInfo = async (jettonMasterAddress: string): Promise<JettonMasterInfo> => {
-  const url = `${tonApiUrl}/v3/jetton/masters?address=${jettonMasterAddress}&limit=1`
+  const url = `${tonApiUrl}/v3/jetton/masters?address=${encodeURIComponent(jettonMasterAddress)}&limit=1`
   const response = await queryUrl<JettonMastersResponse>(url)
 
   const master = response.jetton_masters[0]
@@ -141,7 +141,8 @@ export const getJettonMasterInfo = async (jettonMasterAddress: string): Promise<
   }
 
   const decimalsRaw = indexed?.extra?.decimals ?? content?.decimals
-  const decimals = decimalsRaw !== undefined ? parseInt(decimalsRaw, 10) : 9
+  const parsedDecimals = decimalsRaw !== undefined ? parseInt(decimalsRaw, 10) : NaN
+  const decimals = Number.isFinite(parsedDecimals) ? parsedDecimals : 9
 
   // Prefer Toncenter's imgproxy URLs: the original `image` URL often serves
   // with `Cross-Origin-Resource-Policy: same-origin`, which browsers refuse

--- a/packages/core/chain/coin/token/metadata/chains.ts
+++ b/packages/core/chain/coin/token/metadata/chains.ts
@@ -5,6 +5,7 @@ import { CosmosChain, EvmChain, OtherChain } from '../../../Chain'
 export const chainsWithTokenMetadataDiscovery = [
   ...Object.values(EvmChain),
   OtherChain.Solana,
+  OtherChain.Ton,
   OtherChain.Tron,
   OtherChain.Cardano,
   ...Object.values(CosmosChain),

--- a/packages/core/chain/coin/token/metadata/index.ts
+++ b/packages/core/chain/coin/token/metadata/index.ts
@@ -6,12 +6,14 @@ import { getCardanoTokenMetadata } from './resolvers/cardano'
 import { getCosmosTokenMetadata } from './resolvers/cosmos'
 import { getEvmTokenMetadata } from './resolvers/evm'
 import { getSolanaTokenMetadata } from './resolvers/solana'
+import { getTonTokenMetadata } from './resolvers/ton'
 import { getTronTokenMetadata } from './resolvers/tron'
 
 const resolvers: Record<ChainKindWithTokenMetadataDiscovery, TokenMetadataResolver<any>> = {
   evm: getEvmTokenMetadata,
   solana: getSolanaTokenMetadata,
   cosmos: getCosmosTokenMetadata,
+  ton: getTonTokenMetadata,
   tron: getTronTokenMetadata,
   cardano: getCardanoTokenMetadata,
 }

--- a/packages/core/chain/coin/token/metadata/resolvers/ton.ts
+++ b/packages/core/chain/coin/token/metadata/resolvers/ton.ts
@@ -1,0 +1,14 @@
+import { OtherChain } from '@vultisig/core-chain/Chain'
+import { getJettonMasterInfo } from '@vultisig/core-chain/chains/ton/api'
+
+import { TokenMetadataResolver } from '../resolver'
+
+/**
+ * Resolves TON jetton metadata from the Toncenter v3 `/jetton/masters` endpoint.
+ * The `id` is the jetton master contract address (user-friendly EQ.../UQ... form).
+ */
+export const getTonTokenMetadata: TokenMetadataResolver<OtherChain.Ton> = async ({ id }) => {
+  const { ticker, decimals, logo } = await getJettonMasterInfo(id)
+
+  return { ticker, decimals, logo }
+}

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -1014,6 +1014,11 @@
       "import": "./dist/coin/token/metadata/resolvers/solana.js",
       "default": "./dist/coin/token/metadata/resolvers/solana.js"
     },
+    "./coin/token/metadata/resolvers/ton": {
+      "types": "./dist/coin/token/metadata/resolvers/ton.d.ts",
+      "import": "./dist/coin/token/metadata/resolvers/ton.js",
+      "default": "./dist/coin/token/metadata/resolvers/ton.js"
+    },
     "./coin/token/metadata/resolvers/tron": {
       "types": "./dist/coin/token/metadata/resolvers/tron.d.ts",
       "import": "./dist/coin/token/metadata/resolvers/tron.js",


### PR DESCRIPTION
## Summary

Adds a TON jetton metadata resolver so pasting a jetton master address (`EQ.../UQ...`) into a Vultisig client's add-custom-token flow auto-fills ticker, decimals, and logo — the same UX as EVM, Solana, and Tron.

Unblocks vultisig/vultisig-windows#4029.

## What changed

- **`packages/core/chain/chains/ton/api.ts`** — new `getJettonMasterInfo()` helper hits Toncenter v3 `/jetton/masters?address=<master>&limit=1` (already proxied through `api.vultisig.com`). Prefers the validated indexer `token_info` entry, falls back to the on-chain TEP-64 `jetton_content`.
- **`packages/core/chain/coin/token/metadata/resolvers/ton.ts`** — new `getTonTokenMetadata` resolver thin-wraps `getJettonMasterInfo` into the `TokenMetadataResolver<OtherChain.Ton>` shape.
- **`packages/core/chain/coin/token/metadata/chains.ts`** — adds `OtherChain.Ton` to `chainsWithTokenMetadataDiscovery`.
- **`packages/core/chain/coin/token/metadata/index.ts`** — registers `ton: getTonTokenMetadata` in the resolvers map.

Consumer apps that gate their UI on `chainsWithTokenMetadataDiscovery` (e.g. vultisig-windows' `AddCustomTokenPrompt` and `useGetCoin`) light up TON automatically on bump — no client-side code change required.

## Logo selection — why imgproxy over raw `image`

The resolver prefers Toncenter's `imgproxy.toncenter.com` variants from `token_info.extra._image_{medium,small,big}` before falling back to the raw `image` URL.

Many jetton issuers serve their PNG with `Cross-Origin-Resource-Policy: same-origin` (e.g. one tested mainnet jetton's logo is hosted with that header). Browsers refuse to embed such resources cross-origin into extension popups, desktop webviews, or the SDK example client. The `imgproxy.toncenter.com` variants are normalized, cached, and CORP-friendly, so they load reliably everywhere.

If Toncenter hasn't generated proxy variants for a particular jetton (rare, non-indexed tokens), the resolver still returns the raw URL — display falls back gracefully via `SafeImage` in the consuming UI.

## Test plan

- [x] Live API call to `https://api.vultisig.com/ton/v3/jetton/masters` for a real jetton master returns the expected `{ ticker, decimals, logo }` shape
- [x] Pasting a jetton master address into the add-custom-token flow in `vultisig-windows` auto-fills ticker/decimals/logo and renders the icon (verified locally with the windows app pinned to this branch's `core-chain` build)
- [x] Pasting a non-jetton TON address (e.g. a wallet) surfaces "No jetton master found" → upstream UI renders the "no token found" empty state
- [ ] Type generation + downstream packages build cleanly under changeset version bump

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic TON jetton metadata discovery — paste a jetton master address and the app fills ticker, decimals, and logo.
  * TON discovery now prefers validated token info and improved logo selection (imgproxy variants) for better browser embedding and display.
  * TON is now enabled in the token metadata discovery list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->