### PR TITLE
chore(zcash): update consensus branch ID to NU6.2

### DIFF
--- a/.changeset/update-zcash-consensus-branch-id.md
+++ b/.changeset/update-zcash-consensus-branch-id.md
@@ -1,0 +1,6 @@
+---
+"@vultisig/sdk": patch
+"@vultisig/core-mpc": patch
+---
+
+Update the default Zcash consensus branch ID to NU6.2 (`30f33754`) for SDK UTXO signing and WalletCore signing inputs.

--- a/packages/core/mpc/keysign/signingInputs/resolvers/utxo.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/utxo.test.ts
@@ -119,3 +119,10 @@ describe('getUtxoSigningInputs — general swap address validation', () => {
     ).not.toThrow('destination address')
   })
 })
+
+describe('Zcash branch ID', () => {
+  it('pins the NU6.2 consensus branch ID in WalletCore little-endian hex order', async () => {
+    const mod = await import('./utxo')
+    expect(mod.ZCASH_BRANCH_ID_NU6_2_LE_HEX).toBe('30f33754')
+  })
+})

--- a/packages/core/mpc/keysign/signingInputs/resolvers/utxo.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/utxo.ts
@@ -16,6 +16,8 @@ import { KeysignSwapPayload } from '../../swap/KeysignSwapPayload'
 import { getKeysignChain } from '../../utils/getKeysignChain'
 import { SigningInputsResolver } from '../resolver'
 
+export const ZCASH_BRANCH_ID_NU6_2_LE_HEX = '30f33754'
+
 export const getUtxoSigningInputs: SigningInputsResolver<'utxo'> = ({ keysignPayload, walletCore }) => {
   const chain = getKeysignChain<'utxo'>(keysignPayload)
 
@@ -102,7 +104,7 @@ export const getUtxoSigningInputs: SigningInputsResolver<'utxo'> = ({ keysignPay
   input.plan = TW.Bitcoin.Proto.TransactionPlan.decode(plan)
 
   if (chain === UtxoChain.Zcash) {
-    input.plan.branchId = Buffer.from('f04dec4d', 'hex')
+    input.plan.branchId = Buffer.from(ZCASH_BRANCH_ID_NU6_2_LE_HEX, 'hex')
   }
 
   return [input]

--- a/packages/sdk/src/chains/utxo/index.ts
+++ b/packages/sdk/src/chains/utxo/index.ts
@@ -25,4 +25,5 @@ export {
   getSighashLegacy,
   getUtxoChainSpec,
   ZCASH_BRANCH_ID_NU6_1,
+  ZCASH_BRANCH_ID_NU6_2,
 } from './tx'

--- a/packages/sdk/src/chains/utxo/tx.ts
+++ b/packages/sdk/src/chains/utxo/tx.ts
@@ -443,15 +443,21 @@ export function getSighashLegacy(opts: SighashLegacyOptions): Uint8Array {
 // ---------------------------------------------------------------------------
 
 /**
- * Default Zcash consensus branch ID (NU6.1, the epoch active at the time
- * of writing). Consumers SHOULD override via `buildUtxoSendTx({zcashBranchId})`
- * for pre-activation signing — relying on a compiled-in default means every
+ * Zcash consensus branch ID for NU6.1. Kept exported for callers that need
+ * to reproduce transactions from the previous consensus epoch.
+ */
+export const ZCASH_BRANCH_ID_NU6_1 = 0x4dec4df0
+
+/**
+ * Default Zcash consensus branch ID (NU6.2, the epoch active at the time of
+ * writing). Consumers SHOULD override via `buildUtxoSendTx({zcashBranchId})`
+ * for pre-activation signing - relying on a compiled-in default means every
  * Zcash network upgrade turns into a shipped-SDK-release blocker.
  *
  * Look up the current value at tx-build time from a Zcash node:
  *   zcash-cli getblockchaininfo | jq '.consensus.nextblock'
  */
-export const ZCASH_BRANCH_ID_NU6_1 = 0x4dec4df0
+export const ZCASH_BRANCH_ID_NU6_2 = 0x5437f330
 const ZCASH_V4_VERSION = 0x80000004 // overwintered v4
 const ZCASH_SAPLING_VERSION_GROUP_ID = 0x892f2085
 
@@ -700,7 +706,7 @@ export type BuildUtxoSendOptions = {
   compressedPubKey: Uint8Array
   /**
    * Zcash consensus branch ID (ignored for non-Zcash chains). Defaults to
-   * `ZCASH_BRANCH_ID_NU6_1` at the time of release. Consumers SHOULD fetch
+   * `ZCASH_BRANCH_ID_NU6_2` at the time of release. Consumers SHOULD fetch
    * the current value from a zcash-cli `getblockchaininfo` at tx-build time
    * — hardcoding means every future consensus upgrade requires a shipped
    * SDK release.
@@ -794,7 +800,7 @@ export function buildUtxoSendTx(opts: BuildUtxoSendOptions): UtxoTxBuilderResult
 
   const isBCH = opts.chain === 'Bitcoin-Cash'
   const isZcash = opts.chain === 'Zcash'
-  const zcashBranchId = opts.zcashBranchId ?? ZCASH_BRANCH_ID_NU6_1
+  const zcashBranchId = opts.zcashBranchId ?? ZCASH_BRANCH_ID_NU6_2
 
   const signingHashes: Uint8Array[] = []
   for (let i = 0; i < inputs.length; i++) {

--- a/packages/sdk/src/platforms/react-native/chains/utxo/index.ts
+++ b/packages/sdk/src/platforms/react-native/chains/utxo/index.ts
@@ -36,4 +36,5 @@ export {
   getUtxoChainSpec,
   getUtxos,
   ZCASH_BRANCH_ID_NU6_1,
+  ZCASH_BRANCH_ID_NU6_2,
 } from '../../../../chains/utxo'

--- a/packages/sdk/tests/unit/chains/utxo-zcash-branchid.test.ts
+++ b/packages/sdk/tests/unit/chains/utxo-zcash-branchid.test.ts
@@ -7,18 +7,18 @@
  */
 import { describe, expect, it } from 'vitest'
 
-import { buildUtxoSendTx, ZCASH_BRANCH_ID_NU6_1 } from '../../../src/chains/utxo'
+import { buildUtxoSendTx, ZCASH_BRANCH_ID_NU6_1, ZCASH_BRANCH_ID_NU6_2 } from '../../../src/chains/utxo'
 
 const COMPRESSED_PUBKEY = Uint8Array.from(
   '02aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'.match(/.{2}/g)!.map(b => parseInt(b, 16))
 )
 
 describe('Zcash — branchId parametrization', () => {
-  it('defaults to the NU6.1 constant when `zcashBranchId` is omitted', () => {
-    // Sanity: the exported constant matches the NU6.1 epoch value
+  it('defaults to the NU6.2 constant when `zcashBranchId` is omitted', () => {
+    // Sanity: the exported constant matches the NU6.2 epoch value
     // (https://zips.z.cash/zip-0253) and is little-endian-encoded as
-    // `f04dec4d` into the BLAKE2b personalization.
-    expect(ZCASH_BRANCH_ID_NU6_1).toBe(0x4dec4df0)
+    // `30f33754` into the BLAKE2b personalization.
+    expect(ZCASH_BRANCH_ID_NU6_2).toBe(0x5437f330)
   })
 
   it('produces the same sighash when branchId is omitted vs explicitly set to the default', () => {
@@ -32,7 +32,7 @@ describe('Zcash — branchId parametrization', () => {
       compressedPubKey: COMPRESSED_PUBKEY,
     }
     const defaultBuilder = buildUtxoSendTx(baseArgs)
-    const explicitBuilder = buildUtxoSendTx({ ...baseArgs, zcashBranchId: ZCASH_BRANCH_ID_NU6_1 })
+    const explicitBuilder = buildUtxoSendTx({ ...baseArgs, zcashBranchId: ZCASH_BRANCH_ID_NU6_2 })
     expect(defaultBuilder.signingHashesHex).toEqual(explicitBuilder.signingHashesHex)
   })
 
@@ -46,9 +46,12 @@ describe('Zcash — branchId parametrization', () => {
       feeRate: 1,
       compressedPubKey: COMPRESSED_PUBKEY,
     }
-    const nu6_1 = buildUtxoSendTx(baseArgs)
-    // Arbitrary non-NU6.1 branch id — simulates a hypothetical future epoch.
-    const futureEpoch = buildUtxoSendTx({ ...baseArgs, zcashBranchId: 0x12345678 })
-    expect(nu6_1.signingHashesHex).not.toEqual(futureEpoch.signingHashesHex)
+    const nu6_2 = buildUtxoSendTx(baseArgs)
+    const previousEpoch = buildUtxoSendTx({ ...baseArgs, zcashBranchId: ZCASH_BRANCH_ID_NU6_1 })
+    expect(nu6_2.signingHashesHex).not.toEqual(previousEpoch.signingHashesHex)
+  })
+
+  it('keeps the NU6.1 constant available for callers that explicitly need the previous epoch', () => {
+    expect(ZCASH_BRANCH_ID_NU6_1).toBe(0x4dec4df0)
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Zcash transaction signing now defaults to network protocol version NU6.2, replacing the previous NU6.1 default. This ensures transactions are compatible with the latest Zcash network parameters.
  * Developers can still explicitly specify earlier protocol versions if needed for compatibility.

* **Chores**
  * Released patch updates for SDK and Core MPC packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->