### PR TITLE
feat(sui): add custom token metadata discovery

### DIFF
--- a/.changeset/sui-custom-token.md
+++ b/.changeset/sui-custom-token.md
@@ -1,0 +1,11 @@
+---
+"@vultisig/core-chain": minor
+"@vultisig/sdk": patch
+---
+
+Add custom token support for SUI. SUI is now included in
+`chainsWithTokenMetadataDiscovery`, and a new resolver fetches coin metadata
+(ticker, decimals, logo) from the SUI RPC via `suix_getCoinMetadata`. A new
+`isValidTokenId` helper validates token identifiers per chain — SUI tokens are
+validated as Move struct tags (e.g. `0x2::sui::SUI`) while all other chains keep
+delegating to `isValidAddress`.

--- a/packages/core/chain/coin/token/metadata/chains.ts
+++ b/packages/core/chain/coin/token/metadata/chains.ts
@@ -8,6 +8,7 @@ export const chainsWithTokenMetadataDiscovery = [
   OtherChain.Ton,
   OtherChain.Tron,
   OtherChain.Cardano,
+  OtherChain.Sui,
   ...Object.values(CosmosChain),
 ] as const
 

--- a/packages/core/chain/coin/token/metadata/index.ts
+++ b/packages/core/chain/coin/token/metadata/index.ts
@@ -6,6 +6,7 @@ import { getCardanoTokenMetadata } from './resolvers/cardano'
 import { getCosmosTokenMetadata } from './resolvers/cosmos'
 import { getEvmTokenMetadata } from './resolvers/evm'
 import { getSolanaTokenMetadata } from './resolvers/solana'
+import { getSuiTokenMetadata } from './resolvers/sui'
 import { getTonTokenMetadata } from './resolvers/ton'
 import { getTronTokenMetadata } from './resolvers/tron'
 
@@ -16,6 +17,7 @@ const resolvers: Record<ChainKindWithTokenMetadataDiscovery, TokenMetadataResolv
   ton: getTonTokenMetadata,
   tron: getTronTokenMetadata,
   cardano: getCardanoTokenMetadata,
+  sui: getSuiTokenMetadata,
 }
 
 export const getTokenMetadata: TokenMetadataResolver = async input => {

--- a/packages/core/chain/coin/token/metadata/resolvers/sui.test.ts
+++ b/packages/core/chain/coin/token/metadata/resolvers/sui.test.ts
@@ -24,9 +24,7 @@ describe('getSuiTokenMetadata', () => {
       iconUrl: 'https://example.com/sui.png',
     })
 
-    await expect(
-      getSuiTokenMetadata({ chain: OtherChain.Sui, id })
-    ).resolves.toEqual({
+    await expect(getSuiTokenMetadata({ chain: OtherChain.Sui, id })).resolves.toEqual({
       ticker: 'SUI',
       decimals: 9,
       logo: 'https://example.com/sui.png',
@@ -59,8 +57,6 @@ describe('getSuiTokenMetadata', () => {
   it('throws when no metadata is returned for the coin type', async () => {
     getCoinMetadataMock.mockResolvedValue(null)
 
-    await expect(
-      getSuiTokenMetadata({ chain: OtherChain.Sui, id: '0x123::foo::BAR' })
-    ).rejects.toThrow()
+    await expect(getSuiTokenMetadata({ chain: OtherChain.Sui, id: '0x123::foo::BAR' })).rejects.toThrow()
   })
 })

--- a/packages/core/chain/coin/token/metadata/resolvers/sui.test.ts
+++ b/packages/core/chain/coin/token/metadata/resolvers/sui.test.ts
@@ -1,0 +1,66 @@
+import { OtherChain } from '@vultisig/core-chain/Chain'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getCoinMetadataMock = vi.fn()
+
+vi.mock('@vultisig/core-chain/chains/sui/client', () => ({
+  getSuiClient: () => ({ getCoinMetadata: getCoinMetadataMock }),
+}))
+
+import { getSuiTokenMetadata } from './sui'
+
+describe('getSuiTokenMetadata', () => {
+  beforeEach(() => {
+    getCoinMetadataMock.mockReset()
+  })
+
+  it('maps SUI coin metadata into CoinMetadata', async () => {
+    const id = '0x2::sui::SUI'
+    getCoinMetadataMock.mockResolvedValue({
+      decimals: 9,
+      symbol: 'SUI',
+      name: 'Sui',
+      description: 'Sui native coin',
+      iconUrl: 'https://example.com/sui.png',
+    })
+
+    await expect(
+      getSuiTokenMetadata({ chain: OtherChain.Sui, id })
+    ).resolves.toEqual({
+      ticker: 'SUI',
+      decimals: 9,
+      logo: 'https://example.com/sui.png',
+    })
+
+    expect(getCoinMetadataMock).toHaveBeenCalledWith({ coinType: id })
+  })
+
+  it('omits the logo when iconUrl is missing', async () => {
+    getCoinMetadataMock.mockResolvedValue({
+      decimals: 6,
+      symbol: 'USDC',
+      name: 'USD Coin',
+      description: '',
+      iconUrl: null,
+    })
+
+    await expect(
+      getSuiTokenMetadata({
+        chain: OtherChain.Sui,
+        id: '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC',
+      })
+    ).resolves.toEqual({
+      ticker: 'USDC',
+      decimals: 6,
+      logo: undefined,
+    })
+  })
+
+  it('throws when no metadata is returned for the coin type', async () => {
+    getCoinMetadataMock.mockResolvedValue(null)
+
+    await expect(
+      getSuiTokenMetadata({ chain: OtherChain.Sui, id: '0x123::foo::BAR' })
+    ).rejects.toThrow()
+  })
+})

--- a/packages/core/chain/coin/token/metadata/resolvers/sui.ts
+++ b/packages/core/chain/coin/token/metadata/resolvers/sui.ts
@@ -11,10 +11,7 @@ import { TokenMetadataResolver } from '../resolver'
 export const getSuiTokenMetadata: TokenMetadataResolver<OtherChain.Sui> = async ({ id }) => {
   const client = getSuiClient()
 
-  const metadata = shouldBePresent(
-    await client.getCoinMetadata({ coinType: id }),
-    `SUI coin metadata for ${id}`
-  )
+  const metadata = shouldBePresent(await client.getCoinMetadata({ coinType: id }), `SUI coin metadata for ${id}`)
 
   return {
     ticker: metadata.symbol,

--- a/packages/core/chain/coin/token/metadata/resolvers/sui.ts
+++ b/packages/core/chain/coin/token/metadata/resolvers/sui.ts
@@ -1,0 +1,24 @@
+import { OtherChain } from '@vultisig/core-chain/Chain'
+import { getSuiClient } from '@vultisig/core-chain/chains/sui/client'
+import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
+
+import { TokenMetadataResolver } from '../resolver'
+
+/**
+ * Resolves SUI coin metadata via the `suix_getCoinMetadata` JSON-RPC method.
+ * The `id` is the fully-qualified coin type (e.g. `0x...::module::TYPE`).
+ */
+export const getSuiTokenMetadata: TokenMetadataResolver<OtherChain.Sui> = async ({ id }) => {
+  const client = getSuiClient()
+
+  const metadata = shouldBePresent(
+    await client.getCoinMetadata({ coinType: id }),
+    `SUI coin metadata for ${id}`
+  )
+
+  return {
+    ticker: metadata.symbol,
+    decimals: metadata.decimals,
+    logo: metadata.iconUrl ?? undefined,
+  }
+}

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -1014,6 +1014,11 @@
       "import": "./dist/coin/token/metadata/resolvers/solana.js",
       "default": "./dist/coin/token/metadata/resolvers/solana.js"
     },
+    "./coin/token/metadata/resolvers/sui": {
+      "types": "./dist/coin/token/metadata/resolvers/sui.d.ts",
+      "import": "./dist/coin/token/metadata/resolvers/sui.js",
+      "default": "./dist/coin/token/metadata/resolvers/sui.js"
+    },
     "./coin/token/metadata/resolvers/ton": {
       "types": "./dist/coin/token/metadata/resolvers/ton.d.ts",
       "import": "./dist/coin/token/metadata/resolvers/ton.js",
@@ -1789,6 +1794,11 @@
       "types": "./dist/utils/isValidAddress.d.ts",
       "import": "./dist/utils/isValidAddress.js",
       "default": "./dist/utils/isValidAddress.js"
+    },
+    "./utils/isValidTokenId": {
+      "types": "./dist/utils/isValidTokenId.d.ts",
+      "import": "./dist/utils/isValidTokenId.js",
+      "default": "./dist/utils/isValidTokenId.js"
     },
     "./utils/protobuf/toCompressedString": {
       "types": "./dist/utils/protobuf/toCompressedString.d.ts",

--- a/packages/core/chain/utils/isValidTokenId.ts
+++ b/packages/core/chain/utils/isValidTokenId.ts
@@ -1,0 +1,27 @@
+import { isValidStructTag } from '@mysten/sui/utils'
+import { WalletCore } from '@trustwallet/wallet-core'
+import { Chain } from '@vultisig/core-chain/Chain'
+
+import { isValidAddress } from './isValidAddress'
+
+type Input = {
+  chain: Chain
+  id: string
+  walletCore: WalletCore
+}
+
+/**
+ * Validates a custom token identifier for a given chain.
+ *
+ * For most chains a token is identified by an address (contract/mint), so this
+ * delegates to {@link isValidAddress}. SUI tokens are identified by their fully
+ * qualified coin type (e.g. `0x2::sui::SUI`), which is a Move struct tag rather
+ * than an account address, so it is validated separately.
+ */
+export const isValidTokenId = ({ chain, id, walletCore }: Input) => {
+  if (chain === Chain.Sui) {
+    return isValidStructTag(id.trim())
+  }
+
+  return isValidAddress({ chain, address: id, walletCore })
+}


### PR DESCRIPTION
## Summary

Adds custom token support for **SUI**, mirroring what already exists for EVM, Solana, Tron, Cardano, Ton, and Cosmos. Implements [vultisig-windows#4034](https://github.com/vultisig/vultisig-windows/issues/4034).

## Changes

- **`coin/token/metadata/chains.ts`** — add `OtherChain.Sui` to `chainsWithTokenMetadataDiscovery` (this is what makes the "Add Custom Token" entry appear for SUI in consumers).
- **`coin/token/metadata/resolvers/sui.ts`** (new) — `getSuiTokenMetadata` reads coin metadata via `suix_getCoinMetadata` through the existing `getSuiClient()`, mapping `symbol`/`decimals`/`iconUrl` → `ticker`/`decimals`/`logo`.
- **`coin/token/metadata/index.ts`** — register `sui` in the resolvers record.
- **`utils/isValidTokenId.ts`** (new) — token-id validator. SUI tokens are identified by their Move **coin type** (`0x2::sui::SUI`), not an account address, so this validates SUI ids as struct tags (`isValidStructTag`) and delegates every other chain to the existing `isValidAddress` **unchanged**. A dedicated helper is required because `isValidAddress` is shared with send/deposit/address-book recipient validation and must not be loosened.
- **`resolvers/sui.test.ts`** (new) — unit tests for the resolver (mapping, missing-icon, null-metadata).
- `package.json` exports regenerated for the two new files.

## Verification

- `tsc` core typecheck — pass
- metadata resolver tests (incl. new SUI tests) — **11 passed**
- ESLint on changed files — pass
- `build-shared-packages.mjs --check` (shared exports) — up to date
- End-to-end against live SUI RPC: USDC / DEEP / CETUS / USDT(wormhole) all resolve correctly

## Notes

Other chains' behavior is unchanged — `isValidAddress` itself is untouched, and the only behavioral change is that SUI now accepts coin types (previously impossible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SUI is now included in token metadata discovery; token details (ticker, decimals, logo) are fetched automatically from the SUI network.
  * Added SUI-specific token ID validation to ensure identifiers follow the correct SUI format.

* **Tests**
  * Unit tests added to verify SUI token metadata retrieval, logo handling, and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->