### PR TITLE
feat(core/chain): add Blockaid Sui transaction simulation support

### DIFF
--- a/.changeset/blockaid-sui-simulation.md
+++ b/.changeset/blockaid-sui-simulation.md
@@ -1,0 +1,20 @@
+---
+"@vultisig/core-chain": minor
+"@vultisig/core-mpc": minor
+"@vultisig/sdk": patch
+---
+
+Add Blockaid Sui transaction simulation support. The existing Sui Blockaid
+scan resolver only requested `validation`; this exposes the simulation block
+returned by the same `/sui/transaction/scan` endpoint via a new
+`getSuiTxBlockaidSimulation` resolver and a `parseBlockaidSuiSimulation`
+parser that produces a UI-facing `{ swap } | { transfer }` headline
+(mirroring the Solana shape). `OtherChain.Sui` is now a member of
+`blockaidSimulationSupportedChains`, with a new `getTxBlockaidSimulation`
+overload, and the mpc package gains a matching
+`getSuiBlockaidTxSimulationInput` for the `KeysignPayload`-driven flow.
+
+The parser keeps `null` as its failure mode rather than throwing — Blockaid
+field renames degrade to "no preview" instead of breaking consumers.
+
+Closes #671

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -1210,6 +1210,11 @@
       "import": "./dist/security/blockaid/tx/simulation/resolvers/solana.js",
       "default": "./dist/security/blockaid/tx/simulation/resolvers/solana.js"
     },
+    "./security/blockaid/tx/simulation/resolvers/sui": {
+      "types": "./dist/security/blockaid/tx/simulation/resolvers/sui.d.ts",
+      "import": "./dist/security/blockaid/tx/simulation/resolvers/sui.js",
+      "default": "./dist/security/blockaid/tx/simulation/resolvers/sui.js"
+    },
     "./security/blockaid/tx/validation": {
       "types": "./dist/security/blockaid/tx/validation/index.d.ts",
       "import": "./dist/security/blockaid/tx/validation/index.js",

--- a/packages/core/chain/security/blockaid/simulationChains.ts
+++ b/packages/core/chain/security/blockaid/simulationChains.ts
@@ -2,7 +2,11 @@ import { OtherChain } from '../../Chain'
 import { DeriveChainKind } from '../../ChainKind'
 import { blockaidSupportedEvmChains } from './evmChains'
 
-export const blockaidSimulationSupportedChains = [...blockaidSupportedEvmChains, OtherChain.Solana] as const
+export const blockaidSimulationSupportedChains = [
+  ...blockaidSupportedEvmChains,
+  OtherChain.Solana,
+  OtherChain.Sui,
+] as const
 
 export type BlockaidSimulationSupportedChain = (typeof blockaidSimulationSupportedChains)[number]
 export type BlockaidSimulationSupportedChainKind = DeriveChainKind<BlockaidSimulationSupportedChain>

--- a/packages/core/chain/security/blockaid/tx/simulation/api/core.ts
+++ b/packages/core/chain/security/blockaid/tx/simulation/api/core.ts
@@ -73,13 +73,19 @@ const coinTypeFromAsset = (asset: BlockaidSuiRawAsset): string | null => {
   return null
 }
 
-const toBigInt = (raw: number | string): bigint => {
-  if (typeof raw === 'bigint') return raw
-  if (typeof raw === 'number') return BigInt(Math.trunc(raw))
-  if (/^-?\d+$/.test(raw)) return BigInt(raw)
-  // Fallback for decimal strings ("1.234"). Blockaid usually emits integer
-  // raw_values, but normalise just in case.
-  return BigInt(Math.trunc(Number(raw)))
+// Convert Blockaid's `raw_value` (always an integer in the asset's base unit,
+// emitted as either a JS number or a numeric string) to a bigint. Returns
+// `null` for any input we can't safely represent — `NaN`, `Infinity`, unsafe
+// JS numbers (precision loss above 2^53), or non-integer strings. The parser
+// propagates the `null` so a malformed amount degrades to "no preview"
+// instead of throwing or quietly corrupting the displayed value.
+const toBigInt = (raw: number | string): bigint | null => {
+  if (typeof raw === 'number') {
+    if (!Number.isFinite(raw) || !Number.isSafeInteger(raw)) return null
+    return BigInt(raw)
+  }
+  if (!/^-?\d+$/.test(raw)) return null
+  return BigInt(raw)
 }
 
 /**
@@ -91,9 +97,7 @@ const toBigInt = (raw: number | string): bigint => {
 export const parseBlockaidSuiSimulation = async (
   simulation: BlockaidSuiSimulation
 ): Promise<BlockaidSuiSimulationInfo | null> => {
-  const assetDiffs =
-    simulation.account_summary?.account_assets_diffs ??
-    simulation.account_summary?.account_assets_diff
+  const assetDiffs = simulation.account_summary?.account_assets_diffs ?? simulation.account_summary?.account_assets_diff
   if (!assetDiffs || assetDiffs.length === 0) return null
 
   // When we have 3 items and one is native SUI, filter it out and use the
@@ -112,10 +116,12 @@ export const parseBlockaidSuiSimulation = async (
     if (!diff.out) return null
     const from = blockaidSuiAssetFrom(diff.asset)
     if (!from) return null
+    const fromAmount = toBigInt(diff.out.raw_value)
+    if (fromAmount === null) return null
     return {
       transfer: {
         from,
-        fromAmount: toBigInt(diff.out.raw_value),
+        fromAmount,
       },
     }
   }
@@ -129,12 +135,15 @@ export const parseBlockaidSuiSimulation = async (
     const from = blockaidSuiAssetFrom(outDiff.asset)
     const to = blockaidSuiAssetFrom(inDiff.asset)
     if (from && to && from.coinType !== to.coinType) {
+      const fromAmount = toBigInt(outDiff.out.raw_value)
+      const toAmount = toBigInt(inDiff.in.raw_value)
+      if (fromAmount === null || toAmount === null) return null
       return {
         swap: {
           from,
           to,
-          fromAmount: toBigInt(outDiff.out.raw_value),
-          toAmount: toBigInt(inDiff.in.raw_value),
+          fromAmount,
+          toAmount,
         },
       }
     }
@@ -143,10 +152,12 @@ export const parseBlockaidSuiSimulation = async (
   if (outDiff && outDiff.out) {
     const from = blockaidSuiAssetFrom(outDiff.asset)
     if (from) {
+      const fromAmount = toBigInt(outDiff.out.raw_value)
+      if (fromAmount === null) return null
       return {
         transfer: {
           from,
-          fromAmount: toBigInt(outDiff.out.raw_value),
+          fromAmount,
         },
       }
     }
@@ -155,9 +166,7 @@ export const parseBlockaidSuiSimulation = async (
   return null
 }
 
-const blockaidSuiAssetFrom = (
-  asset: BlockaidSuiRawAsset
-): BlockaidSuiAsset | null => {
+const blockaidSuiAssetFrom = (asset: BlockaidSuiRawAsset): BlockaidSuiAsset | null => {
   const coinType = coinTypeFromAsset(asset)
   if (!coinType) return null
   return {

--- a/packages/core/chain/security/blockaid/tx/simulation/api/core.ts
+++ b/packages/core/chain/security/blockaid/tx/simulation/api/core.ts
@@ -3,7 +3,170 @@ import { isChainOfKind } from '@vultisig/core-chain/ChainKind'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 
 import { Coin } from '../../../../../coin/Coin'
-import { BlockaidEvmBalanceChange, BlockaidEvmSimulationInfo, BlockaidSolanaSimulationInfo } from '../core'
+import {
+  BlockaidEvmBalanceChange,
+  BlockaidEvmSimulationInfo,
+  BlockaidSolanaSimulationInfo,
+  BlockaidSuiAsset,
+  BlockaidSuiSimulationInfo,
+} from '../core'
+
+const SUI_NATIVE_COIN_TYPE = '0x2::sui::SUI'
+
+// Blockaid's `/sui/transaction/scan` simulation block exposes per-asset diffs
+// under `account_summary.account_assets_diffs` (plural). Asset entries use
+// `type === 'NATIVE'` for SUI and `type === 'COIN'` for fungible Move coins,
+// with the Move type tag at `asset.id`. `raw_value` is returned as a JS
+// number for Sui, in the asset's base units. The parser falls back to `null`
+// on any shape it doesn't recognise so a Blockaid response change surfaces
+// as "no preview" instead of crashing the popup.
+type BlockaidSuiRawAssetSide = {
+  usd_price?: number
+  summary?: string
+  value?: number | string
+  raw_value: number | string
+}
+
+type BlockaidSuiRawAsset = {
+  type?: 'NATIVE' | 'COIN' | 'TOKEN' | 'SUI' | string
+  asset_type?: 'NATIVE' | 'COIN' | 'TOKEN' | 'SUI' | string
+  name?: string
+  symbol?: string
+  // Sui Move type tag, e.g. `0xa9…::navx::NAVX`. Native SUI has no `id`.
+  id?: string
+  coin_type?: string
+  address?: string
+  decimals: number
+  logo?: string
+  logo_url?: string
+}
+
+type BlockaidSuiRawAssetDiff = {
+  asset: BlockaidSuiRawAsset
+  in: BlockaidSuiRawAssetSide | null
+  out: BlockaidSuiRawAssetSide | null
+  asset_type?: 'NATIVE' | 'COIN' | 'TOKEN' | 'SUI' | string
+}
+
+export type BlockaidSuiSimulation = {
+  status?: 'Success' | 'Failure'
+  account_summary?: {
+    account_assets_diffs?: BlockaidSuiRawAssetDiff[]
+    // Older / alternate key — keep the singular fallback in case Blockaid
+    // swaps naming without notice.
+    account_assets_diff?: BlockaidSuiRawAssetDiff[]
+  }
+}
+
+const isNativeSui = (asset: BlockaidSuiRawAsset): boolean =>
+  asset.type === 'NATIVE' ||
+  asset.type === 'SUI' ||
+  asset.asset_type === 'NATIVE' ||
+  asset.coin_type === SUI_NATIVE_COIN_TYPE ||
+  (!asset.id && !asset.coin_type && !asset.address && asset.symbol === 'SUI')
+
+const coinTypeFromAsset = (asset: BlockaidSuiRawAsset): string | null => {
+  if (asset.id) return asset.id
+  if (asset.coin_type) return asset.coin_type
+  if (asset.address) return asset.address
+  if (isNativeSui(asset)) return SUI_NATIVE_COIN_TYPE
+  return null
+}
+
+const toBigInt = (raw: number | string): bigint => {
+  if (typeof raw === 'bigint') return raw
+  if (typeof raw === 'number') return BigInt(Math.trunc(raw))
+  if (/^-?\d+$/.test(raw)) return BigInt(raw)
+  // Fallback for decimal strings ("1.234"). Blockaid usually emits integer
+  // raw_values, but normalise just in case.
+  return BigInt(Math.trunc(Number(raw)))
+}
+
+/**
+ * Parse a Blockaid Sui simulation into the user's net balance changes,
+ * mirroring how Solana classifies into a `swap` or `transfer` headline.
+ * Returns `null` if the response shape doesn't expose any asset diffs we can
+ * interpret — the popup falls back to the decoded-command view in that case.
+ */
+export const parseBlockaidSuiSimulation = async (
+  simulation: BlockaidSuiSimulation
+): Promise<BlockaidSuiSimulationInfo | null> => {
+  const assetDiffs =
+    simulation.account_summary?.account_assets_diffs ??
+    simulation.account_summary?.account_assets_diff
+  if (!assetDiffs || assetDiffs.length === 0) return null
+
+  // When we have 3 items and one is native SUI, filter it out and use the
+  // other two tokens — the native SUI is likely the gas charge, not part of
+  // the swap itself. Same heuristic as Solana.
+  let relevantDiffs = assetDiffs
+  if (assetDiffs.length === 3) {
+    const nativeIdx = assetDiffs.findIndex(diff => isNativeSui(diff.asset))
+    if (nativeIdx !== -1) {
+      relevantDiffs = assetDiffs.filter((_, i) => i !== nativeIdx)
+    }
+  }
+
+  if (relevantDiffs.length === 1) {
+    const [diff] = relevantDiffs
+    if (!diff.out) return null
+    const from = blockaidSuiAssetFrom(diff.asset)
+    if (!from) return null
+    return {
+      transfer: {
+        from,
+        fromAmount: toBigInt(diff.out.raw_value),
+      },
+    }
+  }
+
+  // Two or more diffs — try to surface a swap (one out + one in on different
+  // assets). Falls back to a transfer headline if we can't pair them.
+  const outDiff = relevantDiffs.find(d => d.out !== null)
+  const inDiff = relevantDiffs.find(d => d.in !== null && d !== outDiff)
+
+  if (outDiff && outDiff.out && inDiff && inDiff.in) {
+    const from = blockaidSuiAssetFrom(outDiff.asset)
+    const to = blockaidSuiAssetFrom(inDiff.asset)
+    if (from && to && from.coinType !== to.coinType) {
+      return {
+        swap: {
+          from,
+          to,
+          fromAmount: toBigInt(outDiff.out.raw_value),
+          toAmount: toBigInt(inDiff.in.raw_value),
+        },
+      }
+    }
+  }
+
+  if (outDiff && outDiff.out) {
+    const from = blockaidSuiAssetFrom(outDiff.asset)
+    if (from) {
+      return {
+        transfer: {
+          from,
+          fromAmount: toBigInt(outDiff.out.raw_value),
+        },
+      }
+    }
+  }
+
+  return null
+}
+
+const blockaidSuiAssetFrom = (
+  asset: BlockaidSuiRawAsset
+): BlockaidSuiAsset | null => {
+  const coinType = coinTypeFromAsset(asset)
+  if (!coinType) return null
+  return {
+    coinType,
+    symbol: asset.symbol || coinType.split('::').pop() || coinType,
+    decimals: asset.decimals,
+    logo: asset.logo_url ?? asset.logo,
+  }
+}
 
 export type BlockaidSolanaSimulation = {
   account_summary: {

--- a/packages/core/chain/security/blockaid/tx/simulation/api/core.ts
+++ b/packages/core/chain/security/blockaid/tx/simulation/api/core.ts
@@ -91,8 +91,16 @@ const toBigInt = (raw: number | string): bigint | null => {
 /**
  * Parse a Blockaid Sui simulation into the user's net balance changes,
  * mirroring how Solana classifies into a `swap` or `transfer` headline.
- * Returns `null` if the response shape doesn't expose any asset diffs we can
- * interpret — the popup falls back to the decoded-command view in that case.
+ *
+ * Only emits a headline when the relevant diff set is unambiguous:
+ *   - exactly one out-only diff → `transfer`
+ *   - exactly two diffs, one out-only + one in-only on different assets
+ *     → `swap`
+ *
+ * Anything more complex (e.g. a swap that also sends a third asset)
+ * returns `null` — a partial "you're swapping…" headline would hide the
+ * additional movement and mislead users approving the transaction. The
+ * popup falls back to the decoded-command view when this returns `null`.
  */
 export const parseBlockaidSuiSimulation = async (
   simulation: BlockaidSuiSimulation
@@ -113,7 +121,9 @@ export const parseBlockaidSuiSimulation = async (
 
   if (relevantDiffs.length === 1) {
     const [diff] = relevantDiffs
-    if (!diff.out) return null
+    // A single diff with an `in` side but no `out` would be a pure receive;
+    // we don't surface that as a "you're sending" headline.
+    if (!diff.out || diff.in) return null
     const from = blockaidSuiAssetFrom(diff.asset)
     if (!from) return null
     const fromAmount = toBigInt(diff.out.raw_value)
@@ -126,44 +136,34 @@ export const parseBlockaidSuiSimulation = async (
     }
   }
 
-  // Two or more diffs — try to surface a swap (one out + one in on different
-  // assets). Falls back to a transfer headline if we can't pair them.
-  const outDiff = relevantDiffs.find(d => d.out !== null)
-  const inDiff = relevantDiffs.find(d => d.in !== null && d !== outDiff)
+  // Strict two-diff swap: one diff is out-only, the other is in-only, and
+  // they're on different assets. Anything else (mixed in+out on one side,
+  // three+ relevant diffs, same-asset refund pair) returns `null` rather
+  // than risk a misleading partial headline.
+  if (relevantDiffs.length !== 2) return null
 
-  if (outDiff && outDiff.out && inDiff && inDiff.in) {
-    const from = blockaidSuiAssetFrom(outDiff.asset)
-    const to = blockaidSuiAssetFrom(inDiff.asset)
-    if (from && to && from.coinType !== to.coinType) {
-      const fromAmount = toBigInt(outDiff.out.raw_value)
-      const toAmount = toBigInt(inDiff.in.raw_value)
-      if (fromAmount === null || toAmount === null) return null
-      return {
-        swap: {
-          from,
-          to,
-          fromAmount,
-          toAmount,
-        },
-      }
-    }
+  const [a, b] = relevantDiffs
+  const outDiff = !a.in && a.out ? a : !b.in && b.out ? b : null
+  const inDiff = !a.out && a.in ? a : !b.out && b.in ? b : null
+  if (!outDiff || !inDiff || outDiff === inDiff) return null
+  if (!outDiff.out || !inDiff.in) return null
+
+  const from = blockaidSuiAssetFrom(outDiff.asset)
+  const to = blockaidSuiAssetFrom(inDiff.asset)
+  if (!from || !to || from.coinType === to.coinType) return null
+
+  const fromAmount = toBigInt(outDiff.out.raw_value)
+  const toAmount = toBigInt(inDiff.in.raw_value)
+  if (fromAmount === null || toAmount === null) return null
+
+  return {
+    swap: {
+      from,
+      to,
+      fromAmount,
+      toAmount,
+    },
   }
-
-  if (outDiff && outDiff.out) {
-    const from = blockaidSuiAssetFrom(outDiff.asset)
-    if (from) {
-      const fromAmount = toBigInt(outDiff.out.raw_value)
-      if (fromAmount === null) return null
-      return {
-        transfer: {
-          from,
-          fromAmount,
-        },
-      }
-    }
-  }
-
-  return null
 }
 
 const blockaidSuiAssetFrom = (asset: BlockaidSuiRawAsset): BlockaidSuiAsset | null => {

--- a/packages/core/chain/security/blockaid/tx/simulation/core.ts
+++ b/packages/core/chain/security/blockaid/tx/simulation/core.ts
@@ -1,5 +1,28 @@
 import { Coin } from '../../../../coin/Coin'
 
+export type BlockaidSuiAsset = {
+  coinType: string
+  symbol: string
+  decimals: number
+  logo?: string
+}
+
+export type BlockaidSuiSimulationInfo =
+  | {
+      swap: {
+        from: BlockaidSuiAsset
+        to: BlockaidSuiAsset
+        fromAmount: bigint
+        toAmount: bigint
+      }
+    }
+  | {
+      transfer: {
+        from: BlockaidSuiAsset
+        fromAmount: bigint
+      }
+    }
+
 export type BlockaidSolanaSimulationInfo =
   | {
       swap: {

--- a/packages/core/chain/security/blockaid/tx/simulation/index.ts
+++ b/packages/core/chain/security/blockaid/tx/simulation/index.ts
@@ -6,15 +6,18 @@ import { BlockaidSimulationSupportedChain } from '../../simulationChains'
 import { BlockaidSimulationForChainKind, BlockaidTxSimulationInput, BlockaidTxSimulationResolver } from './resolver'
 import { getEvmTxBlockaidSimulation } from './resolvers/evm'
 import { getSolanaTxBlockaidSimulation } from './resolvers/solana'
+import { getSuiTxBlockaidSimulation } from './resolvers/sui'
 
 type ResolverMap = {
   evm: BlockaidTxSimulationResolver<any, 'evm'>
   solana: BlockaidTxSimulationResolver<any, 'solana'>
+  sui: BlockaidTxSimulationResolver<any, 'sui'>
 }
 
 const resolvers: ResolverMap = {
   solana: getSolanaTxBlockaidSimulation,
   evm: getEvmTxBlockaidSimulation,
+  sui: getSuiTxBlockaidSimulation,
 }
 
 export function getTxBlockaidSimulation(
@@ -25,6 +28,10 @@ export function getTxBlockaidSimulation(
   input: BlockaidTxSimulationInput<typeof Chain.Solana>
 ): Promise<BlockaidSimulationForChainKind<'solana'>>
 
+export function getTxBlockaidSimulation(
+  input: BlockaidTxSimulationInput<typeof Chain.Sui>
+): Promise<BlockaidSimulationForChainKind<'sui'>>
+
 export async function getTxBlockaidSimulation<T extends BlockaidSimulationSupportedChain>(
   input: BlockaidTxSimulationInput<T>
 ): Promise<BlockaidSimulationForChainKind<DeriveChainKind<T>>> {
@@ -32,6 +39,10 @@ export async function getTxBlockaidSimulation<T extends BlockaidSimulationSuppor
 
   if (chainKind === 'solana') {
     return resolvers.solana(input) as Promise<BlockaidSimulationForChainKind<DeriveChainKind<T>>>
+  }
+
+  if (chainKind === 'sui') {
+    return resolvers.sui(input) as Promise<BlockaidSimulationForChainKind<DeriveChainKind<T>>>
   }
 
   return resolvers.evm(input) as Promise<BlockaidSimulationForChainKind<DeriveChainKind<T>>>

--- a/packages/core/chain/security/blockaid/tx/simulation/resolver.ts
+++ b/packages/core/chain/security/blockaid/tx/simulation/resolver.ts
@@ -1,7 +1,7 @@
 import { Resolver } from '@vultisig/lib-utils/types/Resolver'
 
 import { BlockaidSimulationSupportedChain, BlockaidSimulationSupportedChainKind } from '../../simulationChains'
-import { BlockaidEVMSimulation, BlockaidSolanaSimulation } from './api/core'
+import { BlockaidEVMSimulation, BlockaidSolanaSimulation, BlockaidSuiSimulation } from './api/core'
 
 export type BlockaidTxSimulationInput<T extends BlockaidSimulationSupportedChain = BlockaidSimulationSupportedChain> = {
   chain: T
@@ -11,6 +11,7 @@ export type BlockaidTxSimulationInput<T extends BlockaidSimulationSupportedChain
 type BlockaidSimulationByKind = {
   evm: BlockaidEVMSimulation
   solana: BlockaidSolanaSimulation
+  sui: BlockaidSuiSimulation
 }
 
 export type BlockaidSimulationForChainKind<K extends BlockaidSimulationSupportedChainKind> = BlockaidSimulationByKind[K]

--- a/packages/core/chain/security/blockaid/tx/simulation/resolvers/sui.ts
+++ b/packages/core/chain/security/blockaid/tx/simulation/resolvers/sui.ts
@@ -1,0 +1,25 @@
+import { OtherChain } from '@vultisig/core-chain/Chain'
+
+import { queryBlockaid } from '../../../core/query'
+import { BlockaidSuiSimulation } from '../api/core'
+import { BlockaidTxSimulationResolver } from '../resolver'
+
+type SuiBlockaidScanResponse = {
+  simulation: BlockaidSuiSimulation
+}
+
+/**
+ * Asks Blockaid's `/sui/transaction/scan` endpoint for the simulation block
+ * only. The same endpoint also serves validation (security risk) — the
+ * separate `getSuiTxBlockaidValidation` resolver requests that.
+ */
+export const getSuiTxBlockaidSimulation: BlockaidTxSimulationResolver<
+  OtherChain.Sui,
+  'sui'
+> = async ({ data }) => {
+  const { simulation } = await queryBlockaid<SuiBlockaidScanResponse>(
+    '/sui/transaction/scan',
+    data
+  )
+  return simulation
+}

--- a/packages/core/chain/security/blockaid/tx/simulation/resolvers/sui.ts
+++ b/packages/core/chain/security/blockaid/tx/simulation/resolvers/sui.ts
@@ -13,13 +13,7 @@ type SuiBlockaidScanResponse = {
  * only. The same endpoint also serves validation (security risk) — the
  * separate `getSuiTxBlockaidValidation` resolver requests that.
  */
-export const getSuiTxBlockaidSimulation: BlockaidTxSimulationResolver<
-  OtherChain.Sui,
-  'sui'
-> = async ({ data }) => {
-  const { simulation } = await queryBlockaid<SuiBlockaidScanResponse>(
-    '/sui/transaction/scan',
-    data
-  )
+export const getSuiTxBlockaidSimulation: BlockaidTxSimulationResolver<OtherChain.Sui, 'sui'> = async ({ data }) => {
+  const { simulation } = await queryBlockaid<SuiBlockaidScanResponse>('/sui/transaction/scan', data)
   return simulation
 }

--- a/packages/core/mpc/package.json
+++ b/packages/core/mpc/package.json
@@ -722,6 +722,11 @@
       "import": "./dist/security/blockaid/tx/simulation/input/resolvers/solana.js",
       "default": "./dist/security/blockaid/tx/simulation/input/resolvers/solana.js"
     },
+    "./security/blockaid/tx/simulation/input/resolvers/sui": {
+      "types": "./dist/security/blockaid/tx/simulation/input/resolvers/sui.d.ts",
+      "import": "./dist/security/blockaid/tx/simulation/input/resolvers/sui.js",
+      "default": "./dist/security/blockaid/tx/simulation/input/resolvers/sui.js"
+    },
     "./security/blockaid/tx/utils/getCompiledTxsForBlockaidInput": {
       "types": "./dist/security/blockaid/tx/utils/getCompiledTxsForBlockaidInput.d.ts",
       "import": "./dist/security/blockaid/tx/utils/getCompiledTxsForBlockaidInput.js",

--- a/packages/core/mpc/security/blockaid/tx/simulation/input/index.ts
+++ b/packages/core/mpc/security/blockaid/tx/simulation/input/index.ts
@@ -10,10 +10,12 @@ import { isOneOf } from '@vultisig/lib-utils/array/isOneOf'
 import { BlockaidTxSimulationInputResolver, BlockaidTxSimulationInputResolverInput } from './resolver'
 import { getEvmBlockaidTxSimulationInput } from './resolvers/evm'
 import { getSolanaBlockaidTxSimulationInput } from './resolvers/solana'
+import { getSuiBlockaidTxSimulationInput } from './resolvers/sui'
 
 const resolvers: Record<BlockaidSimulationSupportedChainKind, BlockaidTxSimulationInputResolver<any>> = {
   solana: getSolanaBlockaidTxSimulationInput,
   evm: getEvmBlockaidTxSimulationInput,
+  sui: getSuiBlockaidTxSimulationInput,
 }
 
 export const getBlockaidTxSimulationInput = (

--- a/packages/core/mpc/security/blockaid/tx/simulation/input/resolvers/sui.ts
+++ b/packages/core/mpc/security/blockaid/tx/simulation/input/resolvers/sui.ts
@@ -1,0 +1,28 @@
+import { OtherChain } from '@vultisig/core-chain/Chain'
+import { decodeSigningOutput } from '@vultisig/core-chain/tw/signingOutput'
+import { assertField } from '@vultisig/lib-utils/record/assertField'
+
+import { getCompiledTxsForBlockaidInput } from '../../../utils/getCompiledTxsForBlockaidInput'
+import { BlockaidTxSimulationInputResolver } from '../resolver'
+
+export const getSuiBlockaidTxSimulationInput: BlockaidTxSimulationInputResolver<OtherChain.Sui> = ({
+  payload,
+  walletCore,
+}) => {
+  const coin = assertField(payload, 'coin')
+
+  const compiledTxs = getCompiledTxsForBlockaidInput({
+    payload,
+    walletCore,
+  })
+
+  const [transaction] = compiledTxs.map(compiledTx => decodeSigningOutput(OtherChain.Sui, compiledTx).unsignedTx)
+
+  return {
+    chain: 'mainnet',
+    options: ['simulation'],
+    account_address: coin.address,
+    transaction,
+    metadata: {},
+  }
+}

--- a/packages/core/mpc/security/blockaid/tx/simulation/input/resolvers/sui.ts
+++ b/packages/core/mpc/security/blockaid/tx/simulation/input/resolvers/sui.ts
@@ -15,6 +15,7 @@ export const getSuiBlockaidTxSimulationInput: BlockaidTxSimulationInputResolver<
     payload,
     walletCore,
   })
+  if (compiledTxs.length === 0) return null
 
   const [transaction] = compiledTxs.map(compiledTx => decodeSigningOutput(OtherChain.Sui, compiledTx).unsignedTx)
 


### PR DESCRIPTION
## Summary

- Adds `OtherChain.Sui` to `blockaidSimulationSupportedChains` and exposes the simulation block already returned by `/sui/transaction/scan` (which the existing Sui resolver only consumes the `validation` half of).
- Mirrors the Solana simulation pipeline end-to-end: new `BlockaidSuiSimulationInfo` (UI-facing `{ swap } | { transfer }` headline with structured asset metadata), `BlockaidSuiSimulation` raw API type, `parseBlockaidSuiSimulation`, `getSuiTxBlockaidSimulation` resolver, and matching `getSuiBlockaidTxSimulationInput` for the KeysignPayload flow.
- Parser facts observed against a live response (encoded into the implementation):
  - diffs are at `account_summary.account_assets_diffs` (plural — Solana uses singular)
  - move type tag is in `asset.id`, absent for native SUI (synthesised to `0x2::sui::SUI` when `asset.type === 'NATIVE'`)
  - `raw_value` is a JS number, not a string
  - parser returns `null` on shape mismatch so a Blockaid field rename degrades to "no preview" rather than crashing consumers

The existing validation pipeline keeps `options: ['validation']` to stay byte-for-byte compatible with current callers. Both options can be requested in a single scan.

Closes #671

## Test plan

- [ ] `yarn typecheck` passes
- [ ] `yarn lint` passes
- [ ] Manual: hit `/sui/transaction/scan` via `getSuiTxBlockaidSimulation` with a real Sui PTB and confirm the parser produces a `{ swap }` headline for a swap and `{ transfer }` for a single-asset send
- [ ] Manual: confirm a malformed / empty `account_summary` returns `null` (no throw)
- [ ] Manual: existing `getSuiTxBlockaidValidation` still returns validation only — no behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transaction simulation and preview support for the Sui blockchain, showing swap and transfer previews before execution.
  * MPC-driven simulation input support enabling Sui transactions to be simulated via the signing flow.

* **Bug Fixes**
  * Parser errors now degrade to “no preview” instead of breaking the preview experience, improving resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->