### PR TITLE
fix(cosmos): point Kujira LCD/REST at polkachu

### DIFF
--- a/.changeset/kujira-rest-polkachu.md
+++ b/.changeset/kujira-rest-polkachu.md
@@ -1,0 +1,7 @@
+---
+'@vultisig/core-chain': patch
+---
+
+fix(cosmos): point Kujira LCD/REST at polkachu
+
+`kujira-rest.publicnode.com` started platform-gating and now returns HTTP 403, breaking Kujira native balance reads. Switch the Kujira LCD/REST endpoint to `https://kujira-api.polkachu.com` (same `/cosmos/bank/v1beta1/balances/{address}` path), matching the host `getCosmosAccountInfo` already uses for Kujira.

--- a/packages/core/chain/chains/cosmos/cosmosRpcUrl.ts
+++ b/packages/core/chain/chains/cosmos/cosmosRpcUrl.ts
@@ -13,7 +13,7 @@ export const cosmosRpcUrl: Record<CosmosChain, string> = {
   Cosmos: 'https://cosmos-rest.publicnode.com',
   Osmosis: 'https://osmosis-rest.publicnode.com',
   Dydx: 'https://dydx-rest.publicnode.com',
-  Kujira: 'https://kujira-rest.publicnode.com',
+  Kujira: 'https://kujira-api.polkachu.com',
   Terra: 'https://terra-lcd.publicnode.com',
   TerraClassic: 'https://terra-classic-lcd.publicnode.com',
   Noble: 'https://noble-api.polkachu.com',

--- a/packages/sdk/tests/unit/cosmos/lcdQueries.test.ts
+++ b/packages/sdk/tests/unit/cosmos/lcdQueries.test.ts
@@ -77,7 +77,7 @@ describe('cosmos staking / URL builders', () => {
 
   it('builds Kujira auth account URL (used for vesting account detection)', () => {
     expect(getAuthAccountUrl('Kujira', 'kujira1abc')).toBe(
-      'https://kujira-rest.publicnode.com/cosmos/auth/v1beta1/accounts/kujira1abc'
+      'https://kujira-api.polkachu.com/cosmos/auth/v1beta1/accounts/kujira1abc'
     )
   })
 })


### PR DESCRIPTION
## what

`https://kujira-rest.publicnode.com` now platform-gates requests and returns **HTTP 403 "unsupported platform"**, so the cosmos LCD balance fetch fails and KUJI balances read as missing/zero for users holding KUJI.

## fix

Point Kujira's LCD/REST endpoint at `https://kujira-api.polkachu.com`. It's a drop-in — same `/cosmos/bank/v1beta1/balances/{address}` path. This matches the host that `getCosmosAccountInfo` already uses for Kujira, and follows the Noble precedent of using polkachu.

## verification

- Live-confirmed `kujira-rest.publicnode.com` returns 403; `kujira-api.polkachu.com` responds normally.
- Updated the `lcdQueries` unit test assertion for the Kujira auth-account URL.
- Added a `@vultisig/core-chain` patch changeset.

Fixes vultisig/vultisig-windows#4126