### PR TITLE
fix(cli): restore client-side tool dispatch via registry instead of dead wire flag

### DIFF
--- a/.changeset/cli-client-side-tool-registry-dispatch.md
+++ b/.changeset/cli-client-side-tool-registry-dispatch.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/cli': patch
+---
+
+Fix CLI client-side tool dispatch. The CLI gated dispatch on a `clientExecuted` wire flag the backend no longer emits, so `sign_typed_data`, `vault_coin`, `vault_chain`, and `address_book` silently stopped dispatching and degraded to display-only progress. Dispatch now keys on the existing client-side-tool registry (mirroring the app's `toolUIRegistry`), restoring those flows.

--- a/clients/cli/src/agent/__tests__/clientSideDispatch.test.ts
+++ b/clients/cli/src/agent/__tests__/clientSideDispatch.test.ts
@@ -255,9 +255,17 @@ describe('SF + CR2 — pendingToolResults catch-block contract', () => {
   })
 })
 
-describe('AgentClient SSE parser — clientExecuted routing', () => {
-  function makeClient(): AgentClient {
+describe('AgentClient SSE parser — registry-based client-side tool routing', () => {
+  // The backend's V1ToolInputAvailable frame carries NO `clientExecuted`
+  // discriminator (the flag was removed). The client must identify client-side
+  // tools via its own registry (mirroring the app's toolUIRegistry), injected
+  // by the session via setClientSideToolNames. These names mirror
+  // CLIENT_SIDE_TOOL_DISPATCH.
+  const CLIENT_SIDE_NAMES = new Set(['sign_typed_data', 'vault_coin', 'vault_chain', 'address_book'])
+
+  function makeClient(registry: Set<string> | null = CLIENT_SIDE_NAMES): AgentClient {
     const c = new AgentClient('http://localhost:8084')
+    if (registry) c.setClientSideToolNames(registry)
     return c
   }
 
@@ -275,22 +283,38 @@ describe('AgentClient SSE parser — clientExecuted routing', () => {
     ;(client as any).handleSSEEvent('', eventJson, result, callbacks, toolNameByCallId)
   }
 
-  it('fires onClientSideToolCall when clientExecuted=true on tool-input-available', () => {
-    const client = makeClient()
+  // Representative CURRENT-backend frame: NO clientExecuted field.
+  const currentBackendVaultCoinEvent = JSON.stringify({
+    type: 'tool-input-available',
+    toolCallId: 'c1',
+    toolName: 'vault_coin',
+    input: { tokens: [{ chain: 'Base', ticker: 'USDC' }] },
+  })
+
+  // BEFORE/AFTER differential — the core of the fix. Against a current-backend
+  // frame (no clientExecuted), the OLD strict `parsed.clientExecuted === true`
+  // check NEVER dispatched (the 4 client-side tools were dead). With the
+  // registry injected, the SAME frame now dispatches by toolName membership.
+  it('PRE-FIX repro: a current-backend frame does NOT dispatch when no registry is set', () => {
+    // No registry injected ⇒ no membership ⇒ no dispatch. This is the dead
+    // state the old clientExecuted gate produced against the live backend.
+    const client = makeClient(null)
     const onClientSideToolCall = vi.fn()
     const onToolProgress = vi.fn()
 
-    feedEvent(
-      client,
-      JSON.stringify({
-        type: 'tool-input-available',
-        toolCallId: 'c1',
-        toolName: 'vault_coin',
-        input: { tokens: [{ chain: 'Base', ticker: 'USDC' }] },
-        clientExecuted: true,
-      }),
-      { onClientSideToolCall, onToolProgress }
-    )
+    feedEvent(client, currentBackendVaultCoinEvent, { onClientSideToolCall, onToolProgress })
+
+    expect(onClientSideToolCall).not.toHaveBeenCalled()
+    // The tool still degrades to display-only progress (the silent regression).
+    expect(onToolProgress).toHaveBeenCalled()
+  })
+
+  it('POST-FIX: the SAME current-backend frame DOES dispatch via registry match', () => {
+    const client = makeClient() // registry injected (as session does)
+    const onClientSideToolCall = vi.fn()
+    const onToolProgress = vi.fn()
+
+    feedEvent(client, currentBackendVaultCoinEvent, { onClientSideToolCall, onToolProgress })
 
     expect(onClientSideToolCall).toHaveBeenCalledOnce()
     expect(onClientSideToolCall).toHaveBeenCalledWith('c1', 'vault_coin', {
@@ -299,7 +323,22 @@ describe('AgentClient SSE parser — clientExecuted routing', () => {
     expect(onToolProgress).toHaveBeenCalled()
   })
 
-  it('does NOT fire onClientSideToolCall when clientExecuted is absent (MCP tool)', () => {
+  it('dispatches every registry tool from a current-backend frame (all 4 tools alive again)', () => {
+    for (const toolName of CLIENT_SIDE_NAMES) {
+      const client = makeClient()
+      const onClientSideToolCall = vi.fn()
+      feedEvent(
+        client,
+        JSON.stringify({ type: 'tool-input-available', toolCallId: 'c', toolName, input: { action: 'add' } }),
+        { onClientSideToolCall }
+      )
+      expect(onClientSideToolCall, `expected ${toolName} to dispatch`).toHaveBeenCalledWith('c', toolName, {
+        action: 'add',
+      })
+    }
+  })
+
+  it('does NOT fire for a non-client-side toolName (server-side / MCP) — no over-trigger', () => {
     const client = makeClient()
     const onClientSideToolCall = vi.fn()
     const onToolProgress = vi.fn()
@@ -319,28 +358,28 @@ describe('AgentClient SSE parser — clientExecuted routing', () => {
     expect(onToolProgress).toHaveBeenCalled()
   })
 
-  it('does NOT fire onClientSideToolCall when clientExecuted is non-true (malformed)', () => {
+  it('ignores a stray clientExecuted flag — identification is registry-only now', () => {
+    // Even if some backend re-introduced the flag, a non-registry tool must
+    // NOT dispatch (registry is the sole source of truth).
     const client = makeClient()
     const onClientSideToolCall = vi.fn()
 
-    for (const v of ['true', 1, 'yes', {}]) {
-      feedEvent(
-        client,
-        JSON.stringify({
-          type: 'tool-input-available',
-          toolCallId: 'c',
-          toolName: 'vault_coin',
-          input: {},
-          clientExecuted: v,
-        }),
-        { onClientSideToolCall }
-      )
-    }
+    feedEvent(
+      client,
+      JSON.stringify({
+        type: 'tool-input-available',
+        toolCallId: 'c',
+        toolName: 'polymarket_search',
+        input: {},
+        clientExecuted: true,
+      }),
+      { onClientSideToolCall }
+    )
 
     expect(onClientSideToolCall).not.toHaveBeenCalled()
   })
 
-  it('does NOT fire onClientSideToolCall on tool-input-start frames', () => {
+  it('does NOT fire on tool-input-start frames (only tool-input-available dispatches)', () => {
     const client = makeClient()
     const onClientSideToolCall = vi.fn()
 
@@ -350,7 +389,6 @@ describe('AgentClient SSE parser — clientExecuted routing', () => {
         type: 'tool-input-start',
         toolCallId: 'c',
         toolName: 'vault_coin',
-        clientExecuted: true, // even if present, only tool-input-available should trigger dispatch
       }),
       { onClientSideToolCall }
     )
@@ -369,7 +407,6 @@ describe('AgentClient SSE parser — clientExecuted routing', () => {
         toolCallId: 'c',
         toolName: 'vault_coin',
         input: null,
-        clientExecuted: true,
       }),
       { onClientSideToolCall }
     )

--- a/clients/cli/src/agent/client.ts
+++ b/clients/cli/src/agent/client.ts
@@ -30,7 +30,12 @@ type StreamCallbacks = {
   // true on a clean result, undefined when the stream carries no output
   // (older backends) so the consumer can fall back to its prior default.
   onToolProgress?: (tool: string, status: 'running' | 'done', label?: string, ok?: boolean) => void
-  // Fired for `tool-input-available` with `clientExecuted: true`.
+  // Fired for `tool-input-available` whose `toolName` is in the client's
+  // client-side tool registry (see `AgentClient.setClientSideToolNames`).
+  // Identification is registry-based — mirroring the app's `toolUIRegistry` —
+  // because the backend deliberately no longer sends a `clientExecuted`
+  // discriminator flag ("clients identify client-side tools via their own
+  // tool registries; the server must not add discriminator flags").
   // Client runs the tool and ships the result via recent_actions.
   // Sync-only: callers must dispatch async work themselves (push to a
   // promise queue) — keeps `void`'d call at the SSE boundary safe from
@@ -133,6 +138,14 @@ export class AgentClient {
   private authToken: string | null = null
   private profile: string = ''
   verbose = false
+  // Names of tools this client executes locally (client-side tools). The
+  // backend's V1ToolInputAvailable frame carries NO discriminator flag —
+  // "clients identify client-side tools via their own tool registries; the
+  // server must not add discriminator flags". So the client mirrors the
+  // app's `toolUIRegistry`: a `tool-input-available` frame triggers local
+  // dispatch iff its `toolName` is in this set. Empty by default (no
+  // client-side dispatch) until the session injects the registry.
+  private clientSideToolNames: Set<string> = new Set()
 
   constructor(baseUrl: string) {
     this.baseUrl = baseUrl.replace(/\/+$/, '')
@@ -140,6 +153,13 @@ export class AgentClient {
 
   setAuthToken(token: string): void {
     this.authToken = token
+  }
+
+  /** Inject the set of tool names this client executes locally. Identification
+   *  of client-side tools is registry-based (mirroring the app's
+   *  `toolUIRegistry`), not a wire flag — see `maybeEmitClientSideToolCall`. */
+  setClientSideToolNames(names: Set<string>): void {
+    this.clientSideToolNames = names
   }
 
   /** Set the billing-profile slug sent as X-Vultisig-Abe-Profile on every
@@ -430,11 +450,17 @@ export class AgentClient {
     callId: string | null,
     toolName?: string
   ): void {
+    // Registry-based identification (mirrors the app's toolUIRegistry): a
+    // `tool-input-available` frame is dispatched locally iff its toolName is
+    // in this client's client-side tool registry. The backend sends no
+    // `clientExecuted` discriminator (it was removed) — keying on a wire flag
+    // here is what left these tools dead, so we key on the registry instead.
+    // Non-registry tools (server-side / MCP) fall through untouched.
     if (
       v1Type !== 'tool-input-available' ||
-      parsed.clientExecuted !== true ||
       !callId ||
       !toolName ||
+      !this.clientSideToolNames.has(toolName) ||
       !callbacks.onClientSideToolCall
     ) {
       return

--- a/clients/cli/src/agent/session.ts
+++ b/clients/cli/src/agent/session.ts
@@ -69,6 +69,11 @@ export class AgentSession {
     this.config = config
     this.client = new AgentClient(config.backendUrl)
     this.client.verbose = !!config.verbose
+    // Registry-based client-side tool identification: tell the client which
+    // tools the CLI executes locally so a `tool-input-available` frame is
+    // dispatched on toolName membership (mirroring the app's toolUIRegistry),
+    // not on a `clientExecuted` wire flag the backend no longer sends.
+    this.client.setClientSideToolNames(new Set(Object.keys(CLIENT_SIDE_TOOL_DISPATCH)))
     if (config.profile) {
       this.client.setProfile(config.profile)
     }


### PR DESCRIPTION
## Summary

The CLI gated client-side tool dispatch on a `clientExecuted` flag in the
`tool-input-available` SSE frame. The backend no longer sends that flag — it
deliberately omits any discriminator and expects clients to identify
client-side tools via their own registry. As a result the strict
`clientExecuted === true` check was permanently false, and the CLI's
client-side tools silently stopped dispatching: they degraded to display-only
progress with no local execution and no result shipped back via
`recent_actions`.

This affected four tools: `sign_typed_data`, `vault_coin`, `vault_chain`, and
`address_book`.

## Fix

Dispatch now keys on the CLI's existing client-side-tool registry
(`CLIENT_SIDE_TOOL_DISPATCH`), mirroring how the app identifies client-side
tools via its `toolUIRegistry`:

- `AgentClient` gains a `clientSideToolNames: Set<string>` registry and a
  `setClientSideToolNames()` injector. A `tool-input-available` frame is
  dispatched locally iff its `toolName` is in that set. The dead
  `clientExecuted !== true` wire-flag check is removed.
- `AgentSession` injects the registry from the existing dispatch table
  (`new Set(Object.keys(CLIENT_SIDE_TOOL_DISPATCH))`) — single source of truth.
- The registry is empty by default, so there is no client-side dispatch until
  the session injects it (safe default).

## Receipts

**Before/after** — driving the SSE handler with a representative
current-backend frame (no `clientExecuted` field):

```json
{ "type": "tool-input-available", "toolCallId": "c1", "toolName": "vault_coin",
  "input": { "tokens": [{ "chain": "Base", "ticker": "USDC" }] } }
```

| Scenario | Before (`clientExecuted === true`) | After (registry membership) |
|---|---|---|
| current-backend frame above | not dispatched → tool dead, display-only | `onClientSideToolCall('c1','vault_coin',…)` fired ✓ |
| all 4 registry tools (`sign_typed_data` / `vault_coin` / `vault_chain` / `address_book`) | dead | all dispatch ✓ |
| non-client-side tool (e.g. `polymarket_search`) | not fired | still not fired ✓ (no over-trigger; falls through to server) |
| `tool-input-start` frame | not fired | not fired ✓ (only `-available` dispatches) |
| stray `clientExecuted` flag present | gated the dispatch | ignored — identification is registry-only ✓ |

These are pinned by tests in `clients/cli/src/agent/__tests__/clientSideDispatch.test.ts`,
including a pre-fix repro (no registry ⇒ no dispatch, progress still fires) and
the post-fix dispatch on the same frame.

**Build / typecheck / test (local):**

- `yarn workspace @vultisig/cli typecheck` → green
- `yarn test:cli` → 17 files / 264 tests pass
- `yarn workspace @vultisig/cli build` → green (`Built @vultisig/cli v2.4.0`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed client-side tool dispatch for sign_typed_data, vault_coin, vault_chain, and address_book operations that were unexpectedly falling back to display-only mode. These tools now execute correctly again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->