### PR TITLE
fix(zcash): fetch live ZIP-243 branch id in SDK

### DIFF
--- a/.changeset/zcash-live-branch-id.md
+++ b/.changeset/zcash-live-branch-id.md
@@ -1,0 +1,7 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/core-mpc': patch
+'@vultisig/sdk': patch
+---
+
+Fetch the live Zcash ZIP-243 consensus branch ID for SDK signing and fail loudly instead of using a stale compiled fallback.

--- a/packages/core/chain/chains/utxo/zcashBranchId.test.ts
+++ b/packages/core/chain/chains/utxo/zcashBranchId.test.ts
@@ -1,0 +1,76 @@
+import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  getZcashBranchId,
+  getZcashBranchIdHex,
+  resetZcashBranchIdCacheForTests,
+  zcashBranchIdToNumber,
+  zcashBranchIdToWalletCoreHex,
+} from './zcashBranchId'
+
+vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
+  queryUrl: vi.fn(),
+}))
+
+const queryUrlMock = vi.mocked(queryUrl)
+
+describe('Zcash branch id', () => {
+  beforeEach(() => {
+    resetZcashBranchIdCacheForTests()
+    queryUrlMock.mockReset()
+  })
+
+  it('converts consensus.nextblock to WalletCore little-endian hex', () => {
+    expect(zcashBranchIdToWalletCoreHex('5437F330')).toBe('30f33754')
+    expect(zcashBranchIdToNumber('5437F330')).toBe(0x5437f330)
+  })
+
+  it('rejects malformed branch ids', () => {
+    expect(() => zcashBranchIdToWalletCoreHex('123')).toThrow('4-byte hex')
+    expect(() => zcashBranchIdToWalletCoreHex('not-hex!')).toThrow('4-byte hex')
+  })
+
+  it('fetches and caches the live branch id', async () => {
+    queryUrlMock.mockResolvedValue({
+      result: {
+        consensus: {
+          nextblock: '5437f330',
+        },
+      },
+      error: null,
+    })
+
+    await expect(getZcashBranchIdHex()).resolves.toBe('30f33754')
+    await expect(getZcashBranchId()).resolves.toBe(0x5437f330)
+    await expect(getZcashBranchIdHex()).resolves.toBe('30f33754')
+
+    expect(queryUrlMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('dedupes concurrent fetches', async () => {
+    queryUrlMock.mockResolvedValue({
+      result: {
+        consensus: {
+          nextblock: '5437f330',
+        },
+      },
+      error: null,
+    })
+
+    await expect(Promise.all([getZcashBranchIdHex(), getZcashBranchIdHex()])).resolves.toEqual(['30f33754', '30f33754'])
+
+    expect(queryUrlMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('fails loud when RPC response has no branch id', async () => {
+    queryUrlMock.mockResolvedValue({
+      result: {
+        consensus: {},
+      },
+      error: null,
+    })
+
+    await expect(getZcashBranchIdHex()).rejects.toThrow('consensus.nextblock')
+  })
+})

--- a/packages/core/chain/chains/utxo/zcashBranchId.test.ts
+++ b/packages/core/chain/chains/utxo/zcashBranchId.test.ts
@@ -1,5 +1,5 @@
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   getZcashBranchId,
@@ -19,6 +19,10 @@ describe('Zcash branch id', () => {
   beforeEach(() => {
     resetZcashBranchIdCacheForTests()
     queryUrlMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('converts consensus.nextblock to WalletCore little-endian hex', () => {
@@ -72,5 +76,25 @@ describe('Zcash branch id', () => {
     })
 
     await expect(getZcashBranchIdHex()).rejects.toThrow('consensus.nextblock')
+  })
+
+  it('times out when RPC does not respond', async () => {
+    vi.useFakeTimers()
+
+    queryUrlMock.mockImplementation(
+      (_url, options) =>
+        new Promise((_resolve, reject) => {
+          options?.signal?.addEventListener('abort', () => {
+            reject(new DOMException('aborted', 'AbortError'))
+          })
+        })
+    )
+
+    const promise = getZcashBranchIdHex()
+    const expectation = expect(promise).rejects.toThrow('Zcash RPC timed out')
+
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    await expectation
   })
 })

--- a/packages/core/chain/chains/utxo/zcashBranchId.ts
+++ b/packages/core/chain/chains/utxo/zcashBranchId.ts
@@ -1,0 +1,96 @@
+import { rootApiUrl } from '@vultisig/core-config'
+import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+
+const cacheTtlMs = 60 * 60 * 1000
+const zcashRpcUrl = `${rootApiUrl}/zcash`
+
+type ZcashBlockchainInfoResponse = {
+  result?: {
+    consensus?: {
+      nextblock?: string
+    }
+  }
+  error?: {
+    message?: string
+  } | null
+}
+
+type Cache = {
+  value: string
+  expiresAt: number
+}
+
+let cache: Cache | undefined
+let inFlight: Promise<string> | undefined
+
+const assertFourByteHex = (hex: string): string => {
+  if (!/^[0-9a-fA-F]{8}$/.test(hex)) {
+    throw new Error(`Invalid Zcash consensus branch id: expected 4-byte hex, received "${hex}"`)
+  }
+
+  return hex.toLowerCase()
+}
+
+export const zcashBranchIdToWalletCoreHex = (bigEndianHex: string): string => {
+  const hex = assertFourByteHex(bigEndianHex)
+  return hex.match(/../g)!.reverse().join('')
+}
+
+export const zcashBranchIdToNumber = (bigEndianHex: string): number =>
+  Number.parseInt(assertFourByteHex(bigEndianHex), 16)
+
+const fetchZcashBranchIdHex = async (): Promise<string> => {
+  const response = await queryUrl<ZcashBlockchainInfoResponse>(zcashRpcUrl, {
+    body: {
+      jsonrpc: '1.0',
+      id: 'vultisig-sdk',
+      method: 'getblockchaininfo',
+      params: [],
+    },
+  })
+
+  if (response.error) {
+    throw new Error(`Zcash RPC error: ${response.error.message ?? 'unknown error'}`)
+  }
+
+  const nextBlock = response.result?.consensus?.nextblock
+  if (!nextBlock) {
+    throw new Error('Zcash RPC response is missing consensus.nextblock')
+  }
+
+  return zcashBranchIdToWalletCoreHex(nextBlock)
+}
+
+export const getZcashBranchIdHex = async (): Promise<string> => {
+  const now = Date.now()
+  if (cache && cache.expiresAt > now) {
+    return cache.value
+  }
+
+  if (!inFlight) {
+    inFlight = fetchZcashBranchIdHex()
+      .then(value => {
+        cache = {
+          value,
+          expiresAt: Date.now() + cacheTtlMs,
+        }
+        return value
+      })
+      .finally(() => {
+        inFlight = undefined
+      })
+  }
+
+  return inFlight
+}
+
+export const getZcashBranchId = async (): Promise<number> => {
+  const walletCoreHex = await getZcashBranchIdHex()
+  const bigEndianHex = walletCoreHex.match(/../g)!.reverse().join('')
+  return zcashBranchIdToNumber(bigEndianHex)
+}
+
+export const resetZcashBranchIdCacheForTests = () => {
+  cache = undefined
+  inFlight = undefined
+}

--- a/packages/core/chain/chains/utxo/zcashBranchId.ts
+++ b/packages/core/chain/chains/utxo/zcashBranchId.ts
@@ -2,6 +2,7 @@ import { rootApiUrl } from '@vultisig/core-config'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
 const cacheTtlMs = 60 * 60 * 1000
+const rpcTimeoutMs = 10_000
 const zcashRpcUrl = `${rootApiUrl}/zcash`
 
 type ZcashBlockchainInfoResponse = {
@@ -40,14 +41,31 @@ export const zcashBranchIdToNumber = (bigEndianHex: string): number =>
   Number.parseInt(assertFourByteHex(bigEndianHex), 16)
 
 const fetchZcashBranchIdHex = async (): Promise<string> => {
-  const response = await queryUrl<ZcashBlockchainInfoResponse>(zcashRpcUrl, {
-    body: {
-      jsonrpc: '1.0',
-      id: 'vultisig-sdk',
-      method: 'getblockchaininfo',
-      params: [],
-    },
-  })
+  const controller = new AbortController()
+  const timeout = setTimeout(() => {
+    controller.abort()
+  }, rpcTimeoutMs)
+
+  let response: ZcashBlockchainInfoResponse
+  try {
+    response = await queryUrl<ZcashBlockchainInfoResponse>(zcashRpcUrl, {
+      body: {
+        jsonrpc: '1.0',
+        id: 'vultisig-sdk',
+        method: 'getblockchaininfo',
+        params: [],
+      },
+      signal: controller.signal,
+    })
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error('Zcash RPC timed out while fetching consensus branch id')
+    }
+
+    throw error
+  } finally {
+    clearTimeout(timeout)
+  }
 
   if (response.error) {
     throw new Error(`Zcash RPC error: ${response.error.message ?? 'unknown error'}`)

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -785,6 +785,11 @@
       "import": "./dist/chains/utxo/tx/UtxoScriptType.js",
       "default": "./dist/chains/utxo/tx/UtxoScriptType.js"
     },
+    "./chains/utxo/zcashBranchId": {
+      "types": "./dist/chains/utxo/zcashBranchId.d.ts",
+      "import": "./dist/chains/utxo/zcashBranchId.js",
+      "default": "./dist/chains/utxo/zcashBranchId.js"
+    },
     "./coin/AccountCoin": {
       "types": "./dist/coin/AccountCoin.d.ts",
       "import": "./dist/coin/AccountCoin.js",

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/polkadot/refine.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/polkadot/refine.ts
@@ -39,7 +39,7 @@ export const refinePolkadotChainSpecific = async ({
     },
   })
 
-  const [txInputData] = getEncodedSigningInputs({
+  const [txInputData] = await getEncodedSigningInputs({
     keysignPayload: payloadWithChainSpecific,
     walletCore,
   })

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/sui/refine.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/sui/refine.ts
@@ -26,7 +26,7 @@ export const refineSuiChainSpecific = async ({
 }: RefineSuiChainSpecificInput): Promise<SuiSpecific> => {
   const client = getSuiClient()
 
-  const [txInputData] = getEncodedSigningInputs({
+  const [txInputData] = await getEncodedSigningInputs({
     keysignPayload: create(KeysignPayloadSchema, {
       ...keysignPayload,
       blockchainSpecific: {

--- a/packages/core/mpc/keysign/cosigner.ts
+++ b/packages/core/mpc/keysign/cosigner.ts
@@ -158,7 +158,7 @@ async function main() {
     chainPublicKeys: vault.chainPublicKeys,
   })
 
-  const inputs = getEncodedSigningInputs({
+  const inputs = await getEncodedSigningInputs({
     keysignPayload,
     walletCore,
     publicKey,

--- a/packages/core/mpc/keysign/fee/index.ts
+++ b/packages/core/mpc/keysign/fee/index.ts
@@ -39,7 +39,7 @@ const resolvers: Record<ChainKind, FeeAmountResolver> = {
   tron: getTronFeeAmount,
 }
 
-export const getFeeAmount = (input: Input): bigint => {
+export const getFeeAmount = async (input: Input): Promise<bigint> => {
   const chain = getKeysignChain(input.keysignPayload)
   const kind = getChainKind(chain)
 

--- a/packages/core/mpc/keysign/fee/resolver.ts
+++ b/packages/core/mpc/keysign/fee/resolver.ts
@@ -9,4 +9,4 @@ type FeeAmountResolverInput = {
   publicKey: PublicKey
 }
 
-export type FeeAmountResolver = Resolver<FeeAmountResolverInput, bigint>
+export type FeeAmountResolver = Resolver<FeeAmountResolverInput, bigint | Promise<bigint>>

--- a/packages/core/mpc/keysign/fee/resolvers/utxo.ts
+++ b/packages/core/mpc/keysign/fee/resolvers/utxo.ts
@@ -3,8 +3,8 @@ import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { getUtxoSigningInputs } from '../../signingInputs/resolvers/utxo'
 import { FeeAmountResolver } from '../resolver'
 
-export const getUtxoFeeAmount: FeeAmountResolver = input => {
-  const [signingInput] = getUtxoSigningInputs(input)
+export const getUtxoFeeAmount: FeeAmountResolver = async input => {
+  const [signingInput] = await getUtxoSigningInputs(input)
 
   return BigInt(shouldBePresent(signingInput?.plan?.fee?.toString(), `UTXO signing input plan fee`))
 }

--- a/packages/core/mpc/keysign/referral/build.ts
+++ b/packages/core/mpc/keysign/referral/build.ts
@@ -52,7 +52,7 @@ export const buildReferralKeysignPayload = async ({
 
   const balance = await getCoinBalance(coin)
 
-  keysignPayload = refineKeysignAmount({
+  keysignPayload = await refineKeysignAmount({
     keysignPayload,
     walletCore,
     publicKey,

--- a/packages/core/mpc/keysign/refine/amount.ts
+++ b/packages/core/mpc/keysign/refine/amount.ts
@@ -17,7 +17,7 @@ type RefineKeysignAmountInput = {
   balance: bigint
 }
 
-export const refineKeysignAmount = (input: RefineKeysignAmountInput) => {
+export const refineKeysignAmount = async (input: RefineKeysignAmountInput) => {
   if (!input.keysignPayload.toAmount || input.keysignPayload.toAmount === '0') {
     return input.keysignPayload
   }
@@ -31,7 +31,7 @@ export const refineKeysignAmount = (input: RefineKeysignAmountInput) => {
     return input.keysignPayload
   }
 
-  const fee = getFeeAmount(input)
+  const fee = await getFeeAmount(input)
 
   const refinedAmount = minBigInt(BigInt(input.keysignPayload.toAmount), input.balance - fee)
 

--- a/packages/core/mpc/keysign/refine/utxo.ts
+++ b/packages/core/mpc/keysign/refine/utxo.ts
@@ -37,7 +37,7 @@ const convertPlanUtxosToUtxoInfo = ({ utxos, walletCore }: ConvertPlanUtxosToUtx
     })
   })
 
-export const refineKeysignUtxo = (input: RefineKeysignUtxoInput): KeysignPayload => {
+export const refineKeysignUtxo = async (input: RefineKeysignUtxoInput): Promise<KeysignPayload> => {
   const utxoSpecific = getBlockchainSpecificValue(input.keysignPayload.blockchainSpecific, 'utxoSpecific')
 
   // PSBTs already have UTXOs defined — skip refinement.
@@ -46,7 +46,7 @@ export const refineKeysignUtxo = (input: RefineKeysignUtxoInput): KeysignPayload
     return input.keysignPayload
   }
 
-  const [signingInput] = getUtxoSigningInputs(input)
+  const [signingInput] = await getUtxoSigningInputs(input)
 
   const plan = shouldBePresent(signingInput.plan, 'UTXO signing input plan')
   const planUtxos = plan.utxos

--- a/packages/core/mpc/keysign/send/build.ts
+++ b/packages/core/mpc/keysign/send/build.ts
@@ -91,7 +91,7 @@ export const buildSendKeysignPayload = async ({
   const balance = await getCoinBalance(coin)
 
   if (publicKey) {
-    keysignPayload = refineKeysignAmount({
+    keysignPayload = await refineKeysignAmount({
       keysignPayload,
       walletCore,
       publicKey,
@@ -99,7 +99,7 @@ export const buildSendKeysignPayload = async ({
     })
 
     if (isChainOfKind(coin.chain, 'utxo')) {
-      keysignPayload = refineKeysignUtxo({
+      keysignPayload = await refineKeysignUtxo({
         keysignPayload,
         walletCore,
         publicKey,

--- a/packages/core/mpc/keysign/send/getSendFeeEstimate.ts
+++ b/packages/core/mpc/keysign/send/getSendFeeEstimate.ts
@@ -14,7 +14,7 @@ export const getSendFeeEstimate = async (input: BuildSendKeysignPayloadInput): P
     return cosmosSpecific.gas
   }
 
-  return getFeeAmount({
+  return await getFeeAmount({
     keysignPayload,
     walletCore: input.walletCore,
     publicKey: shouldBePresent(input.publicKey, 'publicKey required for fee estimate on this chain'),

--- a/packages/core/mpc/keysign/signingInputs/index.ts
+++ b/packages/core/mpc/keysign/signingInputs/index.ts
@@ -41,11 +41,11 @@ export const signingInputResolversByChainKind: Record<ChainKind, SigningInputsRe
   tron: getTronSigningInputs,
 }
 
-export const getEncodedSigningInputs = (input: Input): Uint8Array[] => {
+export const getEncodedSigningInputs = async (input: Input): Promise<Uint8Array[]> => {
   const chain = getKeysignChain(input.keysignPayload)
   const chainKind = getChainKind(chain)
 
-  const signingInputs = signingInputResolversByChainKind[chainKind](input as any)
+  const signingInputs = await signingInputResolversByChainKind[chainKind](input as any)
 
   // Bittensor returns pre-encoded Uint8Array (custom extrinsic builder, not TW proto)
   if (chainKind === 'bittensor' || chainKind === 'qbtc') {

--- a/packages/core/mpc/keysign/signingInputs/resolver.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolver.ts
@@ -11,4 +11,7 @@ type SigningInputsResolverInput<T extends ChainKind> = {
   walletCore: WalletCore
 } & (T extends 'utxo' ? { publicKey: PublicKey } : {})
 
-export type SigningInputsResolver<T extends ChainKind> = Resolver<SigningInputsResolverInput<T>, SigningInput<T>[]>
+export type SigningInputsResolver<T extends ChainKind> = Resolver<
+  SigningInputsResolverInput<T>,
+  SigningInput<T>[] | Promise<SigningInput<T>[]>
+>

--- a/packages/core/mpc/keysign/signingInputs/resolvers/evm/index.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/evm/index.ts
@@ -23,7 +23,7 @@ import { getErc20ApproveSigningInput } from './erc20'
 
 const memoToTxData = (memo: string) => (memo.startsWith('0x') ? toEvmTxData(memo) : Buffer.from(memo, 'utf8'))
 
-export const getEvmSigningInputs: SigningInputsResolver<'evm'> = ({ keysignPayload, walletCore }) => {
+export const getEvmSigningInputs: SigningInputsResolver<'evm'> = async ({ keysignPayload, walletCore }) => {
   const chain = getKeysignChain<'evm'>(keysignPayload)
   const coin = assertField(keysignPayload, 'coin')
 
@@ -35,7 +35,7 @@ export const getEvmSigningInputs: SigningInputsResolver<'evm'> = ({ keysignPaylo
       walletCore,
     })
 
-    const restOfSigningInputs = getEvmSigningInputs({
+    const restOfSigningInputs = await getEvmSigningInputs({
       keysignPayload: incrementKeysignPayloadNonce(create(KeysignPayloadSchema, restOfKeysignPayload)),
       walletCore,
     })

--- a/packages/core/mpc/keysign/signingInputs/resolvers/polkadot.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/polkadot.test.ts
@@ -46,16 +46,16 @@ describe('getPolkadotSigningInputs', () => {
     walletCore = await initWasm()
   })
 
-  it('uses methodIndex 3 (transfer_keep_alive) not 0 (transfer_allow_death)', () => {
-    const [input] = getPolkadotSigningInputs({ keysignPayload: buildPayload(), walletCore })
+  it('uses methodIndex 3 (transfer_keep_alive) not 0 (transfer_allow_death)', async () => {
+    const [input] = await getPolkadotSigningInputs({ keysignPayload: buildPayload(), walletCore })
 
     const callIndices = input.balanceCall?.assetTransfer?.callIndices?.custom
     expect(callIndices).toBeDefined()
     expect(callIndices?.methodIndex).toBe(3)
   })
 
-  it('keeps moduleIndex 10 (pallet_balances on Asset Hub)', () => {
-    const [input] = getPolkadotSigningInputs({ keysignPayload: buildPayload(), walletCore })
+  it('keeps moduleIndex 10 (pallet_balances on Asset Hub)', async () => {
+    const [input] = await getPolkadotSigningInputs({ keysignPayload: buildPayload(), walletCore })
 
     const callIndices = input.balanceCall?.assetTransfer?.callIndices?.custom
     expect(callIndices?.moduleIndex).toBe(10)

--- a/packages/core/mpc/keysign/signingInputs/resolvers/sui.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/sui.test.ts
@@ -60,8 +60,8 @@ beforeAll(async () => {
 })
 
 describe('getSuiSigningInputs — signSui (pre-built PTB)', () => {
-  it('forwards the PTB bytes verbatim via signDirectMessage', () => {
-    const [input] = getSuiSigningInputs({
+  it('forwards the PTB bytes verbatim via signDirectMessage', async () => {
+    const [input] = await getSuiSigningInputs({
       keysignPayload: buildSignSuiPayload(),
       walletCore,
     })
@@ -73,8 +73,8 @@ describe('getSuiSigningInputs — signSui (pre-built PTB)', () => {
     expect(input.paySui).toBeFalsy()
   })
 
-  it('hashes to the transaction-intent digest (parity with the legacy path)', () => {
-    const [txInputData] = getEncodedSigningInputs({
+  it('hashes to the transaction-intent digest (parity with the legacy path)', async () => {
+    const [txInputData] = await getEncodedSigningInputs({
       keysignPayload: buildSignSuiPayload(),
       walletCore,
     })
@@ -91,9 +91,9 @@ describe('getSuiSigningInputs — signSui (pre-built PTB)', () => {
     expect(hex(hashes[0])).toBe(hex(expected))
   })
 
-  it('compiles to a wallet-standard Ed25519 signature over the same bytes', () => {
+  it('compiles to a wallet-standard Ed25519 signature over the same bytes', async () => {
     const privateKey = walletCore.PrivateKey.createWithData(EDDSA_PRIVATE_KEY)
-    const [txInputData] = getEncodedSigningInputs({
+    const [txInputData] = await getEncodedSigningInputs({
       keysignPayload: buildSignSuiPayload(),
       walletCore,
     })

--- a/packages/core/mpc/keysign/signingInputs/resolvers/tron.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/tron.test.ts
@@ -50,28 +50,28 @@ const buildPayload = (memo: string, toAmount = '1000000000') =>
   })
 
 describe('getTronSigningInputs -- FREEZE: / UNFREEZE: feeLimit semantics (BUG-7)', () => {
-  it('FREEZE:BANDWIDTH sets feeLimit to 0 regardless of gasEstimation', () => {
-    const [input] = getTronSigningInputs({ keysignPayload: buildPayload('FREEZE:BANDWIDTH'), walletCore })
+  it('FREEZE:BANDWIDTH sets feeLimit to 0 regardless of gasEstimation', async () => {
+    const [input] = await getTronSigningInputs({ keysignPayload: buildPayload('FREEZE:BANDWIDTH'), walletCore })
     // FreezeBalanceV2 is a bandwidth op; energy feeLimit is semantically irrelevant.
     expect(input.transaction?.feeLimit?.toNumber()).toBe(0)
   })
 
-  it('FREEZE:ENERGY sets feeLimit to 0 regardless of gasEstimation', () => {
-    const [input] = getTronSigningInputs({ keysignPayload: buildPayload('FREEZE:ENERGY'), walletCore })
+  it('FREEZE:ENERGY sets feeLimit to 0 regardless of gasEstimation', async () => {
+    const [input] = await getTronSigningInputs({ keysignPayload: buildPayload('FREEZE:ENERGY'), walletCore })
     expect(input.transaction?.feeLimit?.toNumber()).toBe(0)
   })
 
-  it('UNFREEZE:BANDWIDTH sets feeLimit to 0 regardless of gasEstimation', () => {
-    const [input] = getTronSigningInputs({ keysignPayload: buildPayload('UNFREEZE:BANDWIDTH'), walletCore })
+  it('UNFREEZE:BANDWIDTH sets feeLimit to 0 regardless of gasEstimation', async () => {
+    const [input] = await getTronSigningInputs({ keysignPayload: buildPayload('UNFREEZE:BANDWIDTH'), walletCore })
     expect(input.transaction?.feeLimit?.toNumber()).toBe(0)
   })
 
-  it('UNFREEZE:ENERGY sets feeLimit to 0 regardless of gasEstimation', () => {
-    const [input] = getTronSigningInputs({ keysignPayload: buildPayload('UNFREEZE:ENERGY'), walletCore })
+  it('UNFREEZE:ENERGY sets feeLimit to 0 regardless of gasEstimation', async () => {
+    const [input] = await getTronSigningInputs({ keysignPayload: buildPayload('UNFREEZE:ENERGY'), walletCore })
     expect(input.transaction?.feeLimit?.toNumber()).toBe(0)
   })
 
-  it('gasEstimation value does not leak into FREEZE feeLimit', () => {
+  it('gasEstimation value does not leak into FREEZE feeLimit', async () => {
     // Pre-fix behaviour: feeLimit would have been Long.fromString('100000000').
     // Post-fix: always 0. This assertion pins the regression explicitly.
     const GAS_ESTIMATION = 100_000_000n
@@ -90,7 +90,7 @@ describe('getTronSigningInputs -- FREEZE: / UNFREEZE: feeLimit semantics (BUG-7)
       blockchainSpecific: { case: 'tronSpecific', value: specific },
     })
 
-    const [input] = getTronSigningInputs({ keysignPayload: payload, walletCore })
+    const [input] = await getTronSigningInputs({ keysignPayload: payload, walletCore })
     // Anti-regression: prior to fix, feeLimit was passed gasEstimation
     // (a non-zero energy estimate that's semantically meaningless for
     // system contracts and only served to confuse the UI fee display).

--- a/packages/core/mpc/keysign/signingInputs/resolvers/utxo.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/utxo.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer'
 import { create } from '@bufbuild/protobuf'
 import { TW } from '@trustwallet/wallet-core'
 import { Chain } from '@vultisig/core-chain/Chain'
@@ -10,6 +11,10 @@ import {
   OneInchTransactionSchema,
 } from '@vultisig/core-mpc/types/vultisig/keysign/v1/1inch_swap_payload_pb'
 import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@vultisig/core-chain/chains/utxo/zcashBranchId', () => ({
+  getZcashBranchIdHex: vi.fn(async () => '30f33754'),
+}))
 
 // Minimal walletCore stub — only the surface used by getUtxoSigningInputs general-swap arm.
 // Full signing-path tests (UTXO selection, fee, broadcast) require real WalletCore binaries
@@ -88,21 +93,21 @@ describe('getUtxoSigningInputs — general swap address validation', () => {
   it('throws when toAddress is empty string', async () => {
     const resolver = await getUtxoSigningInputs()
     const payload = buildGeneralSwapPayload('')
-    expect(() => resolver({ keysignPayload: payload, walletCore: makeWalletCore(), publicKey: {} as never })).toThrow(
-      'destination address is missing'
-    )
+    await expect(
+      resolver({ keysignPayload: payload, walletCore: makeWalletCore(), publicKey: {} as never })
+    ).rejects.toThrow('destination address is missing')
   })
 
   it('throws when walletCore rejects the destination address format', async () => {
     const resolver = await getUtxoSigningInputs()
     const payload = buildGeneralSwapPayload('not-a-valid-btc-address')
-    expect(() =>
+    await expect(
       resolver({
         keysignPayload: payload,
         walletCore: makeWalletCore({ isValidAddress: false }),
         publicKey: {} as never,
       })
-    ).toThrow('not valid for this chain')
+    ).rejects.toThrow('not valid for this chain')
   })
 
   it('proceeds when toAddress is a valid address', async () => {
@@ -112,20 +117,42 @@ describe('getUtxoSigningInputs — general swap address validation', () => {
     // With the stub walletCore, AnySigner.plan returns empty bytes which
     // will fail to decode a TransactionPlan — that is expected and not what
     // we are testing here. We only assert the validation guard does NOT throw.
-    expect(() =>
-      resolver({
+    try {
+      await resolver({
         keysignPayload: payload,
         walletCore: makeWalletCore({ isValidAddress: true }),
         publicKey: {} as never,
       })
-    ).not.toThrow('destination address')
+    } catch (error) {
+      expect(error instanceof Error ? error.message : String(error)).not.toContain('destination address')
+    }
   })
 })
 
 describe('Zcash branch ID', () => {
-  it('pins the NU6.2 consensus branch ID in WalletCore little-endian hex order', async () => {
-    const mod = await import('./utxo')
-    expect(mod.ZCASH_BRANCH_ID_NU6_2_LE_HEX).toBe('30f33754')
+  it('stamps the live consensus branch ID in WalletCore little-endian hex order', async () => {
+    const resolver = await getUtxoSigningInputs()
+    const walletCore = makeWalletCore()
+    const payload = create(KeysignPayloadSchema, {
+      coin: create(CoinSchema, {
+        chain: Chain.Zcash,
+        ticker: 'ZEC',
+        address: 't1Source',
+        decimals: 8,
+        isNativeToken: true,
+      }),
+      toAddress: 't1Destination',
+      toAmount: '600000',
+      blockchainSpecific: {
+        case: 'utxoSpecific',
+        value: create(UTXOSpecificSchema, { byteFee: '10', sendMaxAmount: false }),
+      },
+      utxoInfo: [],
+    })
+
+    const [input] = await resolver({ keysignPayload: payload, walletCore, publicKey: {} as never })
+
+    expect(Buffer.from(input.plan!.branchId!).toString('hex')).toBe('30f33754')
   })
 })
 
@@ -151,7 +178,7 @@ describe('Zcash ZIP-317 fee planning', () => {
       utxoInfo: [],
     })
 
-    resolver({ keysignPayload: payload, walletCore, publicKey: {} as never })
+    await resolver({ keysignPayload: payload, walletCore, publicKey: {} as never })
 
     const planInput = vi.mocked(plan).mock.calls[0]?.[0]
     expect(planInput).toBeDefined()

--- a/packages/core/mpc/keysign/signingInputs/resolvers/utxo.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/utxo.ts
@@ -2,6 +2,7 @@ import { Buffer } from 'buffer'
 import { UtxoChain } from '@vultisig/core-chain/Chain'
 import { minUtxo } from '@vultisig/core-chain/chains/utxo/minUtxo'
 import { utxoChainScriptType } from '@vultisig/core-chain/chains/utxo/tx/UtxoScriptType'
+import { getZcashBranchIdHex } from '@vultisig/core-chain/chains/utxo/zcashBranchId'
 import { getCoinType } from '@vultisig/core-chain/coin/coinType'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { match } from '@vultisig/lib-utils/match'
@@ -16,10 +17,9 @@ import { KeysignSwapPayload } from '../../swap/KeysignSwapPayload'
 import { getKeysignChain } from '../../utils/getKeysignChain'
 import { SigningInputsResolver } from '../resolver'
 
-export const ZCASH_BRANCH_ID_NU6_2_LE_HEX = '30f33754'
-
-export const getUtxoSigningInputs: SigningInputsResolver<'utxo'> = ({ keysignPayload, walletCore }) => {
+export const getUtxoSigningInputs: SigningInputsResolver<'utxo'> = async ({ keysignPayload, walletCore }) => {
   const chain = getKeysignChain<'utxo'>(keysignPayload)
+  const zcashBranchIdHex = chain === UtxoChain.Zcash ? await getZcashBranchIdHex() : undefined
 
   const { byteFee, sendMaxAmount } = getBlockchainSpecificValue(keysignPayload.blockchainSpecific, 'utxoSpecific')
 
@@ -105,7 +105,7 @@ export const getUtxoSigningInputs: SigningInputsResolver<'utxo'> = ({ keysignPay
   input.plan = TW.Bitcoin.Proto.TransactionPlan.decode(plan)
 
   if (chain === UtxoChain.Zcash) {
-    input.plan.branchId = Buffer.from(ZCASH_BRANCH_ID_NU6_2_LE_HEX, 'hex')
+    input.plan.branchId = Buffer.from(shouldBePresent(zcashBranchIdHex, 'Zcash branch id'), 'hex')
   }
 
   return [input]

--- a/packages/core/mpc/keysign/swap/build.ts
+++ b/packages/core/mpc/keysign/swap/build.ts
@@ -361,7 +361,7 @@ export const buildSwapKeysignPayload = async ({
   }
 
   if (isChainOfKind(fromCoin.chain, 'utxo')) {
-    keysignPayload = refineKeysignUtxo({
+    keysignPayload = await refineKeysignUtxo({
       keysignPayload,
       walletCore,
       publicKey: fromPublicKey,

--- a/packages/core/mpc/security/blockaid/tx/simulation/input/index.ts
+++ b/packages/core/mpc/security/blockaid/tx/simulation/input/index.ts
@@ -18,9 +18,9 @@ const resolvers: Record<BlockaidSimulationSupportedChainKind, BlockaidTxSimulati
   sui: getSuiBlockaidTxSimulationInput,
 }
 
-export const getBlockaidTxSimulationInput = (
+export const getBlockaidTxSimulationInput = async (
   input: Omit<BlockaidTxSimulationInputResolverInput, 'chain'>
-): BlockaidTxSimulationInput | null => {
+): Promise<BlockaidTxSimulationInput | null> => {
   const chain = getKeysignChain(input.payload)
   if (!isOneOf(chain, blockaidSimulationSupportedChains)) {
     return null
@@ -28,7 +28,7 @@ export const getBlockaidTxSimulationInput = (
 
   const chainKind = getChainKind(chain)
 
-  const data = resolvers[chainKind]({
+  const data = await resolvers[chainKind]({
     ...input,
     chain,
   })

--- a/packages/core/mpc/security/blockaid/tx/simulation/input/resolver.ts
+++ b/packages/core/mpc/security/blockaid/tx/simulation/input/resolver.ts
@@ -23,5 +23,5 @@ export type BlockaidTxSimulationInputResolver<
     chain: T
     raw?: string[]
   },
-  BlockaidTxSimulationInput['data'] | null
+  BlockaidTxSimulationInput['data'] | null | Promise<BlockaidTxSimulationInput['data'] | null>
 >

--- a/packages/core/mpc/security/blockaid/tx/simulation/input/resolvers/solana.ts
+++ b/packages/core/mpc/security/blockaid/tx/simulation/input/resolvers/solana.ts
@@ -5,7 +5,7 @@ import { assertField } from '@vultisig/lib-utils/record/assertField'
 import { getCompiledTxsForBlockaidInput } from '../../../utils/getCompiledTxsForBlockaidInput'
 import { BlockaidTxSimulationInputResolver } from '../resolver'
 
-export const getSolanaBlockaidTxSimulationInput: BlockaidTxSimulationInputResolver<OtherChain.Solana> = ({
+export const getSolanaBlockaidTxSimulationInput: BlockaidTxSimulationInputResolver<OtherChain.Solana> = async ({
   payload,
   walletCore,
   chain,
@@ -23,10 +23,12 @@ export const getSolanaBlockaidTxSimulationInput: BlockaidTxSimulationInputResolv
       metadata: {},
     }
   }
-  const transactions = getCompiledTxsForBlockaidInput({
-    payload,
-    walletCore,
-  }).map(tx => decodeSigningOutput(chain, tx).encoded)
+  const transactions = (
+    await getCompiledTxsForBlockaidInput({
+      payload,
+      walletCore,
+    })
+  ).map(tx => decodeSigningOutput(chain, tx).encoded)
 
   return {
     chain: 'mainnet',

--- a/packages/core/mpc/security/blockaid/tx/simulation/input/resolvers/sui.ts
+++ b/packages/core/mpc/security/blockaid/tx/simulation/input/resolvers/sui.ts
@@ -5,13 +5,13 @@ import { assertField } from '@vultisig/lib-utils/record/assertField'
 import { getCompiledTxsForBlockaidInput } from '../../../utils/getCompiledTxsForBlockaidInput'
 import { BlockaidTxSimulationInputResolver } from '../resolver'
 
-export const getSuiBlockaidTxSimulationInput: BlockaidTxSimulationInputResolver<OtherChain.Sui> = ({
+export const getSuiBlockaidTxSimulationInput: BlockaidTxSimulationInputResolver<OtherChain.Sui> = async ({
   payload,
   walletCore,
 }) => {
   const coin = assertField(payload, 'coin')
 
-  const compiledTxs = getCompiledTxsForBlockaidInput({
+  const compiledTxs = await getCompiledTxsForBlockaidInput({
     payload,
     walletCore,
   })

--- a/packages/core/mpc/security/blockaid/tx/utils/getCompiledTxsForBlockaidInput.ts
+++ b/packages/core/mpc/security/blockaid/tx/utils/getCompiledTxsForBlockaidInput.ts
@@ -17,7 +17,7 @@ type Input = {
   walletCore: WalletCore
 }
 
-export const getCompiledTxsForBlockaidInput = ({ payload, walletCore }: Input) => {
+export const getCompiledTxsForBlockaidInput = async ({ payload, walletCore }: Input) => {
   const chain = getKeysignChain(payload)
   const chainKind = getChainKind(chain)
 
@@ -29,7 +29,7 @@ export const getCompiledTxsForBlockaidInput = ({ payload, walletCore }: Input) =
     walletCore,
   })
 
-  const inputs = getEncodedSigningInputs({
+  const inputs = await getEncodedSigningInputs({
     keysignPayload: payload,
     walletCore,
     publicKey,

--- a/packages/core/mpc/security/blockaid/tx/validation/input/index.ts
+++ b/packages/core/mpc/security/blockaid/tx/validation/input/index.ts
@@ -20,9 +20,9 @@ const resolvers: Record<BlockaidValidationSupportedChainKind, BlockaidTxValidati
   sui: getSuiBlockaidTxValidationInput,
 }
 
-export const getBlockaidTxValidationInput = (
+export const getBlockaidTxValidationInput = async (
   input: Omit<BlockaidTxValidationInputResolverInput, 'chain'>
-): BlockaidTxValidationInput | null => {
+): Promise<BlockaidTxValidationInput | null> => {
   const chain = getKeysignChain(input.payload)
   if (!isOneOf(chain, blockaidValidationSupportedChains)) {
     return null
@@ -30,7 +30,7 @@ export const getBlockaidTxValidationInput = (
 
   const chainKind = getChainKind(chain)
 
-  const data = resolvers[chainKind]({
+  const data = await resolvers[chainKind]({
     ...input,
     chain,
   })

--- a/packages/core/mpc/security/blockaid/tx/validation/input/resolver.ts
+++ b/packages/core/mpc/security/blockaid/tx/validation/input/resolver.ts
@@ -21,5 +21,5 @@ export type BlockaidTxValidationInputResolver<
     walletCore: WalletCore
     chain: T
   },
-  BlockaidTxValidationInput['data'] | null
+  BlockaidTxValidationInput['data'] | null | Promise<BlockaidTxValidationInput['data'] | null>
 >

--- a/packages/core/mpc/security/blockaid/tx/validation/input/resolvers/solana.ts
+++ b/packages/core/mpc/security/blockaid/tx/validation/input/resolvers/solana.ts
@@ -5,17 +5,19 @@ import { assertField } from '@vultisig/lib-utils/record/assertField'
 import { getCompiledTxsForBlockaidInput } from '../../../utils/getCompiledTxsForBlockaidInput'
 import { BlockaidTxValidationInputResolver } from '../resolver'
 
-export const getSolanaBlockaidTxValidationInput: BlockaidTxValidationInputResolver<OtherChain.Solana> = ({
+export const getSolanaBlockaidTxValidationInput: BlockaidTxValidationInputResolver<OtherChain.Solana> = async ({
   payload,
   walletCore,
   chain,
 }) => {
   const coin = assertField(payload, 'coin')
 
-  const transactions = getCompiledTxsForBlockaidInput({
-    payload,
-    walletCore,
-  }).map(tx => decodeSigningOutput(chain, tx).encoded)
+  const transactions = (
+    await getCompiledTxsForBlockaidInput({
+      payload,
+      walletCore,
+    })
+  ).map(tx => decodeSigningOutput(chain, tx).encoded)
 
   return {
     chain: 'mainnet',

--- a/packages/core/mpc/security/blockaid/tx/validation/input/resolvers/sui.ts
+++ b/packages/core/mpc/security/blockaid/tx/validation/input/resolvers/sui.ts
@@ -5,13 +5,13 @@ import { assertField } from '@vultisig/lib-utils/record/assertField'
 import { getCompiledTxsForBlockaidInput } from '../../../utils/getCompiledTxsForBlockaidInput'
 import { BlockaidTxValidationInputResolver } from '../resolver'
 
-export const getSuiBlockaidTxValidationInput: BlockaidTxValidationInputResolver<OtherChain.Sui> = ({
+export const getSuiBlockaidTxValidationInput: BlockaidTxValidationInputResolver<OtherChain.Sui> = async ({
   payload,
   walletCore,
 }) => {
   const coin = assertField(payload, 'coin')
 
-  const compiledTxs = getCompiledTxsForBlockaidInput({
+  const compiledTxs = await getCompiledTxsForBlockaidInput({
     payload,
     walletCore,
   })

--- a/packages/core/mpc/security/blockaid/tx/validation/input/resolvers/utxo.ts
+++ b/packages/core/mpc/security/blockaid/tx/validation/input/resolvers/utxo.ts
@@ -6,14 +6,14 @@ import { getKeysignCoin } from '@vultisig/core-mpc/keysign/utils/getKeysignCoin'
 import { getCompiledTxsForBlockaidInput } from '../../../utils/getCompiledTxsForBlockaidInput'
 import { BlockaidTxValidationInputResolver } from '../resolver'
 
-export const getUtxoBlockaidTxValidationInput: BlockaidTxValidationInputResolver<UtxoChain.Bitcoin> = ({
+export const getUtxoBlockaidTxValidationInput: BlockaidTxValidationInputResolver<UtxoChain.Bitcoin> = async ({
   payload,
   walletCore,
   chain,
 }) => {
   const { address } = getKeysignCoin(payload)
 
-  const compiledTxs = getCompiledTxsForBlockaidInput({
+  const compiledTxs = await getCompiledTxsForBlockaidInput({
     payload,
     walletCore,
   })

--- a/packages/lib/utils/query/queryUrl.ts
+++ b/packages/lib/utils/query/queryUrl.ts
@@ -6,7 +6,7 @@ type ResponseType = 'json' | 'text' | 'none'
 type QueryUrlOptions = {
   responseType?: ResponseType
   body?: any
-} & Pick<RequestInit, 'method' | 'headers'>
+} & Pick<RequestInit, 'method' | 'headers' | 'signal'>
 
 const processBody = (body: any) => {
   if (body === undefined) {
@@ -29,7 +29,7 @@ export function queryUrl<T extends string = string>(
 export function queryUrl<T>(url: string | URL, options?: QueryUrlOptions & { responseType?: 'json' }): Promise<T>
 
 export async function queryUrl<T>(url: string | URL, options: QueryUrlOptions = {}): Promise<T | string | void> {
-  const { responseType = 'json', body, headers, method } = options
+  const { responseType = 'json', body, headers, method, signal } = options
 
   const response = await fetch(
     url,
@@ -40,6 +40,7 @@ export async function queryUrl<T>(url: string | URL, options: QueryUrlOptions = 
         'Content-Type': body ? 'application/json' : undefined,
       }),
       body: processBody(body),
+      signal,
     })
   )
 

--- a/packages/sdk/src/chains/utxo/index.ts
+++ b/packages/sdk/src/chains/utxo/index.ts
@@ -27,3 +27,9 @@ export {
   ZCASH_BRANCH_ID_NU6_1,
   ZCASH_BRANCH_ID_NU6_2,
 } from './tx'
+export {
+  getZcashBranchId,
+  getZcashBranchIdHex,
+  zcashBranchIdToNumber,
+  zcashBranchIdToWalletCoreHex,
+} from '@vultisig/core-chain/chains/utxo/zcashBranchId'

--- a/packages/sdk/src/chains/utxo/tx.ts
+++ b/packages/sdk/src/chains/utxo/tx.ts
@@ -449,13 +449,8 @@ export function getSighashLegacy(opts: SighashLegacyOptions): Uint8Array {
 export const ZCASH_BRANCH_ID_NU6_1 = 0x4dec4df0
 
 /**
- * Default Zcash consensus branch ID (NU6.2, the epoch active at the time of
- * writing). Consumers SHOULD override via `buildUtxoSendTx({zcashBranchId})`
- * for pre-activation signing - relying on a compiled-in default means every
- * Zcash network upgrade turns into a shipped-SDK-release blocker.
- *
- * Look up the current value at tx-build time from a Zcash node:
- *   zcash-cli getblockchaininfo | jq '.consensus.nextblock'
+ * Zcash consensus branch ID for NU6.2. Kept exported only for callers that
+ * need to reproduce historical transactions from that consensus epoch.
  */
 export const ZCASH_BRANCH_ID_NU6_2 = 0x5437f330
 const ZCASH_V4_VERSION = 0x80000004 // overwintered v4
@@ -705,11 +700,9 @@ export type BuildUtxoSendOptions = {
   /** Compressed pubkey (33 bytes) used for scriptSig / witness */
   compressedPubKey: Uint8Array
   /**
-   * Zcash consensus branch ID (ignored for non-Zcash chains). Defaults to
-   * `ZCASH_BRANCH_ID_NU6_2` at the time of release. Consumers SHOULD fetch
-   * the current value from a zcash-cli `getblockchaininfo` at tx-build time
-   * — hardcoding means every future consensus upgrade requires a shipped
-   * SDK release.
+   * Zcash consensus branch ID (ignored for non-Zcash chains). Required for
+   * Zcash so future consensus upgrades fail loud instead of signing with a
+   * stale compiled fallback.
    */
   zcashBranchId?: number
 }
@@ -800,13 +793,16 @@ export function buildUtxoSendTx(opts: BuildUtxoSendOptions): UtxoTxBuilderResult
 
   const isBCH = opts.chain === 'Bitcoin-Cash'
   const isZcash = opts.chain === 'Zcash'
-  const zcashBranchId = opts.zcashBranchId ?? ZCASH_BRANCH_ID_NU6_2
+  const zcashBranchId = opts.zcashBranchId
+  if (isZcash && zcashBranchId === undefined) {
+    throw new Error('buildUtxoSendTx: zcashBranchId is required for Zcash')
+  }
 
   const signingHashes: Uint8Array[] = []
   for (let i = 0; i < inputs.length; i++) {
     let h: Uint8Array
     if (isZcash) {
-      h = getSighashZcash(inputs, outputsRaw, i, fromDec.pubKeyHash, zcashBranchId)
+      h = getSighashZcash(inputs, outputsRaw, i, fromDec.pubKeyHash, zcashBranchId!)
     } else if (isBCH) {
       h = getSighashBIP143({
         inputs,

--- a/packages/sdk/src/vault/services/BroadcastService.ts
+++ b/packages/sdk/src/vault/services/BroadcastService.ts
@@ -86,7 +86,7 @@ export class BroadcastService {
       }
 
       // Get transaction input data (same data used during signing)
-      const txInputsArray = getEncodedSigningInputs({
+      const txInputsArray = await getEncodedSigningInputs({
         keysignPayload,
         walletCore,
         publicKey,

--- a/packages/sdk/src/vault/services/SecurityService.ts
+++ b/packages/sdk/src/vault/services/SecurityService.ts
@@ -17,7 +17,7 @@ export class SecurityService {
     const walletCore = await this.wasmProvider.getWalletCore()
 
     // Build chain-specific input (returns null if chain unsupported)
-    const input = getBlockaidTxValidationInput({
+    const input = await getBlockaidTxValidationInput({
       payload: keysignPayload,
       walletCore,
     })
@@ -43,7 +43,7 @@ export class SecurityService {
     const walletCore = await this.wasmProvider.getWalletCore()
 
     // Build chain-specific input (returns null if chain unsupported)
-    const input = getBlockaidTxSimulationInput({
+    const input = await getBlockaidTxSimulationInput({
       payload: keysignPayload,
       walletCore,
     })

--- a/packages/sdk/src/vault/services/TransactionBuilder.ts
+++ b/packages/sdk/src/vault/services/TransactionBuilder.ts
@@ -273,7 +273,7 @@ export class TransactionBuilder {
             })()
 
       // Get encoded signing inputs (compiled transaction data)
-      const txInputsArray = getEncodedSigningInputs({
+      const txInputsArray = await getEncodedSigningInputs({
         keysignPayload,
         walletCore,
         publicKey,

--- a/packages/sdk/tests/unit/chains/utxo-zcash-branchid.test.ts
+++ b/packages/sdk/tests/unit/chains/utxo-zcash-branchid.test.ts
@@ -14,14 +14,14 @@ const COMPRESSED_PUBKEY = Uint8Array.from(
 )
 
 describe('Zcash — branchId parametrization', () => {
-  it('defaults to the NU6.2 constant when `zcashBranchId` is omitted', () => {
+  it('keeps the NU6.2 constant available for callers that explicitly need that epoch', () => {
     // Sanity: the exported constant matches the NU6.2 epoch value
     // (https://zips.z.cash/zip-0253) and is little-endian-encoded as
     // `30f33754` into the BLAKE2b personalization.
     expect(ZCASH_BRANCH_ID_NU6_2).toBe(0x5437f330)
   })
 
-  it('produces the same sighash when branchId is omitted vs explicitly set to the default', () => {
+  it('throws when branchId is omitted for Zcash', () => {
     const baseArgs = {
       chain: 'Zcash' as const,
       fromAddress: 't1PoLLLwEcVhqMBhk53tANtSepnPXAQJkPM',
@@ -31,9 +31,7 @@ describe('Zcash — branchId parametrization', () => {
       feeRate: 1,
       compressedPubKey: COMPRESSED_PUBKEY,
     }
-    const defaultBuilder = buildUtxoSendTx(baseArgs)
-    const explicitBuilder = buildUtxoSendTx({ ...baseArgs, zcashBranchId: ZCASH_BRANCH_ID_NU6_2 })
-    expect(defaultBuilder.signingHashesHex).toEqual(explicitBuilder.signingHashesHex)
+    expect(() => buildUtxoSendTx(baseArgs)).toThrow('zcashBranchId is required')
   })
 
   it('produces a DIFFERENT sighash when branchId changes (i.e. the parameter actually reaches the personalization)', () => {
@@ -46,7 +44,7 @@ describe('Zcash — branchId parametrization', () => {
       feeRate: 1,
       compressedPubKey: COMPRESSED_PUBKEY,
     }
-    const nu6_2 = buildUtxoSendTx(baseArgs)
+    const nu6_2 = buildUtxoSendTx({ ...baseArgs, zcashBranchId: ZCASH_BRANCH_ID_NU6_2 })
     const previousEpoch = buildUtxoSendTx({ ...baseArgs, zcashBranchId: ZCASH_BRANCH_ID_NU6_1 })
     expect(nu6_2.signingHashesHex).not.toEqual(previousEpoch.signingHashesHex)
   })

--- a/packages/sdk/tests/unit/vault/services/SecurityService.test.ts
+++ b/packages/sdk/tests/unit/vault/services/SecurityService.test.ts
@@ -95,7 +95,7 @@ describe('SecurityService', () => {
     })
 
     it('should return null for unsupported chains', async () => {
-      vi.mocked(getBlockaidTxValidationInput).mockReturnValue(null)
+      vi.mocked(getBlockaidTxValidationInput).mockResolvedValue(null)
 
       const result = await service.validateTransaction(mockKeysignPayload)
 
@@ -103,7 +103,7 @@ describe('SecurityService', () => {
     })
 
     it('should pass walletCore to input resolver', async () => {
-      vi.mocked(getBlockaidTxValidationInput).mockReturnValue(null)
+      vi.mocked(getBlockaidTxValidationInput).mockResolvedValue(null)
 
       await service.validateTransaction(mockKeysignPayload)
 
@@ -153,7 +153,7 @@ describe('SecurityService', () => {
     })
 
     it('should return null for unsupported chains', async () => {
-      vi.mocked(getBlockaidTxSimulationInput).mockReturnValue(null)
+      vi.mocked(getBlockaidTxSimulationInput).mockResolvedValue(null)
 
       const result = await service.simulateTransaction(mockKeysignPayload)
 
@@ -177,7 +177,7 @@ describe('SecurityService', () => {
     })
 
     it('should pass walletCore to simulation input resolver', async () => {
-      vi.mocked(getBlockaidTxSimulationInput).mockReturnValue(null)
+      vi.mocked(getBlockaidTxSimulationInput).mockResolvedValue(null)
 
       await service.simulateTransaction(mockKeysignPayload)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Zcash now dynamically fetches the live consensus branch ID for transaction signing (with caching to reduce repeated network calls).

* **Changes**
  * `zcashBranchId` is required when building Zcash transactions; callers must supply it or allow dynamic fetch.
  * Fetching now fails loudly on missing or timed-out RPC responses to avoid stale fallbacks.
  * Broader async improvements across fee estimation and signing flows for more reliable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->