### PR TITLE
feat(cosmos): add optional feeDenom to BuildCosmosSendOptions

### DIFF
--- a/.changeset/cosmos-send-fee-denom.md
+++ b/.changeset/cosmos-send-fee-denom.md
@@ -1,0 +1,7 @@
+---
+"@vultisig/sdk": patch
+---
+
+feat(cosmos): add optional `feeDenom` to `BuildCosmosSendOptions`
+
+Allows callers to specify a separate gas-fee coin denom when it differs from the send amount denom. Previously `buildCosmosSendTx` always used `denom` (the send coin) as the fee coin — on TerraClassic this meant USTC sends charged fees in USTC instead of LUNC, causing on-chain rejection when the USTC balance was below the fee threshold. Closes vultisig-sdk#624.

--- a/packages/sdk/src/platforms/react-native/chains/cosmos/tx.ts
+++ b/packages/sdk/src/platforms/react-native/chains/cosmos/tx.ts
@@ -352,7 +352,11 @@ export type CosmosTxBuilderResult = {
    * `0x` prefix is tolerated. Anything else throws so the caller sees a
    * clear failure rather than a silently-malformed TxRaw.
    */
-  finalize: (sigHex: string) => { txRawBytes: Uint8Array; txBytesBase64: string; txHashHex: string }
+  finalize: (sigHex: string) => {
+    txRawBytes: Uint8Array
+    txBytesBase64: string
+    txHashHex: string
+  }
 }
 
 export type BuildCosmosSendOptions = {
@@ -382,7 +386,13 @@ export function buildCosmosSendTx(opts: BuildCosmosSendOptions): CosmosTxBuilder
     : buildBankMsgSend(opts.fromAddress, opts.toAddress, opts.amount, opts.denom)
   const msgAny = wrapAny(getMsgSendTypeUrl(opts.chainName), msgSend)
   const txBodyBytes = buildTxBody(msgAny, opts.memo ?? '')
-  const authInfoBytes = buildAuthInfo(opts.pubKeyBytes, opts.sequence, opts.gasLimit, opts.feeDenom ?? opts.denom, opts.feeAmount)
+  const authInfoBytes = buildAuthInfo(
+    opts.pubKeyBytes,
+    opts.sequence,
+    opts.gasLimit,
+    opts.feeDenom ?? opts.denom,
+    opts.feeAmount
+  )
   const signDocBytes = buildSignDoc(txBodyBytes, authInfoBytes, opts.chainId, opts.accountNumber)
   const signingHashHex = bytesToHex(sha256(signDocBytes))
 

--- a/packages/sdk/src/platforms/react-native/chains/cosmos/tx.ts
+++ b/packages/sdk/src/platforms/react-native/chains/cosmos/tx.ts
@@ -362,6 +362,10 @@ export type BuildCosmosSendOptions = {
   toAddress: string
   amount: string
   denom: string
+  /** Gas-fee coin denom. Defaults to `denom` when absent.
+   * Provide this on multi-denom chains (e.g. TerraClassic USTC sends
+   * where fees must be paid in LUNC, not USTC — see vultisig-sdk#624). */
+  feeDenom?: string
   feeAmount: string
   gasLimit: number
   sequence: number
@@ -378,7 +382,7 @@ export function buildCosmosSendTx(opts: BuildCosmosSendOptions): CosmosTxBuilder
     : buildBankMsgSend(opts.fromAddress, opts.toAddress, opts.amount, opts.denom)
   const msgAny = wrapAny(getMsgSendTypeUrl(opts.chainName), msgSend)
   const txBodyBytes = buildTxBody(msgAny, opts.memo ?? '')
-  const authInfoBytes = buildAuthInfo(opts.pubKeyBytes, opts.sequence, opts.gasLimit, opts.denom, opts.feeAmount)
+  const authInfoBytes = buildAuthInfo(opts.pubKeyBytes, opts.sequence, opts.gasLimit, opts.feeDenom ?? opts.denom, opts.feeAmount)
   const signDocBytes = buildSignDoc(txBodyBytes, authInfoBytes, opts.chainId, opts.accountNumber)
   const signingHashHex = bytesToHex(sha256(signDocBytes))
 

--- a/packages/sdk/tests/unit/platforms/react-native/cosmos-send-fee-denom.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/cosmos-send-fee-denom.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Regression: buildCosmosSendTx must use feeDenom (not denom) in AuthInfo
+ * when a separate fee denom is provided.
+ *
+ * Issue vultisig-sdk#624: TerraClassic USTC (uusd) sends were charging gas
+ * fees in USTC because AuthInfo's fee.amount[0].denom matched opts.denom.
+ * On TerraClassic fees must be paid in LUNC (uluna), not USTC.
+ */
+import { AuthInfo } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
+import { describe, expect, it } from 'vitest'
+
+import { buildCosmosSendTx } from '../../../../src/platforms/react-native/chains/cosmos/tx'
+
+const BASE_OPTS = {
+  chainName: 'TerraClassic',
+  chainId: 'columbus-5',
+  fromAddress: 'terra1lmmtpndftpk57js8s4dsxh54q6qhh6nd9kamdj',
+  toAddress: 'terra10mtp3kjs9jh05cp288alz35308jmr6arjfr43r',
+  amount: '1000000',
+  denom: 'uusd', // USTC — send denom
+  feeAmount: '1500000',
+  gasLimit: 2_000_000,
+  sequence: 7,
+  accountNumber: 42,
+  pubKeyBytes: new Uint8Array(33).fill(2),
+  memo: '',
+}
+
+describe('buildCosmosSendTx feeDenom (sdk#624)', () => {
+  it('uses feeDenom in AuthInfo fee when explicitly set', () => {
+    const result = buildCosmosSendTx({ ...BASE_OPTS, feeDenom: 'uluna' })
+    const authInfo = AuthInfo.decode(result.authInfoBytes)
+    const feeCoin = authInfo.fee?.amount[0]
+    expect(feeCoin?.denom).toBe('uluna')
+    expect(feeCoin?.amount).toBe('1500000')
+  })
+
+  it('still uses denom as fee denom when feeDenom is absent (back-compat)', () => {
+    const result = buildCosmosSendTx(BASE_OPTS)
+    const authInfo = AuthInfo.decode(result.authInfoBytes)
+    const feeCoin = authInfo.fee?.amount[0]
+    // Back-compat: no feeDenom → fee coin denom = send denom
+    expect(feeCoin?.denom).toBe('uusd')
+  })
+
+  it('native LUNC send: fee and send both in uluna (no regression)', () => {
+    const result = buildCosmosSendTx({ ...BASE_OPTS, denom: 'uluna', feeDenom: 'uluna', feeAmount: '100000000' })
+    const authInfo = AuthInfo.decode(result.authInfoBytes)
+    expect(authInfo.fee?.amount[0]?.denom).toBe('uluna')
+  })
+})

--- a/packages/sdk/tests/unit/platforms/react-native/cosmos-send-fee-denom.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/cosmos-send-fee-denom.test.ts
@@ -44,7 +44,12 @@ describe('buildCosmosSendTx feeDenom (sdk#624)', () => {
   })
 
   it('native LUNC send: fee and send both in uluna (no regression)', () => {
-    const result = buildCosmosSendTx({ ...BASE_OPTS, denom: 'uluna', feeDenom: 'uluna', feeAmount: '100000000' })
+    const result = buildCosmosSendTx({
+      ...BASE_OPTS,
+      denom: 'uluna',
+      feeDenom: 'uluna',
+      feeAmount: '100000000',
+    })
     const authInfo = AuthInfo.decode(result.authInfoBytes)
     expect(authInfo.fee?.amount[0]?.denom).toBe('uluna')
   })


### PR DESCRIPTION
closes #624

## what

`buildCosmosSendTx` used `opts.denom` as both the MsgSend amount denom AND the AuthInfo fee coin denom. On TerraClassic, sending USTC (`uusd`) charged gas fees in USTC instead of LUNC (`uluna`), causing `code 5: insufficient funds` when the user's USTC balance was below the 1.5 USTC fee.

## fix

Added optional `feeDenom?: string` to `BuildCosmosSendOptions`. When present, it's used as the fee coin in `buildAuthInfo`. When absent, falls back to `denom` — back-compat for all existing callers.

## tests

3 new tests in `cosmos-send-fee-denom.test.ts` decode the AuthInfo bytes via `cosmjs-types` and assert the fee coin denom:
- USTC send with `feeDenom: 'uluna'` → fee in LUNC ✓
- USTC send without `feeDenom` → fee in USTC (back-compat) ✓
- LUNC send with `feeDenom: 'uluna'` → fee in LUNC (no regression) ✓

## downstream

Once this lands + publishes, `vultiagent-app/src/services/cosmosTx.ts` `buildSignBroadcastCosmosSend` can thread `feeDenom: cfg.defaultDenom` through `CosmosTxOpts` → `buildChainTxOpts` → `buildCosmosSendTx` to complete the va#1107 fix end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cosmos transactions now support independent configuration of fee denominations, enabling proper fee handling on multi-denomination blockchain networks

* **Bug Fixes**
  * Resolved fee denomination calculation issues that could cause transaction failures when send and fee denominations differ

* **Tests**
  * Added unit tests validating fee denomination handling, fallback behavior, and backward compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->