### PR TITLE
feat: add Blockaid EVM address reputation scan (scanAddress)

### DIFF
--- a/.changeset/amber-dogs-scan.md
+++ b/.changeset/amber-dogs-scan.md
@@ -1,0 +1,6 @@
+---
+"@vultisig/sdk": patch
+"@vultisig/core-chain": patch
+---
+
+Add scanAddress method for Blockaid EVM address reputation scanning

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -1182,6 +1182,16 @@
       "import": "./dist/scripts/printKnownTokens.js",
       "default": "./dist/scripts/printKnownTokens.js"
     },
+    "./security/blockaid/address": {
+      "types": "./dist/security/blockaid/address/index.d.ts",
+      "import": "./dist/security/blockaid/address/index.js",
+      "default": "./dist/security/blockaid/address/index.js"
+    },
+    "./security/blockaid/address/core": {
+      "types": "./dist/security/blockaid/address/core.d.ts",
+      "import": "./dist/security/blockaid/address/core.js",
+      "default": "./dist/security/blockaid/address/core.js"
+    },
     "./security/blockaid/config": {
       "types": "./dist/security/blockaid/config.d.ts",
       "import": "./dist/security/blockaid/config.js",

--- a/packages/core/chain/security/blockaid/address/core.ts
+++ b/packages/core/chain/security/blockaid/address/core.ts
@@ -1,0 +1,4 @@
+export type BlockaidAddressScanResult = {
+  resultType: 'Benign' | 'Warning' | 'Malicious'
+  features: string[]
+}

--- a/packages/core/chain/security/blockaid/address/index.test.ts
+++ b/packages/core/chain/security/blockaid/address/index.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// Mock the query module before importing the module under test.
+vi.mock('../core/query', () => ({
+  queryBlockaid: vi.fn(),
+}))
+
+// Also mock core-config so tests don't depend on the actual domain.
+vi.mock('@vultisig/core-config', () => ({
+  productRootDomain: 'vultisig.com',
+}))
+
+import { queryBlockaid } from '../core/query'
+import { scanAddressWithBlockaid } from './index'
+
+const mockQuery = vi.mocked(queryBlockaid)
+
+describe('scanAddressWithBlockaid', () => {
+  it('calls queryBlockaid with the correct route and payload', async () => {
+    mockQuery.mockResolvedValueOnce({ result_type: 'Benign', features: [] })
+    await scanAddressWithBlockaid('0x123', 'ethereum')
+    expect(mockQuery).toHaveBeenCalledWith('/evm/address/scan', {
+      address: '0x123',
+      chain: 'ethereum',
+      metadata: { domain: 'vultisig.com' },
+    })
+  })
+
+  it('maps a Malicious response correctly, preserving features array', async () => {
+    mockQuery.mockResolvedValueOnce({
+      result_type: 'Malicious',
+      features: ['mixer', 'drainer'],
+    })
+    const result = await scanAddressWithBlockaid('0xabc', 'ethereum')
+    expect(result).toEqual({ resultType: 'Malicious', features: ['mixer', 'drainer'] })
+  })
+
+  it('maps a Benign response correctly', async () => {
+    mockQuery.mockResolvedValueOnce({ result_type: 'Benign', features: [] })
+    const result = await scanAddressWithBlockaid('0xdef', 'polygon')
+    expect(result).toEqual({ resultType: 'Benign', features: [] })
+  })
+
+  it('maps a Warning response correctly', async () => {
+    mockQuery.mockResolvedValueOnce({
+      result_type: 'Warning',
+      features: ['new_contract'],
+    })
+    const result = await scanAddressWithBlockaid('0xfff', 'base')
+    expect(result).toEqual({ resultType: 'Warning', features: ['new_contract'] })
+  })
+
+  it('defaults features to empty array when proxy omits the field', async () => {
+    mockQuery.mockResolvedValueOnce({ result_type: 'Benign' })
+    const result = await scanAddressWithBlockaid('0x111', 'ethereum')
+    expect(result.features).toEqual([])
+  })
+})

--- a/packages/core/chain/security/blockaid/address/index.ts
+++ b/packages/core/chain/security/blockaid/address/index.ts
@@ -1,0 +1,20 @@
+import { productRootDomain } from '@vultisig/core-config'
+
+import { queryBlockaid } from '../core/query'
+import type { BlockaidAddressScanResult } from './core'
+
+type BlockaidAddressScanResponse = {
+  result_type: 'Benign' | 'Warning' | 'Malicious'
+  features?: string[]
+}
+
+export const scanAddressWithBlockaid = async (
+  address: string,
+  chain: string,
+): Promise<BlockaidAddressScanResult> => {
+  const { result_type, features } = await queryBlockaid<BlockaidAddressScanResponse>(
+    '/evm/address/scan',
+    { address, chain, metadata: { domain: productRootDomain } },
+  )
+  return { resultType: result_type, features: features ?? [] }
+}

--- a/packages/core/chain/security/blockaid/address/index.ts
+++ b/packages/core/chain/security/blockaid/address/index.ts
@@ -8,13 +8,11 @@ type BlockaidAddressScanResponse = {
   features?: string[]
 }
 
-export const scanAddressWithBlockaid = async (
-  address: string,
-  chain: string,
-): Promise<BlockaidAddressScanResult> => {
-  const { result_type, features } = await queryBlockaid<BlockaidAddressScanResponse>(
-    '/evm/address/scan',
-    { address, chain, metadata: { domain: productRootDomain } },
-  )
+export const scanAddressWithBlockaid = async (address: string, chain: string): Promise<BlockaidAddressScanResult> => {
+  const { result_type, features } = await queryBlockaid<BlockaidAddressScanResponse>('/evm/address/scan', {
+    address,
+    chain,
+    metadata: { domain: productRootDomain },
+  })
   return { resultType: result_type, features: features ?? [] }
 }

--- a/packages/sdk/src/Vultisig.ts
+++ b/packages/sdk/src/Vultisig.ts
@@ -5,6 +5,7 @@ import { findCoins as coreFindCoins } from '@vultisig/core-chain/coin/find'
 import { knownTokens, knownTokensIndex } from '@vultisig/core-chain/coin/knownTokens'
 import { getCoinPrices as coreCoinPrices } from '@vultisig/core-chain/coin/price/getCoinPrices'
 import { getCoinPricesWithChange as coreCoinPricesWithChange } from '@vultisig/core-chain/coin/price/getCoinPricesWithChange'
+import { scanAddressWithBlockaid } from '@vultisig/core-chain/security/blockaid/address'
 import { scanSiteWithBlockaid } from '@vultisig/core-chain/security/blockaid/site'
 import { getSwapExplorerUrl, type SwapExplorerProvider } from '@vultisig/core-chain/swap/utils/getSwapExplorerUrl'
 import { getBlockExplorerUrl } from '@vultisig/core-chain/utils/getBlockExplorerUrl'
@@ -53,7 +54,7 @@ import {
   VaultCreationStep,
   VaultData,
 } from './types'
-import type { SiteScanResult } from './types/security'
+import type { AddressScanResult, SiteScanResult } from './types/security'
 import type {
   CoinPricesParams,
   CoinPricesResult,
@@ -1385,5 +1386,15 @@ export class Vultisig extends UniversalEventEmitter<SdkEvents> {
   static async scanSite(url: string): Promise<SiteScanResult> {
     const result = await scanSiteWithBlockaid(url)
     return { isMalicious: result === 'malicious', url }
+  }
+
+  /**
+   * Scan an EVM address for reputation via Blockaid.
+   * @param address - The EVM address to scan (0x-prefixed)
+   * @param chain - The chain name (e.g. 'ethereum', 'polygon')
+   * @returns Scan result with verdict and detector features
+   */
+  static async scanAddress(address: string, chain: string): Promise<AddressScanResult> {
+    return scanAddressWithBlockaid(address, chain)
   }
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -333,7 +333,13 @@ export type {
 // PUBLIC API - Security Scanning
 // ============================================================================
 
-export type { AddressScanResult, RiskLevel, SiteScanResult, TransactionSimulationResult, TransactionValidationResult } from './types'
+export type {
+  AddressScanResult,
+  RiskLevel,
+  SiteScanResult,
+  TransactionSimulationResult,
+  TransactionValidationResult,
+} from './types'
 
 // ============================================================================
 // PUBLIC API - Cosmos Message Type Constants

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -333,7 +333,7 @@ export type {
 // PUBLIC API - Security Scanning
 // ============================================================================
 
-export type { RiskLevel, SiteScanResult, TransactionSimulationResult, TransactionValidationResult } from './types'
+export type { AddressScanResult, RiskLevel, SiteScanResult, TransactionSimulationResult, TransactionValidationResult } from './types'
 
 // ============================================================================
 // PUBLIC API - Cosmos Message Type Constants

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -666,7 +666,13 @@ export type {
 } from './tokens'
 
 // Security scanning types
-export type { RiskLevel, SiteScanResult, TransactionSimulationResult, TransactionValidationResult } from './security'
+export type {
+  AddressScanResult,
+  RiskLevel,
+  SiteScanResult,
+  TransactionSimulationResult,
+  TransactionValidationResult,
+} from './security'
 
 // Cosmos message type constants
 export type { CosmosMsgType as CosmosMsgTypeValue } from './cosmos-msg'

--- a/packages/sdk/src/types/security.ts
+++ b/packages/sdk/src/types/security.ts
@@ -28,3 +28,11 @@ export type SiteScanResult = {
   /** The URL that was scanned */
   url: string
 }
+
+/** EVM address reputation scan result from Blockaid */
+export type AddressScanResult = {
+  /** Reputation verdict from Blockaid */
+  resultType: 'Benign' | 'Warning' | 'Malicious'
+  /** Detector features explaining the verdict */
+  features: string[]
+}


### PR DESCRIPTION
## Summary

Adds `Vultisig.scanAddress(address, chain)` — a new public static method that hits the Vultisig Blockaid proxy (`/blockaid/v0/evm/address/scan`) to return a reputation verdict for any EVM address.

Mirrors the existing `scanSite` / `scanSiteWithBlockaid` pattern exactly:
- New core module: `packages/core/chain/security/blockaid/address/index.ts`
- New type: `AddressScanResult { resultType: 'Benign'|'Warning'|'Malicious', features: string[] }`
- New core type: `BlockaidAddressScanResult` in `address/core.ts`
- Public wrapper: `Vultisig.scanAddress(address, chain): Promise<AddressScanResult>`
- Exported from `packages/sdk/src/index.ts` alongside `SiteScanResult`

## Tests

Unit test in `packages/core/chain/security/blockaid/address/index.test.ts`:
- Verifies the correct proxy route and payload shape (`/evm/address/scan`, address+chain+metadata.domain)
- Covers Benign / Warning / Malicious response mapping
- Covers features array default (empty when proxy omits the field)
- All 5 new tests pass

## Changeset

`patch` bump on `@vultisig/sdk` and `@vultisig/core-chain`.

## QA Guide

**Intent:** Provides a programmatic SDK entry point for address reputation scanning, enabling any consumer (the vultiagent-app address-book flow today, other surfaces tomorrow) to vet EVM addresses before user interaction.

**Verify steps:**
1. Import `@vultisig/sdk` and call `Vultisig.scanAddress('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045', 'ethereum')` in a Node script
2. Expect `{ resultType: 'Benign', features: [...] }` for vitalik.eth

**Expected outcomes:** Returns `AddressScanResult` with `resultType` and `features` array. No throw on Benign.

**Edge cases:** Network timeout → propagates rejection (fail-open handled by the app consumer, not the SDK).

**Prereqs:** `VULTISIG_API_KEY` env var not required — proxy is unauthenticated.

🤖 Agent-generated