### PR TITLE
fix(cli): recover assistant answer + tx_ready when the agent stream drops mid-turn

### DIFF
--- a/.changeset/cli-disconnect-recovery.md
+++ b/.changeset/cli-disconnect-recovery.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/cli': patch
+---
+
+Recover the assistant answer (and any tx_ready signable card) when an agent SSE stream drops mid-turn. The backend keeps processing on a detached context and persists the message, so on a transport disconnect the CLI now polls `/messages/since` (server-clock anchored via `X-Server-Now`, opaque-cursor round-trip, bounded retries) to recover what the dropped stream missed instead of losing the turn. A recovered tx_ready flows through the same confirm/sign gate as a live one. Pipe mode emits a `reconnecting` event so agent consumers can distinguish "still working" from "failed"; a deliberate Ctrl+C abort is unaffected.

--- a/clients/cli/src/agent/__tests__/client.test.ts
+++ b/clients/cli/src/agent/__tests__/client.test.ts
@@ -22,12 +22,46 @@ function makeChunkedStream(chunks: string[]): ReadableStream<Uint8Array> {
   })
 }
 
-function mockFetchSSE(chunks: string[]): typeof fetch {
+function mockFetchSSE(chunks: string[], headers?: Record<string, string>): typeof fetch {
   return vi.fn(
     async () =>
       new Response(makeChunkedStream(chunks), {
         status: 200,
-        headers: { 'Content-Type': 'text/event-stream' },
+        headers: { 'Content-Type': 'text/event-stream', ...headers },
+      })
+  ) as typeof fetch
+}
+
+/**
+ * Stream that yields `chunks` then errors the body mid-flight to simulate a
+ * dropped SSE connection. If `onBeforeError` is provided it runs right before
+ * the body errors (used to flip an AbortController so the read loop sees a
+ * user-cancel rather than a transport drop).
+ */
+function makeDroppingStream(chunks: string[], onBeforeError?: () => void): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder()
+  let i = 0
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (i < chunks.length) {
+        controller.enqueue(encoder.encode(chunks[i++]))
+      } else {
+        onBeforeError?.()
+        controller.error(new Error('ECONNRESET: socket hang up'))
+      }
+    },
+  })
+}
+
+function mockFetchDropping(
+  chunks: string[],
+  opts?: { headers?: Record<string, string>; onBeforeError?: () => void }
+): typeof fetch {
+  return vi.fn(
+    async () =>
+      new Response(makeDroppingStream(chunks, opts?.onBeforeError), {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream', ...opts?.headers },
       })
   ) as typeof fetch
 }
@@ -274,6 +308,56 @@ describe('AgentClient.sendMessageStream', () => {
 
     expect(onError).toHaveBeenCalledWith('boom', AgentErrorCode.UNKNOWN_ERROR)
   })
+
+  it('marks finished + captures X-Server-Now on a clean stream', async () => {
+    globalThis.fetch = mockFetchSSE(
+      [
+        'data: {"type":"text-delta","id":"t","delta":"hi"}\n\n',
+        'data: {"type":"data-message","data":{"message":{"id":"m","conversation_id":"c1","role":"assistant","content":"hi","content_type":"text","created_at":"2026-04-17T00:00:00Z"}}}\n\n',
+        'data: {"type":"finish"}\n\n',
+      ],
+      { 'X-Server-Now': '1718870400000' }
+    )
+
+    const client = new AgentClient('http://example.com')
+    const result = await client.sendMessageStream('c1', { public_key: 'pk', content: 'hi' }, {})
+
+    expect(result.finished).toBe(true)
+    expect(result.disconnected).toBe(false)
+    expect(result.serverNow).toBe('1718870400000')
+    expect(result.message?.content).toBe('hi')
+  })
+
+  // Disconnect-recovery contract: a transport drop mid-turn must NOT throw and
+  // must NOT mark the turn finished — it flags `disconnected` so the caller can
+  // recover via /messages/since. The X-Server-Now header (captured before the
+  // first chunk) survives to anchor that recovery poll.
+  it('flags disconnected (no throw, not finished) when the stream drops mid-turn', async () => {
+    globalThis.fetch = mockFetchDropping(['data: {"type":"text-delta","id":"t","delta":"partial ans"}\n\n'], {
+      headers: { 'X-Server-Now': '1718870400000' },
+    })
+
+    const client = new AgentClient('http://example.com')
+    const result = await client.sendMessageStream('c1', { public_key: 'pk', content: 'hi' }, {})
+
+    expect(result.disconnected).toBe(true)
+    expect(result.finished).toBe(false)
+    expect(result.message).toBeNull() // the answer never arrived on the wire
+    expect(result.fullText).toBe('partial ans') // only the partial delta showed
+    expect(result.serverNow).toBe('1718870400000')
+  })
+
+  // A deliberate Ctrl+C (AbortController.abort()) is NOT a dropped connection:
+  // re-throw so the caller shows "[cancelled]" instead of silently recovering.
+  it('re-throws (does not recover) when the read fails after a user abort', async () => {
+    const ac = new AbortController()
+    globalThis.fetch = mockFetchDropping(['data: {"type":"text-delta","id":"t","delta":"x"}\n\n'], {
+      onBeforeError: () => ac.abort(),
+    })
+
+    const client = new AgentClient('http://example.com')
+    await expect(client.sendMessageStream('c1', { public_key: 'pk', content: 'hi' }, {}, ac.signal)).rejects.toThrow()
+  })
 })
 
 describe('AgentClient — honest tool success (fund-safety #B)', () => {
@@ -301,7 +385,14 @@ describe('AgentClient — honest tool success (fund-safety #B)', () => {
   }
 
   it('reports ok=false when the tool output is {"status":"error"}', async () => {
-    expect(await lastDoneOk({ output: { status: 'error', error: 'execute_send (EVM): invalid address' } })).toBe(false)
+    expect(
+      await lastDoneOk({
+        output: {
+          status: 'error',
+          error: 'execute_send (EVM): invalid address',
+        },
+      })
+    ).toBe(false)
   })
 
   it('reports ok=false when the tool output has an {"error"} field', async () => {

--- a/clients/cli/src/agent/__tests__/sessionRecovery.test.ts
+++ b/clients/cli/src/agent/__tests__/sessionRecovery.test.ts
@@ -153,6 +153,42 @@ describe('recoverDisconnectedTurn — before/after differential', () => {
     expect(streamResult.message).toBeNull() // no worse than today — turn just ends
   })
 
+  it('without a server-clock anchor (no X-Server-Now), recovers the text answer but NOT a signable card', async () => {
+    // Fund-safety: a local-clock fallback anchor can, under clock skew between
+    // rapid turns, reach back to a PRIOR turn's row. Recovering stale text is
+    // cosmetic; replaying a stale tx_ready into the sign gate is not — so the
+    // card must be dropped when the anchor isn't server-derived.
+    const streamResult = makeStreamResult({
+      disconnected: true,
+      serverNow: null, // no X-Server-Now → local-clock fallback anchor
+    })
+    const txReadyData = { chain: 'Ethereum', action: 'send', send_tx: { to: '0xabc', value: '1' } }
+    const messagesSince = vi.fn(async () => ({
+      messages: [
+        recoveredAssistant({
+          parts: [
+            { type: 'text', text: 'Here is your balance: 1.5 ETH' },
+            { type: 'data-tx_ready', id: 'tx1', data: txReadyData },
+          ],
+        }),
+      ],
+      cursor: 'c',
+    }))
+    const onTxReady = vi.fn()
+
+    await (AgentSession.prototype as any).recoverDisconnectedTurn.call(
+      makeRecoveryThis(messagesSince),
+      streamResult,
+      onTxReady
+    )
+
+    // The text answer is recovered…
+    expect(streamResult.message?.content).toBe('Here is your balance: 1.5 ETH')
+    // …but the signable card is NOT replayed (no sign gate, no transactions).
+    expect(onTxReady).not.toHaveBeenCalled()
+    expect(streamResult.transactions).toHaveLength(0)
+  })
+
   it('survives a transient poll error and recovers on a later attempt', async () => {
     const streamResult = makeStreamResult({
       disconnected: true,

--- a/clients/cli/src/agent/__tests__/sessionRecovery.test.ts
+++ b/clients/cli/src/agent/__tests__/sessionRecovery.test.ts
@@ -1,0 +1,329 @@
+// Mid-turn SSE disconnect recovery (audit cat4-cli-disconnect-recovery).
+//
+// A dropped SSE stream must not lose the assistant's answer or a tx_ready
+// signable card. The backend keeps processing on a detached context and
+// persists the message; the CLI recovers it by polling /messages/since.
+//
+// These exercise the private recovery methods + the processMessageLoop wiring
+// through the prototype with a minimal `this`, so no real vault/network is hit.
+import { describe, expect, it, vi } from 'vitest'
+
+import { AgentSession, serverNowToIso } from '../session'
+import type { ConversationMessage } from '../types'
+
+function makeStreamResult(over: Partial<any> = {}) {
+  return {
+    fullText: '',
+    suggestions: [],
+    transactions: [] as any[],
+    message: null as ConversationMessage | null,
+    finished: false,
+    disconnected: false,
+    serverNow: null as string | null,
+    ...over,
+  }
+}
+
+function recoveredAssistant(over: Partial<ConversationMessage> = {}): ConversationMessage {
+  return {
+    id: 'm-recovered',
+    conversation_id: 'conv-1',
+    role: 'assistant',
+    content: 'Here is your balance: 1.5 ETH',
+    content_type: 'text',
+    created_at: '2026-06-20T00:00:01Z',
+    ...over,
+  }
+}
+
+describe('serverNowToIso', () => {
+  it('converts epoch millis header to RFC3339', () => {
+    expect(serverNowToIso('1718870400000')).toBe('2024-06-20T08:00:00.000Z')
+  })
+  it('returns null for absent/garbage headers (caller falls back to local clock)', () => {
+    expect(serverNowToIso(null)).toBeNull()
+    expect(serverNowToIso('')).toBeNull()
+    expect(serverNowToIso('not-a-number')).toBeNull()
+    expect(serverNowToIso('0')).toBeNull()
+  })
+})
+
+describe('recoverDisconnectedTurn — before/after differential', () => {
+  function makeRecoveryThis(messagesSince: any) {
+    return {
+      conversationId: 'conv-1',
+      publicKey: 'pk-test',
+      config: { verbose: false },
+      recoveryMaxPolls: 5,
+      recoveryPollIntervalMs: 0,
+      client: { messagesSince },
+      recoverySleep: (AgentSession.prototype as any).recoverySleep,
+      applyRecoveredMessage: (AgentSession.prototype as any).applyRecoveredMessage,
+    }
+  }
+
+  it('recovers the persisted answer + tx_ready that the dropped stream lost', async () => {
+    // BEFORE: the stream dropped mid-turn — no message, no transactions.
+    const streamResult = makeStreamResult({
+      disconnected: true,
+      serverNow: '1718870400000',
+    })
+    expect(streamResult.message).toBeNull()
+    expect(streamResult.transactions).toHaveLength(0)
+
+    const txReadyData = {
+      chain: 'Ethereum',
+      action: 'send',
+      send_tx: { to: '0xabc', value: '1' },
+    }
+    const messagesSince = vi.fn(async () => ({
+      messages: [
+        recoveredAssistant({
+          parts: [
+            { type: 'text', text: 'Here is your balance: 1.5 ETH' },
+            { type: 'data-tx_ready', id: 'tx1', data: txReadyData },
+          ],
+        }),
+      ],
+      cursor: 'opaque-cursor-1',
+    }))
+    const onTxReady = vi.fn()
+
+    await (AgentSession.prototype as any).recoverDisconnectedTurn.call(
+      makeRecoveryThis(messagesSince),
+      streamResult,
+      onTxReady
+    )
+
+    // AFTER: the answer and the tx_ready card are both recovered.
+    expect(streamResult.message?.content).toBe('Here is your balance: 1.5 ETH')
+    expect(streamResult.transactions).toEqual([txReadyData])
+    expect(onTxReady).toHaveBeenCalledExactlyOnceWith(txReadyData)
+
+    // Bootstrap poll anchors on the server clock (X-Server-Now), not Date.now().
+    expect(messagesSince).toHaveBeenCalledWith('conv-1', {
+      since: '2024-06-20T08:00:00.000Z',
+    })
+  })
+
+  it('keeps polling (cursor round-trip) until the answer lands, then stops', async () => {
+    const streamResult = makeStreamResult({
+      disconnected: true,
+      serverNow: '1718870400000',
+    })
+    const messagesSince = vi
+      .fn()
+      .mockResolvedValueOnce({ messages: [], cursor: 'cursor-A' }) // empty poll
+      .mockResolvedValueOnce({
+        messages: [recoveredAssistant()],
+        cursor: 'cursor-B',
+      })
+
+    await (AgentSession.prototype as any).recoverDisconnectedTurn.call(
+      makeRecoveryThis(messagesSince),
+      streamResult,
+      undefined
+    )
+
+    expect(messagesSince).toHaveBeenCalledTimes(2)
+    // First poll bootstraps with `since`; second round-trips the opaque cursor.
+    expect(messagesSince).toHaveBeenNthCalledWith(1, 'conv-1', {
+      since: '2024-06-20T08:00:00.000Z',
+    })
+    expect(messagesSince).toHaveBeenNthCalledWith(2, 'conv-1', {
+      cursor: 'cursor-A',
+    })
+    expect(streamResult.message?.content).toBe('Here is your balance: 1.5 ETH')
+  })
+
+  it('is bounded: gives up after recoveryMaxPolls when nothing ever persists', async () => {
+    const streamResult = makeStreamResult({
+      disconnected: true,
+      serverNow: '1718870400000',
+    })
+    const messagesSince = vi.fn(async () => ({ messages: [], cursor: 'c' }))
+
+    await (AgentSession.prototype as any).recoverDisconnectedTurn.call(
+      makeRecoveryThis(messagesSince),
+      streamResult,
+      undefined
+    )
+
+    expect(messagesSince).toHaveBeenCalledTimes(5) // recoveryMaxPolls
+    expect(streamResult.message).toBeNull() // no worse than today — turn just ends
+  })
+
+  it('survives a transient poll error and recovers on a later attempt', async () => {
+    const streamResult = makeStreamResult({
+      disconnected: true,
+      serverNow: '1718870400000',
+    })
+    const messagesSince = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('ETIMEDOUT'))
+      .mockResolvedValueOnce({ messages: [recoveredAssistant()], cursor: 'c' })
+
+    await (AgentSession.prototype as any).recoverDisconnectedTurn.call(
+      makeRecoveryThis(messagesSince),
+      streamResult,
+      undefined
+    )
+
+    expect(messagesSince).toHaveBeenCalledTimes(2)
+    expect(streamResult.message?.content).toBe('Here is your balance: 1.5 ETH')
+  })
+})
+
+describe('processMessageLoop — disconnect recovery wiring (end-to-end)', () => {
+  function makeHarness(opts: { recover: boolean }) {
+    const txReadyData = {
+      chain: 'Ethereum',
+      action: 'send',
+      send_tx: { to: '0xR', value: '1' },
+    }
+    const calls: string[] = []
+    const client = {
+      sendMessageStream: vi.fn(async (_conv: string, _req: any, _cb: any) => {
+        calls.push('stream')
+        // Turn 1 drops mid-flight; turn 2 (after the recovered tx is signed and
+        // reported) returns a clean closing message.
+        if (calls.filter(c => c === 'stream').length === 1) {
+          return makeStreamResult({
+            disconnected: true,
+            serverNow: '1718870400000',
+          })
+        }
+        return makeStreamResult({
+          message: { content: 'done' },
+          finished: true,
+        })
+      }),
+      messagesSince: vi.fn(async () => ({
+        messages: [
+          recoveredAssistant({
+            parts: opts.recover
+              ? [
+                  { type: 'text', text: 'Recovered answer' },
+                  { type: 'data-tx_ready', id: 'tx1', data: txReadyData },
+                ]
+              : undefined,
+            content: opts.recover ? 'Recovered answer' : '',
+          }),
+        ],
+        cursor: 'c',
+      })),
+    }
+    const executor = {
+      storeServerTransaction: vi.fn(() => true),
+      setPassword: vi.fn(),
+      getPendingSummary: () => 'send 1 ETH on Ethereum to 0xR',
+      signTxFromBuffer: vi.fn(async () => ({
+        tool: 'sign_tx',
+        success: true,
+        data: { tx_hash: '0xfeed', chain: 'Ethereum' },
+      })),
+      clearPendingTransaction: vi.fn(),
+    }
+    const ui = {
+      onTextDelta: vi.fn(),
+      onToolCall: vi.fn(),
+      onToolResult: vi.fn(),
+      onAssistantMessage: vi.fn(),
+      onSuggestions: vi.fn(),
+      onTxStatus: vi.fn(),
+      onError: vi.fn(),
+      onReconnecting: vi.fn(),
+      onDone: vi.fn(),
+      requestPassword: vi.fn(async () => 'pw'),
+      requestConfirmation: vi.fn(async () => true),
+    }
+    const fakeThis: any = {
+      conversationId: 'conv-1',
+      publicKey: 'pk-test',
+      cachedContext: { addresses: {} },
+      config: { password: 'pw', askMode: true, verbose: false },
+      pendingToolResults: [],
+      abortController: null,
+      recoveryMaxPolls: 5,
+      recoveryPollIntervalMs: 0,
+      client,
+      executor,
+      processMessageLoop: (AgentSession.prototype as any).processMessageLoop,
+      runPasswordGatedTool: (AgentSession.prototype as any).runPasswordGatedTool,
+      dispatchClientSideTool: (AgentSession.prototype as any).dispatchClientSideTool,
+      recoverDisconnectedTurn: (AgentSession.prototype as any).recoverDisconnectedTurn,
+      recoverySleep: (AgentSession.prototype as any).recoverySleep,
+      applyRecoveredMessage: (AgentSession.prototype as any).applyRecoveredMessage,
+    }
+    const run = () => (AgentSession.prototype as any).processMessageLoop.call(fakeThis, 'whats my balance', ui, 0)
+    return { run, ui, client, executor }
+  }
+
+  it('recovers answer + tx_ready after a drop, signs through the gate, completes', async () => {
+    const h = makeHarness({ recover: true })
+    await h.run()
+
+    // The drop was signalled to the consumer (pipe emits a `reconnecting` event).
+    expect(h.ui.onReconnecting).toHaveBeenCalledOnce()
+    // The recovered answer surfaced to the user.
+    expect(h.ui.onAssistantMessage).toHaveBeenCalledWith('Recovered answer')
+    // The recovered tx_ready flowed through the confirm/sign gate.
+    expect(h.ui.requestConfirmation).toHaveBeenCalledOnce()
+    expect(h.executor.storeServerTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({ chain: 'Ethereum', action: 'send' })
+    )
+    expect(h.executor.signTxFromBuffer).toHaveBeenCalledOnce()
+    expect(h.ui.onTxStatus).toHaveBeenCalledWith('0xfeed', 'Ethereum', 'pending', undefined)
+    expect(h.ui.onDone).toHaveBeenCalledOnce()
+  })
+
+  it('happy path (no disconnect) does not poll /messages/since', async () => {
+    const txReadyData = { chain: 'Ethereum' }
+    const client = {
+      sendMessageStream: vi.fn(async () => makeStreamResult({ message: { content: 'hello' }, finished: true })),
+      messagesSince: vi.fn(),
+    }
+    const ui = {
+      onTextDelta: vi.fn(),
+      onToolCall: vi.fn(),
+      onToolResult: vi.fn(),
+      onAssistantMessage: vi.fn(),
+      onSuggestions: vi.fn(),
+      onTxStatus: vi.fn(),
+      onError: vi.fn(),
+      onReconnecting: vi.fn(),
+      onDone: vi.fn(),
+      requestPassword: vi.fn(async () => 'pw'),
+      requestConfirmation: vi.fn(async () => true),
+    }
+    void txReadyData
+    const fakeThis: any = {
+      conversationId: 'conv-1',
+      publicKey: 'pk-test',
+      cachedContext: { addresses: {} },
+      config: { password: 'pw', askMode: true, verbose: false },
+      pendingToolResults: [],
+      abortController: null,
+      recoveryMaxPolls: 5,
+      recoveryPollIntervalMs: 0,
+      client,
+      executor: {
+        storeServerTransaction: vi.fn(() => true),
+        setPassword: vi.fn(),
+      },
+      processMessageLoop: (AgentSession.prototype as any).processMessageLoop,
+      runPasswordGatedTool: (AgentSession.prototype as any).runPasswordGatedTool,
+      dispatchClientSideTool: (AgentSession.prototype as any).dispatchClientSideTool,
+      recoverDisconnectedTurn: (AgentSession.prototype as any).recoverDisconnectedTurn,
+      recoverySleep: (AgentSession.prototype as any).recoverySleep,
+      applyRecoveredMessage: (AgentSession.prototype as any).applyRecoveredMessage,
+    }
+
+    await (AgentSession.prototype as any).processMessageLoop.call(fakeThis, 'hi', ui, 0)
+
+    expect(client.messagesSince).not.toHaveBeenCalled()
+    expect(ui.onReconnecting).not.toHaveBeenCalled()
+    expect(ui.onAssistantMessage).toHaveBeenCalledWith('hello')
+    expect(ui.onDone).toHaveBeenCalledOnce()
+  })
+})

--- a/clients/cli/src/agent/client.ts
+++ b/clients/cli/src/agent/client.ts
@@ -15,6 +15,7 @@ import type {
   GetConversationResponse,
   ListConversationsRequest,
   ListConversationsResponse,
+  MessagesSinceResponse,
   SendMessageRequest,
   SendMessageResponse,
   Suggestion,
@@ -217,6 +218,28 @@ export class AgentClient {
     return this.post<SendMessageResponse>(`/agent/conversations/${conversationId}/messages`, req)
   }
 
+  /**
+   * Reconnect-and-replay: fetch messages persisted to the conversation after
+   * the supplied anchor. Used to recover a turn whose SSE stream dropped
+   * mid-flight (the backend keeps processing on a detached context and
+   * persists the assistant answer + any tx_ready card).
+   *
+   * First poll passes `{ since: <RFC3339> }` (bootstrap, anchored to the
+   * server clock from X-Server-Now); subsequent polls round-trip the opaque
+   * `{ cursor }` returned in the previous response so no tied row is skipped.
+   * See agent-backend messages_since.go (issue #209 / PR #219).
+   */
+  async messagesSince(
+    conversationId: string,
+    anchor: { since?: string; cursor?: string }
+  ): Promise<MessagesSinceResponse> {
+    const qs = new URLSearchParams()
+    // cursor wins on tie (matches the backend's parseMessagesSinceAnchor).
+    if (anchor.cursor) qs.set('cursor', anchor.cursor)
+    else if (anchor.since) qs.set('since', anchor.since)
+    return this.get<MessagesSinceResponse>(`/agent/conversations/${conversationId}/messages/since?${qs.toString()}`)
+  }
+
   // ============================================================================
   // Messages - SSE Streaming mode
   // ============================================================================
@@ -253,6 +276,13 @@ export class AgentClient {
       suggestions: [],
       transactions: [],
       message: null,
+      finished: false,
+      disconnected: false,
+      // A-C2 contract: the backend stamps server-side wall-clock (epoch ms) on
+      // the SSE response headers before the first chunk, so the recovery poll
+      // anchors /messages/since to the server clock instead of Date.now()
+      // (eliminates NTP-skew-induced poll swallowing). See message.go.
+      serverNow: res.headers.get('X-Server-Now'),
     }
 
     // Per-stream map: v1 tool-output-available frames omit toolName (see
@@ -317,6 +347,19 @@ export class AgentClient {
           break
         }
       }
+    } catch (err) {
+      // A user-initiated cancel (Ctrl+C → AbortController.abort()) is a
+      // deliberate stop, not a dropped connection — re-throw so the caller
+      // surfaces "[cancelled]" and does NOT try to recover the turn.
+      if (signal?.aborted) {
+        throw err
+      }
+      // Any other read failure is a mid-turn transport drop. The backend keeps
+      // processing on a detached context and persists the answer (+ tx_ready),
+      // so flag the partial result and let the caller poll /messages/since to
+      // recover what we missed instead of losing the turn outright.
+      result.disconnected = true
+      if (this.verbose) process.stderr.write(`[SSE] stream dropped mid-turn: ${sseErrorToMessage(err)}\n`)
     } finally {
       reader.releaseLock()
     }
@@ -381,7 +424,8 @@ export class AgentClient {
           break
         }
         case 'done':
-          // Stream complete
+          // Terminal finish frame — the turn completed cleanly, no recovery needed.
+          result.finished = true
           break
       }
     } catch (e) {
@@ -487,6 +531,23 @@ export class AgentClient {
   // Private helpers
   // ============================================================================
 
+  private async get<T>(path: string): Promise<T> {
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      method: 'GET',
+      headers: {
+        ...(this.authToken ? { Authorization: `Bearer ${this.authToken}` } : {}),
+        ...this.profileHeader(),
+      },
+    })
+
+    if (!res.ok) {
+      const errorBody = (await res.json().catch(() => ({ error: res.statusText }))) as JsonErrorBody
+      throw new Error(`Request failed (${res.status}): ${errorBody.error || res.statusText}`)
+    }
+
+    return (await res.json()) as T
+  }
+
   private async post<T>(path: string, body: unknown): Promise<T> {
     const res = await fetch(`${this.baseUrl}${path}`, {
       method: 'POST',
@@ -529,4 +590,15 @@ export type SSEStreamResult = {
   suggestions: Suggestion[]
   transactions: TxReadyPayload[]
   message: ConversationMessage | null
+  /** True once the terminal finish/done frame was seen — the turn completed
+   *  cleanly and no /messages/since recovery is required. */
+  finished: boolean
+  /** True when the SSE read loop ended on a transport error mid-turn (a
+   *  dropped connection, not a user abort). Signals the caller to recover the
+   *  persisted answer via /messages/since. */
+  disconnected: boolean
+  /** X-Server-Now (epoch millis as a string) captured from the SSE response
+   *  headers — the server-clock bootstrap anchor for the recovery poll.
+   *  null when the header is absent (older backend). */
+  serverNow: string | null
 }

--- a/clients/cli/src/agent/pipe.ts
+++ b/clients/cli/src/agent/pipe.ts
@@ -55,7 +55,11 @@ export class PipeInterface {
         type: 'history',
         messages: history
           .filter(m => m.content_type !== 'action_result')
-          .map(m => ({ role: m.role, content: m.content, created_at: m.created_at })),
+          .map(m => ({
+            role: m.role,
+            content: m.content,
+            created_at: m.created_at,
+          })),
       })
     }
 
@@ -176,6 +180,10 @@ export class PipeInterface {
         this.emit({ type: 'error', message, code })
       },
 
+      onReconnecting: () => {
+        this.emit({ type: 'reconnecting' })
+      },
+
       onDone: () => {
         this.emit({ type: 'done' })
       },
@@ -185,7 +193,11 @@ export class PipeInterface {
         return new Promise(resolve => {
           this.pendingPasswordResolve = resolve
           // Signal that password is needed
-          this.emit({ type: 'error', message: 'PASSWORD_REQUIRED', code: AgentErrorCode.PASSWORD_REQUIRED })
+          this.emit({
+            type: 'error',
+            message: 'PASSWORD_REQUIRED',
+            code: AgentErrorCode.PASSWORD_REQUIRED,
+          })
         })
       },
 

--- a/clients/cli/src/agent/session.ts
+++ b/clients/cli/src/agent/session.ts
@@ -17,10 +17,17 @@ import { MemoryStorage, PushNotificationService, type VaultBase } from '@vultisi
 
 import { AgentErrorCode } from './agentErrors'
 import { authenticateVault } from './auth'
-import { AgentClient } from './client'
+import { AgentClient, type SSEStreamResult } from './client'
 import { buildMessageContext, buildMinimalContext } from './context'
 import { AgentExecutor } from './executor'
-import type { AgentConfig, ConversationMessage, MessageContext, RecentAction, UICallbacks } from './types'
+import type {
+  AgentConfig,
+  ConversationMessage,
+  MessageContext,
+  RecentAction,
+  TxReadyPayload,
+  UICallbacks,
+} from './types'
 
 // Tools that prompt for the vault password before dispatch. `sign_tx` is
 // reached via tx_ready synthesis (not a registry tool name) but uses the
@@ -50,6 +57,12 @@ export const CLIENT_SIDE_TOOL_DISPATCH: Record<
 // 2x the backend's 8-iteration cap — belt-and-suspenders against runaway loops.
 const MAX_MESSAGE_LOOP_DEPTH = 16
 
+// Mid-turn disconnect recovery (matches the app's 2s poller / ~3min ceiling).
+// On a dropped SSE stream the session polls /messages/since this many times,
+// this far apart, for the assistant message the detached backend persisted.
+const RECOVERY_POLL_INTERVAL_MS = 2000
+const RECOVERY_MAX_POLLS = 90
+
 export class AgentSession {
   private client: AgentClient
   private vault: VaultBase
@@ -63,6 +76,10 @@ export class AgentSession {
   private pushService: PushNotificationService | null = null
   // Flushed into context.recent_actions on the next outbound request.
   private pendingToolResults: RecentAction[] = []
+  // Disconnect-recovery poll cadence — instance fields so tests can drive the
+  // poll loop without real 2s waits.
+  private recoveryPollIntervalMs = RECOVERY_POLL_INTERVAL_MS
+  private recoveryMaxPolls = RECOVERY_MAX_POLLS
 
   constructor(vault: VaultBase, config: AgentConfig) {
     this.vault = vault
@@ -378,6 +395,18 @@ export class AgentSession {
       await Promise.all(pendingDispatches)
     }
 
+    // Mid-turn disconnect recovery: the SSE stream dropped before the backend
+    // delivered the final assistant message. The backend keeps processing on a
+    // detached context and persists the answer (+ any tx_ready card), so poll
+    // /messages/since to recover what the dropped stream missed. Bounded so a
+    // backend that never persists can't hang the turn. `onTxReady` reuses the
+    // same callback the live stream uses, so a recovered tx_ready flows through
+    // the identical confirm/sign gate below.
+    if (streamResult.disconnected && !streamResult.message) {
+      ui.onReconnecting?.()
+      await this.recoverDisconnectedTurn(streamResult, callbacks.onTxReady)
+    }
+
     // Final message event wins over streamed deltas (which may be partial).
     const responseText = streamResult.message?.content || streamResult.fullText || ''
 
@@ -424,6 +453,89 @@ export class AgentSession {
     }
 
     ui.onDone()
+  }
+
+  /**
+   * Recover a turn whose SSE stream dropped before delivering the final
+   * assistant message. Polls /messages/since (server-clock anchored via
+   * X-Server-Now) until the persisted assistant message lands or the bounded
+   * budget is exhausted. On success it patches `streamResult.message` so the
+   * normal downstream flow surfaces the answer, and replays any persisted
+   * `data-tx_ready` part through `onTxReady` so a recovered signable card hits
+   * the same confirm/sign gate as a live one.
+   */
+  private async recoverDisconnectedTurn(
+    streamResult: SSEStreamResult,
+    onTxReady: ((tx: TxReadyPayload) => void) | undefined
+  ): Promise<void> {
+    if (!this.conversationId) return
+
+    // Prefer the server clock (X-Server-Now, epoch ms); fall back to a slightly
+    // back-dated local clock so a missing header can't skew the anchor past the
+    // just-persisted message.
+    const since = serverNowToIso(streamResult.serverNow) ?? new Date(Date.now() - 2000).toISOString()
+    let cursor: string | undefined
+
+    for (let attempt = 0; attempt < this.recoveryMaxPolls; attempt++) {
+      let resp
+      try {
+        resp = await this.client.messagesSince(this.conversationId, cursor ? { cursor } : { since })
+      } catch (err: any) {
+        if (this.config.verbose) {
+          process.stderr.write(`[session] recovery poll ${attempt + 1} failed: ${err?.message ?? err}\n`)
+        }
+        await this.recoverySleep()
+        continue
+      }
+
+      // Advance the opaque cursor so subsequent polls never re-scan or skip ties.
+      if (resp.cursor) cursor = resp.cursor
+
+      // The detached backend writes the assistant message last; take the newest
+      // assistant row that actually carries content or a recovered card.
+      const assistant = [...resp.messages]
+        .reverse()
+        .find(m => m.role === 'assistant' && (!!m.content || hasTxReadyPart(m.parts)))
+      if (assistant) {
+        if (this.config.verbose) {
+          process.stderr.write(`[session] recovered assistant message after ${attempt + 1} poll(s)\n`)
+        }
+        this.applyRecoveredMessage(assistant, streamResult, onTxReady)
+        return
+      }
+
+      await this.recoverySleep()
+    }
+
+    if (this.config.verbose) {
+      process.stderr.write(`[session] recovery exhausted after ${this.recoveryMaxPolls} polls; turn answer lost\n`)
+    }
+  }
+
+  /** Sleep between recovery polls. Separate method so tests can stub it out. */
+  private recoverySleep(): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, this.recoveryPollIntervalMs))
+  }
+
+  /**
+   * Fold a recovered assistant message back into the live stream result: the
+   * authoritative message wins over any partial deltas, and any persisted
+   * `data-tx_ready` part is replayed through the live tx_ready callback so the
+   * card flows through the same confirm/sign gate.
+   */
+  private applyRecoveredMessage(
+    msg: ConversationMessage,
+    streamResult: SSEStreamResult,
+    onTxReady: ((tx: TxReadyPayload) => void) | undefined
+  ): void {
+    streamResult.message = msg
+    for (const part of msg.parts ?? []) {
+      if (part.type === 'data-tx_ready' && part.data && typeof part.data === 'object') {
+        const tx = part.data as TxReadyPayload
+        streamResult.transactions.push(tx)
+        onTxReady?.(tx)
+      }
+    }
   }
 
   /**
@@ -496,7 +608,10 @@ export class AgentSession {
         const failure: RecentAction = {
           tool: toolName,
           success: false,
-          data: { error: 'Password not provided', code: AgentErrorCode.PASSWORD_REQUIRED },
+          data: {
+            error: 'Password not provided',
+            code: AgentErrorCode.PASSWORD_REQUIRED,
+          },
         }
         ui.onToolCall(toolCallId, toolName, input)
         ui.onToolResult(
@@ -633,6 +748,24 @@ export function stripLeakedToolCallTags(text: string): string {
     .replace(/<\/?minimax:tool_call>/g, '')
     .replace(/\n{3,}/g, '\n\n')
     .trim()
+}
+
+/**
+ * Convert an X-Server-Now header (epoch milliseconds as a string) into an
+ * RFC3339 timestamp for the /messages/since bootstrap anchor. Returns null
+ * when the header is absent or unparseable so the caller can fall back to a
+ * local-clock anchor.
+ */
+export function serverNowToIso(serverNow: string | null): string | null {
+  if (!serverNow) return null
+  const ms = Number(serverNow)
+  if (!Number.isFinite(ms) || ms <= 0) return null
+  return new Date(ms).toISOString()
+}
+
+/** True if any message part is a persisted `data-tx_ready` signable card. */
+function hasTxReadyPart(parts: ConversationMessage['parts']): boolean {
+  return !!parts?.some(p => p.type === 'data-tx_ready' && !!p.data)
 }
 
 // ============================================================================

--- a/clients/cli/src/agent/session.ts
+++ b/clients/cli/src/agent/session.ts
@@ -473,7 +473,19 @@ export class AgentSession {
     // Prefer the server clock (X-Server-Now, epoch ms); fall back to a slightly
     // back-dated local clock so a missing header can't skew the anchor past the
     // just-persisted message.
-    const since = serverNowToIso(streamResult.serverNow) ?? new Date(Date.now() - 2000).toISOString()
+    //
+    // Fund-safety: the local-clock fallback is only trustworthy enough to
+    // recover the *text* answer. Under clock skew between rapid consecutive
+    // turns, a back-dated local anchor can reach back far enough that
+    // /messages/since returns a PRIOR turn's assistant row; replaying that
+    // row's `data-tx_ready` would route an already-superseded transaction into
+    // the sign gate (and auto-broadcast it under --yes). So signable cards are
+    // replayed only when the anchor came from the server clock — which reliably
+    // excludes earlier turns. A stale recovered *text* answer is at worst a
+    // cosmetic glitch; a stale recovered *transaction* is not.
+    const serverAnchor = serverNowToIso(streamResult.serverNow)
+    const since = serverAnchor ?? new Date(Date.now() - 2000).toISOString()
+    const replaySignableCards = serverAnchor !== null
     let cursor: string | undefined
 
     for (let attempt = 0; attempt < this.recoveryMaxPolls; attempt++) {
@@ -500,7 +512,7 @@ export class AgentSession {
         if (this.config.verbose) {
           process.stderr.write(`[session] recovered assistant message after ${attempt + 1} poll(s)\n`)
         }
-        this.applyRecoveredMessage(assistant, streamResult, onTxReady)
+        this.applyRecoveredMessage(assistant, streamResult, onTxReady, replaySignableCards)
         return
       }
 
@@ -522,13 +534,20 @@ export class AgentSession {
    * authoritative message wins over any partial deltas, and any persisted
    * `data-tx_ready` part is replayed through the live tx_ready callback so the
    * card flows through the same confirm/sign gate.
+   *
+   * `replaySignableCards` gates the tx_ready replay: it is false when the
+   * recovery anchor was the local-clock fallback (no X-Server-Now), where a
+   * recovered card cannot be proven to belong to the current turn. See
+   * recoverDisconnectedTurn — a stale tx_ready must never reach the signer.
    */
   private applyRecoveredMessage(
     msg: ConversationMessage,
     streamResult: SSEStreamResult,
-    onTxReady: ((tx: TxReadyPayload) => void) | undefined
+    onTxReady: ((tx: TxReadyPayload) => void) | undefined,
+    replaySignableCards: boolean
   ): void {
     streamResult.message = msg
+    if (!replaySignableCards) return
     for (const part of msg.parts ?? []) {
       if (part.type === 'data-tx_ready' && part.data && typeof part.data === 'object') {
         const tx = part.data as TxReadyPayload

--- a/clients/cli/src/agent/session.ts
+++ b/clients/cli/src/agent/session.ts
@@ -504,7 +504,21 @@ export class AgentSession {
       if (resp.cursor) cursor = resp.cursor
 
       // The detached backend writes the assistant message last; take the newest
-      // assistant row that actually carries content or a recovered card.
+      // assistant row that actually carries content or a recovered card. Newest
+      // (not oldest) is deliberate: a single turn can persist several assistant
+      // rows (clarifier / fast-path ack, then the final answer), and we want the
+      // final one — oldest-after-anchor would surface an early clarifier instead.
+      //
+      // Fund-safety cross-repo invariant: this "newest qualifying row" is only
+      // safe to route to the sign gate because no concurrent writer persists an
+      // *executable* tx_ready (full txArgs/send_tx/swap_tx) into a live
+      // conversation during the recovery window. The single concurrent writer
+      // today — the scheduler — persists an inert `{ proposal_id }` sidecar that
+      // `storeServerTransaction` rejects (no tx envelope → returns false → never
+      // signed). If a future background path ever persists an executable
+      // tx_ready into a shared conversation, this selection + the server-anchor
+      // gate would route it straight to the signer (auto-broadcast under --yes);
+      // such a writer must scope its conversation or this must filter by turn.
       const assistant = [...resp.messages]
         .reverse()
         .find(m => m.role === 'assistant' && (!!m.content || hasTxReadyPart(m.parts)))

--- a/clients/cli/src/agent/tui.ts
+++ b/clients/cli/src/agent/tui.ts
@@ -225,6 +225,14 @@ export class ChatTUI {
         console.log(`  ${chalk.red('Error')}: ${message}${suffix}`)
       },
 
+      onReconnecting: () => {
+        if (this.isStreaming) {
+          process.stdout.write('\n')
+          this.isStreaming = false
+        }
+        console.log(chalk.gray('  Connection dropped — recovering response…'))
+      },
+
       onDone: () => {
         if (this.isStreaming) {
           // Flush any remaining streamed text

--- a/clients/cli/src/agent/types.ts
+++ b/clients/cli/src/agent/types.ts
@@ -109,6 +109,30 @@ export type ConversationMessage = {
   audio_url?: string
   metadata?: Record<string, unknown>
   created_at: string
+  // AI-SDK UIMessagePart list, present on messages fetched from
+  // /messages/since (the disconnect-recovery endpoint). Text parts carry the
+  // assistant answer; `data-tx_ready` parts carry a persisted signable card so
+  // a turn that dropped its SSE stream mid-flight can still recover both.
+  parts?: ConversationMessagePart[]
+}
+
+// Minimal projection of the backend's UIMessagePart (internal/types/parts.go).
+// Only the fields the CLI recovery path reads are typed; `type` is the
+// discriminator ("text", "data-tx_ready", "tool-<name>", …).
+export type ConversationMessagePart = {
+  type: string
+  text?: string
+  id?: string
+  data?: unknown
+}
+
+// Response body of GET /agent/conversations/:id/messages/since — the
+// reconnect-and-replay contract (agent-backend messages_since.go). `cursor` is
+// an OPAQUE composite (created_at, id) token to round-trip on the next poll.
+export type MessagesSinceResponse = {
+  messages: ConversationMessage[]
+  cursor: string
+  toolResults?: Record<string, unknown>
 }
 
 // ============================================================================
@@ -294,7 +318,11 @@ export type UsageInfo = {
 // ============================================================================
 
 export type SSETextDelta = { delta: string }
-export type SSEToolProgress = { tool: string; status: 'running' | 'done'; label?: string }
+export type SSEToolProgress = {
+  tool: string
+  status: 'running' | 'done'
+  label?: string
+}
 export type SSETitle = { title: string }
 export type SSESuggestions = { suggestions: Suggestion[] }
 export type SSETxReady = TxReadyPayload
@@ -322,7 +350,10 @@ export type SSEEvent =
 export type PipeOutputEvent =
   | { type: 'ready'; vault: string; addresses: Record<string, string> }
   | { type: 'session'; id: string }
-  | { type: 'history'; messages: Array<{ role: string; content: string; created_at: string }> }
+  | {
+      type: 'history'
+      messages: Array<{ role: string; content: string; created_at: string }>
+    }
   | { type: 'auth'; status: 'authenticated' | 'failed'; error?: string }
   | { type: 'conversation'; id: string }
   | { type: 'text_delta'; delta: string }
@@ -351,6 +382,10 @@ export type PipeOutputEvent =
     }
   | { type: 'assistant'; content: string }
   | { type: 'suggestions'; suggestions: Suggestion[] }
+  // Emitted when the SSE stream dropped mid-turn and the CLI is polling
+  // /messages/since to recover the answer — lets an agent consumer
+  // distinguish "still working" from "failed".
+  | { type: 'reconnecting' }
   | { type: 'error'; message: string; code: AgentErrorCode }
   | { type: 'done' }
 
@@ -379,6 +414,9 @@ export type UICallbacks = {
   onTxStatus: (txHash: string, chain: string, status: string, explorerUrl?: string) => void
   onError: (message: string, code: AgentErrorCode) => void
   onDone: () => void
+  // Fired when a mid-turn SSE disconnect is detected and the session begins
+  // polling /messages/since to recover the dropped answer/tx_ready.
+  onReconnecting?: () => void
   onNotification?: (title: string, body: string) => void
   requestPassword: () => Promise<string>
   requestConfirmation: (message: string) => Promise<boolean>


### PR DESCRIPTION
## Summary

When the agent SSE stream drops mid-turn, the CLI was throwing out of the stream read loop and losing the turn's authoritative assistant message — along with any `tx_ready` signable card the backend emitted after the drop. The user would see only whatever partial deltas had already streamed, with no answer and no transaction to confirm. The next turn just sent fresh context, so the work was gone.

This is especially painful for `--via-agent` automation, where a transient disconnect on a long-running pipe silently dropped results.

## What changed

The backend keeps processing on a detached context after a client disconnect and persists the assistant message (plus a `data-tx_ready` UI part for any signable card). It exposes a purpose-built recovery endpoint, `GET /messages/since`, with a server-clock anchor (`X-Server-Now`) and an opaque composite cursor. The CLI now uses it:

- **`sendMessageStream` no longer throws on a mid-turn transport drop.** It re-throws only when the signal is aborted (a deliberate Ctrl+C); otherwise it flags the partial result as `disconnected` and captures the `X-Server-Now` anchor.
- **On a disconnect with no recovered message yet, the session polls `/messages/since`** (server-clock anchored, opaque-cursor round-trip, bounded retries — 2s cadence, ~3min ceiling, matching the web app's poller) until the persisted answer lands, then surfaces it through the normal downstream path.
- **A recovered `tx_ready` part is replayed through the same confirm/sign gate as a live card** — same confirmation prompt, same signing path.
- **Pipe mode emits a `reconnecting` event** so agent consumers can distinguish "still working" from "failed".
- **The happy path is unchanged** and never polls `/messages/since`.

## Receipts

### Before / after

| Scenario | Before | After |
|----------|--------|-------|
| SSE drops mid-turn | `reader.read()` throws → turn lost; assistant answer and any tx_ready gone | `disconnected=true`, no throw, `X-Server-Now` captured; session polls `/messages/since`, recovers the answer **and** the `tx_ready` card (routed through the confirm/sign gate) |
| User Ctrl+C (abort) mid-stream | throws (cancelled) | still re-throws — recovery NOT triggered |
| Happy path (clean finish) | answer shown | unchanged; `/messages/since` never polled, `reconnecting` never fired |
| Backend never persists | n/a | bounded: gives up after the poll cap, turn ends cleanly (no hang) |
| Transient poll error | n/a | swallowed; recovers on a later poll |

### Tests

New `sessionRecovery.test.ts` and extended `client.test.ts` drive a `ReadableStream` that errors mid-flight to simulate a dropped socket. An end-to-end test runs the real message loop: turn-1 stream drops → recovery fetches the persisted answer + tx_ready → confirmation → signing → status, then turn-2 closes cleanly.

```
yarn test:cli  →  18 suites / 273 tests pass
CLI build       →  Built @vultisig/cli v2.4.0, clean
typecheck       →  0 errors (CLI workspace, after build:all)
eslint/prettier →  clean on all changed files
```

A `@vultisig/cli` patch changeset is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CLI now recovers from mid-turn SSE disconnects by fetching missed conversation messages and continuing the interaction without losing progress.
  * Added a “reconnecting” event/indicator so the pipe mode and TUI clearly show recovery in progress.
  * Recovered `tx_ready` actions now follow the same confirmation and signing flow as live responses.

* **Tests**
  * Expanded coverage for reconnect/replay timing, partial-stream behavior, and message-loop recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->