### PR TITLE
fix(zcash): add trailing slash to branch-id RPC URL

### DIFF
--- a/.changeset/zcash-branch-id-trailing-slash.md
+++ b/.changeset/zcash-branch-id-trailing-slash.md
@@ -1,0 +1,12 @@
+---
+"@vultisig/core-chain": patch
+"@vultisig/sdk": patch
+---
+
+fix(zcash): add trailing slash to branch-id RPC URL
+
+The live ZIP-243 branch-id fetch POSTs to a bare `${rootApiUrl}/zcash`, which the
+proxy now 301-redirects to `/zcash/`. Following a 301 downgrades POST→GET, so the
+request lands as `GET /zcash/` → HTTP 405, breaking all Zcash signing on the
+"Sign Transaction" screen. Add the trailing slash so the POST hits the working
+endpoint directly (live-verified 200 with consensus.nextblock).

--- a/packages/core/chain/chains/utxo/zcashBranchId.ts
+++ b/packages/core/chain/chains/utxo/zcashBranchId.ts
@@ -3,7 +3,7 @@ import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
 const cacheTtlMs = 60 * 60 * 1000
 const rpcTimeoutMs = 10_000
-const zcashRpcUrl = `${rootApiUrl}/zcash`
+const zcashRpcUrl = `${rootApiUrl}/zcash/`
 
 type ZcashBlockchainInfoResponse = {
   result?: {


### PR DESCRIPTION
## What

One-char fix: `${rootApiUrl}/zcash` → `${rootApiUrl}/zcash/` in `zcashBranchId.ts`.

## Why

The live ZIP-243 branch-id fetch added in #714 POSTs to the **bare** `${rootApiUrl}/zcash`. The api.vultisig.com proxy 301-redirects that to `/zcash/`, and following a 301 downgrades `POST` → `GET`, so the request lands as `GET /zcash/` → **HTTP 405 Method Not Allowed**. Zcash signing fails on the "Sign Transaction" screen (before broadcast), surfacing as:

> HTTP 405 Error: Request failed for https://api.vultisig.com/zcash/

Zcash is the **only** endpoint that POSTs to a bare `${rootApiUrl}/<chain>` with no sub-path — every other chain either appends a path (`/cardano/address_info`, `/ton/v2/...`) or already carries the slash (`/eth/`, `/solana/`), so none hit the bare-path redirect. The bug was introduced with the feature in #714, not a regression of existing code.

## receipts

Reproduced against production:

| Call | Result |
|------|--------|
| `POST /zcash` (pre-fix) | 301 → `Location: /zcash/` |
| `GET /zcash/` (redirect downgrade) | **405** |
| `POST /zcash/` (this fix) | **200** ✅ |

Post-fix endpoint returns valid signer input: `consensus.nextblock: 5437f330`, `error: None`.

## Rollout note

A complementary **proxy-side** fix can unblock already-installed builds immediately (no release cycle): make `POST /zcash` work **while keeping `POST /zcash/` working as-is** — return 308 (not 301) on `/zcash`, or accept POST on both paths. Do **not** add a reverse `/zcash/` → `/zcash` redirect, or this client fix would clash. With either safe option, all rollout orders coexist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Zcash RPC endpoint connectivity configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->