### PR TITLE
fix(cosmos): use polkachu for Kujira LCD + RPC endpoints (publicnode 403s)

### DIFF
--- a/.changeset/kujira-lcd-endpoint.md
+++ b/.changeset/kujira-lcd-endpoint.md
@@ -1,5 +1,6 @@
 ---
 "@vultisig/core-chain": patch
+"@vultisig/sdk": patch
 ---
 
 fix(cosmos): use polkachu for the Kujira LCD + RPC endpoints

--- a/.changeset/kujira-lcd-endpoint.md
+++ b/.changeset/kujira-lcd-endpoint.md
@@ -1,0 +1,11 @@
+---
+"@vultisig/core-chain": patch
+---
+
+fix(cosmos): use polkachu for the Kujira LCD + RPC endpoints
+
+`kujira-rest.publicnode.com` and `kujira-rpc.publicnode.com` both now return
+HTTP 403 "unsupported platform" for our clients, breaking Kujira balance reads
+and tx broadcasts. Point `cosmosRpcUrl` and `tendermintRpcUrl` for Kujira at
+polkachu (the same provider Noble uses, and the one `getCosmosAccountInfo`
+already falls back to). Live-verified 200 with the real ukuji balance.

--- a/packages/core/chain/chains/cosmos/cosmosRpcUrl.ts
+++ b/packages/core/chain/chains/cosmos/cosmosRpcUrl.ts
@@ -13,7 +13,9 @@ export const cosmosRpcUrl: Record<CosmosChain, string> = {
   Cosmos: 'https://cosmos-rest.publicnode.com',
   Osmosis: 'https://osmosis-rest.publicnode.com',
   Dydx: 'https://dydx-rest.publicnode.com',
-  Kujira: 'https://kujira-rest.publicnode.com',
+  // kujira-rest.publicnode.com returns HTTP 403 "unsupported platform"; use polkachu
+  // (same provider Noble uses below + COSMOS_LCD_FALLBACK_URLS in getCosmosAccountInfo).
+  Kujira: 'https://kujira-api.polkachu.com',
   Terra: 'https://terra-lcd.publicnode.com',
   TerraClassic: 'https://terra-classic-lcd.publicnode.com',
   Noble: 'https://noble-api.polkachu.com',

--- a/packages/core/chain/chains/cosmos/tendermintRpcUrl.ts
+++ b/packages/core/chain/chains/cosmos/tendermintRpcUrl.ts
@@ -4,7 +4,7 @@ export const tendermintRpcUrl: Record<CosmosChain, string> = {
   Cosmos: 'https://cosmos-rpc.publicnode.com:443',
   Osmosis: 'https://osmosis-rpc.publicnode.com:443',
   Dydx: 'https://dydx-rpc.publicnode.com:443',
-  Kujira: 'https://kujira-rpc.publicnode.com:443',
+  Kujira: 'https://kujira-rpc.polkachu.com', // kujira-rpc.publicnode.com 403s "unsupported platform"
   Terra: 'https://terra-rpc.publicnode.com:443',
   TerraClassic: 'https://terra-classic-rpc.publicnode.com:443',
   Noble: 'https://noble-rpc.polkachu.com/',

--- a/packages/sdk/tests/unit/cosmos/lcdQueries.test.ts
+++ b/packages/sdk/tests/unit/cosmos/lcdQueries.test.ts
@@ -77,7 +77,7 @@ describe('cosmos staking / URL builders', () => {
 
   it('builds Kujira auth account URL (used for vesting account detection)', () => {
     expect(getAuthAccountUrl('Kujira', 'kujira1abc')).toBe(
-      'https://kujira-rest.publicnode.com/cosmos/auth/v1beta1/accounts/kujira1abc'
+      'https://kujira-api.polkachu.com/cosmos/auth/v1beta1/accounts/kujira1abc'
     )
   })
 })


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#733

## what

Point Kujira's cosmos endpoints at polkachu:
- `cosmosRpcUrl` (REST/LCD): `kujira-rest.publicnode.com` -> `https://kujira-api.polkachu.com`
- `tendermintRpcUrl` (RPC): `kujira-rpc.publicnode.com:443` -> `https://kujira-rpc.polkachu.com`

## why

Both kujira publicnode hosts now return **HTTP 403 "unsupported platform"** for our clients, so Kujira balance reads fail and `getCosmosAccountInfo` eats a failed primary request before its polkachu fallback kicks in on every signing turn. polkachu is the same provider Noble uses in this registry and the one `COSMOS_LCD_FALLBACK_URLS` already lists for Kujira, so this promotes it to the primary. Only the kujira publicnode host is affected (cosmos/osmosis/terra/dydx/akash still 200).

## receipts (live curl)

```
OLD publicnode:
  REST .../cosmos/bank/v1beta1/balances/<addr>  -> 403
  REST .../cosmos/auth/v1beta1/accounts/<addr>  -> 403
  RPC  kujira-rpc.publicnode.com:443/status     -> 403

NEW polkachu:
  REST kujira-api.polkachu.com/.../balances/<addr>  -> 200  {"balances":[{"denom":"ukuji","amount":"195561951"}]}
  REST kujira-api.polkachu.com/.../accounts/<addr>  -> 200  BaseAccount (pubkey + sequence)
  RPC  kujira-rpc.polkachu.com/status                -> 200  node_info
```

## test

`vitest tests/unit/cosmos` -> 16/16 pass (incl. the Kujira auth-account URL builder, assertion updated to polkachu). Changeset added (`@vultisig/core-chain` patch).

## companion PRs (same dead endpoint, other clients)

vultiagent-app#1312, vultisig-ios#4578, vultisig-android#4915, vultisig-windows#4126.