### PR TITLE
fix: correct QBTC block explorer URL

### DIFF
--- a/packages/core/chain/utils/getBlockExplorerUrl/index.ts
+++ b/packages/core/chain/utils/getBlockExplorerUrl/index.ts
@@ -50,7 +50,7 @@ const blockExplorerBaseUrl: Record<Chain, string> = {
   [Chain.Mantle]: 'https://explorer.mantle.xyz',
   [Chain.Hyperliquid]: hyperliquidBlockExplorerUrl,
   [Chain.Sei]: 'https://seiscan.io',
-  [Chain.QBTC]: 'https://explorer.qbtc-testnet.io',
+  [Chain.QBTC]: 'https://explorer.qbtc.net/qbtc',
 }
 
 export const getBlockExplorerUrl = ({ chain, entity, value }: GetBlockExplorerUrlInput): string => {
@@ -95,7 +95,7 @@ export const getBlockExplorerUrl = ({ chain, entity, value }: GetBlockExplorerUr
         [Chain.Mantle]: () => `${baseUrl}/address/${value}`,
         [Chain.Hyperliquid]: () => `${baseUrl}/address/${value}`,
         [Chain.Sei]: () => `${baseUrl}/address/${value}`,
-        [Chain.QBTC]: () => `${baseUrl}/address/${value}`,
+        [Chain.QBTC]: () => `${baseUrl}/account/${value}`,
       }),
     tx: () =>
       match(chain, {


### PR DESCRIPTION
## Problem

QBTC block explorer links pointed at the defunct host/path `https://explorer.qbtc-testnet.io/address/[address]`, so opening a QBTC address or transaction from the wallet led to a dead page.

## Fix

Updated the QBTC entry in `getBlockExplorerUrl`:

- Base URL: `https://explorer.qbtc-testnet.io` → `https://explorer.qbtc.net/qbtc`
- Address path: `/address/${value}` → `/account/${value}`
- Transaction path unchanged (`/tx/${value}`), now correctly resolves under the new base

Resulting URLs:

| Entity | Before | After |
|--------|--------|-------|
| Address | `https://explorer.qbtc-testnet.io/address/[address]` | `https://explorer.qbtc.net/qbtc/account/[address]` |
| Transaction | `https://explorer.qbtc-testnet.io/tx/[hash]` | `https://explorer.qbtc.net/qbtc/tx/[hash]` |

Tx format confirmed against a live example: `https://explorer.qbtc.net/qbtc/tx/C214B24572696BF9875EBDE6F3D0F3E092D5A39B54CA5F5A119C099AFDED6BDB`

Reported in vultisig/vultisig-windows#4043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated QBTC block explorer to use the mainnet endpoint instead of testnet.
  * Corrected address URL paths for QBTC block explorer lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->