### PR TITLE
feat(cli): --auto-verify for headless fast-vault OTP via AgentMail

### DIFF
--- a/clients/cli/src/commands/vault-management.ts
+++ b/clients/cli/src/commands/vault-management.ts
@@ -318,7 +318,21 @@ export async function executeImport(ctx: CommandContext, file: string, flagPassw
 export async function executeVerify(
   ctx: CommandContext,
   vaultId: string,
-  options: { resend?: boolean; code?: string; email?: string; password?: string } = {}
+  options: {
+    resend?: boolean
+    code?: string
+    email?: string
+    password?: string
+    /**
+     * Poll AgentMail for the OTP instead of prompting (headless/CI). Requires
+     * AGENTMAIL_API_KEY (env or --agentmail-key) + the inbox email (--email)
+     * + the vault name (--name) so the message can be matched.
+     */
+    autoVerify?: boolean
+    agentmailKey?: string
+    name?: string
+    signal?: AbortSignal
+  } = {}
 ): Promise<boolean> {
   if (options.resend) {
     // Get email and password - prompt if not provided via flags
@@ -367,6 +381,30 @@ export async function executeVerify(
   }
 
   let code = options.code
+
+  // Headless OTP: poll AgentMail for the code instead of prompting. Needs the
+  // inbox email + vault name to match the message, and the API key (flag/env).
+  if (!code && options.autoVerify) {
+    const apiKey = options.agentmailKey || process.env.AGENTMAIL_API_KEY
+    const inboxEmail = options.email || process.env.AGENTMAIL_EMAIL
+    const vaultName = options.name
+    if (!apiKey || !inboxEmail || !vaultName) {
+      error(
+        '--auto-verify needs an AgentMail key (AGENTMAIL_API_KEY or --agentmail-key), the inbox email (--email), and the vault name (--name).'
+      )
+      return false
+    }
+    const { fetchVaultOtp } = await import('../lib/agentmail-otp')
+    const spinner = createSpinner('Waiting for the AgentMail verification code…')
+    try {
+      code = await fetchVaultOtp({ inboxEmail, apiKey, vaultName, signal: options.signal })
+      spinner.succeed('Verification code received from AgentMail.')
+    } catch (otpErr: any) {
+      spinner.fail('Could not auto-fetch the verification code')
+      error(otpErr?.message || 'AgentMail OTP polling failed.')
+      return false
+    }
+  }
 
   if (!code) {
     const codeAnswer = await inquirer.prompt([

--- a/clients/cli/src/index.ts
+++ b/clients/cli/src/index.ts
@@ -568,11 +568,28 @@ program
   .description('Verify vault with email verification code')
   .option('-r, --resend', 'Resend verification email')
   .option('--code <code>', 'Verification code')
-  .option('--email <email>', 'Email address (required for --resend)')
+  .option('--email <email>', 'Email address (required for --resend / --auto-verify)')
   .option('--password <password>', 'Vault password (required for --resend)')
+  .option(
+    '--auto-verify',
+    'Poll AgentMail for the OTP instead of prompting (headless/CI). Needs AGENTMAIL_API_KEY (or --agentmail-key), --email, and --name'
+  )
+  .option('--agentmail-key <key>', 'AgentMail API key (defaults to AGENTMAIL_API_KEY env)')
+  .option('--name <name>', 'Vault name, used to match the AgentMail verification message (with --auto-verify)')
   .action(
     withExit(
-      async (vaultId: string, options: { resend?: boolean; code?: string; email?: string; password?: string }) => {
+      async (
+        vaultId: string,
+        options: {
+          resend?: boolean
+          code?: string
+          email?: string
+          password?: string
+          autoVerify?: boolean
+          agentmailKey?: string
+          name?: string
+        }
+      ) => {
         const context = await init(program.opts().vault)
         const verified = await executeVerify(context, vaultId, options)
         if (!verified) {

--- a/clients/cli/src/lib/__tests__/agentmail-otp.test.ts
+++ b/clients/cli/src/lib/__tests__/agentmail-otp.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchVaultOtp } from '../agentmail-otp'
+
+// Helper to build a fetch mock that returns a sequence of JSON bodies keyed by
+// URL substring. List requests return the inbox; message requests return text.
+function mockFetch(responses: Array<{ match: string; body: any; ok?: boolean }>) {
+  // Match the LONGEST matching pattern so a message-detail URL
+  // (".../messages/m-1") doesn't get captured by the list pattern ("/messages").
+  const ordered = [...responses].sort((a, b) => b.match.length - a.match.length)
+  return vi.fn(async (url: string) => {
+    const r = ordered.find(x => url.includes(x.match))
+    if (!r) throw new Error('unexpected fetch url: ' + url)
+    return {
+      ok: r.ok ?? true,
+      status: r.ok === false ? 500 : 200,
+      statusText: r.ok === false ? 'err' : 'OK',
+      json: async () => r.body,
+    } as any
+  })
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('fetchVaultOtp', () => {
+  it('extracts the OTP from a message matched by vault name', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch([
+        {
+          match: '/messages',
+          body: {
+            messages: [
+              { message_id: 'm-other', subject: 'unrelated', preview: 'hi' },
+              { message_id: 'm-1', subject: 'Verify MyTestVault', preview: 'code inside' },
+            ],
+          },
+        },
+        { match: '/messages/m-1', body: { text: 'Your Vultisig code is 482913. Expires soon.' } },
+      ])
+    )
+    const code = await fetchVaultOtp({
+      inboxEmail: 'vs_dev@agentmail.to',
+      apiKey: 'test-key',
+      vaultName: 'MyTestVault',
+      maxAttempts: 2,
+      intervalMs: 1,
+    })
+    expect(code).toBe('482913')
+  })
+
+  it('matches on preview when the subject does not contain the vault name', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch([
+        {
+          match: '/messages',
+          body: { messages: [{ message_id: 'm-2', subject: 'Verification', preview: 'For MyTestVault' }] },
+        },
+        { match: '/messages/m-2', body: { extracted_text: 'OTP: 5678' } },
+      ])
+    )
+    const code = await fetchVaultOtp({
+      inboxEmail: 'vs_dev@agentmail.to',
+      apiKey: 'test-key',
+      vaultName: 'MyTestVault',
+      maxAttempts: 2,
+      intervalMs: 1,
+    })
+    expect(code).toBe('5678')
+  })
+
+  it('throws a timeout error when no matching message arrives', async () => {
+    vi.stubGlobal('fetch', mockFetch([{ match: '/messages', body: { messages: [] } }]))
+    await expect(
+      fetchVaultOtp({
+        inboxEmail: 'vs_dev@agentmail.to',
+        apiKey: 'test-key',
+        vaultName: 'Nope',
+        maxAttempts: 2,
+        intervalMs: 1,
+      })
+    ).rejects.toThrow(/Timed out/)
+  })
+
+  it('does not include the api key in the thrown error', async () => {
+    vi.stubGlobal('fetch', mockFetch([{ match: '/messages', body: { messages: [] } }]))
+    const err: Error = await fetchVaultOtp({
+      inboxEmail: 'vs_dev@agentmail.to',
+      apiKey: 'super-secret-key',
+      vaultName: 'Nope',
+      maxAttempts: 1,
+      intervalMs: 1,
+    }).then(
+      () => new Error('should have thrown'),
+      (e: unknown) => (e instanceof Error ? e : new Error(String(e)))
+    )
+    expect(err.message).not.toContain('super-secret-key')
+  })
+})

--- a/clients/cli/src/lib/agentmail-otp.ts
+++ b/clients/cli/src/lib/agentmail-otp.ts
@@ -12,7 +12,7 @@
 const AGENTMAIL_BASE = 'https://api.agentmail.to/v0/inboxes'
 const OTP_CODE_RE = /\b(\d{4,6})\b/
 
-export interface AgentMailOtpOptions {
+export type AgentMailOtpOptions = {
   /** AgentMail inbox address the verification email is sent to. */
   inboxEmail: string
   /** AgentMail API key (Bearer). */
@@ -27,7 +27,7 @@ export interface AgentMailOtpOptions {
   signal?: AbortSignal
 }
 
-interface AgentMailMessage {
+type AgentMailMessage = {
   message_id: string
   subject?: string
   preview?: string

--- a/clients/cli/src/lib/agentmail-otp.ts
+++ b/clients/cli/src/lib/agentmail-otp.ts
@@ -1,0 +1,91 @@
+/**
+ * AgentMail OTP fetcher — polls an AgentMail inbox for the fast-vault
+ * verification code so `verify --auto-verify` can run fully headless (no
+ * human pasting the OTP). Mirrors the logic the mobile maestro test harness
+ * already uses (vultiagent-app/maestro/scripts/fetch-otp.js): list the inbox,
+ * match the message to the vault name, extract the 4-6 digit code.
+ *
+ * Opt-in only: requires AGENTMAIL_API_KEY + the inbox email. Never reads or
+ * logs the key. Intended for automated/CI vault-creation flows, not prod.
+ */
+
+const AGENTMAIL_BASE = 'https://api.agentmail.to/v0/inboxes'
+const OTP_CODE_RE = /\b(\d{4,6})\b/
+
+export interface AgentMailOtpOptions {
+  /** AgentMail inbox address the verification email is sent to. */
+  inboxEmail: string
+  /** AgentMail API key (Bearer). */
+  apiKey: string
+  /** Vault name to match the message against (subject/preview contains it). */
+  vaultName: string
+  /** Max poll attempts (default 30). */
+  maxAttempts?: number
+  /** Delay between attempts in ms (default 3000). */
+  intervalMs?: number
+  /** Abort signal to cancel polling. */
+  signal?: AbortSignal
+}
+
+interface AgentMailMessage {
+  message_id: string
+  subject?: string
+  preview?: string
+}
+
+async function getJson(url: string, apiKey: string, signal?: AbortSignal): Promise<any> {
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+    signal,
+  })
+  if (!res.ok) {
+    throw new Error(`AgentMail request failed: ${res.status} ${res.statusText}`)
+  }
+  return res.json()
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) return reject(new Error('Operation cancelled'))
+    const t = setTimeout(resolve, ms)
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(t)
+        reject(new Error('Operation cancelled'))
+      },
+      { once: true }
+    )
+  })
+}
+
+/**
+ * Poll the AgentMail inbox until a verification message matching `vaultName`
+ * arrives, then return its extracted OTP code. Throws on timeout / abort.
+ */
+export async function fetchVaultOtp(opts: AgentMailOtpOptions): Promise<string> {
+  const { inboxEmail, apiKey, vaultName } = opts
+  const maxAttempts = opts.maxAttempts ?? 30
+  const intervalMs = opts.intervalMs ?? 3000
+  const listUrl = `${AGENTMAIL_BASE}/${encodeURIComponent(inboxEmail)}/messages`
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    if (opts.signal?.aborted) throw new Error('Operation cancelled')
+    try {
+      const list = await getJson(listUrl, apiKey, opts.signal)
+      const messages: AgentMailMessage[] = list?.messages ?? []
+      const matched = messages.find(m => (m.preview ?? '').includes(vaultName) || (m.subject ?? '').includes(vaultName))
+      if (matched) {
+        const msg = await getJson(`${listUrl}/${matched.message_id}`, apiKey, opts.signal)
+        const text: string = msg?.text ?? msg?.extracted_text ?? ''
+        const code = text.match(OTP_CODE_RE)
+        if (code) return code[1]
+      }
+    } catch (err) {
+      // Transient list/read failure — keep polling unless it was an abort.
+      if (err instanceof Error && /cancelled/i.test(err.message)) throw err
+    }
+    if (attempt < maxAttempts) await sleep(intervalMs, opts.signal)
+  }
+  throw new Error(`Timed out after ${maxAttempts} attempts waiting for the AgentMail OTP for vault "${vaultName}".`)
+}


### PR DESCRIPTION
## Summary

Adds `verify --auto-verify` to `@vultisig/cli` so fast-vault creation can run **fully headless** — the one gap that blocked a scripted/CI agent E2E from the CLI. Fast vaults require an email OTP, which the CLI could previously only obtain via an interactive prompt. This polls **AgentMail** for the code, reusing the exact logic the mobile maestro test harness already uses (`vultiagent-app/maestro/scripts/fetch-otp.js`).

Motivation: enable headless agent E2E / regression testing without the app. Because the CLI shares the `@vultisig/sdk` signing path and already enforces the `--confirm` approve-gate, this also makes the CLI usable as a **frontend regression harness**.

## What's added

- `clients/cli/src/lib/agentmail-otp.ts` — typed AgentMail poller (list inbox → match the message by vault name → extract the 4–6 digit code). Opt-in; never logs the API key.
- `verify --auto-verify [--agentmail-key <k>] [--email <e>] --name <n>` — polls instead of prompting. Key falls back to `AGENTMAIL_API_KEY`. Missing creds → a clear, actionable error (no crash, no prompt under `--ci`).

One-shot headless flow it enables:
```
vsig create-from-seedphrase fast --mnemonic "<words>" --password <pw> --email <inbox> --name Test
vsig verify <vaultId> --auto-verify --email <inbox> --name Test
vsig agent --backend-url <url> --password <pw>   # then query / send --confirm / swap
```

## Receipts

**New unit tests (poller: success, match-by-preview, timeout, no-key-leak) + full suite green:**
```
$ npm run test:cli
 ✓ src/lib/__tests__/agentmail-otp.test.ts (4 tests)
 Test Files  17 passed (17)
      Tests  256 passed (256)     # was 252 before this PR
```

**Flag is wired + the headless error path is clean (no interactive prompt under --ci):**
```
$ npx tsx src/index.ts verify --help
  --auto-verify          Poll AgentMail for the OTP instead of prompting (headless/CI)...
  --agentmail-key <key>  AgentMail API key (defaults to AGENTMAIL_API_KEY env)
  --name <name>          Vault name, used to match the AgentMail verification message

$ npx tsx src/index.ts verify someVaultId --auto-verify --ci
  --auto-verify needs an AgentMail key (AGENTMAIL_API_KEY or --agentmail-key), the inbox email (--email), and the vault name (--name).
  {"success": false, ...}   # clean JSON failure, exit 7 — no crash, no hung prompt
```

Build: `npm run build` → "Built @vultisig/cli v2.2.0".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
