### PR TITLE
fix: replace dead Hyperliquid explorer liquidscan.io with hypurrscan.io

### DIFF
--- a/.changeset/hyperliquid-explorer-hypurrscan.md
+++ b/.changeset/hyperliquid-explorer-hypurrscan.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/sdk': patch
+---
+
+Replace the dead Hyperliquid block explorer liquidscan.io with hypurrscan.io.

--- a/packages/core/chain/chains/evm/chainInfo.ts
+++ b/packages/core/chain/chains/evm/chainInfo.ts
@@ -22,7 +22,7 @@ import {
 } from 'viem/chains'
 
 const hyperliquidRpcUrl = `${rootApiUrl}/hyperevm/`
-export const hyperliquidBlockExplorerUrl = 'https://liquidscan.io'
+export const hyperliquidBlockExplorerUrl = 'https://hypurrscan.io'
 const hyperliquidNativeCoin = chainFeeCoin[EvmChain.Hyperliquid]
 
 export const hyperliquid = defineChain({
@@ -39,7 +39,7 @@ export const hyperliquid = defineChain({
     public: { http: [hyperliquidRpcUrl] },
   },
   blockExplorers: {
-    default: { name: 'LiquidScan', url: hyperliquidBlockExplorerUrl },
+    default: { name: 'Hypurrscan', url: hyperliquidBlockExplorerUrl },
   },
 })
 


### PR DESCRIPTION
## Summary
- `liquidscan.io` (Hyperliquid explorer) is dead — DNS no longer resolves, so the explorer URL the SDK exposes for Hyperliquid (chain id 999) is broken
- Replace `hyperliquidBlockExplorerUrl` with `https://hypurrscan.io` and the explorer name with `Hypurrscan`

## Changes
| File | Change |
|------|--------|
| `packages/core/chain/chains/evm/chainInfo.ts` | `hyperliquidBlockExplorerUrl` → hypurrscan.io; `blockExplorers.default.name` → Hypurrscan |

## Context
Closes #717. Dead link example: https://liquidscan.io/address/0x15E9eBd862E8d7cd571062D0fBd41D695A9575AF → working replacement: https://hypurrscan.io/address/0x15E9eBd862E8d7cd571062D0fBd41D695A9575AF

SDK consumers (agent-app; Windows has no Hyperliquid explorer reference of its own) pick this up on the next SDK bump.

## Test plan
- [x] `tsc --noEmit` clean on root tsconfig
- [x] Old/new explorer reachability verified via curl (see receipts)

## receipts
```bash
$ curl -sS -o /dev/null -w "%{http_code}\n" "https://liquidscan.io/address/0x15E9eBd862E8d7cd571062D0fBd41D695A9575AF"
curl: (6) Could not resolve host: liquidscan.io

$ curl -sS -o /dev/null -w "address: %{http_code}\n" -L "https://hypurrscan.io/address/0x15E9eBd862E8d7cd571062D0fBd41D695A9575AF"
address: 200
```
URL-constant-only change; no logic touched.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Hyperliquid block explorer link to a new provider/domain and refreshed the displayed explorer name accordingly.
  * Adjusted version bump settings for related packages to use patch-level updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->