### PR TITLE
fix(zcash): enable ZIP-317 fee planning

### DIFF
--- a/.changeset/zcash-zip317-fee.md
+++ b/.changeset/zcash-zip317-fee.md
@@ -1,0 +1,7 @@
+---
+"@vultisig/core-chain": patch
+"@vultisig/core-mpc": patch
+"@vultisig/sdk": patch
+---
+
+Enable WalletCore ZIP-317 fee planning for Zcash UTXO signing inputs.

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -1821,7 +1821,7 @@
     "@solana/web3.js": "^1.98.4",
     "@ton/core": "^0.63.1",
     "@ton/crypto": "^3.3.0",
-    "@trustwallet/wallet-core": "^4.6.9",
+    "@trustwallet/wallet-core": "^4.6.13",
     "@vultisig/core-config": "0.9.1",
     "@vultisig/lib-utils": "0.10.1",
     "bip32": "^5.0.1",

--- a/packages/core/mpc/keysign/signingInputs/resolvers/utxo.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/utxo.test.ts
@@ -1,4 +1,5 @@
 import { create } from '@bufbuild/protobuf'
+import { TW } from '@trustwallet/wallet-core'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { UTXOSpecificSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
 import { CoinSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/coin_pb'
@@ -36,6 +37,7 @@ const makeWalletCore = ({ isValidAddress = true }: { isValidAddress?: boolean } 
     },
     CoinType: {
       bitcoin: { value: 0 },
+      zcash: { value: 133 },
     },
   }) as never
 
@@ -124,5 +126,35 @@ describe('Zcash branch ID', () => {
   it('pins the NU6.2 consensus branch ID in WalletCore little-endian hex order', async () => {
     const mod = await import('./utxo')
     expect(mod.ZCASH_BRANCH_ID_NU6_2_LE_HEX).toBe('30f33754')
+  })
+})
+
+describe('Zcash ZIP-317 fee planning', () => {
+  it('enables ZIP-317 on the WalletCore planner input for Zcash sends', async () => {
+    const resolver = await getUtxoSigningInputs()
+    const walletCore = makeWalletCore()
+    const plan = (walletCore as unknown as { AnySigner: { plan: ReturnType<typeof vi.fn> } }).AnySigner.plan
+    const payload = create(KeysignPayloadSchema, {
+      coin: create(CoinSchema, {
+        chain: Chain.Zcash,
+        ticker: 'ZEC',
+        address: 't1Source',
+        decimals: 8,
+        isNativeToken: true,
+      }),
+      toAddress: 't1Destination',
+      toAmount: '600000',
+      blockchainSpecific: {
+        case: 'utxoSpecific',
+        value: create(UTXOSpecificSchema, { byteFee: '10', sendMaxAmount: false }),
+      },
+      utxoInfo: [],
+    })
+
+    resolver({ keysignPayload: payload, walletCore, publicKey: {} as never })
+
+    const planInput = vi.mocked(plan).mock.calls[0]?.[0]
+    expect(planInput).toBeDefined()
+    expect(TW.Bitcoin.Proto.SigningInput.decode(planInput).zip_0317).toBe(true)
   })
 })

--- a/packages/core/mpc/keysign/signingInputs/resolvers/utxo.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/utxo.ts
@@ -74,6 +74,7 @@ export const getUtxoSigningInputs: SigningInputsResolver<'utxo'> = ({ keysignPay
     toAddress: destinationAddress,
     changeAddress: coin.address,
     byteFee: Long.fromString(byteFee),
+    zip_0317: chain === UtxoChain.Zcash,
     coinType: coinType.value,
     fixedDustThreshold: Long.fromBigInt(minUtxo[chain]),
     scripts: {

--- a/packages/core/mpc/package.json
+++ b/packages/core/mpc/package.json
@@ -998,7 +998,7 @@
     "@mysten/sui": "^2.17.0",
     "@noble/hashes": "^1.8.0",
     "@solana/web3.js": "^1.98.4",
-    "@trustwallet/wallet-core": "^4.6.9",
+    "@trustwallet/wallet-core": "^4.6.13",
     "@vultisig/core-chain": "2.10.1",
     "@vultisig/core-config": "0.9.1",
     "@vultisig/lib-dkls": "0.9.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -183,7 +183,7 @@
     "@solana/web3.js": "^1.98.4",
     "@ton/core": "^0.63.1",
     "@ton/crypto": "^3.3.0",
-    "@trustwallet/wallet-core": "^4.6.9",
+    "@trustwallet/wallet-core": "^4.6.13",
     "@vultisig/lib-dkls": "workspace:*",
     "@vultisig/lib-mldsa": "workspace:*",
     "@vultisig/lib-schnorr": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6734,12 +6734,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@trustwallet/wallet-core@npm:^4.6.9":
-  version: 4.6.9
-  resolution: "@trustwallet/wallet-core@npm:4.6.9"
+"@trustwallet/wallet-core@npm:^4.6.13":
+  version: 4.6.13
+  resolution: "@trustwallet/wallet-core@npm:4.6.13"
   dependencies:
     protobufjs: "npm:>=6.11.3"
-  checksum: 10c0/2158625201fb178345fcefb4fef76794b2ff1aa77f46f6d4f2109e00250939cfe76f6c2d575dd17fc8bddfb0a27f5ab30200fcca5776466d0ad536211c9386ee
+  checksum: 10c0/e1919de71be76553c0c8b428c0ab92f953940e077379023b6064f2b9b3c255d75e888808ba5046ddab7c26b2b4860dd308ea399d38602597b3e5137d9570056a
   languageName: node
   linkType: hard
 
@@ -7546,7 +7546,7 @@ __metadata:
     "@solana/web3.js": "npm:^1.98.4"
     "@ton/core": "npm:^0.63.1"
     "@ton/crypto": "npm:^3.3.0"
-    "@trustwallet/wallet-core": "npm:^4.6.9"
+    "@trustwallet/wallet-core": "npm:^4.6.13"
     "@vultisig/core-config": "npm:0.9.1"
     "@vultisig/lib-utils": "npm:0.10.1"
     bip32: "npm:^5.0.1"
@@ -7578,7 +7578,7 @@ __metadata:
     "@mysten/sui": "npm:^2.17.0"
     "@noble/hashes": "npm:^1.8.0"
     "@solana/web3.js": "npm:^1.98.4"
-    "@trustwallet/wallet-core": "npm:^4.6.9"
+    "@trustwallet/wallet-core": "npm:^4.6.13"
     "@vultisig/core-chain": "npm:2.10.1"
     "@vultisig/core-config": "npm:0.9.1"
     "@vultisig/lib-dkls": "npm:0.9.0"
@@ -7795,7 +7795,7 @@ __metadata:
     "@solana/web3.js": "npm:^1.98.4"
     "@ton/core": "npm:^0.63.1"
     "@ton/crypto": "npm:^3.3.0"
-    "@trustwallet/wallet-core": "npm:^4.6.9"
+    "@trustwallet/wallet-core": "npm:^4.6.13"
     "@types/chrome": "npm:^0.1.27"
     "@types/events": "npm:^3"
     "@types/node": "npm:^25.9.1"


### PR DESCRIPTION
## Summary
- Enable WalletCore ZIP-317 fee planning for Zcash UTXO signing inputs.
- Bump `@trustwallet/wallet-core` to `^4.6.13` so the JS protobuf includes `zip_0317`.
- Add a regression test that decodes the bytes passed to `AnySigner.plan` and verifies Zcash sets `zip_0317`.

Reference: https://github.com/vultisig/vultisig-ios/pull/4488

## Verification
- `yarn build:all`
- `yarn lint`
- `yarn test`
- `yarn cli:build`
- Built CLI Zcash dry-run: isolated Fast Vault import, added Zcash, self-send preview `0.0001 ZEC` returned `success: true`.
- Windows local SDK tarball smoke passed: `.codex/receipts/windows-desktop-smoke/desktop-smoke-2026-06-05T13-21-17-266Z.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled ZIP-317 fee planning for Zcash transactions, improving fee estimation accuracy.

* **Tests**
  * Added tests validating ZIP-317 fee planning for Zcash UTXO signing.

* **Chores**
  * Bumped WalletCore dependency versions across packages and added a changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->