### PR TITLE
feat(custom-rpc): app-wide per-chain custom RPC endpoint overrides

### DIFF
--- a/.changeset/custom-rpc-overrides.md
+++ b/.changeset/custom-rpc-overrides.md
@@ -1,0 +1,8 @@
+---
+'@vultisig/core-chain': minor
+'@vultisig/sdk': minor
+---
+
+feat(custom-rpc): app-wide per-chain custom RPC endpoint overrides
+
+Add an in-memory override registry that the EVM and Cosmos URL resolvers consult, so a host app can point a supported chain at its own node. v1 covers the EVM chains and the IBC-enabled Cosmos chains; the override maps to the EVM RPC URL for EVM chains and to the LCD/REST endpoint for Cosmos (balance fallback, account info, fee). Includes `customRpcSupportedChains` as a single source of truth and an `rpcHealthProbe` (EVM `eth_chainId` identity check, Cosmos `node_info` liveness). Default behaviour is byte-identical when no override is set.

--- a/packages/core/chain/chains/cosmos/account/getCosmosAccountInfo.ts
+++ b/packages/core/chain/chains/cosmos/account/getCosmosAccountInfo.ts
@@ -2,7 +2,7 @@ import type { Pubkey } from '@cosmjs/amino'
 import { Chain, CosmosChain } from '@vultisig/core-chain/Chain'
 import { ChainAccount } from '@vultisig/core-chain/ChainAccount'
 import { getCosmosClient } from '@vultisig/core-chain/chains/cosmos/client'
-import { cosmosRpcUrl } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
+import { getCosmosRpcUrl } from '../getCosmosRpcUrl'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
 type LcdAccountResponse = {
@@ -104,7 +104,7 @@ const tryLcd = async (base: string, address: string): Promise<ParsedAccount | nu
 }
 
 const fetchAccountViaLcd = async (chain: CosmosChain, address: string): Promise<ParsedAccount | null> => {
-  const base = cosmosRpcUrl[chain]
+  const base = getCosmosRpcUrl(chain)
   if (!base) return null
   const primary = await tryLcd(base, address)
   if (primary) return primary

--- a/packages/core/chain/chains/cosmos/account/getCosmosAccountInfo.ts
+++ b/packages/core/chain/chains/cosmos/account/getCosmosAccountInfo.ts
@@ -2,8 +2,9 @@ import type { Pubkey } from '@cosmjs/amino'
 import { Chain, CosmosChain } from '@vultisig/core-chain/Chain'
 import { ChainAccount } from '@vultisig/core-chain/ChainAccount'
 import { getCosmosClient } from '@vultisig/core-chain/chains/cosmos/client'
-import { getCosmosRpcUrl } from '../getCosmosRpcUrl'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+
+import { getCosmosRpcUrl } from '../getCosmosRpcUrl'
 
 type LcdAccountResponse = {
   account?: {

--- a/packages/core/chain/chains/cosmos/account/getCosmosAccountInfo.ts
+++ b/packages/core/chain/chains/cosmos/account/getCosmosAccountInfo.ts
@@ -2,9 +2,8 @@ import type { Pubkey } from '@cosmjs/amino'
 import { Chain, CosmosChain } from '@vultisig/core-chain/Chain'
 import { ChainAccount } from '@vultisig/core-chain/ChainAccount'
 import { getCosmosClient } from '@vultisig/core-chain/chains/cosmos/client'
+import { getCosmosRpcUrl } from '@vultisig/core-chain/chains/cosmos/getCosmosRpcUrl'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
-
-import { getCosmosRpcUrl } from '../getCosmosRpcUrl'
 
 type LcdAccountResponse = {
   account?: {

--- a/packages/core/chain/chains/cosmos/client.ts
+++ b/packages/core/chain/chains/cosmos/client.ts
@@ -4,6 +4,11 @@ import { memoizeAsync } from '@vultisig/lib-utils/memoizeAsync'
 
 import { tendermintRpcUrl } from './tendermintRpcUrl'
 
+// Note: a custom RPC override is treated as an LCD/REST endpoint (see
+// getCosmosRpcUrl + the RPC health probe), so it is intentionally NOT applied
+// here — the StargateClient speaks Tendermint RPC, a different protocol. The
+// override therefore covers the LCD paths (fee, account info, LCD balance
+// fallback); this Tendermint client keeps its default endpoint.
 export const getCosmosClient = memoizeAsync(async (chain: CosmosChain) =>
   StargateClient.connect(tendermintRpcUrl[chain])
 )

--- a/packages/core/chain/chains/cosmos/cosmosRpcUrl.ts
+++ b/packages/core/chain/chains/cosmos/cosmosRpcUrl.ts
@@ -1,9 +1,8 @@
 import { CosmosChain } from '@vultisig/core-chain/Chain'
+import { getCustomRpcOverride } from '@vultisig/core-chain/chains/customRpc/customRpcOverrides'
 import { AccountCoinKey } from '@vultisig/core-chain/coin/AccountCoin'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { base64Encode } from '@vultisig/lib-utils/base64Encode'
-
-import { getCustomRpcOverride } from '../customRpc/customRpcOverrides'
 
 type CosmosWasmContract = {
   chain: CosmosChain

--- a/packages/core/chain/chains/cosmos/cosmosRpcUrl.ts
+++ b/packages/core/chain/chains/cosmos/cosmosRpcUrl.ts
@@ -3,6 +3,8 @@ import { AccountCoinKey } from '@vultisig/core-chain/coin/AccountCoin'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { base64Encode } from '@vultisig/lib-utils/base64Encode'
 
+import { getCustomRpcOverride } from '../customRpc/customRpcOverrides'
+
 type CosmosWasmContract = {
   chain: CosmosChain
   id: string
@@ -32,7 +34,7 @@ export const isCosmosWasmTokenId = (id?: string): id is string => {
 }
 
 export const getCosmosWasmSmartQueryUrl = ({ chain, id }: CosmosWasmContract, query: object) =>
-  `${cosmosRpcUrl[chain]}/cosmwasm/wasm/v1/contract/${id}/smart/${base64Encode(JSON.stringify(query))}`
+  `${getCustomRpcOverride(chain) ?? cosmosRpcUrl[chain]}/cosmwasm/wasm/v1/contract/${id}/smart/${base64Encode(JSON.stringify(query))}`
 
 export const getCosmosWasmTokenBalanceUrl = ({ chain, id, address }: AccountCoinKey<CosmosChain>) =>
   getCosmosWasmSmartQueryUrl(

--- a/packages/core/chain/chains/cosmos/gas.ts
+++ b/packages/core/chain/chains/cosmos/gas.ts
@@ -2,7 +2,7 @@ import { Chain, IbcEnabledCosmosChain } from '../../Chain'
 import type { CoinKey } from '../../coin/Coin'
 import { cosmosFeeCoinDenom } from './cosmosFeeCoinDenom'
 import { getCosmosGasLimit } from './cosmosGasLimitRecord'
-import { cosmosRpcUrl } from './cosmosRpcUrl'
+import { getCosmosRpcUrl } from './getCosmosRpcUrl'
 
 const defaultGas = 7500n
 
@@ -111,7 +111,7 @@ const fetchMinGasPrice = async (chain: IbcEnabledCosmosChain, { fetchImpl = fetc
   try {
     return await Promise.race([
       (async () => {
-        const response = await fetchImpl(`${cosmosRpcUrl[chain]}${minGasPriceConfigPath}`, {
+        const response = await fetchImpl(`${getCosmosRpcUrl(chain)}${minGasPriceConfigPath}`, {
           signal: timeoutController.controller.signal,
         })
 

--- a/packages/core/chain/chains/cosmos/getCosmosRpcUrl.ts
+++ b/packages/core/chain/chains/cosmos/getCosmosRpcUrl.ts
@@ -1,6 +1,6 @@
 import { CosmosChain } from '@vultisig/core-chain/Chain'
+import { getCustomRpcOverride } from '@vultisig/core-chain/chains/customRpc/customRpcOverrides'
 
-import { getCustomRpcOverride } from '../customRpc/customRpcOverrides'
 import { cosmosRpcUrl } from './cosmosRpcUrl'
 
 /**

--- a/packages/core/chain/chains/cosmos/getCosmosRpcUrl.ts
+++ b/packages/core/chain/chains/cosmos/getCosmosRpcUrl.ts
@@ -8,5 +8,4 @@ import { cosmosRpcUrl } from './cosmosRpcUrl'
  * custom RPC override when one is set and falling back to the default endpoint
  * otherwise. Byte-identical to the default when no override is configured.
  */
-export const getCosmosRpcUrl = (chain: CosmosChain): string =>
-  getCustomRpcOverride(chain) ?? cosmosRpcUrl[chain]
+export const getCosmosRpcUrl = (chain: CosmosChain): string => getCustomRpcOverride(chain) ?? cosmosRpcUrl[chain]

--- a/packages/core/chain/chains/cosmos/getCosmosRpcUrl.ts
+++ b/packages/core/chain/chains/cosmos/getCosmosRpcUrl.ts
@@ -1,0 +1,12 @@
+import { CosmosChain } from '@vultisig/core-chain/Chain'
+
+import { getCustomRpcOverride } from '../customRpc/customRpcOverrides'
+import { cosmosRpcUrl } from './cosmosRpcUrl'
+
+/**
+ * Resolves the LCD/REST base URL for a Cosmos chain, honoring an app-wide
+ * custom RPC override when one is set and falling back to the default endpoint
+ * otherwise. Byte-identical to the default when no override is configured.
+ */
+export const getCosmosRpcUrl = (chain: CosmosChain): string =>
+  getCustomRpcOverride(chain) ?? cosmosRpcUrl[chain]

--- a/packages/core/chain/chains/customRpc/customRpc.test.ts
+++ b/packages/core/chain/chains/customRpc/customRpc.test.ts
@@ -1,19 +1,16 @@
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { Chain, CosmosChain, EvmChain, UtxoChain } from '../../Chain'
-import { getEvmRpcUrl } from '../evm/chainInfo'
-import { getCosmosRpcUrl } from '../cosmos/getCosmosRpcUrl'
 import { cosmosRpcUrl } from '../cosmos/cosmosRpcUrl'
+import { getCosmosRpcUrl } from '../cosmos/getCosmosRpcUrl'
+import { getEvmRpcUrl } from '../evm/chainInfo'
 import {
   clearCustomRpcOverride,
   getCustomRpcOverride,
   setCustomRpcOverride,
   setCustomRpcOverrides,
 } from './customRpcOverrides'
-import {
-  customRpcSupportedChains,
-  isCustomRpcSupported,
-} from './customRpcSupportedChains'
+import { customRpcSupportedChains, isCustomRpcSupported } from './customRpcSupportedChains'
 
 const ethDefaultRpcUrl = getEvmRpcUrl(EvmChain.Ethereum)
 
@@ -36,9 +33,7 @@ describe('custom RPC override registry', () => {
   })
 
   it('resolves the override Cosmos LCD URL when set, default otherwise', () => {
-    expect(getCosmosRpcUrl(CosmosChain.Cosmos)).toBe(
-      cosmosRpcUrl[CosmosChain.Cosmos]
-    )
+    expect(getCosmosRpcUrl(CosmosChain.Cosmos)).toBe(cosmosRpcUrl[CosmosChain.Cosmos])
 
     setCustomRpcOverride(CosmosChain.Cosmos, 'https://my-cosmos.example')
     expect(getCosmosRpcUrl(CosmosChain.Cosmos)).toBe('https://my-cosmos.example')
@@ -46,9 +41,7 @@ describe('custom RPC override registry', () => {
 
   it('keeps overrides isolated per chain', () => {
     setCustomRpcOverride(EvmChain.Ethereum, 'https://eth-node.example/')
-    expect(getCustomRpcOverride(EvmChain.Ethereum)).toBe(
-      'https://eth-node.example/'
-    )
+    expect(getCustomRpcOverride(EvmChain.Ethereum)).toBe('https://eth-node.example/')
     expect(getCustomRpcOverride(EvmChain.Avalanche)).toBeUndefined()
   })
 
@@ -57,15 +50,17 @@ describe('custom RPC override registry', () => {
     setCustomRpcOverrides({ [EvmChain.Base]: 'https://base-node.example/' })
 
     expect(getCustomRpcOverride(EvmChain.Ethereum)).toBeUndefined()
-    expect(getCustomRpcOverride(EvmChain.Base)).toBe(
-      'https://base-node.example/'
-    )
+    expect(getCustomRpcOverride(EvmChain.Base)).toBe('https://base-node.example/')
   })
 })
 
 describe('custom RPC supported chains', () => {
   it('includes every EVM chain and the IBC-enabled Cosmos chains', () => {
-    expect(customRpcSupportedChains).toContain(EvmChain.Ethereum)
+    for (const chain of Object.values(EvmChain)) {
+      expect(customRpcSupportedChains).toContain(chain)
+      expect(isCustomRpcSupported(chain)).toBe(true)
+    }
+
     expect(customRpcSupportedChains).toContain(CosmosChain.Osmosis)
   })
 

--- a/packages/core/chain/chains/customRpc/customRpc.test.ts
+++ b/packages/core/chain/chains/customRpc/customRpc.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { Chain, CosmosChain, EvmChain, UtxoChain } from '../../Chain'
-import { cosmosRpcUrl } from '../cosmos/cosmosRpcUrl'
+import { cosmosRpcUrl, getCosmosWasmTokenBalanceUrl } from '../cosmos/cosmosRpcUrl'
 import { getCosmosRpcUrl } from '../cosmos/getCosmosRpcUrl'
 import { getEvmRpcUrl } from '../evm/chainInfo'
 import {
@@ -37,6 +37,25 @@ describe('custom RPC override registry', () => {
 
     setCustomRpcOverride(CosmosChain.Cosmos, 'https://my-cosmos.example')
     expect(getCosmosRpcUrl(CosmosChain.Cosmos)).toBe('https://my-cosmos.example')
+  })
+
+  it('routes CW20 wasm queries through the override host', () => {
+    const wasmId = `osmo1${'a'.repeat(40)}`
+
+    const defaultUrl = getCosmosWasmTokenBalanceUrl({
+      chain: CosmosChain.Osmosis,
+      id: wasmId,
+      address: 'osmo1abc',
+    })
+    expect(defaultUrl.startsWith(cosmosRpcUrl[CosmosChain.Osmosis])).toBe(true)
+
+    setCustomRpcOverride(CosmosChain.Osmosis, 'https://my-cosmos.example')
+    const overriddenUrl = getCosmosWasmTokenBalanceUrl({
+      chain: CosmosChain.Osmosis,
+      id: wasmId,
+      address: 'osmo1abc',
+    })
+    expect(overriddenUrl.startsWith('https://my-cosmos.example/')).toBe(true)
   })
 
   it('keeps overrides isolated per chain', () => {

--- a/packages/core/chain/chains/customRpc/customRpc.test.ts
+++ b/packages/core/chain/chains/customRpc/customRpc.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { Chain, CosmosChain, EvmChain, UtxoChain } from '../../Chain'
+import { getEvmRpcUrl } from '../evm/chainInfo'
+import { getCosmosRpcUrl } from '../cosmos/getCosmosRpcUrl'
+import { cosmosRpcUrl } from '../cosmos/cosmosRpcUrl'
+import {
+  clearCustomRpcOverride,
+  getCustomRpcOverride,
+  setCustomRpcOverride,
+  setCustomRpcOverrides,
+} from './customRpcOverrides'
+import {
+  customRpcSupportedChains,
+  isCustomRpcSupported,
+} from './customRpcSupportedChains'
+
+const ethDefaultRpcUrl = getEvmRpcUrl(EvmChain.Ethereum)
+
+afterEach(() => {
+  // Reset the in-memory mirror so each test starts from defaults.
+  setCustomRpcOverrides({})
+})
+
+describe('custom RPC override registry', () => {
+  it('returns the default EVM RPC URL when no override is set', () => {
+    expect(getEvmRpcUrl(EvmChain.Ethereum)).toBe(ethDefaultRpcUrl)
+  })
+
+  it('resolves the override EVM RPC URL when set, and clears back to default', () => {
+    setCustomRpcOverride(EvmChain.Ethereum, 'https://my-node.example/')
+    expect(getEvmRpcUrl(EvmChain.Ethereum)).toBe('https://my-node.example/')
+
+    clearCustomRpcOverride(EvmChain.Ethereum)
+    expect(getEvmRpcUrl(EvmChain.Ethereum)).toBe(ethDefaultRpcUrl)
+  })
+
+  it('resolves the override Cosmos LCD URL when set, default otherwise', () => {
+    expect(getCosmosRpcUrl(CosmosChain.Cosmos)).toBe(
+      cosmosRpcUrl[CosmosChain.Cosmos]
+    )
+
+    setCustomRpcOverride(CosmosChain.Cosmos, 'https://my-cosmos.example')
+    expect(getCosmosRpcUrl(CosmosChain.Cosmos)).toBe('https://my-cosmos.example')
+  })
+
+  it('keeps overrides isolated per chain', () => {
+    setCustomRpcOverride(EvmChain.Ethereum, 'https://eth-node.example/')
+    expect(getCustomRpcOverride(EvmChain.Ethereum)).toBe(
+      'https://eth-node.example/'
+    )
+    expect(getCustomRpcOverride(EvmChain.Avalanche)).toBeUndefined()
+  })
+
+  it('replaces the whole map on hydrate, dropping stale entries', () => {
+    setCustomRpcOverride(EvmChain.Ethereum, 'https://eth-node.example/')
+    setCustomRpcOverrides({ [EvmChain.Base]: 'https://base-node.example/' })
+
+    expect(getCustomRpcOverride(EvmChain.Ethereum)).toBeUndefined()
+    expect(getCustomRpcOverride(EvmChain.Base)).toBe(
+      'https://base-node.example/'
+    )
+  })
+})
+
+describe('custom RPC supported chains', () => {
+  it('includes every EVM chain and the IBC-enabled Cosmos chains', () => {
+    expect(customRpcSupportedChains).toContain(EvmChain.Ethereum)
+    expect(customRpcSupportedChains).toContain(CosmosChain.Osmosis)
+  })
+
+  it('excludes vault-based Cosmos, UTXO, and QBTC chains', () => {
+    expect(isCustomRpcSupported(Chain.THORChain)).toBe(false)
+    expect(isCustomRpcSupported(Chain.MayaChain)).toBe(false)
+    expect(isCustomRpcSupported(UtxoChain.Bitcoin)).toBe(false)
+    expect(isCustomRpcSupported(Chain.QBTC)).toBe(false)
+  })
+})

--- a/packages/core/chain/chains/customRpc/customRpcOverrides.ts
+++ b/packages/core/chain/chains/customRpc/customRpcOverrides.ts
@@ -18,13 +18,24 @@ import { Chain } from '@vultisig/core-chain/Chain'
  */
 const overridesByChain = new Map<string, string>()
 
-/** Synchronous lookup of the override URL for `chain`, or `undefined` when unset. */
-export const getCustomRpcOverride = (chain: Chain): string | undefined =>
-  overridesByChain.get(chain)
+// Trims surrounding whitespace and treats a blank URL as "no override", so an
+// empty string can never become an active override that breaks RPC resolution.
+const normalizeOverrideUrl = (url: string): string | undefined => {
+  const trimmed = url.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
 
-/** Persist a single override into the in-memory mirror. */
+/** Synchronous lookup of the override URL for `chain`, or `undefined` when unset. */
+export const getCustomRpcOverride = (chain: Chain): string | undefined => overridesByChain.get(chain)
+
+/** Persist a single override into the in-memory mirror. A blank URL clears it. */
 export const setCustomRpcOverride = (chain: Chain, url: string): void => {
-  overridesByChain.set(chain, url)
+  const normalized = normalizeOverrideUrl(url)
+  if (normalized) {
+    overridesByChain.set(chain, normalized)
+  } else {
+    overridesByChain.delete(chain)
+  }
 }
 
 /** Remove a single override from the in-memory mirror. */
@@ -37,17 +48,17 @@ export const clearCustomRpcOverride = (chain: Chain): void => {
  * from persisted storage at launch and after each write, so the networking
  * layer always reflects the latest persisted state.
  */
-export const setCustomRpcOverrides = (
-  overrides: Partial<Record<Chain, string>>
-): void => {
+export const setCustomRpcOverrides = (overrides: Partial<Record<Chain, string>>): void => {
   overridesByChain.clear()
   for (const [chain, url] of Object.entries(overrides)) {
-    if (url) {
-      overridesByChain.set(chain, url)
+    if (typeof url === 'string') {
+      const normalized = normalizeOverrideUrl(url)
+      if (normalized) {
+        overridesByChain.set(chain, normalized)
+      }
     }
   }
 }
 
 /** Snapshot of all current overrides, keyed by chain. */
-export const getCustomRpcOverrides = (): Partial<Record<Chain, string>> =>
-  Object.fromEntries(overridesByChain)
+export const getCustomRpcOverrides = (): Partial<Record<Chain, string>> => Object.fromEntries(overridesByChain)

--- a/packages/core/chain/chains/customRpc/customRpcOverrides.ts
+++ b/packages/core/chain/chains/customRpc/customRpcOverrides.ts
@@ -1,0 +1,53 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+
+/**
+ * App-wide, per-chain custom RPC endpoint overrides.
+ *
+ * The persisted source of truth lives in the host app (desktop + extension
+ * storage). This module is the in-memory mirror the networking layer reads
+ * from: the EVM / Cosmos URL resolvers build their clients off the main thread
+ * via *synchronous, non-async* lookups and cannot await storage, so the host
+ * hydrates this map at launch and keeps it in sync on every write.
+ *
+ * `undefined` from {@link getCustomRpcOverride} means "no override", and the
+ * caller keeps its hardcoded default — guaranteeing byte-identical default
+ * behaviour for users who never configured one.
+ *
+ * Keyed by the raw `string` chain id (which `Chain` already is) so reads/writes
+ * stay assertion-free.
+ */
+const overridesByChain = new Map<string, string>()
+
+/** Synchronous lookup of the override URL for `chain`, or `undefined` when unset. */
+export const getCustomRpcOverride = (chain: Chain): string | undefined =>
+  overridesByChain.get(chain)
+
+/** Persist a single override into the in-memory mirror. */
+export const setCustomRpcOverride = (chain: Chain, url: string): void => {
+  overridesByChain.set(chain, url)
+}
+
+/** Remove a single override from the in-memory mirror. */
+export const clearCustomRpcOverride = (chain: Chain): void => {
+  overridesByChain.delete(chain)
+}
+
+/**
+ * Replace the entire override map. Used by the host app to hydrate the mirror
+ * from persisted storage at launch and after each write, so the networking
+ * layer always reflects the latest persisted state.
+ */
+export const setCustomRpcOverrides = (
+  overrides: Partial<Record<Chain, string>>
+): void => {
+  overridesByChain.clear()
+  for (const [chain, url] of Object.entries(overrides)) {
+    if (url) {
+      overridesByChain.set(chain, url)
+    }
+  }
+}
+
+/** Snapshot of all current overrides, keyed by chain. */
+export const getCustomRpcOverrides = (): Partial<Record<Chain, string>> =>
+  Object.fromEntries(overridesByChain)

--- a/packages/core/chain/chains/customRpc/customRpcSupportedChains.ts
+++ b/packages/core/chain/chains/customRpc/customRpcSupportedChains.ts
@@ -1,8 +1,4 @@
-import {
-  Chain,
-  EvmChain,
-  IbcEnabledCosmosChain,
-} from '@vultisig/core-chain/Chain'
+import { Chain, EvmChain, IbcEnabledCosmosChain } from '@vultisig/core-chain/Chain'
 
 /**
  * Single source of truth for which chains accept an app-wide custom RPC
@@ -22,17 +18,12 @@ export const customRpcSupportedEvmChains: EvmChain[] = Object.values(EvmChain)
  * Cosmos chains that accept a custom RPC override. The IBC-enabled set excludes
  * the vault-based chains (THORChain / MayaChain) and QBTC by construction.
  */
-export const customRpcSupportedCosmosChains: IbcEnabledCosmosChain[] =
-  Object.values(IbcEnabledCosmosChain)
+export const customRpcSupportedCosmosChains: IbcEnabledCosmosChain[] = Object.values(IbcEnabledCosmosChain)
 
 /** All chains that accept a custom RPC override, in display order (EVM then Cosmos). */
-export const customRpcSupportedChains: Chain[] = [
-  ...customRpcSupportedEvmChains,
-  ...customRpcSupportedCosmosChains,
-]
+export const customRpcSupportedChains: Chain[] = [...customRpcSupportedEvmChains, ...customRpcSupportedCosmosChains]
 
 const supportedChainIds = new Set<string>(customRpcSupportedChains)
 
 /** Whether `chain` accepts an app-wide custom RPC override. */
-export const isCustomRpcSupported = (chain: Chain): boolean =>
-  supportedChainIds.has(chain)
+export const isCustomRpcSupported = (chain: Chain): boolean => supportedChainIds.has(chain)

--- a/packages/core/chain/chains/customRpc/customRpcSupportedChains.ts
+++ b/packages/core/chain/chains/customRpc/customRpcSupportedChains.ts
@@ -1,0 +1,38 @@
+import {
+  Chain,
+  EvmChain,
+  IbcEnabledCosmosChain,
+} from '@vultisig/core-chain/Chain'
+
+/**
+ * Single source of truth for which chains accept an app-wide custom RPC
+ * override. Shared by the resolution funnel (EVM / Cosmos URL resolvers) and
+ * the Custom RPC UI so the two can never disagree — a chain shown in the picker
+ * is exactly a chain the funnel honors.
+ *
+ * v1 scope is intentionally limited to EVM and the IBC-enabled Cosmos chains,
+ * the two groups whose networking resolves through a single per-chain RPC URL.
+ * UTXO chains (proxy-only, no coherent node insertion point), the vault-based
+ * Cosmos chains (THORChain / MayaChain) and QBTC (a Vultisig proxy with no
+ * real-node equivalent) are excluded, mirroring the iOS / Android rationale.
+ */
+export const customRpcSupportedEvmChains: EvmChain[] = Object.values(EvmChain)
+
+/**
+ * Cosmos chains that accept a custom RPC override. The IBC-enabled set excludes
+ * the vault-based chains (THORChain / MayaChain) and QBTC by construction.
+ */
+export const customRpcSupportedCosmosChains: IbcEnabledCosmosChain[] =
+  Object.values(IbcEnabledCosmosChain)
+
+/** All chains that accept a custom RPC override, in display order (EVM then Cosmos). */
+export const customRpcSupportedChains: Chain[] = [
+  ...customRpcSupportedEvmChains,
+  ...customRpcSupportedCosmosChains,
+]
+
+const supportedChainIds = new Set<string>(customRpcSupportedChains)
+
+/** Whether `chain` accepts an app-wide custom RPC override. */
+export const isCustomRpcSupported = (chain: Chain): boolean =>
+  supportedChainIds.has(chain)

--- a/packages/core/chain/chains/customRpc/rpcHealthProbe.ts
+++ b/packages/core/chain/chains/customRpc/rpcHealthProbe.ts
@@ -26,11 +26,7 @@ export type RpcHealthResult =
 const probeTimeoutMs = 8_000
 const cosmosNodeInfoPath = 'cosmos/base/tendermint/v1beta1/node_info'
 
-const probeEvm = async (
-  chain: Chain,
-  url: string,
-  signal: AbortSignal
-): Promise<RpcHealthResult> => {
+const probeEvm = async (chain: Chain, url: string, signal: AbortSignal): Promise<RpcHealthResult> => {
   const startedAt = Date.now()
   const response = await fetch(url, {
     method: 'POST',
@@ -49,19 +45,25 @@ const probeEvm = async (
     return { status: 'unreachable' }
   }
 
-  const body: { result?: unknown } = await response.json()
-  if (typeof body.result !== 'string') {
+  // A non-JSON body means the endpoint is alive but not speaking JSON-RPC, so
+  // classify it as invalidResponse rather than letting it fall through to the
+  // caller's catch (which would mislabel a live endpoint as unreachable).
+  let body: { result?: unknown }
+  try {
+    body = await response.json()
+  } catch {
+    return { status: 'invalidResponse' }
+  }
+
+  // Strict hex match: Number.parseInt stops at the first invalid digit, so
+  // "0x1g" would otherwise parse to 1 and could false-match a chain id.
+  if (typeof body.result !== 'string' || !/^0x[0-9a-f]+$/i.test(body.result)) {
     return { status: 'invalidResponse' }
   }
 
   const reportedChainId = Number.parseInt(body.result, 16)
-  if (Number.isNaN(reportedChainId)) {
-    return { status: 'invalidResponse' }
-  }
 
-  const expectedChainId = isChainOfKind(chain, 'evm')
-    ? Number.parseInt(getEvmChainId(chain), 16)
-    : undefined
+  const expectedChainId = isChainOfKind(chain, 'evm') ? Number.parseInt(getEvmChainId(chain), 16) : undefined
 
   if (expectedChainId === undefined) {
     return { status: 'reachable', latencyMs, networkVerified: false }
@@ -72,35 +74,22 @@ const probeEvm = async (
     : { status: 'wrongChain' }
 }
 
-const probeCosmos = async (
-  url: string,
-  signal: AbortSignal
-): Promise<RpcHealthResult> => {
+const probeCosmos = async (url: string, signal: AbortSignal): Promise<RpcHealthResult> => {
   const startedAt = Date.now()
   // The LCD node_info endpoint confirms liveness. We don't verify the reported
   // network id against the chain here, so this stays a liveness-only result.
-  const response = await fetch(
-    `${url.replace(/\/+$/, '')}/${cosmosNodeInfoPath}`,
-    { signal }
-  )
+  const response = await fetch(`${url.replace(/\/+$/, '')}/${cosmosNodeInfoPath}`, { signal })
   const latencyMs = Date.now() - startedAt
 
-  return response.ok
-    ? { status: 'reachable', latencyMs, networkVerified: false }
-    : { status: 'unreachable' }
+  return response.ok ? { status: 'reachable', latencyMs, networkVerified: false } : { status: 'unreachable' }
 }
 
-const probeReachability = async (
-  url: string,
-  signal: AbortSignal
-): Promise<RpcHealthResult> => {
+const probeReachability = async (url: string, signal: AbortSignal): Promise<RpcHealthResult> => {
   const startedAt = Date.now()
   const response = await fetch(url, { signal })
   const latencyMs = Date.now() - startedAt
 
-  return response.ok
-    ? { status: 'reachable', latencyMs, networkVerified: false }
-    : { status: 'unreachable' }
+  return response.ok ? { status: 'reachable', latencyMs, networkVerified: false } : { status: 'unreachable' }
 }
 
 type ProbeRpcHealthInput = {
@@ -114,10 +103,7 @@ type ProbeRpcHealthInput = {
  * back to a plain reachability check. A timeout or transport error resolves to
  * `unreachable` rather than throwing.
  */
-export const probeRpcHealth = async ({
-  chain,
-  url,
-}: ProbeRpcHealthInput): Promise<RpcHealthResult> => {
+export const probeRpcHealth = async ({ chain, url }: ProbeRpcHealthInput): Promise<RpcHealthResult> => {
   const endpoint = url.trim()
   if (!endpoint) {
     return { status: 'unreachable' }

--- a/packages/core/chain/chains/customRpc/rpcHealthProbe.ts
+++ b/packages/core/chain/chains/customRpc/rpcHealthProbe.ts
@@ -1,0 +1,142 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+
+import { isChainOfKind } from '../../ChainKind'
+import { getEvmChainId } from '../evm/chainInfo'
+
+/**
+ * Outcome of probing a candidate custom RPC endpoint for liveness (and, where
+ * possible, network identity), so the Custom RPC editor can show a "Test"
+ * result.
+ */
+export type RpcHealthResult =
+  /**
+   * The endpoint responded successfully. `networkVerified` is true only when the
+   * probe could confirm the endpoint serves the expected chain (EVM
+   * `eth_chainId` match); for chains without a cheap identity check it is a
+   * liveness-only result.
+   */
+  | { status: 'reachable'; latencyMs: number; networkVerified: boolean }
+  /** The endpoint did not respond, timed out, or returned a transport/HTTP error. */
+  | { status: 'unreachable' }
+  /** The endpoint is alive but serves a different chain than expected (EVM chainId mismatch). */
+  | { status: 'wrongChain' }
+  /** The endpoint responded but the payload could not be understood as the expected RPC shape. */
+  | { status: 'invalidResponse' }
+
+const probeTimeoutMs = 8_000
+const cosmosNodeInfoPath = 'cosmos/base/tendermint/v1beta1/node_info'
+
+const probeEvm = async (
+  chain: Chain,
+  url: string,
+  signal: AbortSignal
+): Promise<RpcHealthResult> => {
+  const startedAt = Date.now()
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'eth_chainId',
+      params: [],
+    }),
+    signal,
+  })
+  const latencyMs = Date.now() - startedAt
+
+  if (!response.ok) {
+    return { status: 'unreachable' }
+  }
+
+  const body: { result?: unknown } = await response.json()
+  if (typeof body.result !== 'string') {
+    return { status: 'invalidResponse' }
+  }
+
+  const reportedChainId = Number.parseInt(body.result, 16)
+  if (Number.isNaN(reportedChainId)) {
+    return { status: 'invalidResponse' }
+  }
+
+  const expectedChainId = isChainOfKind(chain, 'evm')
+    ? Number.parseInt(getEvmChainId(chain), 16)
+    : undefined
+
+  if (expectedChainId === undefined) {
+    return { status: 'reachable', latencyMs, networkVerified: false }
+  }
+
+  return reportedChainId === expectedChainId
+    ? { status: 'reachable', latencyMs, networkVerified: true }
+    : { status: 'wrongChain' }
+}
+
+const probeCosmos = async (
+  url: string,
+  signal: AbortSignal
+): Promise<RpcHealthResult> => {
+  const startedAt = Date.now()
+  // The LCD node_info endpoint confirms liveness. We don't verify the reported
+  // network id against the chain here, so this stays a liveness-only result.
+  const response = await fetch(
+    `${url.replace(/\/+$/, '')}/${cosmosNodeInfoPath}`,
+    { signal }
+  )
+  const latencyMs = Date.now() - startedAt
+
+  return response.ok
+    ? { status: 'reachable', latencyMs, networkVerified: false }
+    : { status: 'unreachable' }
+}
+
+const probeReachability = async (
+  url: string,
+  signal: AbortSignal
+): Promise<RpcHealthResult> => {
+  const startedAt = Date.now()
+  const response = await fetch(url, { signal })
+  const latencyMs = Date.now() - startedAt
+
+  return response.ok
+    ? { status: 'reachable', latencyMs, networkVerified: false }
+    : { status: 'unreachable' }
+}
+
+type ProbeRpcHealthInput = {
+  chain: Chain
+  url: string
+}
+
+/**
+ * Probes a candidate custom RPC URL: EVM endpoints verify chain identity via
+ * `eth_chainId`, Cosmos endpoints check LCD liveness, and any other chain falls
+ * back to a plain reachability check. A timeout or transport error resolves to
+ * `unreachable` rather than throwing.
+ */
+export const probeRpcHealth = async ({
+  chain,
+  url,
+}: ProbeRpcHealthInput): Promise<RpcHealthResult> => {
+  const endpoint = url.trim()
+  if (!endpoint) {
+    return { status: 'unreachable' }
+  }
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), probeTimeoutMs)
+
+  try {
+    if (isChainOfKind(chain, 'evm')) {
+      return await probeEvm(chain, endpoint, controller.signal)
+    }
+    if (isChainOfKind(chain, 'cosmos')) {
+      return await probeCosmos(endpoint, controller.signal)
+    }
+    return await probeReachability(endpoint, controller.signal)
+  } catch {
+    return { status: 'unreachable' }
+  } finally {
+    clearTimeout(timeout)
+  }
+}

--- a/packages/core/chain/chains/evm/chainInfo.ts
+++ b/packages/core/chain/chains/evm/chainInfo.ts
@@ -1,4 +1,5 @@
 import { EvmChain } from '@vultisig/core-chain/Chain'
+import { getCustomRpcOverride } from '../customRpc/customRpcOverrides'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { rootApiUrl } from '@vultisig/core-config'
 import { numberToHex } from '@vultisig/lib-utils/hex/numberToHex'
@@ -87,6 +88,14 @@ export const evmChainInfo = recordMap(evmDefaultChainInfo, (chain, chainKey) => 
     },
   }
 })
+
+/**
+ * Resolves the RPC URL for an EVM chain, honoring an app-wide custom RPC
+ * override when one is set and falling back to the default endpoint otherwise.
+ * Byte-identical to the default when no override is configured.
+ */
+export const getEvmRpcUrl = (chain: EvmChain): string =>
+  getCustomRpcOverride(chain) ?? evmChainRpcUrls[chain]
 
 export const getEvmChainId = (chain: EvmChain): string => {
   return evmChainId[chain]

--- a/packages/core/chain/chains/evm/chainInfo.ts
+++ b/packages/core/chain/chains/evm/chainInfo.ts
@@ -1,5 +1,4 @@
 import { EvmChain } from '@vultisig/core-chain/Chain'
-import { getCustomRpcOverride } from '../customRpc/customRpcOverrides'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { rootApiUrl } from '@vultisig/core-config'
 import { numberToHex } from '@vultisig/lib-utils/hex/numberToHex'
@@ -20,6 +19,8 @@ import {
   sei,
   zksync,
 } from 'viem/chains'
+
+import { getCustomRpcOverride } from '../customRpc/customRpcOverrides'
 
 const hyperliquidRpcUrl = `${rootApiUrl}/hyperevm/`
 export const hyperliquidBlockExplorerUrl = 'https://liquidscan.io'
@@ -94,8 +95,7 @@ export const evmChainInfo = recordMap(evmDefaultChainInfo, (chain, chainKey) => 
  * override when one is set and falling back to the default endpoint otherwise.
  * Byte-identical to the default when no override is configured.
  */
-export const getEvmRpcUrl = (chain: EvmChain): string =>
-  getCustomRpcOverride(chain) ?? evmChainRpcUrls[chain]
+export const getEvmRpcUrl = (chain: EvmChain): string => getCustomRpcOverride(chain) ?? evmChainRpcUrls[chain]
 
 export const getEvmChainId = (chain: EvmChain): string => {
   return evmChainId[chain]

--- a/packages/core/chain/chains/evm/chainInfo.ts
+++ b/packages/core/chain/chains/evm/chainInfo.ts
@@ -1,4 +1,5 @@
 import { EvmChain } from '@vultisig/core-chain/Chain'
+import { getCustomRpcOverride } from '@vultisig/core-chain/chains/customRpc/customRpcOverrides'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { rootApiUrl } from '@vultisig/core-config'
 import { numberToHex } from '@vultisig/lib-utils/hex/numberToHex'
@@ -19,8 +20,6 @@ import {
   sei,
   zksync,
 } from 'viem/chains'
-
-import { getCustomRpcOverride } from '../customRpc/customRpcOverrides'
 
 const hyperliquidRpcUrl = `${rootApiUrl}/hyperevm/`
 export const hyperliquidBlockExplorerUrl = 'https://liquidscan.io'

--- a/packages/core/chain/chains/evm/client.ts
+++ b/packages/core/chain/chains/evm/client.ts
@@ -2,11 +2,17 @@ import { EvmChain } from '@vultisig/core-chain/Chain'
 import { memoize } from '@vultisig/lib-utils/memoize'
 import { createPublicClient, http, PublicClient } from 'viem'
 
-import { evmChainInfo } from './chainInfo'
+import { evmChainInfo, getEvmRpcUrl } from './chainInfo'
 
-export const getEvmClient = memoize((chain: EvmChain): PublicClient => {
-  return createPublicClient({
-    chain: evmChainInfo[chain],
-    transport: http(),
-  })
-})
+// Keyed on the resolved RPC URL (not just the chain) so toggling an app-wide
+// custom RPC override yields a fresh client, while default users keep a single
+// cached instance with byte-identical behaviour.
+export const getEvmClient = memoize(
+  (chain: EvmChain): PublicClient => {
+    return createPublicClient({
+      chain: evmChainInfo[chain],
+      transport: http(getEvmRpcUrl(chain)),
+    })
+  },
+  (chain: EvmChain) => `${chain}:${getEvmRpcUrl(chain)}`
+)

--- a/packages/core/chain/coin/balance/resolvers/cosmos.ts
+++ b/packages/core/chain/coin/balance/resolvers/cosmos.ts
@@ -1,10 +1,10 @@
 import { CosmosChain } from '@vultisig/core-chain/Chain'
 import { getCosmosClient } from '@vultisig/core-chain/chains/cosmos/client'
 import { getCosmosWasmTokenBalanceUrl, isCosmosWasmTokenId } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
+import { getCosmosRpcUrl } from '@vultisig/core-chain/chains/cosmos/getCosmosRpcUrl'
 import { getDenom } from '@vultisig/core-chain/coin/utils/getDenom'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
-import { getCosmosRpcUrl } from '../../../chains/cosmos/getCosmosRpcUrl'
 import { CoinBalanceResolver } from '../resolver'
 
 type LcdBalanceResponse = {

--- a/packages/core/chain/coin/balance/resolvers/cosmos.ts
+++ b/packages/core/chain/coin/balance/resolvers/cosmos.ts
@@ -1,10 +1,10 @@
 import { CosmosChain } from '@vultisig/core-chain/Chain'
 import { getCosmosClient } from '@vultisig/core-chain/chains/cosmos/client'
 import {
-  cosmosRpcUrl,
   getCosmosWasmTokenBalanceUrl,
   isCosmosWasmTokenId,
 } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
+import { getCosmosRpcUrl } from '../../../chains/cosmos/getCosmosRpcUrl'
 import { getDenom } from '@vultisig/core-chain/coin/utils/getDenom'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
@@ -31,7 +31,7 @@ type LcdBalanceResponse = {
 // a second chance before we ship a "you have 0" UX that contradicts the
 // on-chain reality.
 const fetchBalanceViaLcd = async (chain: CosmosChain, address: string, denom: string): Promise<bigint | null> => {
-  const base = cosmosRpcUrl[chain]
+  const base = getCosmosRpcUrl(chain)
   if (!base) return null
   try {
     const resp = await queryUrl<LcdBalanceResponse>(

--- a/packages/core/chain/coin/balance/resolvers/cosmos.ts
+++ b/packages/core/chain/coin/balance/resolvers/cosmos.ts
@@ -1,13 +1,10 @@
 import { CosmosChain } from '@vultisig/core-chain/Chain'
 import { getCosmosClient } from '@vultisig/core-chain/chains/cosmos/client'
-import {
-  getCosmosWasmTokenBalanceUrl,
-  isCosmosWasmTokenId,
-} from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
-import { getCosmosRpcUrl } from '../../../chains/cosmos/getCosmosRpcUrl'
+import { getCosmosWasmTokenBalanceUrl, isCosmosWasmTokenId } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
 import { getDenom } from '@vultisig/core-chain/coin/utils/getDenom'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
+import { getCosmosRpcUrl } from '../../../chains/cosmos/getCosmosRpcUrl'
 import { CoinBalanceResolver } from '../resolver'
 
 type LcdBalanceResponse = {

--- a/packages/core/chain/coin/token/metadata/resolvers/cosmos.ts
+++ b/packages/core/chain/coin/token/metadata/resolvers/cosmos.ts
@@ -1,9 +1,5 @@
 import { CosmosChain } from '@vultisig/core-chain/Chain'
-import {
-  getCosmosWasmTokenInfoUrl,
-  isCosmosWasmTokenId,
-} from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
-import { getCosmosRpcUrl } from '../../../../chains/cosmos/getCosmosRpcUrl'
+import { getCosmosWasmTokenInfoUrl, isCosmosWasmTokenId } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { CoinMetadata } from '@vultisig/core-chain/coin/Coin'
 import { knownCosmosTokens } from '@vultisig/core-chain/coin/knownTokens/cosmos'
@@ -12,6 +8,8 @@ import { getLastItem } from '@vultisig/lib-utils/array/getLastItem'
 import { attempt } from '@vultisig/lib-utils/attempt'
 import { asyncFallbackChain } from '@vultisig/lib-utils/promise/asyncFallbackChain'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+
+import { getCosmosRpcUrl } from '../../../../chains/cosmos/getCosmosRpcUrl'
 
 type DenomUnits = { denom: string; exponent: number }
 type DenomMetadata = {

--- a/packages/core/chain/coin/token/metadata/resolvers/cosmos.ts
+++ b/packages/core/chain/coin/token/metadata/resolvers/cosmos.ts
@@ -1,5 +1,6 @@
 import { CosmosChain } from '@vultisig/core-chain/Chain'
 import { getCosmosWasmTokenInfoUrl, isCosmosWasmTokenId } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
+import { getCosmosRpcUrl } from '@vultisig/core-chain/chains/cosmos/getCosmosRpcUrl'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { CoinMetadata } from '@vultisig/core-chain/coin/Coin'
 import { knownCosmosTokens } from '@vultisig/core-chain/coin/knownTokens/cosmos'
@@ -8,8 +9,6 @@ import { getLastItem } from '@vultisig/lib-utils/array/getLastItem'
 import { attempt } from '@vultisig/lib-utils/attempt'
 import { asyncFallbackChain } from '@vultisig/lib-utils/promise/asyncFallbackChain'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
-
-import { getCosmosRpcUrl } from '../../../../chains/cosmos/getCosmosRpcUrl'
 
 type DenomUnits = { denom: string; exponent: number }
 type DenomMetadata = {

--- a/packages/core/chain/coin/token/metadata/resolvers/cosmos.ts
+++ b/packages/core/chain/coin/token/metadata/resolvers/cosmos.ts
@@ -1,9 +1,9 @@
 import { CosmosChain } from '@vultisig/core-chain/Chain'
 import {
-  cosmosRpcUrl,
   getCosmosWasmTokenInfoUrl,
   isCosmosWasmTokenId,
 } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
+import { getCosmosRpcUrl } from '../../../../chains/cosmos/getCosmosRpcUrl'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { CoinMetadata } from '@vultisig/core-chain/coin/Coin'
 import { knownCosmosTokens } from '@vultisig/core-chain/coin/knownTokens/cosmos'
@@ -152,7 +152,7 @@ const getIbcDenomTraceFromLCD = async (lcdBase: string, denom: string): Promise<
 }
 
 const getBankDenomMetadata = async (chain: CosmosChain, id: string): Promise<CoinMetadata> => {
-  const lcd = cosmosRpcUrl[chain]
+  const lcd = getCosmosRpcUrl(chain)
   const meta = await getDenomMetaFromLCD(lcd, id)
   if (meta) {
     try {

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -225,6 +225,11 @@
       "import": "./dist/chains/cosmos/gas.js",
       "default": "./dist/chains/cosmos/gas.js"
     },
+    "./chains/cosmos/getCosmosRpcUrl": {
+      "types": "./dist/chains/cosmos/getCosmosRpcUrl.d.ts",
+      "import": "./dist/chains/cosmos/getCosmosRpcUrl.js",
+      "default": "./dist/chains/cosmos/getCosmosRpcUrl.js"
+    },
     "./chains/cosmos/protoEncoding": {
       "types": "./dist/chains/cosmos/protoEncoding.d.ts",
       "import": "./dist/chains/cosmos/protoEncoding.js",
@@ -439,6 +444,21 @@
       "types": "./dist/chains/cosmos/utils/parseCosmosSerialized.d.ts",
       "import": "./dist/chains/cosmos/utils/parseCosmosSerialized.js",
       "default": "./dist/chains/cosmos/utils/parseCosmosSerialized.js"
+    },
+    "./chains/customRpc/customRpcOverrides": {
+      "types": "./dist/chains/customRpc/customRpcOverrides.d.ts",
+      "import": "./dist/chains/customRpc/customRpcOverrides.js",
+      "default": "./dist/chains/customRpc/customRpcOverrides.js"
+    },
+    "./chains/customRpc/customRpcSupportedChains": {
+      "types": "./dist/chains/customRpc/customRpcSupportedChains.d.ts",
+      "import": "./dist/chains/customRpc/customRpcSupportedChains.js",
+      "default": "./dist/chains/customRpc/customRpcSupportedChains.js"
+    },
+    "./chains/customRpc/rpcHealthProbe": {
+      "types": "./dist/chains/customRpc/rpcHealthProbe.d.ts",
+      "import": "./dist/chains/customRpc/rpcHealthProbe.js",
+      "default": "./dist/chains/customRpc/rpcHealthProbe.js"
     },
     "./chains/evm/chainInfo": {
       "types": "./dist/chains/evm/chainInfo.d.ts",


### PR DESCRIPTION
## What

Adds the SDK-side plumbing for **app-wide, per-chain custom RPC endpoint overrides**, so a host app (windows desktop + extension) can point a supported chain at the user's own node. This is the SDK half of the Custom RPC feature (Silver-tier perk; iOS #4469 / Android #4796 parity). The host populates the registry and gates it; this PR only provides the resolution + probe primitives.

## Changes (`@vultisig/core-chain`)

- **`chains/customRpc/customRpcOverrides.ts`** — in-memory override registry with a synchronous, non-async read path (`getCustomRpcOverride`) plus `set/clear` and a bulk `setCustomRpcOverrides` for hydration. The networking layer resolves URLs synchronously off the React tree, so it can't await storage; the host hydrates this mirror at launch and on each write.
- **`chains/customRpc/customRpcSupportedChains.ts`** — single source of truth shared by the resolvers and the UI: all EVM chains + the IBC-enabled Cosmos chains. Vault-based Cosmos (THORChain/MayaChain), UTXO, and QBTC are excluded (proxy-only / no coherent raw-node insertion point), matching iOS/Android.
- **EVM funnel** — `getEvmRpcUrl()` resolves `override ?? default`; `getEvmClient` builds its client from it and memoizes per resolved URL, so toggling an override yields a fresh client while default users keep a single cached instance.
- **Cosmos funnel** — `getCosmosRpcUrl()` resolves the LCD/REST override and is wired into account info, fee/min-gas, the LCD balance fallback, and token metadata. The Tendermint `StargateClient` intentionally keeps its default endpoint: the override is an LCD/REST URL (also what the health probe validates), a different protocol from Tendermint RPC, so applying it there would break balance-primary/broadcast for a user who enters an LCD.
- **`chains/customRpc/rpcHealthProbe.ts`** — `probeRpcHealth()` for the editor's "Test": EVM verifies chain identity via `eth_chainId`, Cosmos checks LCD `node_info` liveness, others fall back to a reachability check; 8 s timeout, errors resolve to `unreachable`.

**Default behaviour is byte-identical when no override is set.**

## Tests

- `chains/customRpc/customRpc.test.ts` — override resolution (EVM + Cosmos), per-chain isolation, hydrate-replaces-map, and supported/excluded membership. Existing `getCosmosAccountInfo` suite still green.

## Notes

- `package.json` `exports` regenerated by `yarn build:shared` to expose the new modules.
- Changeset bumps `@vultisig/core-chain` and `@vultisig/sdk` (bundled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added app-wide, per-chain Custom RPC overrides for all EVM chains and IBC-enabled Cosmos chains, with an RPC health probe (liveness + EVM chain identity verification).
  * Introduced public RPC URL resolvers for EVM and Cosmos that honor overrides.
* **Enhancements**
  * Cosmos LCD/REST and WASM smart-query URL resolution now uses the override when configured, while keeping default behavior byte-identical when unset.
  * Client caching refreshes when the effective RPC URL changes.
* **Tests**
  * Added coverage for override resolution, per-chain isolation, full-map replacement/clearing, supported-chain detection, and health probe outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->