### PR TITLE
Populate THORChain payload fees

### DIFF
--- a/.changeset/thorchain-payload-fee.md
+++ b/.changeset/thorchain-payload-fee.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/sdk": patch
+---
+
+Populate THORChain custom Cosmos payload fees from SignAmino input fees.

--- a/packages/sdk/src/vault/services/cosmos/buildCosmosPayload.ts
+++ b/packages/sdk/src/vault/services/cosmos/buildCosmosPayload.ts
@@ -68,12 +68,17 @@ async function buildCosmosBlockchainSpecific(
   if (chainKind === 'vaultBased') {
     // THORChain or MayaChain
     if (chain === 'THORChain') {
+      const feeAmount = fee?.amount?.[0]?.amount
+      if (fee && feeAmount == null) {
+        throw new Error('THORChain fee.amount[0].amount is required when fee is provided')
+      }
+
       return {
         case: 'thorchainSpecific',
         value: create(THORChainSpecificSchema, {
           accountNumber: BigInt(accountNumber),
           sequence: BigInt(sequence),
-          fee: BigInt(fee?.amount[0]?.amount ?? 0),
+          fee: BigInt(feeAmount ?? 0),
         }),
       }
     } else {

--- a/packages/sdk/src/vault/services/cosmos/buildCosmosPayload.ts
+++ b/packages/sdk/src/vault/services/cosmos/buildCosmosPayload.ts
@@ -60,6 +60,7 @@ async function buildCosmosBlockchainSpecific(
   coin: AccountCoin,
   accountNumber: string,
   sequence: string,
+  fee?: CosmosFeeInput,
   skipChainSpecificFetch?: boolean
 ): Promise<KeysignPayload['blockchainSpecific']> {
   const chainKind = getCosmosChainKind(chain)
@@ -72,6 +73,7 @@ async function buildCosmosBlockchainSpecific(
         value: create(THORChainSpecificSchema, {
           accountNumber: BigInt(accountNumber),
           sequence: BigInt(sequence),
+          fee: BigInt(fee?.amount[0]?.amount ?? 0),
         }),
       }
     } else {
@@ -172,6 +174,7 @@ export async function buildSignAminoKeysignPayload(input: BuildSignAminoPayloadI
     coin,
     accountNumber,
     sequence,
+    fee,
     skipChainSpecificFetch
   )
 
@@ -234,6 +237,7 @@ export async function buildSignDirectKeysignPayload(input: BuildSignDirectPayloa
     coin,
     accountNumber,
     sequence,
+    undefined,
     skipChainSpecificFetch
   )
 

--- a/packages/sdk/tests/unit/vault/services/cosmos/buildCosmosPayload.test.ts
+++ b/packages/sdk/tests/unit/vault/services/cosmos/buildCosmosPayload.test.ts
@@ -73,9 +73,11 @@ describe('buildCosmosPayload', () => {
         const thor = payload.blockchainSpecific?.value as {
           accountNumber: bigint
           sequence: bigint
+          fee: bigint
         }
         expect(thor.accountNumber).toBe(0n)
         expect(thor.sequence).toBe(0n)
+        expect(thor.fee).toBe(2_000_000n)
       })
 
       it('uses mayaSpecific for MayaChain', async () => {

--- a/packages/sdk/tests/unit/vault/services/cosmos/buildCosmosPayload.test.ts
+++ b/packages/sdk/tests/unit/vault/services/cosmos/buildCosmosPayload.test.ts
@@ -80,6 +80,30 @@ describe('buildCosmosPayload', () => {
         expect(thor.fee).toBe(2_000_000n)
       })
 
+      it('throws when THORChain fee is provided without an amount', async () => {
+        await expect(
+          buildSignAminoKeysignPayload({
+            chain: Chain.THORChain,
+            coin: {
+              chain: Chain.THORChain,
+              address: 'thor1test',
+              decimals: 8,
+              ticker: 'RUNE',
+            },
+            msgs: [{ type: 'types/MsgDeposit', value: '{}' }],
+            fee: {
+              amount: [],
+              gas: '400000',
+            },
+            vaultId: 'vault-ecdsa',
+            localPartyId: 'device-1',
+            publicKey: fakePublicKey,
+            libType,
+            skipChainSpecificFetch: true,
+          })
+        ).rejects.toThrow('THORChain fee.amount[0].amount is required when fee is provided')
+      })
+
       it('uses mayaSpecific for MayaChain', async () => {
         const payload = await buildSignAminoKeysignPayload({
           chain: Chain.MayaChain,


### PR DESCRIPTION
Closes #415

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved THORChain Cosmos payload fee handling so fees are populated from SignAmino input fees when available, with a default of `0` when no fee is provided.
  * Added validation to raise an error if a THORChain fee is supplied without the required fee amount data.

* **Tests**
  * Updated and added unit tests covering THORChain fee population and the new validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->