### PR TITLE
feat(ton): rebrand native token TON → GRAM

### DIFF
--- a/.changeset/ton-gram-rebrand.md
+++ b/.changeset/ton-gram-rebrand.md
@@ -1,0 +1,13 @@
+---
+"@vultisig/core-chain": patch
+"@vultisig/sdk": patch
+---
+
+feat(ton): rebrand native token Toncoin (TON) → Gram (GRAM)
+
+The Open Network renamed its native token TON → GRAM (effective 2026-06-15).
+Update the display fields of `chainFeeCoin[Chain.Ton]`: `ticker` `TON` → `GRAM`
+and `logo` `ton` → `gram`. This is a cosmetic token rebrand only — the chain
+identity (`Chain.Ton`), `priceProviderId` (`the-open-network`), and `decimals`
+are unchanged, and there is no swap/migration. Patch-bumps `@vultisig/sdk` to
+rebundle.

--- a/packages/core/chain/coin/chainFeeCoin.ts
+++ b/packages/core/chain/coin/chainFeeCoin.ts
@@ -67,8 +67,8 @@ const leanChainFeeCoin: Record<Chain, KnownCoinMetadata> = {
     priceProviderId: 'solana',
   },
   [Chain.Ton]: {
-    ticker: 'TON',
-    logo: 'ton',
+    ticker: 'GRAM',
+    logo: 'gram',
     decimals: 9,
     priceProviderId: 'the-open-network',
   },


### PR DESCRIPTION
## What

Rebrands the native token of The Open Network from **Toncoin (TON)** to **Gram (GRAM)** in `chainFeeCoin[Chain.Ton]`.

```diff
   [Chain.Ton]: {
-    ticker: 'TON',
-    logo: 'ton',
+    ticker: 'GRAM',
+    logo: 'gram',
     decimals: 9,
     priceProviderId: 'the-open-network',
   },
```

Includes a changeset (`@vultisig/core-chain` + `@vultisig/sdk` patch).

## Why

The Open Network community voted (81.22% in favor) to rename the native token to Gram, effective 2026-06-15. This is a cosmetic **token** rebrand (name/ticker/logo) — the blockchain stays "The Open Network" and there is no swap/bridge/claim/migration.

## Deliberately unchanged (protocol / external identifiers)

- `Chain.Ton` enum value and chain kind — protobuf identity shared with iOS/Android
- `priceProviderId: 'the-open-network'` — kept until CoinGecko renames its id (changing early breaks price lookups)
- `decimals: 9`
- SwapKit / Banxa asset codes that map `Chain.Ton → 'TON'` — third-party identifiers, stay until those providers rebrand

## Consumer follow-up

`logo: 'gram'` is a name string each consumer resolves to its own bundled asset. Apps must add a `gram` **coin** logo while keeping the existing **TON chain** logo (the chain icon is decoupled from the fee-coin logo). The data source-of-truth lands in commondata#92.

## Test

`yarn test:core` — 1100 passed.

Refs vultisig-windows#4129, commondata#92, vultisig-android#4981, vultisig-ios#4617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated native token branding for the Open Network from TON to GRAM, effective June 15, 2026.
  * Updated token ticker and logo display to reflect the new native token name. All other token properties remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->