### PR TITLE
fix(qbtc): set Cosmos SDK chain ID to qbtc

### DIFF
--- a/.changeset/qbtc-chain-id.md
+++ b/.changeset/qbtc-chain-id.md
@@ -1,0 +1,9 @@
+---
+"@vultisig/core-mpc": patch
+"@vultisig/sdk": patch
+---
+
+fix(qbtc): set QBTC Cosmos SDK chain ID to `qbtc` (was `qbtc-testnet`)
+
+The SignDoc built by `QBTCHelper` now uses `qbtc` as the chain ID so signed
+transactions match the live QBTC chain. Patch-bumps `@vultisig/sdk` to rebundle.

--- a/packages/core/mpc/chains/cosmos/qbtc/QBTCHelper.ts
+++ b/packages/core/mpc/chains/cosmos/qbtc/QBTCHelper.ts
@@ -22,7 +22,7 @@ const msgVoteTypeURL = '/cosmos.gov.v1beta1.MsgVote'
 
 /** QBTC fee denom and chain ID (Cosmos SDK). */
 const denom = 'qbtc'
-const chainID = 'qbtc-testnet'
+const chainID = 'qbtc'
 
 type QBTCKeysignInput = {
   keysignPayload: KeysignPayload


### PR DESCRIPTION
## What

Sets the QBTC Cosmos SDK chain ID to `qbtc` instead of `qbtc-testnet`.

The SignDoc built by `QBTCHelper` (`packages/core/mpc/chains/cosmos/qbtc/QBTCHelper.ts`) used `qbtc-testnet` as the chain ID. This changes it to `qbtc` so signed transactions match the live QBTC chain.

## Notes

- `priceProviderId: 'qbtc-testnet'` in `chainFeeCoin.ts` is intentionally left unchanged — it is a price-provider id, not the chain ID.
- Includes a changeset (`@vultisig/core-mpc` patch, `@vultisig/sdk` patch).
- Companion PR in `vultisig-windows` updates the desktop core UI and extension to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated QBTC chain identifier to production value. Signed transactions now correctly match the live QBTC chain.

* **Chores**
  * Updated SDK dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->