### PR TITLE
Add THORChain limit swap memo builder

### DIFF
--- a/.changeset/thorchain-limit-swap-memos.md
+++ b/.changeset/thorchain-limit-swap-memos.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/core-chain': minor
+'@vultisig/sdk': patch
+---
+
+Add THORChain limit swap memo builder, validation helpers, and JSON test vectors.

--- a/package.json
+++ b/package.json
@@ -191,6 +191,7 @@
     "readable-stream": "3.6.2",
     "@lifi/sdk/@solana/web3.js": "1.98.4",
     "@cosmjs/encoding/@scure/base": "1.2.6",
+    "shell-quote": "1.8.4",
     "tmp@npm:^0.0.33": "0.2.6",
     "tmp@npm:^0.2.0": "0.2.6"
   }

--- a/packages/core/chain/fixtures/limit-swap-memos.json
+++ b/packages/core/chain/fixtures/limit-swap-memos.json
@@ -1,0 +1,170 @@
+[
+  {
+    "name": "eth-to-btc-12h",
+    "source_chain_kind": "other",
+    "affiliate_included": true,
+    "inputs": {
+      "source_asset": "ETH.ETH",
+      "source_amount": 100000000,
+      "target_asset": "BTC.BTC",
+      "dest_addr": "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+      "target_price": 0.04,
+      "expiry_hours": 12
+    },
+    "expected_memo": "=<:BTC.BTC:bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh:4000000/7200/0:v0:50"
+  },
+  {
+    "name": "eth-to-btc-24h",
+    "source_chain_kind": "other",
+    "affiliate_included": true,
+    "inputs": {
+      "source_asset": "ETH.ETH",
+      "source_amount": 100000000,
+      "target_asset": "BTC.BTC",
+      "dest_addr": "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+      "target_price": 0.04,
+      "expiry_hours": 24
+    },
+    "expected_memo": "=<:BTC.BTC:bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh:4000000/14400/0:v0:50"
+  },
+  {
+    "name": "eth-to-btc-3d",
+    "source_chain_kind": "other",
+    "affiliate_included": true,
+    "inputs": {
+      "source_asset": "ETH.ETH",
+      "source_amount": 100000000,
+      "target_asset": "BTC.BTC",
+      "dest_addr": "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+      "target_price": 0.04,
+      "expiry_hours": 72
+    },
+    "expected_memo": "=<:BTC.BTC:bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh:4000000/43200/0:v0:50"
+  },
+  {
+    "name": "btc-to-eth-12h",
+    "source_chain_kind": "utxo",
+    "affiliate_included": true,
+    "inputs": {
+      "source_asset": "BTC.BTC",
+      "source_amount": 100000000,
+      "target_asset": "ETH.ETH",
+      "dest_addr": "0x742d35Cc6634C0532925a3b844Bc9e7595f12345",
+      "target_price": 16,
+      "expiry_hours": 12
+    },
+    "expected_memo": "=<:ETH.ETH:0x742d35Cc6634C0532925a3b844Bc9e7595f12345:1600000000/7200/0:v0:50"
+  },
+  {
+    "name": "btc-to-eth-24h",
+    "source_chain_kind": "utxo",
+    "affiliate_included": true,
+    "inputs": {
+      "source_asset": "BTC.BTC",
+      "source_amount": 100000000,
+      "target_asset": "ETH.ETH",
+      "dest_addr": "0x742d35Cc6634C0532925a3b844Bc9e7595f12345",
+      "target_price": 16,
+      "expiry_hours": 24
+    },
+    "expected_memo": "=<:ETH.ETH:0x742d35Cc6634C0532925a3b844Bc9e7595f12345:1600000000/14400/0:v0:50"
+  },
+  {
+    "name": "btc-to-eth-3d",
+    "source_chain_kind": "utxo",
+    "affiliate_included": true,
+    "inputs": {
+      "source_asset": "BTC.BTC",
+      "source_amount": 100000000,
+      "target_asset": "ETH.ETH",
+      "dest_addr": "0x742d35Cc6634C0532925a3b844Bc9e7595f12345",
+      "target_price": 16,
+      "expiry_hours": 72
+    },
+    "expected_memo": "=<:ETH.ETH:0x742d35Cc6634C0532925a3b844Bc9e7595f12345:1600000000/43200/0:v0:50"
+  },
+  {
+    "name": "usdt-to-btc-12h",
+    "source_chain_kind": "other",
+    "affiliate_included": true,
+    "inputs": {
+      "source_asset": "ETH.USDT-0XDAC17F958D2EE523A2206206994597C13D831EC7",
+      "source_amount": 100000000,
+      "target_asset": "BTC.BTC",
+      "dest_addr": "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+      "target_price": 0.00001,
+      "expiry_hours": 12
+    },
+    "expected_memo": "=<:BTC.BTC:bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh:1000/7200/0:v0:50"
+  },
+  {
+    "name": "usdt-to-btc-24h",
+    "source_chain_kind": "other",
+    "affiliate_included": true,
+    "inputs": {
+      "source_asset": "ETH.USDT-0XDAC17F958D2EE523A2206206994597C13D831EC7",
+      "source_amount": 100000000,
+      "target_asset": "BTC.BTC",
+      "dest_addr": "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+      "target_price": 0.00001,
+      "expiry_hours": 24
+    },
+    "expected_memo": "=<:BTC.BTC:bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh:1000/14400/0:v0:50"
+  },
+  {
+    "name": "usdt-to-btc-3d",
+    "source_chain_kind": "other",
+    "affiliate_included": true,
+    "inputs": {
+      "source_asset": "ETH.USDT-0XDAC17F958D2EE523A2206206994597C13D831EC7",
+      "source_amount": 100000000,
+      "target_asset": "BTC.BTC",
+      "dest_addr": "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+      "target_price": 0.00001,
+      "expiry_hours": 72
+    },
+    "expected_memo": "=<:BTC.BTC:bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh:1000/43200/0:v0:50"
+  },
+  {
+    "name": "btc-to-rune-12h",
+    "source_chain_kind": "utxo",
+    "affiliate_included": true,
+    "inputs": {
+      "source_asset": "BTC.BTC",
+      "source_amount": 100000000,
+      "target_asset": "THOR.RUNE",
+      "dest_addr": "thor1x2whgc2nt665y0kc44uywhynazvp0l8tp0vtu6",
+      "target_price": 10,
+      "expiry_hours": 12
+    },
+    "expected_memo": "=<:THOR.RUNE:thor1x2whgc2nt665y0kc44uywhynazvp0l8tp0vtu6:1000000000/7200/0:v0:50"
+  },
+  {
+    "name": "btc-to-rune-24h",
+    "source_chain_kind": "utxo",
+    "affiliate_included": false,
+    "inputs": {
+      "source_asset": "BTC.BTC",
+      "source_amount": 100000000,
+      "target_asset": "THOR.RUNE",
+      "dest_addr": "thor1x2whgc2nt665y0kc44uywhynazvp0l8tp0vtu6",
+      "target_price": 10,
+      "expiry_hours": 24
+    },
+    "expected_memo": "=<:THOR.RUNE:thor1x2whgc2nt665y0kc44uywhynazvp0l8tp0vtu6:1000000000/14400/0"
+  },
+  {
+    "name": "btc-to-rune-3d",
+    "source_chain_kind": "utxo",
+    "affiliate_included": false,
+    "inputs": {
+      "source_asset": "BTC.BTC",
+      "source_amount": 100000000,
+      "target_asset": "THOR.RUNE",
+      "dest_addr": "thor1x2whgc2nt665y0kc44uywhynazvp0l8tp0vtu6",
+      "target_price": 10,
+      "expiry_hours": 72
+    },
+    "expected_memo": "=<:THOR.RUNE:thor1x2whgc2nt665y0kc44uywhynazvp0l8tp0vtu6:1000000000/43200/0"
+  }
+]

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -11,7 +11,8 @@
   "type": "module",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "fixtures"
   ],
   "exports": {
     "./amount/fromChainAmount": {
@@ -1074,6 +1075,7 @@
       "import": "./dist/coin/utils/sortCoinsByBalance.js",
       "default": "./dist/coin/utils/sortCoinsByBalance.js"
     },
+    "./fixtures/limit-swap-memos.json": "./fixtures/limit-swap-memos.json",
     "./package.json": "./package.json",
     "./publicKey/address/bittensor": {
       "types": "./dist/publicKey/address/bittensor.d.ts",
@@ -1469,6 +1471,11 @@
       "types": "./dist/swap/native/asset/toNativeSwapAsset.d.ts",
       "import": "./dist/swap/native/asset/toNativeSwapAsset.js",
       "default": "./dist/swap/native/asset/toNativeSwapAsset.js"
+    },
+    "./swap/native/limitSwapMemo": {
+      "types": "./dist/swap/native/limitSwapMemo.d.ts",
+      "import": "./dist/swap/native/limitSwapMemo.js",
+      "default": "./dist/swap/native/limitSwapMemo.js"
     },
     "./swap/native/minimum/getNativeSwapMinAmountIn": {
       "types": "./dist/swap/native/minimum/getNativeSwapMinAmountIn.d.ts",

--- a/packages/core/chain/swap/native/limitSwapMemo.test.ts
+++ b/packages/core/chain/swap/native/limitSwapMemo.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest'
+
+import limitSwapMemoFixtures from '../../fixtures/limit-swap-memos.json'
+import type { LimitSwapMemoInput, LimitSwapSourceChainKind } from './limitSwapMemo'
+import {
+  assertMemoByteLength,
+  buildLimitSwapMemo,
+  getLimitSwapLimitAmount,
+  getLimitSwapSourceChainKind,
+  validateLimitSwapInputs,
+} from './limitSwapMemo'
+
+type LimitSwapMemoFixture = {
+  name: string
+  source_chain_kind: LimitSwapSourceChainKind
+  affiliate_included: boolean
+  inputs: LimitSwapMemoInput
+  expected_memo: string
+}
+
+const fixtures = limitSwapMemoFixtures as LimitSwapMemoFixture[]
+
+const validInput: LimitSwapMemoInput = {
+  source_asset: 'BTC.BTC',
+  source_amount: 100_000_000,
+  target_asset: 'ETH.ETH',
+  dest_addr: '0x742d35Cc6634C0532925a3b844Bc9e7595f12345',
+  target_price: 16,
+  expiry_hours: 24,
+}
+
+describe('buildLimitSwapMemo', () => {
+  it.each(fixtures)('matches fixture $name', ({ inputs, expected_memo, source_chain_kind, affiliate_included }) => {
+    const memo = buildLimitSwapMemo(inputs)
+
+    expect(memo).toBe(expected_memo)
+    expect(getLimitSwapSourceChainKind(inputs.source_asset)).toBe(source_chain_kind)
+    expect(memo.includes(':v0:50')).toBe(affiliate_included)
+  })
+
+  it('computes LIM with integer math and floors sub-1e8 remainders', () => {
+    expect(
+      getLimitSwapLimitAmount({
+        source_amount: 123_456_789,
+        target_price: '1.23456789',
+      })
+    ).toBe(152_415_787n)
+  })
+
+  it('drops affiliate on UTXO source memos only when required by the 80-byte cap', () => {
+    expect(
+      buildLimitSwapMemo({
+        ...validInput,
+        target_asset: 'THOR.RUNE',
+        dest_addr: 'thor1x2whgc2nt665y0kc44uywhynazvp0l8tp0vtu6',
+        expiry_hours: 24,
+      })
+    ).toBe('=<:THOR.RUNE:thor1x2whgc2nt665y0kc44uywhynazvp0l8tp0vtu6:1600000000/14400/0')
+  })
+})
+
+describe('validateLimitSwapInputs', () => {
+  it('accepts valid inputs', () => {
+    expect(() => validateLimitSwapInputs(validInput)).not.toThrow()
+  })
+
+  it('rejects unsupported source assets', () => {
+    expect(() =>
+      validateLimitSwapInputs({
+        ...validInput,
+        source_asset: 'NOPE.NOPE',
+      })
+    ).toThrow(/unsupported THORChain asset prefix/)
+  })
+
+  it('rejects unsupported target assets', () => {
+    expect(() =>
+      validateLimitSwapInputs({
+        ...validInput,
+        target_asset: 'NOPE.NOPE',
+      })
+    ).toThrow(/unsupported THORChain asset prefix/)
+  })
+
+  it('rejects malformed destination addresses', () => {
+    expect(() =>
+      validateLimitSwapInputs({
+        ...validInput,
+        dest_addr: 'not-an-address',
+      })
+    ).toThrow(/valid Ethereum address/)
+
+    expect(() =>
+      validateLimitSwapInputs({
+        ...validInput,
+        dest_addr: 'bc1q has spaces',
+      })
+    ).toThrow(/whitespace/)
+
+    expect(() =>
+      validateLimitSwapInputs({
+        ...validInput,
+        dest_addr: 'aaaaaaaaaa',
+      })
+    ).toThrow(/valid Ethereum address/)
+  })
+
+  it('rejects invalid source amounts', () => {
+    expect(() =>
+      validateLimitSwapInputs({
+        ...validInput,
+        source_amount: 0,
+      })
+    ).toThrow(/positive safe integer/)
+
+    expect(() =>
+      validateLimitSwapInputs({
+        ...validInput,
+        source_amount: '1.1',
+      })
+    ).toThrow(/positive integer/)
+  })
+
+  it('rejects non-positive target prices', () => {
+    expect(() =>
+      validateLimitSwapInputs({
+        ...validInput,
+        target_price: '0',
+      })
+    ).toThrow(/greater than 0/)
+  })
+
+  it('rejects target prices with more than 8 fractional digits', () => {
+    expect(() =>
+      validateLimitSwapInputs({
+        ...validInput,
+        target_price: '1.123456789',
+      })
+    ).toThrow(/at most 8 fractional digits/)
+  })
+
+  it('accepts tiny numeric target prices with 8 decimal places', () => {
+    expect(
+      getLimitSwapLimitAmount({
+        source_amount: 100_000_000,
+        target_price: 0.00000001,
+      })
+    ).toBe(1n)
+  })
+
+  it('rejects unsupported expiries', () => {
+    expect(() =>
+      validateLimitSwapInputs({
+        ...validInput,
+        expiry_hours: 6 as 12,
+      })
+    ).toThrow(/expiry_hours/)
+  })
+
+  it.each(['BTC.BTC', 'BCH.BCH', 'DASH.DASH', 'DOGE.DOGE', 'LTC.LTC', 'ZEC.ZEC'])(
+    'applies the UTXO memo byte rule for %s sources',
+    source_asset => {
+      expect(getLimitSwapSourceChainKind(source_asset)).toBe('utxo')
+      expect(
+        new TextEncoder().encode(
+          buildLimitSwapMemo({
+            ...validInput,
+            source_asset,
+          })
+        ).length
+      ).toBeLessThanOrEqual(80)
+    }
+  )
+})
+
+describe('assertMemoByteLength', () => {
+  it('measures UTF-8 bytes, not JavaScript string length', () => {
+    expect(() => assertMemoByteLength('€'.repeat(27), 'utxo')).toThrow(/81 bytes/)
+  })
+
+  it('throws when a UTXO memo exceeds 80 bytes', () => {
+    expect(() => assertMemoByteLength('x'.repeat(81), 'utxo')).toThrow(/exceeding utxo limit 80/)
+  })
+
+  it('allows non-UTXO memos up to 250 bytes', () => {
+    expect(() => assertMemoByteLength('x'.repeat(250), 'other')).not.toThrow()
+  })
+})

--- a/packages/core/chain/swap/native/limitSwapMemo.test.ts
+++ b/packages/core/chain/swap/native/limitSwapMemo.test.ts
@@ -103,6 +103,27 @@ describe('validateLimitSwapInputs', () => {
         dest_addr: 'aaaaaaaaaa',
       })
     ).toThrow(/valid Ethereum address/)
+
+    expect(() =>
+      validateLimitSwapInputs({
+        ...validInput,
+        dest_addr: 'thor1abc:def',
+      })
+    ).toThrow(/must not contain memo separators/)
+
+    expect(() =>
+      validateLimitSwapInputs({
+        ...validInput,
+        dest_addr: 'thor1abc/def',
+      })
+    ).toThrow(/must not contain memo separators/)
+
+    expect(() =>
+      validateLimitSwapInputs({
+        ...validInput,
+        dest_addr: 'thor1x2whgc2nt665y0kc44uywhynazvp0l8tp0vtu6\u20ac',
+      })
+    ).toThrow(/printable ASCII/)
   })
 
   it('rejects invalid source amounts', () => {

--- a/packages/core/chain/swap/native/limitSwapMemo.ts
+++ b/packages/core/chain/swap/native/limitSwapMemo.ts
@@ -1,0 +1,244 @@
+import { fromBech32 } from '@cosmjs/encoding'
+
+import { Chain } from '../../Chain'
+import { getChainKind } from '../../ChainKind'
+import { chainPrefixToChain } from '../../chains/cosmos/thor/lp/lpChainMap'
+import { assertValidPoolId } from '../../chains/cosmos/thor/lp/pools'
+import { baseAffiliateBps } from '../affiliate/config'
+import { nativeSwapAffiliateConfig } from './nativeSwapAffiliateConfig'
+
+export const limitSwapExpiryHours = [12, 24, 72] as const
+export type LimitSwapExpiryHours = (typeof limitSwapExpiryHours)[number]
+
+export type LimitSwapNumericInput = bigint | number | string
+
+export type LimitSwapMemoInput = {
+  source_asset: string
+  source_amount: LimitSwapNumericInput
+  target_asset: string
+  dest_addr: string
+  target_price: LimitSwapNumericInput
+  expiry_hours: LimitSwapExpiryHours
+}
+
+export type LimitSwapSourceChainKind = 'utxo' | 'other'
+
+export const limitSwapMemoByteLimit: Record<LimitSwapSourceChainKind, number> = {
+  utxo: 80,
+  other: 250,
+}
+
+const priceScale = 100_000_000n
+
+const expiryHoursToIntervalBlocks: Record<LimitSwapExpiryHours, number> = {
+  12: 7_200,
+  24: 14_400,
+  72: 43_200,
+}
+
+const assertMemoSegmentSafe = (value: string, fieldName: string): void => {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${fieldName} must be a non-empty string`)
+  }
+  if (value.includes(':') || value.includes('/')) {
+    throw new Error(`${fieldName} must not contain memo separators ":" or "/"`)
+  }
+  if (/\s/.test(value)) {
+    throw new Error(`${fieldName} must not contain whitespace`)
+  }
+  if (!/^[\x21-\x7E]+$/.test(value)) {
+    throw new Error(`${fieldName} must contain printable ASCII characters only`)
+  }
+}
+
+const getAssetChainPrefix = (asset: string): string => {
+  const [prefix] = asset.split('.')
+  return prefix
+}
+
+const getSupportedThorchainAssetChain = (asset: string, fieldName: string): Chain => {
+  assertValidPoolId(asset)
+
+  const prefix = getAssetChainPrefix(asset)
+  const chain = chainPrefixToChain(prefix)
+  if (!chain) {
+    throw new Error(`${fieldName} has unsupported THORChain asset prefix: ${prefix}`)
+  }
+  return chain
+}
+
+const parsePositiveInteger = (value: LimitSwapNumericInput, fieldName: string): bigint => {
+  if (typeof value === 'bigint') {
+    if (value > 0n) return value
+    throw new Error(`${fieldName} must be greater than 0`)
+  }
+
+  if (typeof value === 'number') {
+    if (Number.isSafeInteger(value) && value > 0) return BigInt(value)
+    throw new Error(`${fieldName} must be a positive safe integer`)
+  }
+
+  const normalized = value.trim()
+  if (!/^[1-9]\d*$/.test(normalized)) {
+    throw new Error(`${fieldName} must be a positive integer string`)
+  }
+  return BigInt(normalized)
+}
+
+const parsePositiveDecimal = (value: LimitSwapNumericInput, fieldName: string): bigint => {
+  if (typeof value === 'bigint') {
+    if (value > 0n) return value * priceScale
+    throw new Error(`${fieldName} must be greater than 0`)
+  }
+
+  let normalized: string
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new Error(`${fieldName} must be greater than 0`)
+    }
+    normalized = value.toString()
+    if (normalized.includes('e')) {
+      normalized = value.toFixed(8)
+    }
+    if (Number(normalized) !== value) {
+      throw new Error(`${fieldName} must be a positive decimal with at most 8 fractional digits`)
+    }
+  } else {
+    normalized = value.trim()
+  }
+
+  const match = normalized.match(/^(\d+)(?:\.(\d{1,8})?)?$/)
+  if (!match) {
+    throw new Error(`${fieldName} must be a positive decimal with at most 8 fractional digits`)
+  }
+
+  const [, whole, fractional = ''] = match
+  const scaled = BigInt(whole) * priceScale + BigInt(fractional.padEnd(8, '0'))
+  if (scaled <= 0n) {
+    throw new Error(`${fieldName} must be greater than 0`)
+  }
+  return scaled
+}
+
+export const getLimitSwapSourceChainKind = (sourceAsset: string): LimitSwapSourceChainKind => {
+  const chain = getSupportedThorchainAssetChain(sourceAsset, 'source_asset')
+  return getChainKind(chain) === 'utxo' ? 'utxo' : 'other'
+}
+
+export const getLimitSwapIntervalBlocks = (expiryHours: LimitSwapExpiryHours): number => {
+  const interval = expiryHoursToIntervalBlocks[expiryHours]
+  if (!interval) {
+    throw new Error(`expiry_hours must be one of ${limitSwapExpiryHours.join(', ')}, got ${expiryHours}`)
+  }
+  return interval
+}
+
+export const getLimitSwapLimitAmount = ({
+  source_amount,
+  target_price,
+}: Pick<LimitSwapMemoInput, 'source_amount' | 'target_price'>): bigint => {
+  const sourceAmount = parsePositiveInteger(source_amount, 'source_amount')
+  const targetPrice = parsePositiveDecimal(target_price, 'target_price')
+
+  return (sourceAmount * targetPrice) / priceScale
+}
+
+export const assertMemoByteLength = (memo: string, sourceChainKind: LimitSwapSourceChainKind): void => {
+  const limit = limitSwapMemoByteLimit[sourceChainKind]
+  if (!limit) {
+    throw new Error(`Unknown source chain kind: ${sourceChainKind}`)
+  }
+
+  const byteLength = new TextEncoder().encode(memo).length
+  if (byteLength > limit) {
+    throw new Error(`THORChain limit swap memo is ${byteLength} bytes, exceeding ${sourceChainKind} limit ${limit}`)
+  }
+}
+
+const base58AddressChars = '1-9A-HJ-NP-Za-km-z'
+
+const isBech32Address = (address: string, prefix: string): boolean => {
+  try {
+    const decoded = fromBech32(address)
+    return decoded.prefix === prefix && decoded.data.length > 0
+  } catch {
+    return false
+  }
+}
+
+const isEvmAddress = (address: string): boolean => /^0x[0-9a-fA-F]{40}$/.test(address)
+
+const limitSwapDestinationValidators: Partial<Record<Chain, (address: string) => boolean>> = {
+  [Chain.Arbitrum]: isEvmAddress,
+  [Chain.Avalanche]: isEvmAddress,
+  [Chain.Base]: isEvmAddress,
+  [Chain.BSC]: isEvmAddress,
+  [Chain.Ethereum]: isEvmAddress,
+
+  [Chain.Bitcoin]: address =>
+    new RegExp(`^(bc1[ac-hj-np-z02-9]{11,71}|[13][${base58AddressChars}]{25,34})$`, 'i').test(address),
+  [Chain.BitcoinCash]: address =>
+    new RegExp(`^([qp][0-9a-z]{41}|[13][${base58AddressChars}]{25,34})$`, 'i').test(address),
+  [Chain.Dash]: address => new RegExp(`^X[${base58AddressChars}]{33}$`).test(address),
+  [Chain.Dogecoin]: address => new RegExp(`^D[5-9A-HJ-NP-U][${base58AddressChars}]{32}$`).test(address),
+  [Chain.Litecoin]: address =>
+    new RegExp(`^(ltc1[ac-hj-np-z02-9]{11,71}|[LM3][${base58AddressChars}]{25,34})$`, 'i').test(address),
+  [Chain.Zcash]: address => new RegExp(`^t[13][${base58AddressChars}]{33}$`).test(address),
+
+  [Chain.Cosmos]: address => isBech32Address(address, 'cosmos'),
+  [Chain.Kujira]: address => isBech32Address(address, 'kujira'),
+  [Chain.THORChain]: address => isBech32Address(address, 'thor'),
+
+  [Chain.Ripple]: address => new RegExp(`^r[${base58AddressChars}]{24,34}$`).test(address),
+  [Chain.Tron]: address => new RegExp(`^T[${base58AddressChars}]{33}$`).test(address),
+}
+
+const assertValidLimitSwapDestinationAddress = (targetChain: Chain, address: string): void => {
+  const validator = limitSwapDestinationValidators[targetChain]
+  if (!validator) {
+    throw new Error(`target_asset chain ${targetChain} is not supported for limit swap destinations`)
+  }
+  if (!validator(address)) {
+    throw new Error(`dest_addr is not a valid ${targetChain} address`)
+  }
+}
+
+export const validateLimitSwapInputs = (inputs: LimitSwapMemoInput): void => {
+  getSupportedThorchainAssetChain(inputs.source_asset, 'source_asset')
+  const targetChain = getSupportedThorchainAssetChain(inputs.target_asset, 'target_asset')
+  assertMemoSegmentSafe(inputs.dest_addr, 'dest_addr')
+  assertValidLimitSwapDestinationAddress(targetChain, inputs.dest_addr)
+
+  parsePositiveInteger(inputs.source_amount, 'source_amount')
+  parsePositiveDecimal(inputs.target_price, 'target_price')
+  getLimitSwapIntervalBlocks(inputs.expiry_hours)
+}
+
+const buildMemo = (inputs: LimitSwapMemoInput, includeAffiliate: boolean): string => {
+  const limit = getLimitSwapLimitAmount(inputs)
+  const interval = getLimitSwapIntervalBlocks(inputs.expiry_hours)
+  const memo = `=<:${inputs.target_asset}:${inputs.dest_addr}:${limit}/${interval}/0`
+
+  return includeAffiliate ? `${memo}:${nativeSwapAffiliateConfig.affiliateFeeAddress}:${baseAffiliateBps}` : memo
+}
+
+export const buildLimitSwapMemo = (inputs: LimitSwapMemoInput): string => {
+  validateLimitSwapInputs(inputs)
+
+  const sourceChainKind = getLimitSwapSourceChainKind(inputs.source_asset)
+  const affiliateMemo = buildMemo(inputs, true)
+
+  if (sourceChainKind === 'utxo') {
+    try {
+      assertMemoByteLength(affiliateMemo, sourceChainKind)
+      return affiliateMemo
+    } catch {
+      const memoWithoutAffiliate = buildMemo(inputs, false)
+      assertMemoByteLength(memoWithoutAffiliate, sourceChainKind)
+      return memoWithoutAffiliate
+    }
+  }
+
+  assertMemoByteLength(affiliateMemo, sourceChainKind)
+  return affiliateMemo
+}

--- a/scripts/generate-shared-exports.mjs
+++ b/scripts/generate-shared-exports.mjs
@@ -5,17 +5,25 @@ import path from 'node:path'
  * Replaces package.json "exports" with explicit subpath entries so Node/TS/Vite
  * resolve both flat modules (foo.js) and directory modules (foo/index.js).
  */
-function walkJsFiles(distDir, visitor, rel = '') {
-  for (const name of readdirSync(distDir)) {
-    const full = path.join(distDir, name)
+function walkFiles(dir, visitor, rel = '') {
+  for (const name of readdirSync(dir)) {
+    const full = path.join(dir, name)
     const st = statSync(full)
     const r = rel ? `${rel}/${name}` : name
     if (st.isDirectory()) {
-      walkJsFiles(full, visitor, r)
-    } else if (name.endsWith('.js') && !name.endsWith('.js.map')) {
-      visitor(r.replace(/\\/g, '/'))
+      walkFiles(full, visitor, r)
+    } else {
+      visitor(r.replace(/\\/g, '/'), name)
     }
   }
+}
+
+function walkJsFiles(distDir, visitor) {
+  walkFiles(distDir, (rel, name) => {
+    if (name.endsWith('.js') && !name.endsWith('.js.map')) {
+      visitor(rel)
+    }
+  })
 }
 
 function jsRelToExportKey(rel) {
@@ -36,7 +44,7 @@ function jsRelToImportPath(rel) {
   return `./dist/${rel}`
 }
 
-export function generateSharedExports(distDir) {
+export function generateSharedExports(distDir, { packageRoot = path.dirname(distDir) } = {}) {
   const byKey = new Map()
 
   walkJsFiles(distDir, rel => {
@@ -51,6 +59,15 @@ export function generateSharedExports(distDir) {
   })
 
   byKey.set('./package.json', './package.json')
+
+  const fixturesDir = path.join(packageRoot, 'fixtures')
+  if (existsSync(fixturesDir)) {
+    walkFiles(fixturesDir, (rel, name) => {
+      if (name.endsWith('.json')) {
+        byKey.set(`./fixtures/${rel}`, `./fixtures/${rel}`)
+      }
+    })
+  }
 
   const exportsField = Object.fromEntries([...byKey.entries()].sort(([a], [b]) => a.localeCompare(b)))
 
@@ -83,7 +100,9 @@ function exportValueKey(value) {
 export function diffSharedExports(packageJsonPath, distDir) {
   const pkg = readPackageJson(packageJsonPath)
   const actual = pkg.exports ?? {}
-  const expected = generateSharedExports(distDir)
+  const expected = generateSharedExports(distDir, {
+    packageRoot: path.dirname(packageJsonPath),
+  })
   const actualKeys = new Set(Object.keys(actual))
   const expectedKeys = new Set(Object.keys(expected))
 
@@ -159,6 +178,8 @@ export function getSharedExportDiffMessage(packageJsonPath, distDir, options) {
 
 export function applySharedExports(packageJsonPath, distDir) {
   const pkg = readPackageJson(packageJsonPath)
-  pkg.exports = generateSharedExports(distDir)
+  pkg.exports = generateSharedExports(distDir, {
+    packageRoot: path.dirname(packageJsonPath),
+  })
   writeFileSync(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`)
 }

--- a/scripts/generate-shared-exports.test.mjs
+++ b/scripts/generate-shared-exports.test.mjs
@@ -33,6 +33,12 @@ function scaffold(files, pkg = {}) {
   }
 }
 
+function writeFixture(root, rel, contents = '{}') {
+  const abs = path.join(root, 'fixtures', rel)
+  mkdirSync(path.dirname(abs), { recursive: true })
+  writeFileSync(abs, contents)
+}
+
 test('generateSharedExports maps flat, directory, and package.json exports', () => {
   const { dist, cleanup } = scaffold(['index.js', 'foo.js', 'bar/index.js'])
   try {
@@ -52,6 +58,25 @@ test('generateSharedExports maps flat, directory, and package.json exports', () 
         import: './dist/foo.js',
         default: './dist/foo.js',
       },
+      './package.json': './package.json',
+    })
+  } finally {
+    cleanup()
+  }
+})
+
+test('generateSharedExports maps package fixture JSON files', () => {
+  const { root, dist, cleanup } = scaffold(['index.js'])
+  writeFixture(root, 'limit-swap-memos.json', '[]')
+
+  try {
+    assert.deepEqual(generateSharedExports(dist), {
+      '.': {
+        types: './dist/index.d.ts',
+        import: './dist/index.js',
+        default: './dist/index.js',
+      },
+      './fixtures/limit-swap-memos.json': './fixtures/limit-swap-memos.json',
       './package.json': './package.json',
     })
   } finally {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19448,10 +19448,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:1.8.3":
-  version: 1.8.3
-  resolution: "shell-quote@npm:1.8.3"
-  checksum: 10c0/bee87c34e1e986cfb4c30846b8e6327d18874f10b535699866f368ade11ea4ee45433d97bf5eada22c4320c27df79c3a6a7eb1bf3ecfc47f2c997d9e5e2672fd
+"shell-quote@npm:1.8.4":
+  version: 1.8.4
+  resolution: "shell-quote@npm:1.8.4"
+  checksum: 10c0/86c93678bc394cb81f5ddcdc87df9c95d279ef9652775cd1cd1eed361404169a8d8cbaacaeed232ab09919e36ee1e5363863570390d78571f8c22b7f6312fb40
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #312

## Summary
- Added THORChain limit swap memo builder with validation, 12/24/72 hour expiry windows, and JSON vectors.
- Exported the builder and fixture JSON from @vultisig/core-chain for package consumers.
- Added a root shell-quote resolution to 1.8.4 intentionally because local check:ci quality:audit fails on the existing transitive 1.8.3 via concurrently; 1.8.4 is the first patched/current npm release for GHSA-w7jw-789q-3m8p / CVE-2026-9277.

## Checks
- yarn check:ci
- yarn node package export smoke test for @vultisig/core-chain/swap/native/limitSwapMemo and fixture JSON


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced THORChain limit swap functionality including automatic memo generation, comprehensive input validation for destination addresses, amounts, prices, and expiry windows, plus support for affiliate memo integration with automatic fallback handling.

* **Tests**
  * Added comprehensive test suite with fixture data covering multiple limit swap scenarios across different asset pairs and blockchain networks, including validation rules and edge cases.

* **Chores**
  * Updated package exports and dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->