### PR TITLE
fix(sui): reject memo in keysign instead of silently dropping it

### DIFF
--- a/.changeset/sui-reject-memo.md
+++ b/.changeset/sui-reject-memo.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/core-mpc': patch
+'@vultisig/sdk': patch
+---
+
+Reject a memo on Sui keysigns instead of silently dropping it. Sui has no native memo field (a transaction is a Programmable Transaction Block), so the Sui signing-input resolver now throws when `keysignPayload.memo` is set, surfacing the unsupported request to callers.

--- a/packages/core/mpc/keysign/signingInputs/resolvers/sui.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/sui.test.ts
@@ -150,9 +150,7 @@ describe('getSuiSigningInputs — native send', () => {
       memo: 'deposit-12345',
     })
 
-    expect(() =>
-      getSuiSigningInputs({ keysignPayload, walletCore })
-    ).toThrow('do not support a memo')
+    expect(() => getSuiSigningInputs({ keysignPayload, walletCore })).toThrow('do not support a memo')
   })
 })
 

--- a/packages/core/mpc/keysign/signingInputs/resolvers/sui.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/sui.test.ts
@@ -136,6 +136,26 @@ describe('getSuiSigningInputs — signSui (pre-built PTB)', () => {
   })
 })
 
+describe('getSuiSigningInputs — native send', () => {
+  it('rejects a memo (Sui has no native memo field)', async () => {
+    const keysignPayload = create(KeysignPayloadSchema, {
+      coin: create(CoinSchema, {
+        chain: Chain.Sui,
+        ticker: 'SUI',
+        address: signer,
+        decimals: 9,
+        isNativeToken: true,
+        hexPublicKey: hex(publicKey.data()),
+      }),
+      memo: 'deposit-12345',
+    })
+
+    expect(() =>
+      getSuiSigningInputs({ keysignPayload, walletCore })
+    ).toThrow('do not support a memo')
+  })
+})
+
 describe('getSuiChainSpecific — signSui (pre-built PTB)', () => {
   it('returns an empty SuiSpecific without touching the RPC', async () => {
     const chainSpecific = await getSuiChainSpecific({

--- a/packages/core/mpc/keysign/signingInputs/resolvers/sui.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/sui.ts
@@ -28,6 +28,13 @@ export const getSuiSigningInputs: SigningInputsResolver<'sui'> = ({ keysignPaylo
     ]
   }
 
+  // Sui has no native memo concept — a transaction is a Programmable
+  // Transaction Block with no memo field. Rather than silently dropping a
+  // memo, fail loudly so callers don't assume it was attached.
+  if (keysignPayload.memo) {
+    throw new Error('Sui transactions do not support a memo')
+  }
+
   const { coins, referenceGasPrice, gasBudget } = getBlockchainSpecificValue(
     keysignPayload.blockchainSpecific,
     'suicheSpecific'


### PR DESCRIPTION
## Problem
Sui has no native memo concept — a Sui transaction is a Programmable Transaction Block, with no memo field. `getSuiSigningInputs` builds `Pay`/`PaySui` from coins and never reads `keysignPayload.memo`, so any memo was silently dropped. A caller (or the wallet UI) could pass a memo and wrongly assume it was attached.

## Change
Throw a clear error (`"Sui transactions do not support a memo"`) when `keysignPayload.memo` is set, on the native send path of the Sui signing-input resolver. Adds a regression test.

## Companion change
The Windows/extension UI hides the memo field for Sui (separate PR in `vultisig-windows`), so this is a defense-in-depth guard for any caller that still passes one.

## Out of scope
Building a custom PTB that embeds memo bytes (app-level pure-bytes input / Move call). Sui exchanges use unique deposit addresses, not memos.

Refs vultisig/vultisig-windows#4124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sui transactions now reject memos with an explicit error instead of silently dropping them, ensuring unsupported features are properly surfaced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->