### PR TITLE
Expose SDK Electron main export

### DIFF
--- a/.changeset/sdk-electron-main-export.md
+++ b/.changeset/sdk-electron-main-export.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Expose the documented `@vultisig/sdk/electron/main` subpath in the published SDK package.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -52,7 +52,13 @@
       "default": "./dist/index.rn-preamble.js"
     },
     "./electron": {
-      "types": "./dist/index.node.d.ts",
+      "types": "./dist/index.electron-main.d.ts",
+      "import": "./dist/index.electron-main.cjs",
+      "require": "./dist/index.electron-main.cjs",
+      "default": "./dist/index.electron-main.cjs"
+    },
+    "./electron/main": {
+      "types": "./dist/index.electron-main.d.ts",
       "import": "./dist/index.electron-main.cjs",
       "require": "./dist/index.electron-main.cjs",
       "default": "./dist/index.electron-main.cjs"

--- a/packages/sdk/rollup.types.config.js
+++ b/packages/sdk/rollup.types.config.js
@@ -41,6 +41,17 @@ export default defineConfig([
     },
     plugins: [dts(dtsPluginOptions)],
   },
+  // Electron main process platform types. This entry exposes Electron-specific
+  // storage, crypto, and polyfill implementations in addition to the public SDK
+  // surface.
+  {
+    input: 'src/platforms/electron-main/index.ts',
+    output: {
+      file: 'dist/index.electron-main.d.ts',
+      format: 'es',
+    },
+    plugins: [dts(dtsPluginOptions)],
+  },
   // React Native platform types — RN-specific exports (e.g. keysign) that
   // aren't reachable from src/index.ts because that entry stays platform
   // agnostic. Consumers resolving under the "react-native" export condition

--- a/scripts/quality-contracts.mjs
+++ b/scripts/quality-contracts.mjs
@@ -284,6 +284,9 @@ import path from 'node:path'
 const require = createRequire(import.meta.url)
 const entry = require.resolve('@vultisig/sdk')
 const pkgDir = path.resolve(path.dirname(entry), '..')
+const electronMainEntry = require.resolve('@vultisig/sdk/electron/main')
+const electronMain = require('@vultisig/sdk/electron/main')
+const electronMainImport = await import('@vultisig/sdk/electron/main')
 
 assert.equal(typeof root.Vultisig, 'function', 'root exports Vultisig')
 assert.ok(root.Chain !== undefined, 'root exports Chain')
@@ -294,11 +297,25 @@ assert.equal(typeof node.Vultisig, 'function', '@vultisig/sdk/node exports Vulti
 
 assert.ok(browser.Chain !== undefined, '@vultisig/sdk/browser resolves')
 assert.ok(vite && (vite.default || vite), '@vultisig/sdk/vite resolves')
+assert.equal(
+  path.basename(electronMainEntry),
+  'index.electron-main.cjs',
+  '@vultisig/sdk/electron/main resolves the Electron main process bundle'
+)
+assert.equal(typeof electronMain.Vultisig, 'function', '@vultisig/sdk/electron/main exports Vultisig')
+assert.equal(typeof electronMainImport.Vultisig, 'function', 'ESM import resolves @vultisig/sdk/electron/main')
+assert.equal(
+  typeof electronMainImport.ElectronMainCrypto,
+  'function',
+  'ESM import exposes Electron-specific exports'
+)
 
 const rnJs = path.join(pkgDir, 'dist/index.react-native.js')
 assert.ok(existsSync(rnJs), 'react-native bundle file exists on disk')
 const rnDts = path.join(pkgDir, 'dist/index.react-native.d.ts')
 assert.ok(existsSync(rnDts), 'react-native types exist on disk')
+const electronMainDts = path.join(pkgDir, 'dist/index.electron-main.d.ts')
+assert.ok(existsSync(electronMainDts), 'electron main types exist on disk')
 `
   )
 
@@ -321,10 +338,13 @@ assert.ok(existsSync(rnDts), 'react-native types exist on disk')
       path.join(consumer, 'types-smoke.ts'),
       `import type { Chain } from '@vultisig/sdk'
 import type { Vultisig } from '@vultisig/sdk/node'
+import type { ElectronMainCrypto, Vultisig as ElectronMainVultisig } from '@vultisig/sdk/electron/main'
 import '@vultisig/sdk/browser'
 import '@vultisig/sdk/vite'
 export type X = Chain
 export type Y = Vultisig
+export type Z = ElectronMainVultisig
+export type ElectronCrypto = ElectronMainCrypto
 `
     )
     run(process.execPath, [tscBin, '-p', path.join(consumer, 'tsconfig.json')], {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the published `@vultisig/sdk/electron/main` subpath to consistently serve the Electron main CommonJS build with matching TypeScript declarations.

* **Build & Packaging**
  * Added an Electron main-process type bundle to ensure the subpath’s `.d.ts` files are included in the published package.
  * Updated the package export map so the subpath resolves to the Electron main targets.

* **Tests**
  * Extended contract and TypeScript smoke checks to cover `@vultisig/sdk/electron/main`, including runtime export verification for both CJS and ESM import styles.

* **Chores**
  * Added a patch changeset for `@vultisig/sdk` publication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->