### PR TITLE
fix(cosmos): restore kujira lcd fallback redundancy with distinct provider

### DIFF
--- a/.changeset/fix-kujira-lcd-fallback-redundancy.md
+++ b/.changeset/fix-kujira-lcd-fallback-redundancy.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/core-chain': patch
+---
+
+Use a distinct provider for Kujira's LCD fallback so primary (polkachu) and fallback (rest.cosmos.directory) are independent - restoring real redundancy if polkachu degrades.

--- a/packages/core/chain/chains/cosmos/account/getCosmosAccountInfo.ts
+++ b/packages/core/chain/chains/cosmos/account/getCosmosAccountInfo.ts
@@ -85,7 +85,11 @@ const parseLcdAccount = (resp: LcdAccountResponse): ParsedAccount | null => {
 const COSMOS_LCD_FALLBACK_URLS: Partial<Record<CosmosChain, string>> = {
   [Chain.Cosmos]: 'https://cosmos-api.polkachu.com',
   [Chain.Osmosis]: 'https://osmosis-api.polkachu.com',
-  [Chain.Kujira]: 'https://kujira-api.polkachu.com',
+  // rest.cosmos.directory/kujira proxies across multiple independent providers
+  // (confirmed live 2026-06-16 via node_info + auth endpoint returning valid cosmos SDK JSON).
+  // Distinct from the polkachu primary in cosmosRpcUrl.ts so a polkachu degradation
+  // does not take out both legs simultaneously (the failure mode flagged in #735).
+  [Chain.Kujira]: 'https://rest.cosmos.directory/kujira',
   [Chain.Terra]: 'https://terra-api.polkachu.com',
   [Chain.TerraClassic]: 'https://lcd.terra-classic.hexxagon.io',
   [Chain.THORChain]: 'https://thorchain-api.polkachu.com',


### PR DESCRIPTION
## what

After #735 switched Kujira's primary LCD to polkachu, `COSMOS_LCD_FALLBACK_URLS[Chain.Kujira]` was left pointing at the same `kujira-api.polkachu.com` host. The fallback existed in the map but offered zero real redundancy: if polkachu degrades, both the primary and the fallback hit the same dead host and Kujira signing fails with no recovery path.

This is exactly the failure mode the per-chain LCD fallback mechanism was introduced to prevent (vultiagent-app#1017, SamYap Terra Classic degradation report).

Ehsan-saradar flagged this on #735 as a `potential-issue` but it was merged without a fix. This PR is the follow-up.

## how

Switch `COSMOS_LCD_FALLBACK_URLS[Chain.Kujira]` from `https://kujira-api.polkachu.com` to `https://rest.cosmos.directory/kujira`.

`rest.cosmos.directory` is a multi-provider aggregator maintained by the Cosmos ecosystem that proxies across multiple independent node operators. It is a genuinely distinct infra path from polkachu, so a polkachu degradation now routes the fallback leg to different infrastructure.

## curl receipt (endpoint live as of 2026-06-16)

Node info (200, valid cosmos SDK JSON, network=kaiyo-1):
```
$ curl -s -m8 https://rest.cosmos.directory/kujira/cosmos/base/tendermint/v1beta1/node_info | head -1
{"default_node_info":{"protocol_version":...,"network":"kaiyo-1","version":"v1.1.0-alphab-mod"...}}
```

Auth endpoint routing correctly (500 = bech32 decode error on test addr, proves the host is live and routing to the cosmos SDK handler):
```
$ curl -s -m8 https://rest.cosmos.directory/kujira/cosmos/auth/v1beta1/accounts/kujira190g5j8aszqhvtg7cprmev8xcxs6csra7xnk3n3
{"code":2,"message":"decoding bech32 failed: invalid checksum...","details":[]}
```

Polkachu primary (unchanged, still 200):
```
$ curl -s -o /dev/null -w "%{http_code}" -m8 https://kujira-api.polkachu.com/cosmos/base/tendermint/v1beta1/node_info
200
```

## build / test

- `corepack yarn build:shared` - clean
- `corepack yarn vitest run packages/core/chain/chains/cosmos/account/getCosmosAccountInfo.test.ts` - 9/9 pass
- `corepack yarn tsc --noEmit --project .config/tsconfig.json` - no errors

## risk

Low - isolated to the Kujira fallback leg only. The fallback is only attempted after the polkachu primary already failed, so this change has zero effect on the happy path. Adds real recovery for the unhappy path.

Refs: #735, vultiagent-app#1017

🤖 Agent-generated