### PR TITLE
fix(ton): use owner_id + jetton_master_id in jetton wallet proxy calls

### DIFF
--- a/packages/core/chain/chains/ton/api.test.ts
+++ b/packages/core/chain/chains/ton/api.test.ts
@@ -20,7 +20,7 @@ vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
   },
 }))
 
-import { getJettonBalance,getJettonWalletAddress } from './api'
+import { getJettonBalance, getJettonWalletAddress } from './api'
 
 const OWNER = 'EQDAFuDWly4z3eA16Ej_JHpoL6CcXdt0IRUrODKKsu60HYMi'
 const MASTER = 'EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs' // USDT mainnet

--- a/packages/core/chain/chains/ton/api.test.ts
+++ b/packages/core/chain/chains/ton/api.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Regression: getJettonWalletsUrl must use `owner_id` + `jetton_master_id` query params.
+ *
+ * The Vultisig proxy at /ton/v3/jetton/wallets silently ignores the old
+ * `owner_address` / `jetton_address` params and returns an empty array,
+ * making every balance call return 0 and every transfer fail with
+ * "No jetton wallet found". Parity fix with mcp-ts#324.
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+const capturedUrls: string[] = []
+
+vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
+  queryUrl: (url: string) => {
+    capturedUrls.push(url)
+    return Promise.resolve({
+      jetton_wallets: [{ address: '0:abc123', jetton: '0:master', balance: '5000000000' }],
+      address_book: { '0:abc123': { user_friendly: 'EQAbc123' } },
+    })
+  },
+}))
+
+import { getJettonBalance,getJettonWalletAddress } from './api'
+
+const OWNER = 'EQDAFuDWly4z3eA16Ej_JHpoL6CcXdt0IRUrODKKsu60HYMi'
+const MASTER = 'EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs' // USDT mainnet
+
+describe('getJettonWalletAddress', () => {
+  it('uses owner_id + jetton_master_id in the proxy request URL', async () => {
+    capturedUrls.length = 0
+
+    await getJettonWalletAddress({ ownerAddress: OWNER, jettonMasterAddress: MASTER })
+
+    const url = capturedUrls[0] ?? ''
+    expect(url).toContain('owner_id=')
+    expect(url).toContain('jetton_master_id=')
+    expect(url).not.toContain('owner_address=')
+    expect(url).not.toContain('jetton_address=')
+  })
+
+  it('returns the user_friendly address from the address_book', async () => {
+    capturedUrls.length = 0
+
+    const address = await getJettonWalletAddress({ ownerAddress: OWNER, jettonMasterAddress: MASTER })
+
+    expect(address).toBe('EQAbc123')
+  })
+})
+
+describe('getJettonBalance', () => {
+  it('uses owner_id + jetton_master_id in the proxy request URL', async () => {
+    capturedUrls.length = 0
+
+    await getJettonBalance({ ownerAddress: OWNER, jettonMasterAddress: MASTER })
+
+    const url = capturedUrls[0] ?? ''
+    expect(url).toContain('owner_id=')
+    expect(url).toContain('jetton_master_id=')
+    expect(url).not.toContain('owner_address=')
+    expect(url).not.toContain('jetton_address=')
+  })
+
+  it('returns the balance as bigint', async () => {
+    capturedUrls.length = 0
+
+    const balance = await getJettonBalance({ ownerAddress: OWNER, jettonMasterAddress: MASTER })
+
+    expect(balance).toBe(5000000000n)
+  })
+})

--- a/packages/core/chain/chains/ton/api.ts
+++ b/packages/core/chain/chains/ton/api.ts
@@ -24,12 +24,17 @@ type GetJettonWalletInput = {
   jettonMasterAddress: string
 }
 
-/** Builds the toncenter v3 jetton wallets query URL, converting addresses to raw format. */
+/**
+ * Builds the Vultisig proxy jetton wallets query URL.
+ * The proxy expects `owner_id` + `jetton_master_id` (not `owner_address` / `jetton_address`).
+ * Using the wrong param names returns an empty array without an error, silently
+ * making every jetton balance call return 0 and every transfer fail with "no jetton wallet".
+ */
 const getJettonWalletsUrl = ({ ownerAddress, jettonMasterAddress }: GetJettonWalletInput): string => {
   const rawOwner = tonAddressToRaw(ownerAddress)
   const rawMaster = tonAddressToRaw(jettonMasterAddress)
 
-  return `${tonApiUrl}/v3/jetton/wallets?owner_address=${rawOwner}&jetton_address=${rawMaster}`
+  return `${tonApiUrl}/v3/jetton/wallets?owner_id=${rawOwner}&jetton_master_id=${rawMaster}`
 }
 
 /** Resolves the user-friendly jetton wallet address for a given owner and jetton master. */

--- a/packages/core/chain/chains/ton/api.ts
+++ b/packages/core/chain/chains/ton/api.ts
@@ -55,7 +55,7 @@ export const getJettonBalance = async (input: GetJettonWalletInput): Promise<big
   const response = await queryUrl<JettonWalletResponse>(getJettonWalletsUrl(input))
 
   const balance = response.jetton_wallets[0]?.balance
-  return BigInt(balance ?? 0)
+  return BigInt(balance || '0')
 }
 
 type AddressInformationResponse = {


### PR DESCRIPTION
Sibling to mcp-ts#324 - sdk-side `getJettonWalletsUrl` had the same stale `owner_address`/`jetton_address` params.

## what

The Vultisig proxy at `/ton/v3/jetton/wallets` requires `owner_id` + `jetton_master_id`. The code was sending `owner_address` + `jetton_address` - params the proxy silently ignores, returning an empty array every time.

Result: `getJettonBalance` always returned `0n`, `getJettonWalletAddress` always threw `"No jetton wallet found"`. Every SDK-side TON jetton balance query and jetton transfer broke silently regardless of actual holdings.

One surface affected in `packages/core/chain/chains/ton/api.ts`:
- `getJettonWalletsUrl` (called by both `getJettonWalletAddress` and `getJettonBalance`)

## receipts

```
yarn test:core

 ✓ packages/core/chain/chains/ton/api.test.ts > getJettonWalletAddress > uses owner_id + jetton_master_id in the proxy request URL 1ms
 ✓ packages/core/chain/chains/ton/api.test.ts > getJettonWalletAddress > returns the user_friendly address from the address_book 0ms
 ✓ packages/core/chain/chains/ton/api.test.ts > getJettonBalance > uses owner_id + jetton_master_id in the proxy request URL 0ms
 ✓ packages/core/chain/chains/ton/api.test.ts > getJettonBalance > returns the balance as bigint 0ms

 Test Files  95 passed (95)
      Tests  899 passed (899)
```

🤖 Agent-generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected TON jetton wallet and balance lookups to avoid empty or incorrect results; balances are now returned reliably and as integer values to prevent transfer/display issues.

* **Tests**
  * Added regression tests to validate TON jetton API behavior and prevent future regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->