### PR TITLE
fix(cli): render balance cards in the terminal instead of raw JSON

### DIFF
--- a/.changeset/cli-supported-surfaces.md
+++ b/.changeset/cli-supported-surfaces.md
@@ -8,4 +8,7 @@ the backend's legacy "echo card_payload JSON verbatim" path. Adds a defensive
 fallback that pretty-renders a balance card envelope if it ever arrives embedded
 in message content (older backend). Cards surface in the TUI (table), pipe mode
 (`balance_summary` NDJSON event), and `agent ask` (`cards` field / rendered
-table).
+table). Card string fields (token symbol, chain, address, amounts) are stripped
+of terminal control bytes at the parse boundary so attacker-influenced on-chain
+metadata or a legacy-echoed payload can't inject ANSI/OSC escape sequences into
+the rendered balances table.

--- a/.changeset/cli-supported-surfaces.md
+++ b/.changeset/cli-supported-surfaces.md
@@ -1,0 +1,11 @@
+---
+'@vultisig/cli': minor
+---
+
+Advertise `supported_surfaces: ["balance_summary"]` to the agent backend and
+render the `data-balance_summary` card as a terminal table instead of triggering
+the backend's legacy "echo card_payload JSON verbatim" path. Adds a defensive
+fallback that pretty-renders a balance card envelope if it ever arrives embedded
+in message content (older backend). Cards surface in the TUI (table), pipe mode
+(`balance_summary` NDJSON event), and `agent ask` (`cards` field / rendered
+table).

--- a/clients/cli/src/agent/__tests__/cards.test.ts
+++ b/clients/cli/src/agent/__tests__/cards.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  CLI_SUPPORTED_SURFACES,
+  extractBalanceSummaryFromText,
+  parseBalanceSummaryEnvelope,
+  renderBalanceSummaryCard,
+} from '../cards'
+
+const VALID_ENVELOPE = {
+  surface: 'balance_summary',
+  accounts: [
+    {
+      chainId: 'Ethereum',
+      address: '0x1234567890abcdef1234567890abcdef12345678',
+      tokens: [
+        { symbol: 'ETH', amountDecimal: '1.5', amountUsd: '$4,500.00' },
+        { symbol: 'USDC', amountDecimal: '100', amountUsd: '$100.00' },
+      ],
+    },
+    {
+      chainId: 'Bitcoin',
+      address: 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh',
+      tokens: [{ symbol: 'BTC', amountDecimal: '0.05', amountUsd: '$3,000.00' }],
+    },
+  ],
+}
+
+describe('CLI_SUPPORTED_SURFACES', () => {
+  it('advertises balance_summary', () => {
+    expect(CLI_SUPPORTED_SURFACES).toContain('balance_summary')
+  })
+})
+
+describe('parseBalanceSummaryEnvelope', () => {
+  it('parses a valid envelope', () => {
+    const card = parseBalanceSummaryEnvelope(VALID_ENVELOPE)
+    expect(card).not.toBeNull()
+    expect(card!.surface).toBe('balance_summary')
+    expect(card!.accounts).toHaveLength(2)
+    expect(card!.accounts[0].tokens).toHaveLength(2)
+  })
+
+  it('carries the stale freshness cue through', () => {
+    const card = parseBalanceSummaryEnvelope({ ...VALID_ENVELOPE, stale: true, stale_secs: 120 })
+    expect(card!.stale).toBe(true)
+    expect(card!.staleSecs).toBe(120)
+  })
+
+  it('rejects a non-balance_summary surface', () => {
+    expect(parseBalanceSummaryEnvelope({ surface: 'yield_opportunities', accounts: [] })).toBeNull()
+  })
+
+  it('rejects an envelope with no renderable accounts', () => {
+    expect(parseBalanceSummaryEnvelope({ surface: 'balance_summary', accounts: [{ tokens: [] }] })).toBeNull()
+  })
+
+  it('rejects junk', () => {
+    expect(parseBalanceSummaryEnvelope(null)).toBeNull()
+    expect(parseBalanceSummaryEnvelope('nope')).toBeNull()
+    expect(parseBalanceSummaryEnvelope({ surface: 'balance_summary' })).toBeNull()
+  })
+
+  it('drops accounts without a chainId but keeps the rest', () => {
+    const card = parseBalanceSummaryEnvelope({
+      surface: 'balance_summary',
+      accounts: [{ tokens: [{ symbol: 'X', amountDecimal: '1' }] }, VALID_ENVELOPE.accounts[0]],
+    })
+    expect(card!.accounts).toHaveLength(1)
+    expect(card!.accounts[0].chainId).toBe('Ethereum')
+  })
+})
+
+describe('renderBalanceSummaryCard', () => {
+  it('renders a human-readable table, not raw JSON', () => {
+    const out = renderBalanceSummaryCard(parseBalanceSummaryEnvelope(VALID_ENVELOPE)!)
+    expect(out).toContain('Ethereum')
+    expect(out).toContain('ETH')
+    expect(out).toContain('USDC')
+    expect(out).toContain('BTC')
+    // No raw envelope JSON in the output.
+    expect(out).not.toContain('"surface"')
+    expect(out).not.toContain('amountDecimal')
+  })
+
+  it('shows a USD total when amounts are priced', () => {
+    const out = renderBalanceSummaryCard(parseBalanceSummaryEnvelope(VALID_ENVELOPE)!)
+    // 4500 + 100 + 3000 = 7600
+    expect(out).toContain('7,600.00')
+    expect(out).toContain('Total')
+  })
+
+  it('shortens long addresses', () => {
+    const out = renderBalanceSummaryCard(parseBalanceSummaryEnvelope(VALID_ENVELOPE)!)
+    expect(out).toContain('…')
+    expect(out).not.toContain('0x1234567890abcdef1234567890abcdef12345678')
+  })
+})
+
+describe('extractBalanceSummaryFromText (legacy verbatim-echo fallback)', () => {
+  it('returns null for plain prose', () => {
+    expect(extractBalanceSummaryFromText('Your total is about $7,600.')).toBeNull()
+  })
+
+  it('extracts a bare echoed envelope and strips it from the text', () => {
+    const text = JSON.stringify(VALID_ENVELOPE)
+    const res = extractBalanceSummaryFromText(text)
+    expect(res).not.toBeNull()
+    expect(res!.card.accounts).toHaveLength(2)
+    expect(res!.remainingText).toBe('')
+  })
+
+  it('extracts an envelope wrapped in a ```json code fence', () => {
+    const text = 'Here are your balances:\n```json\n' + JSON.stringify(VALID_ENVELOPE) + '\n```'
+    const res = extractBalanceSummaryFromText(text)
+    expect(res).not.toBeNull()
+    expect(res!.card.accounts).toHaveLength(2)
+    // prose preserved, fence + JSON removed
+    expect(res!.remainingText).toContain('Here are your balances')
+    expect(res!.remainingText).not.toContain('surface')
+    expect(res!.remainingText).not.toContain('```')
+  })
+
+  it('extracts an envelope embedded in surrounding prose', () => {
+    const text = `Done. ${JSON.stringify(VALID_ENVELOPE)} Let me know if you need more.`
+    const res = extractBalanceSummaryFromText(text)
+    expect(res).not.toBeNull()
+    expect(res!.remainingText).toContain('Done.')
+    expect(res!.remainingText).toContain('Let me know')
+    expect(res!.remainingText).not.toContain('surface')
+  })
+
+  it('ignores a non-card JSON object that mentions balance_summary', () => {
+    const text = 'The {"foo":"balance_summary mention"} is not a card.'
+    expect(extractBalanceSummaryFromText(text)).toBeNull()
+  })
+})

--- a/clients/cli/src/agent/__tests__/cards.test.ts
+++ b/clients/cli/src/agent/__tests__/cards.test.ts
@@ -75,6 +75,36 @@ describe('parseBalanceSummaryEnvelope', () => {
     expect(card!.accounts).toHaveLength(1)
     expect(card!.accounts[0].chainId).toBe('Ethereum')
   })
+
+  it('strips terminal control/ANSI bytes from attacker-controlled fields', () => {
+    // Token symbol/chain come from on-chain metadata (a scam token can pick any
+    // symbol); on the legacy-echo path JSON.parse decodes an escape into a real
+    // ESC byte. Neither must inject escape sequences into the table (OSC 8
+    // hyperlink spoofing, OSC 52 clipboard writes, cursor moves). Build the
+    // control bytes programmatically so no literal control char lives in source.
+    const ESC = String.fromCharCode(0x1b)
+    const BEL = String.fromCharCode(0x07)
+    const C1_CSI = String.fromCharCode(0x9b) // single-byte C1 CSI introducer
+    const card = parseBalanceSummaryEnvelope({
+      surface: 'balance_summary',
+      accounts: [
+        {
+          chainId: `Eth${ESC}[31mereum`,
+          address: '0xabc',
+          tokens: [{ symbol: `EV${ESC}]8;;http://evil${BEL}IL`, amountDecimal: `1\r\n0${C1_CSI}`, amountUsd: '$10' }],
+        },
+      ],
+    })!
+    // Parser strips the control bytes at the boundary, leaving only inert
+    // printable text; the renderer only ever prints these parsed fields, so the
+    // ESC/BEL/C1 introducers can no longer form an escape sequence on the TTY.
+    expect(card.accounts[0].chainId).toBe('Eth[31mereum')
+    expect(card.accounts[0].tokens[0].symbol).toBe('EV]8;;http://evilIL')
+    expect(card.accounts[0].tokens[0].amountDecimal).toBe('10')
+    // renderBalanceSummaryCard must not throw on the coerced card. (Its output
+    // still carries chalk's own SGR styling — expected, distinct from injection.)
+    expect(() => renderBalanceSummaryCard(card)).not.toThrow()
+  })
 })
 
 describe('renderBalanceSummaryCard', () => {
@@ -139,5 +169,12 @@ describe('extractBalanceSummaryFromText (legacy verbatim-echo fallback)', () => 
   it('ignores a non-card JSON object that mentions balance_summary', () => {
     const text = 'The {"foo":"balance_summary mention"} is not a card.'
     expect(extractBalanceSummaryFromText(text)).toBeNull()
+  })
+
+  it('bails on pathological oversized content instead of scanning O(n²)', () => {
+    // A crafted message of deeply nested braces would make matchBrace O(n²);
+    // content past the backstop returns null (raw text prints) rather than hang.
+    const huge = 'balance_summary ' + '{'.repeat(150_000) + '}'.repeat(150_000)
+    expect(extractBalanceSummaryFromText(huge)).toBeNull()
   })
 })

--- a/clients/cli/src/agent/__tests__/cards.test.ts
+++ b/clients/cli/src/agent/__tests__/cards.test.ts
@@ -47,6 +47,12 @@ describe('parseBalanceSummaryEnvelope', () => {
     expect(card!.staleSecs).toBe(120)
   })
 
+  it('does not orphan staleSecs when stale is unset', () => {
+    const card = parseBalanceSummaryEnvelope({ ...VALID_ENVELOPE, stale_secs: 120 })
+    expect(card!.stale).toBeUndefined()
+    expect(card!.staleSecs).toBeUndefined()
+  })
+
   it('rejects a non-balance_summary surface', () => {
     expect(parseBalanceSummaryEnvelope({ surface: 'yield_opportunities', accounts: [] })).toBeNull()
   })

--- a/clients/cli/src/agent/__tests__/client.test.ts
+++ b/clients/cli/src/agent/__tests__/client.test.ts
@@ -299,6 +299,30 @@ describe('AgentClient.sendMessageStream', () => {
     expect(onToolProgress).not.toHaveBeenCalled()
   })
 
+  // cat4-cli-supported-surfaces: the backend emits data-balance_summary when
+  // the client advertised "balance_summary" in supported_surfaces. Previously
+  // this v1 part routed to the 'ignore' bucket (client.ts:421) and the card was
+  // silently dropped; now it surfaces via onBalanceSummary.
+  it('routes data-balance_summary to onBalanceSummary with the envelope payload', async () => {
+    const onBalanceSummary = vi.fn()
+
+    const envelope = {
+      surface: 'balance_summary',
+      accounts: [{ chainId: 'Ethereum', address: '0xabc', tokens: [{ symbol: 'ETH', amountDecimal: '1.0' }] }],
+    }
+
+    globalThis.fetch = mockFetchSSE([
+      `data: ${JSON.stringify({ type: 'data-balance_summary', data: envelope })}\n\n`,
+      'data: {"type":"finish"}\n\n',
+    ])
+
+    const client = new AgentClient('http://example.com')
+    await client.sendMessageStream('c1', { public_key: 'pk', content: 'balance' }, { onBalanceSummary })
+
+    expect(onBalanceSummary).toHaveBeenCalledTimes(1)
+    expect(onBalanceSummary).toHaveBeenCalledWith(envelope)
+  })
+
   it('handles v1 error events via errorText', async () => {
     const onError = vi.fn()
     globalThis.fetch = mockFetchSSE(['data: {"type":"error","errorText":"boom"}\n\n'])

--- a/clients/cli/src/agent/__tests__/sessionConfirmGate.test.ts
+++ b/clients/cli/src/agent/__tests__/sessionConfirmGate.test.ts
@@ -205,3 +205,91 @@ describe('processMessageLoop — tx_ready wiring through the gate', () => {
     expect(h.ui.onDone).toHaveBeenCalledOnce()
   })
 })
+
+// Balance-card rendering through processMessageLoop. Exercises the typed SSE
+// path, the legacy verbatim-echo fallback, and the both-paths-fire case the
+// `balanceCardRendered` guard / renderEchoedBalanceCard helper exists for.
+describe('processMessageLoop — balance_summary card rendering', () => {
+  const ENVELOPE = {
+    surface: 'balance_summary',
+    accounts: [
+      { chainId: 'Ethereum', address: '0xabc', tokens: [{ symbol: 'ETH', amountDecimal: '1.0', amountUsd: '$3,000' }] },
+    ],
+  }
+
+  function makeCardHarness(opts: { fireSse: boolean; content: string }) {
+    const streamRequests: any[] = []
+    const client = {
+      sendMessageStream: vi.fn(async (_conv: string, request: any, callbacks: any) => {
+        streamRequests.push(request)
+        if (opts.fireSse) callbacks.onBalanceSummary(ENVELOPE)
+        return { message: { content: opts.content }, fullText: '', transactions: [] }
+      }),
+    }
+    const ui = {
+      onTextDelta: vi.fn(),
+      onToolCall: vi.fn(),
+      onToolResult: vi.fn(),
+      onAssistantMessage: vi.fn(),
+      onBalanceSummary: vi.fn(),
+      onSuggestions: vi.fn(),
+      onTxStatus: vi.fn(),
+      onError: vi.fn(),
+      onDone: vi.fn(),
+      requestPassword: vi.fn(async () => 'pw'),
+      requestConfirmation: vi.fn(async () => true),
+    }
+    const fakeThis: any = {
+      conversationId: 'conv-1',
+      publicKey: 'pk-test',
+      cachedContext: { addresses: {} },
+      config: { password: 'pw', askMode: true, verbose: false },
+      pendingToolResults: [],
+      abortController: null,
+      client,
+      executor: { storeServerTransaction: vi.fn(() => false), setPassword: vi.fn() },
+      processMessageLoop: (AgentSession.prototype as any).processMessageLoop,
+      runPasswordGatedTool: (AgentSession.prototype as any).runPasswordGatedTool,
+      dispatchClientSideTool: (AgentSession.prototype as any).dispatchClientSideTool,
+      renderEchoedBalanceCard: (AgentSession.prototype as any).renderEchoedBalanceCard,
+    }
+    const run = () => (AgentSession.prototype as any).processMessageLoop.call(fakeThis, 'balances?', ui, 0)
+    return { run, ui, streamRequests }
+  }
+
+  it('advertises supported_surfaces on every request', async () => {
+    const h = makeCardHarness({ fireSse: true, content: 'Your ETH balance is 1.0.' })
+    await h.run()
+    expect(h.streamRequests[0].supported_surfaces).toContain('balance_summary')
+  })
+
+  it('typed SSE path: renders the card once and shows the narration prose', async () => {
+    const h = makeCardHarness({ fireSse: true, content: 'You hold 1 ETH (~$3,000).' })
+    await h.run()
+    expect(h.ui.onBalanceSummary).toHaveBeenCalledOnce()
+    expect(h.ui.onAssistantMessage).toHaveBeenCalledWith('You hold 1 ETH (~$3,000).')
+  })
+
+  it('both paths fire: card renders once (SSE) and the echoed JSON is stripped from the text', async () => {
+    // Misbehaving/transitional backend: emits the typed SSE part AND lets the
+    // model echo the envelope JSON into message content. The card must render
+    // exactly once and the raw JSON must never reach onAssistantMessage.
+    const content = `Here you go: ${JSON.stringify(ENVELOPE)} all set.`
+    const h = makeCardHarness({ fireSse: true, content })
+    await h.run()
+    expect(h.ui.onBalanceSummary).toHaveBeenCalledOnce()
+    const shown = h.ui.onAssistantMessage.mock.calls[0]?.[0] ?? ''
+    expect(shown).not.toContain('"surface"')
+    expect(shown).toContain('Here you go:')
+    expect(shown).toContain('all set.')
+  })
+
+  it('legacy-only fallback: echoed JSON with no SSE part still renders the card and strips the JSON', async () => {
+    const content = JSON.stringify(ENVELOPE)
+    const h = makeCardHarness({ fireSse: false, content })
+    await h.run()
+    expect(h.ui.onBalanceSummary).toHaveBeenCalledOnce()
+    // The message was nothing but the envelope → no empty assistant message.
+    expect(h.ui.onAssistantMessage).not.toHaveBeenCalled()
+  })
+})

--- a/clients/cli/src/agent/__tests__/sessionConfirmGate.test.ts
+++ b/clients/cli/src/agent/__tests__/sessionConfirmGate.test.ts
@@ -172,6 +172,7 @@ describe('processMessageLoop — tx_ready wiring through the gate', () => {
       processMessageLoop: (AgentSession.prototype as any).processMessageLoop,
       runPasswordGatedTool: (AgentSession.prototype as any).runPasswordGatedTool,
       dispatchClientSideTool: (AgentSession.prototype as any).dispatchClientSideTool,
+      renderEchoedBalanceCard: (AgentSession.prototype as any).renderEchoedBalanceCard,
     }
     const run = () => (AgentSession.prototype as any).processMessageLoop.call(fakeThis, 'hello', ui, 0)
     return { run, ui, client, streamRequests, signTxFromBuffer, clearPendingTransaction }

--- a/clients/cli/src/agent/__tests__/sessionRecovery.test.ts
+++ b/clients/cli/src/agent/__tests__/sessionRecovery.test.ts
@@ -162,7 +162,11 @@ describe('recoverDisconnectedTurn — before/after differential', () => {
       disconnected: true,
       serverNow: null, // no X-Server-Now → local-clock fallback anchor
     })
-    const txReadyData = { chain: 'Ethereum', action: 'send', send_tx: { to: '0xabc', value: '1' } }
+    const txReadyData = {
+      chain: 'Ethereum',
+      action: 'send',
+      send_tx: { to: '0xabc', value: '1' },
+    }
     const messagesSince = vi.fn(async () => ({
       messages: [
         recoveredAssistant({
@@ -290,6 +294,7 @@ describe('processMessageLoop — disconnect recovery wiring (end-to-end)', () =>
       recoverDisconnectedTurn: (AgentSession.prototype as any).recoverDisconnectedTurn,
       recoverySleep: (AgentSession.prototype as any).recoverySleep,
       applyRecoveredMessage: (AgentSession.prototype as any).applyRecoveredMessage,
+      renderEchoedBalanceCard: (AgentSession.prototype as any).renderEchoedBalanceCard,
     }
     const run = () => (AgentSession.prototype as any).processMessageLoop.call(fakeThis, 'whats my balance', ui, 0)
     return { run, ui, client, executor }
@@ -353,6 +358,7 @@ describe('processMessageLoop — disconnect recovery wiring (end-to-end)', () =>
       recoverDisconnectedTurn: (AgentSession.prototype as any).recoverDisconnectedTurn,
       recoverySleep: (AgentSession.prototype as any).recoverySleep,
       applyRecoveredMessage: (AgentSession.prototype as any).applyRecoveredMessage,
+      renderEchoedBalanceCard: (AgentSession.prototype as any).renderEchoedBalanceCard,
     }
 
     await (AgentSession.prototype as any).processMessageLoop.call(fakeThis, 'hi', ui, 0)

--- a/clients/cli/src/agent/ask.ts
+++ b/clients/cli/src/agent/ask.ts
@@ -12,6 +12,7 @@
  *   vultisig agent ask "Send 0.01567 HYPE to myself" --session <id> --vault t1 --password 1
  */
 import type { AgentErrorCode } from './agentErrors'
+import type { BalanceSummaryCard } from './cards'
 import type { AgentSession } from './session'
 import type { Suggestion, UICallbacks } from './types'
 
@@ -30,6 +31,8 @@ export type AskResult = {
     chain: string
     explorerUrl?: string
   }>
+  /** Server-built balance_summary cards rendered this turn. */
+  cards: BalanceSummaryCard[]
 }
 
 export class AskInterface {
@@ -39,6 +42,7 @@ export class AskInterface {
   private responseParts: string[] = []
   private toolCalls: AskResult['toolCalls'] = []
   private transactions: AskResult['transactions'] = []
+  private cards: BalanceSummaryCard[] = []
 
   constructor(session: AgentSession, verbose = false, autoApprove = false) {
     this.session = session
@@ -84,6 +88,10 @@ export class AskInterface {
         if (content) {
           this.responseParts.push(content)
         }
+      },
+
+      onBalanceSummary: (card: BalanceSummaryCard) => {
+        this.cards.push(card)
       },
 
       onSuggestions: (_suggestions: Suggestion[]) => {
@@ -133,6 +141,7 @@ export class AskInterface {
     this.responseParts = []
     this.toolCalls = []
     this.transactions = []
+    this.cards = []
 
     const callbacks = this.getCallbacks()
     await this.session.sendMessage(message, callbacks)
@@ -142,6 +151,7 @@ export class AskInterface {
       response: this.responseParts[this.responseParts.length - 1] || '',
       toolCalls: this.toolCalls,
       transactions: this.transactions,
+      cards: this.cards,
     }
   }
 }

--- a/clients/cli/src/agent/cards.ts
+++ b/clients/cli/src/agent/cards.ts
@@ -42,8 +42,32 @@ export type BalanceSummaryCard = {
   staleSecs?: number
 }
 
+/**
+ * Strip terminal control bytes (C0 0x00–0x1F, DEL 0x7F, C1 0x80–0x9F) from a
+ * value before it can reach the TTY. Card string fields flow from
+ * attacker-influenced sources — token `symbol`/`chainId` come from on-chain
+ * metadata (a scam token can pick any symbol), and on the legacy-echo fallback
+ * path `JSON.parse` decodes an escape into a real ESC byte. Every ANSI/OSC
+ * escape sequence requires one of these introducer bytes, so removing the range
+ * neutralizes cursor-move / OSC 8 hyperlink-spoof / OSC 52 clipboard-write
+ * injection into the balances table while leaving all printable text (incl.
+ * Unicode) intact. Done at the parse boundary so both the typed-SSE and
+ * legacy-echo render paths defend in depth rather than trusting the backend
+ * sanitizer (balance_summary_sanitize.go) — the fallback exists precisely for
+ * backends that don't sanitize.
+ */
+function stripControlChars(s: string): string {
+  let out = ''
+  for (const ch of s) {
+    const code = ch.codePointAt(0) ?? 0
+    if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) continue
+    out += ch
+  }
+  return out
+}
+
 function asString(v: unknown): string {
-  return typeof v === 'string' ? v : ''
+  return typeof v === 'string' ? stripControlChars(v) : ''
 }
 
 function parseToken(v: unknown): BalanceSummaryToken | null {
@@ -126,6 +150,12 @@ export function extractBalanceSummaryFromText(
   content: string
 ): { card: BalanceSummaryCard; remainingText: string } | null {
   if (!content || !content.includes('balance_summary')) return null
+
+  // Backstop against adversarial input: matchBrace is O(n) per `{`, so a crafted
+  // blob of deeply nested braces makes the scan O(n²). A real echoed card is
+  // small (a few KB); a single assistant message this large is pathological, so
+  // bail and let the raw text print rather than pin the CPU.
+  if (content.length > 200_000) return null
 
   // Scan every `{`-delimited object; the envelope may sit inside a code fence
   // or be wrapped in prose. Take the first one that parses as a balance card.

--- a/clients/cli/src/agent/cards.ts
+++ b/clients/cli/src/agent/cards.ts
@@ -1,0 +1,209 @@
+/**
+ * Server-built card surfaces
+ *
+ * The agent-backend negotiates rich "cards" with the client via the
+ * `supported_surfaces` request field (see backend
+ * internal/service/agent/types.go SendMessageRequest.SupportedSurfaces). When
+ * the client advertises a surface, the backend emits a typed `data-<surface>`
+ * SSE part and strips the raw payload from the model-visible tool result so the
+ * LLM narrates instead of echoing JSON.
+ *
+ * When the client does NOT advertise a surface, the backend falls back to the
+ * legacy path where the model echoes the `card_payload` JSON verbatim into the
+ * message content (the #341/#582 raw-JSON-in-the-terminal incidents). The CLI
+ * historically advertised nothing, so a balance query dumped raw card JSON.
+ *
+ * This module owns the one surface the CLI renders today — `balance_summary` —
+ * plus the defensive fallback that pretty-renders a card envelope if the legacy
+ * verbatim-echo path ever fires (older backend, or a backend that ignores the
+ * advertised surface).
+ */
+import chalk from 'chalk'
+
+/** Surface keys the CLI declares it can render. Sent as `supported_surfaces`. */
+export const CLI_SUPPORTED_SURFACES = ['balance_summary'] as const
+
+export type BalanceSummaryToken = {
+  symbol: string
+  amountDecimal: string
+  amountUsd?: string
+}
+
+export type BalanceSummaryAccount = {
+  chainId: string
+  address: string
+  tokens: BalanceSummaryToken[]
+}
+
+export type BalanceSummaryCard = {
+  surface: 'balance_summary'
+  accounts: BalanceSummaryAccount[]
+  stale?: boolean
+  staleSecs?: number
+}
+
+function asString(v: unknown): string {
+  return typeof v === 'string' ? v : ''
+}
+
+function parseToken(v: unknown): BalanceSummaryToken | null {
+  if (!v || typeof v !== 'object') return null
+  const o = v as Record<string, unknown>
+  const symbol = asString(o.symbol)
+  const amountDecimal = asString(o.amountDecimal)
+  if (!symbol && !amountDecimal) return null
+  const token: BalanceSummaryToken = { symbol, amountDecimal }
+  const amountUsd = asString(o.amountUsd)
+  if (amountUsd) token.amountUsd = amountUsd
+  return token
+}
+
+function parseAccount(v: unknown): BalanceSummaryAccount | null {
+  if (!v || typeof v !== 'object') return null
+  const o = v as Record<string, unknown>
+  const chainId = asString(o.chainId)
+  if (!chainId) return null
+  const tokensRaw = Array.isArray(o.tokens) ? o.tokens : []
+  const tokens = tokensRaw.map(parseToken).filter((t): t is BalanceSummaryToken => t !== null)
+  return { chainId, address: asString(o.address) || '—', tokens }
+}
+
+/**
+ * Validate + coerce an arbitrary value into a {@link BalanceSummaryCard}.
+ * Returns null when it isn't a balance_summary envelope with at least one
+ * renderable account. Mirrors the backend's allow-listing
+ * (balance_summary_sanitize.go) so a malformed/foreign payload is rejected
+ * rather than rendered.
+ */
+export function parseBalanceSummaryEnvelope(value: unknown): BalanceSummaryCard | null {
+  if (!value || typeof value !== 'object') return null
+  const o = value as Record<string, unknown>
+  if (o.surface !== 'balance_summary') return null
+  if (!Array.isArray(o.accounts)) return null
+  const accounts = o.accounts.map(parseAccount).filter((a): a is BalanceSummaryAccount => a !== null)
+  if (accounts.length === 0) return null
+  const card: BalanceSummaryCard = { surface: 'balance_summary', accounts }
+  if (o.stale === true) card.stale = true
+  if (typeof o.stale_secs === 'number') card.staleSecs = o.stale_secs
+  return card
+}
+
+/** Find the matching `}` for the `{` at `start`, respecting JSON strings. */
+function matchBrace(text: string, start: number): number {
+  let depth = 0
+  let inString = false
+  let escaped = false
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i]
+    if (inString) {
+      if (escaped) escaped = false
+      else if (ch === '\\') escaped = true
+      else if (ch === '"') inString = false
+      continue
+    }
+    if (ch === '"') inString = true
+    else if (ch === '{') depth++
+    else if (ch === '}') {
+      depth--
+      if (depth === 0) return i
+    }
+  }
+  return -1
+}
+
+/**
+ * Legacy-path fallback: detect a balance_summary card envelope embedded in
+ * assistant message content (the model echoing `card_payload` verbatim, possibly
+ * inside a ```json code fence or surrounded by prose) and return both the parsed
+ * card and the message text with the JSON blob removed. Returns null when no
+ * card envelope is present, so normal prose passes through untouched.
+ */
+export function extractBalanceSummaryFromText(
+  content: string
+): { card: BalanceSummaryCard; remainingText: string } | null {
+  if (!content || !content.includes('balance_summary')) return null
+
+  // Scan every `{`-delimited object; the envelope may sit inside a code fence
+  // or be wrapped in prose. Take the first one that parses as a balance card.
+  for (let i = content.indexOf('{'); i !== -1; i = content.indexOf('{', i + 1)) {
+    const end = matchBrace(content, i)
+    if (end === -1) break
+    const blob = content.slice(i, end + 1)
+    if (!blob.includes('balance_summary')) continue
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(blob)
+    } catch {
+      continue
+    }
+    const card = parseBalanceSummaryEnvelope(parsed)
+    if (!card) continue
+    // Remove the JSON blob (and any enclosing ```json fence) from the text.
+    const before = content.slice(0, i).replace(/```(?:json)?\s*$/i, '')
+    const after = content.slice(end + 1).replace(/^\s*```/, '')
+    const remainingText = (before + after).trim()
+    return { card, remainingText }
+  }
+  return null
+}
+
+function shortenAddress(address: string): string {
+  if (!address || address === '—') return address || '—'
+  if (address.length <= 16) return address
+  return `${address.slice(0, 8)}…${address.slice(-6)}`
+}
+
+/** Parse a USD string ("$4,500.00", "4500") into a number, or null. */
+function parseUsd(amountUsd?: string): number | null {
+  if (!amountUsd) return null
+  const cleaned = amountUsd.replace(/[$,\s]/g, '')
+  if (!cleaned) return null
+  const n = Number(cleaned)
+  return Number.isFinite(n) ? n : null
+}
+
+function formatUsd(n: number): string {
+  return `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+}
+
+/**
+ * Render a balance_summary card as a terminal table. Replaces the legacy
+ * raw-JSON dump with a human-readable breakdown grouped by chain, with a USD
+ * total when amounts are priced.
+ */
+export function renderBalanceSummaryCard(card: BalanceSummaryCard): string {
+  const lines: string[] = []
+  const staleCue = card.stale
+    ? chalk.gray(` (stale${card.staleSecs ? ` ~${Math.round(card.staleSecs / 60)}m` : ''}, refreshing…)`)
+    : ''
+  lines.push(chalk.bold('  Balances') + staleCue)
+
+  let total = 0
+  let sawUsd = false
+
+  for (const account of card.accounts) {
+    lines.push(`  ${chalk.cyan(account.chainId)} ${chalk.gray(`(${shortenAddress(account.address)})`)}`)
+    if (account.tokens.length === 0) {
+      lines.push(chalk.gray('    (no balances)'))
+      continue
+    }
+    for (const token of account.tokens) {
+      const usd = parseUsd(token.amountUsd)
+      if (usd !== null) {
+        total += usd
+        sawUsd = true
+      }
+      const symbol = token.symbol.padEnd(10)
+      const amount = token.amountDecimal.padStart(16)
+      const usdCol = token.amountUsd ? chalk.gray(`  ${token.amountUsd}`) : ''
+      lines.push(`    ${chalk.bold(symbol)}${amount}${usdCol}`)
+    }
+  }
+
+  if (sawUsd) {
+    lines.push(chalk.gray('  ' + '─'.repeat(36)))
+    lines.push(`  ${chalk.bold('Total')}  ${chalk.green(formatUsd(total))}`)
+  }
+
+  return lines.join('\n')
+}

--- a/clients/cli/src/agent/cards.ts
+++ b/clients/cli/src/agent/cards.ts
@@ -83,8 +83,12 @@ export function parseBalanceSummaryEnvelope(value: unknown): BalanceSummaryCard 
   const accounts = o.accounts.map(parseAccount).filter((a): a is BalanceSummaryAccount => a !== null)
   if (accounts.length === 0) return null
   const card: BalanceSummaryCard = { surface: 'balance_summary', accounts }
-  if (o.stale === true) card.stale = true
-  if (typeof o.stale_secs === 'number') card.staleSecs = o.stale_secs
+  // staleSecs is only meaningful (and only rendered) alongside stale, so keep
+  // it gated on the stale flag rather than letting it orphan when stale is unset.
+  if (o.stale === true) {
+    card.stale = true
+    if (typeof o.stale_secs === 'number') card.staleSecs = o.stale_secs
+  }
   return card
 }
 

--- a/clients/cli/src/agent/client.ts
+++ b/clients/cli/src/agent/client.ts
@@ -45,6 +45,11 @@ type StreamCallbacks = {
   onTitle?: (title: string) => void
   onSuggestions?: (suggestions: Suggestion[]) => void
   onTxReady?: (tx: TxReadyPayload) => void
+  // Fired for the `data-balance_summary` SSE part the backend emits when the
+  // client advertised "balance_summary" in supported_surfaces. Carries the raw
+  // card envelope; the consumer validates + renders it. Replaces the legacy
+  // verbatim-echo path where the card arrived as raw JSON in message content.
+  onBalanceSummary?: (card: unknown) => void
   onMessage?: (msg: ConversationMessage) => void
   onError?: (error: string, code: AgentErrorCode) => void
 }
@@ -433,6 +438,13 @@ export class AgentClient {
             callbacks.onTxReady?.(txReady)
           }
           break
+        case 'balance_summary': {
+          // v1 custom-data part: envelope under `.data`. Legacy event-header
+          // form would carry it inline, so accept both shapes.
+          const card = v1Data ?? parsed.data ?? parsed
+          callbacks.onBalanceSummary?.(card)
+          break
+        }
         case 'message': {
           const msg = v1Data?.message ?? parsed.message ?? parsed
           result.message = msg
@@ -542,6 +554,8 @@ export class AgentClient {
         return 'suggestions'
       case 'data-tx_ready':
         return 'tx_ready'
+      case 'data-balance_summary':
+        return 'balance_summary'
       case 'data-message':
         return 'message'
       case 'error':

--- a/clients/cli/src/agent/index.ts
+++ b/clients/cli/src/agent/index.ts
@@ -11,6 +11,13 @@ export { AgentErrorCode, inferAgentErrorCodeFromMessage, isAgentErrorCode, norma
 export type { AskResult } from './ask'
 export { AskInterface } from './ask'
 export { authenticateVault } from './auth'
+export type { BalanceSummaryAccount, BalanceSummaryCard, BalanceSummaryToken } from './cards'
+export {
+  CLI_SUPPORTED_SURFACES,
+  extractBalanceSummaryFromText,
+  parseBalanceSummaryEnvelope,
+  renderBalanceSummaryCard,
+} from './cards'
 export { AgentClient } from './client'
 export { buildMessageContext, buildMinimalContext } from './context'
 export { AgentExecutor } from './executor'

--- a/clients/cli/src/agent/pipe.ts
+++ b/clients/cli/src/agent/pipe.ts
@@ -10,6 +10,7 @@
 import * as readline from 'node:readline'
 
 import { AgentErrorCode, normalizeAgentError } from './agentErrors'
+import type { BalanceSummaryCard } from './cards'
 import type { AgentSession } from './session'
 import type { PipeInputCommand, PipeOutputEvent, Suggestion, UICallbacks } from './types'
 
@@ -160,6 +161,10 @@ export class PipeInterface {
 
       onAssistantMessage: (content: string) => {
         this.emit({ type: 'assistant', content })
+      },
+
+      onBalanceSummary: (card: BalanceSummaryCard) => {
+        this.emit({ type: 'balance_summary', card })
       },
 
       onSuggestions: (suggestions: Suggestion[]) => {

--- a/clients/cli/src/agent/session.ts
+++ b/clients/cli/src/agent/session.ts
@@ -17,11 +17,7 @@ import { MemoryStorage, PushNotificationService, type VaultBase } from '@vultisi
 
 import { AgentErrorCode } from './agentErrors'
 import { authenticateVault } from './auth'
-import {
-  CLI_SUPPORTED_SURFACES,
-  extractBalanceSummaryFromText,
-  parseBalanceSummaryEnvelope,
-} from './cards'
+import { CLI_SUPPORTED_SURFACES, extractBalanceSummaryFromText, parseBalanceSummaryEnvelope } from './cards'
 import { AgentClient, type SSEStreamResult } from './client'
 import { buildMessageContext, buildMinimalContext } from './context'
 import { AgentExecutor } from './executor'

--- a/clients/cli/src/agent/session.ts
+++ b/clients/cli/src/agent/session.ts
@@ -17,6 +17,11 @@ import { MemoryStorage, PushNotificationService, type VaultBase } from '@vultisi
 
 import { AgentErrorCode } from './agentErrors'
 import { authenticateVault } from './auth'
+import {
+  CLI_SUPPORTED_SURFACES,
+  extractBalanceSummaryFromText,
+  parseBalanceSummaryEnvelope,
+} from './cards'
 import { AgentClient, type SSEStreamResult } from './client'
 import { buildMessageContext, buildMinimalContext } from './context'
 import { AgentExecutor } from './executor'
@@ -279,6 +284,12 @@ export class AgentSession {
     const request: any = {
       public_key: this.publicKey,
       context: this.cachedContext ? { ...this.cachedContext } : {},
+      // Advertise the card surfaces the CLI can render. Without this the backend
+      // takes the legacy path and instructs the model to echo card_payload JSON
+      // verbatim into message content (raw JSON in the terminal). With it, the
+      // backend emits a typed data-balance_summary SSE part and the model
+      // narrates. See cards.ts / backend types.go SupportedSurfaces.
+      supported_surfaces: [...CLI_SUPPORTED_SURFACES],
     }
 
     // Signal to backend that an AI agent is calling (adjusts prompt for structured output)
@@ -304,6 +315,11 @@ export class AgentSession {
 
     // tx_ready count is NOT streamResult.transactions.length — errors/empty events also push there.
     let serverTxStoredFromStream = 0
+    // Whether a balance_summary card was rendered from the SSE data part this
+    // turn. When true, the message-content fallback is skipped so a card isn't
+    // rendered twice (it won't be — the model is told not to echo — but this
+    // makes the invariant explicit).
+    let balanceCardRendered = false
     const pendingDispatches: Promise<void>[] = []
     // Serialize client-side tool dispatches in SSE arrival order. Without
     // this, ordering-sensitive flows (vault_chain add → vault_coin add) race
@@ -348,6 +364,13 @@ export class AgentSession {
           if (this.config.password) {
             this.executor.setPassword(this.config.password)
           }
+        }
+      },
+      onBalanceSummary: (raw: unknown) => {
+        const card = parseBalanceSummaryEnvelope(raw)
+        if (card) {
+          balanceCardRendered = true
+          ui.onBalanceSummary?.(card)
         }
       },
       onMessage: (_msg: any) => {
@@ -415,7 +438,21 @@ export class AgentSession {
     // Final message event wins over streamed deltas (which may be partial).
     const responseText = streamResult.message?.content || streamResult.fullText || ''
 
-    const displayText = stripLeakedToolCallTags(responseText)
+    let displayText = stripLeakedToolCallTags(responseText)
+
+    // Legacy-path fallback: if the backend ignored supported_surfaces (older
+    // build) and the model echoed a balance_summary card_payload verbatim into
+    // the message content, pretty-render it instead of dumping raw JSON. Skip
+    // when the SSE card already fired this turn.
+    if (!balanceCardRendered && displayText) {
+      const extracted = extractBalanceSummaryFromText(displayText)
+      if (extracted) {
+        balanceCardRendered = true
+        ui.onBalanceSummary?.(extracted.card)
+        displayText = extracted.remainingText
+      }
+    }
+
     if (displayText) {
       ui.onAssistantMessage(displayText)
     }

--- a/clients/cli/src/agent/session.ts
+++ b/clients/cli/src/agent/session.ts
@@ -441,22 +441,8 @@ export class AgentSession {
 
     let displayText = stripLeakedToolCallTags(responseText)
 
-    // Legacy-path fallback: if the backend ignored supported_surfaces (older
-    // build) and the model echoed a balance_summary card_payload verbatim into
-    // the message content, pretty-render it instead of dumping raw JSON. We run
-    // the extractor even when the SSE card already fired this turn — a
-    // misbehaving backend could emit BOTH the typed part and an echoed blob, so
-    // we always STRIP the leftover JSON from the displayed text; we only render
-    // the card if one wasn't already rendered (no double-render).
     if (displayText) {
-      const extracted = extractBalanceSummaryFromText(displayText)
-      if (extracted) {
-        if (!balanceCardRendered) {
-          balanceCardRendered = true
-          ui.onBalanceSummary?.(extracted.card)
-        }
-        displayText = extracted.remainingText
-      }
+      displayText = this.renderEchoedBalanceCard(displayText, balanceCardRendered, ui)
     }
 
     if (displayText) {
@@ -617,6 +603,25 @@ export class AgentSession {
         onTxReady?.(tx)
       }
     }
+  }
+
+  /**
+   * Legacy-path fallback for echoed balance_summary cards. If the backend
+   * ignored supported_surfaces (older build) and the model echoed a
+   * card_payload verbatim into the message content, pretty-render it instead
+   * of dumping raw JSON. The extractor runs even when the SSE card already
+   * fired this turn — a misbehaving backend could emit BOTH the typed part and
+   * an echoed blob, so we always STRIP the leftover JSON from the displayed
+   * text; we only render the card when one wasn't already rendered (no
+   * double-render). Returns the text to display with any JSON blob stripped.
+   */
+  private renderEchoedBalanceCard(displayText: string, alreadyRendered: boolean, ui: UICallbacks): string {
+    const extracted = extractBalanceSummaryFromText(displayText)
+    if (!extracted) return displayText
+    if (!alreadyRendered) {
+      ui.onBalanceSummary?.(extracted.card)
+    }
+    return extracted.remainingText
   }
 
   /**

--- a/clients/cli/src/agent/session.ts
+++ b/clients/cli/src/agent/session.ts
@@ -316,9 +316,10 @@ export class AgentSession {
     // tx_ready count is NOT streamResult.transactions.length — errors/empty events also push there.
     let serverTxStoredFromStream = 0
     // Whether a balance_summary card was rendered from the SSE data part this
-    // turn. When true, the message-content fallback is skipped so a card isn't
-    // rendered twice (it won't be — the model is told not to echo — but this
-    // makes the invariant explicit).
+    // turn. When true, the message-content fallback still runs to STRIP any
+    // leftover echoed JSON from the displayed text, but does not render a second
+    // card (guards against a misbehaving backend emitting both the typed part
+    // and a verbatim echo).
     let balanceCardRendered = false
     const pendingDispatches: Promise<void>[] = []
     // Serialize client-side tool dispatches in SSE arrival order. Without

--- a/clients/cli/src/agent/session.ts
+++ b/clients/cli/src/agent/session.ts
@@ -442,13 +442,18 @@ export class AgentSession {
 
     // Legacy-path fallback: if the backend ignored supported_surfaces (older
     // build) and the model echoed a balance_summary card_payload verbatim into
-    // the message content, pretty-render it instead of dumping raw JSON. Skip
-    // when the SSE card already fired this turn.
-    if (!balanceCardRendered && displayText) {
+    // the message content, pretty-render it instead of dumping raw JSON. We run
+    // the extractor even when the SSE card already fired this turn — a
+    // misbehaving backend could emit BOTH the typed part and an echoed blob, so
+    // we always STRIP the leftover JSON from the displayed text; we only render
+    // the card if one wasn't already rendered (no double-render).
+    if (displayText) {
       const extracted = extractBalanceSummaryFromText(displayText)
       if (extracted) {
-        balanceCardRendered = true
-        ui.onBalanceSummary?.(extracted.card)
+        if (!balanceCardRendered) {
+          balanceCardRendered = true
+          ui.onBalanceSummary?.(extracted.card)
+        }
         displayText = extracted.remainingText
       }
     }

--- a/clients/cli/src/agent/tui.ts
+++ b/clients/cli/src/agent/tui.ts
@@ -14,6 +14,7 @@ import * as readline from 'node:readline'
 import chalk from 'chalk'
 
 import type { AgentErrorCode } from './agentErrors'
+import { type BalanceSummaryCard, renderBalanceSummaryCard } from './cards'
 import type { AgentSession } from './session'
 import type { ConversationMessage, Suggestion, UICallbacks } from './types'
 
@@ -196,6 +197,14 @@ export class ChatTUI {
           console.log(`${chalk.gray(ts)} ${chalk.cyan.bold('Agent')}: ${renderMarkdown(content)}`)
         }
         this.currentStreamText = ''
+      },
+
+      onBalanceSummary: (card: BalanceSummaryCard) => {
+        if (this.isStreaming) {
+          process.stdout.write('\n')
+          this.isStreaming = false
+        }
+        console.log(renderBalanceSummaryCard(card))
       },
 
       onSuggestions: (suggestions: Suggestion[]) => {

--- a/clients/cli/src/agent/types.ts
+++ b/clients/cli/src/agent/types.ts
@@ -7,6 +7,7 @@
 import type { Vultisig } from '@vultisig/sdk'
 
 import type { AgentErrorCode } from './agentErrors'
+import type { BalanceSummaryCard } from './cards'
 
 // ============================================================================
 // Configuration
@@ -209,6 +210,14 @@ export type SendMessageRequest = {
   selected_suggestion_id?: string
   /** Signals that the caller is an AI agent; backend adjusts prompt accordingly */
   via_agent?: boolean
+  /**
+   * Data-part surface keys the CLI can render. When "balance_summary" is
+   * present the backend emits a `data-balance_summary` SSE part and strips
+   * `card_payload` from the model-visible tool result, so the model narrates
+   * instead of echoing raw card JSON into message content (the legacy
+   * verbatim-echo path). See backend types.go SupportedSurfaces.
+   */
+  supported_surfaces?: string[]
 }
 
 export type ToolDefinition = {
@@ -381,6 +390,7 @@ export type PipeOutputEvent =
       explorer_url?: string
     }
   | { type: 'assistant'; content: string }
+  | { type: 'balance_summary'; card: BalanceSummaryCard }
   | { type: 'suggestions'; suggestions: Suggestion[] }
   // Emitted when the SSE stream dropped mid-turn and the CLI is polling
   // /messages/since to recover the answer — lets an agent consumer
@@ -410,6 +420,9 @@ export type UICallbacks = {
     code?: AgentErrorCode
   ) => void
   onAssistantMessage: (content: string) => void
+  /** Render a server-built balance_summary card (data-balance_summary SSE part,
+   *  or the legacy verbatim-echo fallback parsed from message content). */
+  onBalanceSummary?: (card: BalanceSummaryCard) => void
   onSuggestions: (suggestions: Suggestion[]) => void
   onTxStatus: (txHash: string, chain: string, status: string, explorerUrl?: string) => void
   onError: (message: string, code: AgentErrorCode) => void

--- a/clients/cli/src/commands/agent.ts
+++ b/clients/cli/src/commands/agent.ts
@@ -18,6 +18,7 @@ import Table from 'cli-table3'
 import type { AgentConfig } from '../agent'
 import { AgentClient, AgentSession, AskInterface, authenticateVault, ChatTUI, PipeInterface } from '../agent'
 import { AgentErrorCode, normalizeAgentError } from '../agent/agentErrors'
+import { renderBalanceSummaryCard } from '../agent/cards'
 import type { CommandContext } from '../core'
 import { isJsonOutput, outputJson, printResult, setSilentMode } from '../lib/output'
 
@@ -158,6 +159,7 @@ export async function executeAgentAsk(ctx: CommandContext, message: string, opti
         response: result.response,
         tool_calls: result.toolCalls,
         transactions: result.transactions,
+        ...(result.cards.length > 0 ? { cards: result.cards } : {}),
         ...(confirmationRequired ? { confirmation_required: true } : {}),
         ...(proposed ? { proposed } : {}),
       })
@@ -169,6 +171,11 @@ export async function executeAgentAsk(ctx: CommandContext, message: string, opti
         if (proposed) {
           process.stdout.write(`proposed:${proposed}\n`)
         }
+      }
+
+      // Balance cards (rendered as a table instead of raw JSON)
+      for (const card of result.cards) {
+        process.stdout.write(`\n${renderBalanceSummaryCard(card)}\n`)
       }
 
       // Response text


### PR DESCRIPTION
## Summary

The CLI's agent was never declaring which rich-card surfaces it can render. As a result the backend fell back to its legacy path: instead of emitting a structured `data-balance_summary` card, it instructed the model to **echo the card payload JSON verbatim into the message**. Users running a balance query in the terminal saw a raw `{"surface":"balance_summary",...}` blob instead of a readable summary.

This PR makes the CLI advertise `supported_surfaces: ["balance_summary"]` on every request and renders the resulting card as a terminal table. Because advertising the surface flips the backend to its "card already rendered, reply with one short sentence" contract, advertising **and** rendering are done together — otherwise the balance breakdown would be dropped entirely.

## What changed

- **Advertise the surface** — every agent request now sends `supported_surfaces: ["balance_summary"]`, so the backend emits a structured `data-balance_summary` envelope instead of inlining JSON.
- **Render the card** — `data-balance_summary` is routed through a new callback and rendered as a terminal table grouped by chain (shortened addresses, per-token USD, total, stale cue).
  - TUI: table (flushes any in-flight stream first).
  - Pipe mode: structured `{type:"balance_summary",card}` NDJSON event.
  - `agent ask`: collected on `cards` (JSON mode) / printed as a table (text mode).
- **Defensive fallback** — if a card envelope ever arrives embedded in message content (older backend echoing JSON), a brace-matched scan extracts it, renders the table, and strips the JSON from the displayed text (guarded so a card never renders twice).

Only `balance_summary` is wired. Other model-emitted card contracts (e.g. polymarket / yield) are only injected by the backend when their surface is declared, so the CLI correctly continues to receive prose for those; the surface list and renderers can be extended later.

## Receipts

### Before / after (driving the real `AgentClient.sendMessageStream` against a mock backend that replicates the backend's surface-gating)

- **Before** (no `supported_surfaces`): terminal text = `{"surface":"balance_summary","accounts":[…]}` — raw envelope dumped. `contains raw envelope JSON: true`.
- **After · happy path** (`supported_surfaces:["balance_summary"]`): backend emits `data-balance_summary`; CLI prints a table (chains, tokens, `Total $7,600.00`); message text = `"Your portfolio is worth about $7,600 across 2 chains."`; `contains raw envelope JSON: false`.
- **After · legacy fallback** (backend ignores surfaces, still echoes JSON): fallback detects the envelope, renders the table, strips the JSON → `card rendered as table: true`, no raw JSON.

### Build / typecheck / tests

- `yarn workspace @vultisig/cli build` → `Built @vultisig/cli v2.4.0` ✅
- `yarn workspace @vultisig/cli typecheck` → 26 errors, **all pre-existing** in untouched files (`vault-management.ts`, `core/errors.ts`, `agentErrors.ts`); **zero in any changed file** ✅
- `yarn test:cli` → **278 passed** (new: `agent/__tests__/cards.test.ts` parse/render/fallback + `data-balance_summary` routing case in `client.test.ts`) ✅

A changeset is included (`@vultisig/cli` minor).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Balance summary cards now render as formatted terminal tables with chain grouping and USD totals
  * Agent advertises supported card surfaces for optimized rendering

* **Bug Fixes**
  * Sanitized balance card strings to prevent ANSI escape sequence injection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->