### PR TITLE
fix: fiatToAmount — resolve usd amounts for cosmos and non-evm tokens

### DIFF
--- a/.changeset/cosmos-fiat-amount-fix.md
+++ b/.changeset/cosmos-fiat-amount-fix.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/sdk": patch
+---
+
+fix fiatToAmount throwing "EVM chains only" for Cosmos and other non-EVM token swaps. USD-denominated swap amounts now resolve correctly for TerraClassic (USTC/LUNC), Cosmos Hub (ATOM), Osmosis (IBC denoms), Solana SPL tokens, Polkadot asset-hub tokens, TON jettons, and any chain with entries in the knownTokens registry. Native Cosmos denoms (uluna, uatom, etc.) are also handled via cosmosFeeCoinDenom fallback.

--- a/packages/sdk/src/utils/fiatToAmount.ts
+++ b/packages/sdk/src/utils/fiatToAmount.ts
@@ -1,8 +1,10 @@
 import { Chain } from '@vultisig/core-chain/Chain'
 import { isChainOfKind } from '@vultisig/core-chain/ChainKind'
+import { cosmosFeeCoinDenom } from '@vultisig/core-chain/chains/cosmos/cosmosFeeCoinDenom'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { getErc20Prices } from '@vultisig/core-chain/coin/price/evm/getErc20Prices'
 import { getCoinPrices } from '@vultisig/core-chain/coin/price/getCoinPrices'
+import { resolveTokenPriceId } from '@vultisig/core-chain/coin/price/resolveTokenPriceId'
 import { fiatCurrencies, type FiatCurrency } from '@vultisig/core-config/FiatCurrency'
 
 /** Thrown when a fiat -> token amount conversion fails. Message is LLM-readable. */
@@ -95,17 +97,34 @@ export const fiatToAmount = async (params: FiatToAmountParams): Promise<string> 
   let price: number
   try {
     if (tokenId) {
-      if (!isChainOfKind(chain, 'evm')) {
-        throw new FiatToAmountError(
-          `Token price lookup by contract address is only supported on EVM chains. Got chain "${chain}" with tokenId "${tokenId}".`
-        )
+      if (isChainOfKind(chain, 'evm')) {
+        const prices = await getErc20Prices({
+          ids: [tokenId],
+          chain,
+          fiatCurrency: normalizedCurrency,
+        })
+        price = prices[tokenId.toLowerCase()] ?? 0
+      } else {
+        // Non-EVM chains (Cosmos, Solana, TON, Polkadot, etc.) identify tokens by
+        // denom / mint / asset-id, not a contract address. Resolve via the curated
+        // knownTokens registry which already maps these to CoinGecko ids.
+        // For Cosmos chains, also accept the native fee-coin denom (e.g. "uluna" on
+        // TerraClassic, "uatom" on Cosmos) which identifies the native coin by its
+        // on-chain denomination rather than the absence of a tokenId.
+        const nativeCosmosDenom = cosmosFeeCoinDenom[chain as keyof typeof cosmosFeeCoinDenom]
+        const isNativeCosmosDenom = nativeCosmosDenom != null && tokenId.toLowerCase() === nativeCosmosDenom
+        const priceId =
+          resolveTokenPriceId(chain, tokenId) ??
+          (isNativeCosmosDenom ? chainFeeCoin[chain]?.priceProviderId : undefined)
+        if (!priceId) {
+          throw new FiatToAmountError(
+            `Could not resolve a price provider id for token "${tokenId}" on chain "${chain}". ` +
+              `The token may not be in the known-tokens registry.`
+          )
+        }
+        const prices = await getCoinPrices({ ids: [priceId], fiatCurrency: normalizedCurrency })
+        price = prices[priceId.toLowerCase()] ?? 0
       }
-      const prices = await getErc20Prices({
-        ids: [tokenId],
-        chain,
-        fiatCurrency: normalizedCurrency,
-      })
-      price = prices[tokenId.toLowerCase()] ?? 0
     } else {
       const feeCoin = chainFeeCoin[chain]
       if (!feeCoin) {

--- a/packages/sdk/tests/unit/utils/fiatToAmount.test.ts
+++ b/packages/sdk/tests/unit/utils/fiatToAmount.test.ts
@@ -14,6 +14,10 @@ vi.mock('@vultisig/core-chain/coin/chainFeeCoin', () => ({
       priceProviderId: 'polygon-ecosystem-token',
     },
     Bittensor: { ticker: 'TAO', decimals: 9, priceProviderId: 'bittensor' },
+    TerraClassic: { ticker: 'LUNC', decimals: 6, priceProviderId: 'terra-luna' },
+    Cosmos: { ticker: 'ATOM', decimals: 6, priceProviderId: 'cosmos' },
+    // Required by kujiraCoinsOnThorChain module init — reads THORChain decimals at import time
+    THORChain: { ticker: 'RUNE', decimals: 8, priceProviderId: 'thorchain' },
   },
 }))
 
@@ -143,15 +147,86 @@ describe('fiatToAmount', () => {
     await expect(fiatToAmount({ fiatValue: 'abc', chain: Chain.Ethereum, decimals: 18 })).rejects.toThrow(/fiat value/i)
   })
 
-  it('throws when ERC-20 price lookup is requested on a non-EVM chain', async () => {
-    await expect(
-      fiatToAmount({
-        fiatValue: 10,
-        chain: Chain.Solana,
-        tokenId: 'some-mint',
-        decimals: 6,
-      })
-    ).rejects.toThrow(/EVM/i)
+  it('throws a registry-miss error (not EVM-only) when tokenId is unknown on a non-EVM chain', async () => {
+    // 'some-unknown-mint' is not in knownTokensIndex for Solana
+    const err = await fiatToAmount({
+      fiatValue: 10,
+      chain: Chain.Solana,
+      tokenId: 'some-unknown-mint',
+      decimals: 6,
+    }).catch(e => e)
+
+    expect(err).toBeInstanceOf(FiatToAmountError)
+    // Must NOT say "EVM chains" — that message is wrong for non-EVM tokens
+    expect(err.message).not.toMatch(/EVM/i)
+    // Must mention the registry so the LLM can understand the gap
+    expect(err.message).toMatch(/registry/i)
+  })
+
+  it('resolves USTC (uusd) on TerraClassic via knownTokens registry', async () => {
+    const { getCoinPrices } = await import('@vultisig/core-chain/coin/price/getCoinPrices')
+    // USTC ~ $0.02
+    vi.mocked(getCoinPrices).mockResolvedValue({ terrausd: 0.02 })
+
+    // $1 / $0.02 per USTC = 50 USTC
+    const result = await fiatToAmount({
+      fiatValue: 1,
+      chain: Chain.TerraClassic,
+      tokenId: 'uusd',
+      decimals: 6,
+    })
+
+    expect(getCoinPrices).toHaveBeenCalledWith(expect.objectContaining({ ids: ['terrausd'] }))
+    expect(result).toBe('50')
+  })
+
+  it('resolves LUNC (uluna) on TerraClassic via knownTokens registry', async () => {
+    const { getCoinPrices } = await import('@vultisig/core-chain/coin/price/getCoinPrices')
+    // LUNC ~ $0.0001
+    vi.mocked(getCoinPrices).mockResolvedValue({ 'terra-luna': 0.0001 })
+
+    // $0.1 / $0.0001 per LUNC = 1000 LUNC
+    const result = await fiatToAmount({
+      fiatValue: 0.1,
+      chain: Chain.TerraClassic,
+      tokenId: 'uluna',
+      decimals: 6,
+    })
+
+    expect(getCoinPrices).toHaveBeenCalledWith(expect.objectContaining({ ids: ['terra-luna'] }))
+    expect(result).toBe('1000')
+  })
+
+  it('resolves ATOM IBC denom on Osmosis via knownTokens registry', async () => {
+    const { getCoinPrices } = await import('@vultisig/core-chain/coin/price/getCoinPrices')
+    vi.mocked(getCoinPrices).mockResolvedValue({ cosmos: 8 })
+
+    // $40 / $8 per ATOM = 5 ATOM
+    const result = await fiatToAmount({
+      fiatValue: 40,
+      chain: Chain.Osmosis,
+      tokenId: 'ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2',
+      decimals: 6,
+    })
+
+    expect(getCoinPrices).toHaveBeenCalledWith(expect.objectContaining({ ids: ['cosmos'] }))
+    expect(result).toBe('5')
+  })
+
+  it('resolves EVM USDC on Ethereum via getErc20Prices — no regression', async () => {
+    const { getErc20Prices } = await import('@vultisig/core-chain/coin/price/evm/getErc20Prices')
+    const usdcAddress = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+    vi.mocked(getErc20Prices).mockResolvedValue({ [usdcAddress.toLowerCase()]: 1 })
+
+    const result = await fiatToAmount({
+      fiatValue: 25,
+      chain: Chain.Ethereum,
+      tokenId: usdcAddress,
+      decimals: 6,
+    })
+
+    expect(getErc20Prices).toHaveBeenCalledWith(expect.objectContaining({ ids: [usdcAddress], chain: Chain.Ethereum }))
+    expect(result).toBe('25')
   })
 
   it('expands scientific-notation results into plain decimal strings', async () => {


### PR DESCRIPTION
closes vultisig/vultisig-sdk#643

## what

`fiatToAmount` was gated on `isChainOfKind(chain, 'evm')` when a `tokenId` was provided, throwing:

> Token price lookup by contract address is only supported on EVM chains.

...for any non-EVM swap path (TerraClassic USTC/LUNC, Cosmos Hub ATOM, Osmosis IBC denoms, Solana SPL, Polkadot asset-hub, TON jettons, etc.).

## how

Flipped the EVM branch to route non-EVM tokens through `resolveTokenPriceId` — the existing function that maps denom/mint/asset-id strings to CoinGecko price IDs via `knownTokensIndex`. That registry already has the right mappings:

- `uusd` on TerraClassic -> `terrausd`
- Osmosis IBC ATOM hash -> `cosmos`
- Solana USDC mint -> `usd-coin`
- etc.

Added a targeted fallback for the Cosmos native-denom case (e.g. `uluna` on TerraClassic, `uatom` on Cosmos) via `cosmosFeeCoinDenom`. These denoms identify the chain's own native coin by denomination string — they're not in `knownTokensIndex` (which tracks tokens, not native coins), so the fallback checks `cosmosFeeCoinDenom[chain] === tokenId` before using `chainFeeCoin[chain].priceProviderId`. Unknown mints on non-Cosmos chains still throw a clear registry-miss error.

No changes to `resolveTokenPriceId` or any other shared utility.

## tests

Added 5 new unit test cases in `fiatToAmount.test.ts`:
- `resolves USTC (uusd) on TerraClassic via knownTokens registry`
- `resolves LUNC (uluna) on TerraClassic via knownTokens registry`
- `resolves ATOM IBC denom on Osmosis via knownTokens registry`
- `resolves EVM USDC on Ethereum via getErc20Prices — no regression`
- `throws a registry-miss error (not EVM-only) when tokenId is unknown on a non-EVM chain`

All 1490 unit tests pass. `tsc --noEmit` clean.

## receipts

Verified end-to-end via `list_swap_routes` through a local mcp-ts build pointing at the patched SDK.

**BEFORE** (old SDK — the exact issue repro):
```
list_swap_routes: could not convert USD 0.1 → USTC on TerraClassic:
Token price lookup by contract address is only supported on EVM chains.
Got chain "TerraClassic" with tokenId "uusd".
```

**AFTER** (patched SDK — fix confirmed):
```json
{
  "from": {"chain":"TerraClassic","symbol":"USTC","contract_address":"uusd","decimals":6},
  "to": {"chain":"TerraClassic","symbol":"LUNC","decimals":6},
  "amount_base_units": "17102700",
  "routes": [{
    "venue": "Skip",
    "path": ["columbus-5","osmosis-1","columbus-5"],
    "expected_output": "1495048230",
    "summary": "Skip Go (osmosis-poolmanager): USTC on TerraClassic → LUNC on TerraClassic via osmosis-1",
    "usd_amount_in": "0.10",
    "usd_amount_out": "0.10",
    "txs_required": 1
  }],
  "errors": []
}
```

LUNC USD swap also confirmed:
```json
{
  "from": {"chain":"TerraClassic","symbol":"LUNC","decimals":6},
  "amount_base_units": "1502629601",
  "routes": [{"venue":"Skip", "usd_amount_in":"0.10", "usd_amount_out":"0.10"}],
  "errors": []
}
```

Sim screenshot (Vultisig wallet on the device used for testing): https://files.catbox.moe/07mx8d.png

🤖 Agent-generated

## sim receipt (added post-PR-open)

Drove `swap $.1 of USTC to LUNC` on the iOS sim against the local stack with SDK linked from this branch. The previously-blocking error `Token price lookup by contract address is only supported on EVM chains. Got chain "TerraClassic" with tokenId "uusd"` is GONE. The Skip route now resolves (backend log shows `execute_swap` mcp_result_len=3895 — route metadata returned).

Sim screenshot showing the new state: https://files.catbox.moe/319v3s.png

Note: the swap still does not complete end-to-end because of TWO separate downstream bugs that this PR does not touch:
1. Validator over-strict on Skip multi-hop route metadata (IBC denoms / pool IDs / channel pairs flagged as fabricated_address) — followup issue
2. Model claims "Swap prepared" copy even when execute_swap was blocked — followup issue

This SDK PR is the prerequisite for those followup fixes to make end-to-end work. Promoting to ready.
