### PR TITLE
fix(lib-utils): resolve registrable domain via Public Suffix List

### DIFF
--- a/.changeset/psl-aware-base-domain.md
+++ b/.changeset/psl-aware-base-domain.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/lib-utils": patch
+---
+
+Make `getUrlBaseDomain` resolve the registrable (eTLD+1) domain using the Public Suffix List instead of taking the last two hostname labels. Sites under multi-label public suffixes (`*.vercel.app`, `*.github.io`, `*.pages.dev`, `*.web.app`, `*.co.uk`, …) now resolve to distinct domains, so a connection authorized for one site is no longer treated as authorized for an unrelated sibling under the same suffix.

--- a/.changeset/psl-aware-base-domain.md
+++ b/.changeset/psl-aware-base-domain.md
@@ -1,5 +1,6 @@
 ---
 "@vultisig/lib-utils": patch
+"@vultisig/sdk": patch
 ---
 
 Make `getUrlBaseDomain` resolve the registrable (eTLD+1) domain using the Public Suffix List instead of taking the last two hostname labels. Sites under multi-label public suffixes (`*.vercel.app`, `*.github.io`, `*.pages.dev`, `*.web.app`, `*.co.uk`, …) now resolve to distinct domains, so a connection authorized for one site is no longer treated as authorized for an unrelated sibling under the same suffix.

--- a/packages/lib/utils/package.json
+++ b/packages/lib/utils/package.json
@@ -677,6 +677,7 @@
   "dependencies": {
     "buffer": "^6.0.3",
     "long": "^5.3.2",
+    "tldts": "^6.1.0",
     "viem": "^2.52.2"
   }
 }

--- a/packages/lib/utils/url/baseDomain.test.ts
+++ b/packages/lib/utils/url/baseDomain.test.ts
@@ -6,23 +6,15 @@ describe('getUrlBaseDomain', () => {
   it('returns the registrable domain for normal hosts', () => {
     expect(getUrlBaseDomain('https://app.uniswap.org')).toBe('uniswap.org')
     expect(getUrlBaseDomain('https://uniswap.org')).toBe('uniswap.org')
-    expect(getUrlBaseDomain('https://a.b.c.example.com/path?q=1')).toBe(
-      'example.com'
-    )
+    expect(getUrlBaseDomain('https://a.b.c.example.com/path?q=1')).toBe('example.com')
   })
 
   it('treats multi-label public suffixes as distinct registrable domains', () => {
     // Regression: previously both collapsed to `vercel.app`, letting an
     // attacker site inherit a sibling's authorized dApp session.
-    expect(getUrlBaseDomain('https://good-app.vercel.app')).toBe(
-      'good-app.vercel.app'
-    )
-    expect(getUrlBaseDomain('https://attacker.vercel.app')).toBe(
-      'attacker.vercel.app'
-    )
-    expect(getUrlBaseDomain('https://good-app.vercel.app')).not.toBe(
-      getUrlBaseDomain('https://attacker.vercel.app')
-    )
+    expect(getUrlBaseDomain('https://good-app.vercel.app')).toBe('good-app.vercel.app')
+    expect(getUrlBaseDomain('https://attacker.vercel.app')).toBe('attacker.vercel.app')
+    expect(getUrlBaseDomain('https://good-app.vercel.app')).not.toBe(getUrlBaseDomain('https://attacker.vercel.app'))
   })
 
   it('handles other common multi-label public suffixes', () => {
@@ -32,9 +24,7 @@ describe('getUrlBaseDomain', () => {
   })
 
   it('handles ccSLD public suffixes', () => {
-    expect(getUrlBaseDomain('https://shop.example.co.uk')).toBe(
-      'example.co.uk'
-    )
+    expect(getUrlBaseDomain('https://shop.example.co.uk')).toBe('example.co.uk')
   })
 
   it('falls back to the hostname when there is no registrable domain', () => {

--- a/packages/lib/utils/url/baseDomain.test.ts
+++ b/packages/lib/utils/url/baseDomain.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { getUrlBaseDomain } from './baseDomain'
+
+describe('getUrlBaseDomain', () => {
+  it('returns the registrable domain for normal hosts', () => {
+    expect(getUrlBaseDomain('https://app.uniswap.org')).toBe('uniswap.org')
+    expect(getUrlBaseDomain('https://uniswap.org')).toBe('uniswap.org')
+    expect(getUrlBaseDomain('https://a.b.c.example.com/path?q=1')).toBe(
+      'example.com'
+    )
+  })
+
+  it('treats multi-label public suffixes as distinct registrable domains', () => {
+    // Regression: previously both collapsed to `vercel.app`, letting an
+    // attacker site inherit a sibling's authorized dApp session.
+    expect(getUrlBaseDomain('https://good-app.vercel.app')).toBe(
+      'good-app.vercel.app'
+    )
+    expect(getUrlBaseDomain('https://attacker.vercel.app')).toBe(
+      'attacker.vercel.app'
+    )
+    expect(getUrlBaseDomain('https://good-app.vercel.app')).not.toBe(
+      getUrlBaseDomain('https://attacker.vercel.app')
+    )
+  })
+
+  it('handles other common multi-label public suffixes', () => {
+    expect(getUrlBaseDomain('https://me.github.io')).toBe('me.github.io')
+    expect(getUrlBaseDomain('https://site.pages.dev')).toBe('site.pages.dev')
+    expect(getUrlBaseDomain('https://app.web.app')).toBe('app.web.app')
+  })
+
+  it('handles ccSLD public suffixes', () => {
+    expect(getUrlBaseDomain('https://shop.example.co.uk')).toBe(
+      'example.co.uk'
+    )
+  })
+
+  it('falls back to the hostname when there is no registrable domain', () => {
+    expect(getUrlBaseDomain('http://localhost:8080')).toBe('localhost')
+    expect(getUrlBaseDomain('http://127.0.0.1:3000')).toBe('127.0.0.1')
+  })
+})

--- a/packages/lib/utils/url/baseDomain.ts
+++ b/packages/lib/utils/url/baseDomain.ts
@@ -1,1 +1,15 @@
-export const getUrlBaseDomain = (url: string) => new URL(url).hostname.split('.').slice(-2).join('.')
+import { getDomain } from 'tldts'
+
+/**
+ * Resolve the registrable (eTLD+1) domain used to key dApp connection sessions.
+ *
+ * Uses the Public Suffix List (including its private section, via
+ * `allowPrivateDomains`) so multi-label public suffixes are handled correctly:
+ * `good.vercel.app` and `attacker.vercel.app` resolve to distinct keys rather
+ * than collapsing to the shared suffix `vercel.app`. Falls back to the bare
+ * hostname for inputs without a registrable domain (e.g. `localhost`, IPs).
+ */
+export const getUrlBaseDomain = (url: string): string => {
+  const { hostname } = new URL(url)
+  return getDomain(hostname, { allowPrivateDomains: true }) ?? hostname
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7024,6 +7024,7 @@ __metadata:
   dependencies:
     buffer: "npm:^6.0.3"
     long: "npm:^5.3.2"
+    tldts: "npm:^6.1.0"
     viem: "npm:^2.52.2"
   languageName: unknown
   linkType: soft
@@ -18768,6 +18769,24 @@ __metadata:
   version: 3.1.0
   resolution: "tinyrainbow@npm:3.1.0"
   checksum: 10c0/f11cf387a26c5c9255bec141a90ac511b26172981b10c3e50053bc6700ea7d2336edcc4a3a21dbb8412fe7c013477d2ba4d7e4877800f3f8107be5105aad6511
+  languageName: node
+  linkType: hard
+
+"tldts-core@npm:^6.1.86":
+  version: 6.1.86
+  resolution: "tldts-core@npm:6.1.86"
+  checksum: 10c0/8133c29375f3f99f88fce5f4d62f6ecb9532b106f31e5423b27c1eb1b6e711bd41875184a456819ceaed5c8b94f43911b1ad57e25c6eb86e1fc201228ff7e2af
+  languageName: node
+  linkType: hard
+
+"tldts@npm:^6.1.0":
+  version: 6.1.86
+  resolution: "tldts@npm:6.1.86"
+  dependencies:
+    tldts-core: "npm:^6.1.86"
+  bin:
+    tldts: bin/cli.js
+  checksum: 10c0/27ae7526d9d78cb97b2de3f4d102e0b4321d1ccff0648a7bb0e039ed54acbce86bacdcd9cd3c14310e519b457854e7bafbef1f529f58a1e217a737ced63f0940
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem

`getUrlBaseDomain` computed the session-keying domain by taking the last two hostname labels:

```ts
new URL(url).hostname.split('.').slice(-2).join('.')
```

"Last two labels" is not the registrable domain. On multi-label public suffixes — `*.vercel.app`, `*.github.io`, `*.pages.dev`, `*.web.app`, `*.co.uk`, … — distinct sites collapse to the shared suffix (`vercel.app`). Anything that keys dApp connection sessions on this value then treats unrelated sibling sites as the same authorized origin: after a user connects to `good-app.vercel.app`, `attacker.vercel.app` resolves to the same key and is treated as already authorized (can read addresses/public keys without a prompt, appears "connected"). Normal domains also share a single session across all subdomains.

## Fix

Use `tldts` `getDomain` with `allowPrivateDomains: true` to compute the registrable (eTLD+1) domain from the Public Suffix List. The `allowPrivateDomains` flag is what makes the PSL's private section (`vercel.app`, `github.io`, …) count as suffixes, so `good-app.vercel.app` and `attacker.vercel.app` resolve to distinct keys. Falls back to the bare hostname for inputs with no registrable domain (`localhost`, IPs).

```ts
export const getUrlBaseDomain = (url: string): string => {
  const { hostname } = new URL(url)
  return getDomain(hostname, { allowPrivateDomains: true }) ?? hostname
}
```

The public signature is unchanged (`(url: string) => string`), so consumers pick up the new behavior transparently.

## Tests

New `baseDomain.test.ts` (vitest, `yarn test:core`): registrable-domain extraction, the `good-app.vercel.app` ≠ `attacker.vercel.app` regression, other multi-label suffixes (`github.io`, `pages.dev`, `web.app`), ccSLD (`co.uk`), and `localhost`/IP fallback. All pass.

## Notes

- Adds `tldts` as a dependency of `@vultisig/lib-utils`; changeset included (patch).
- **Behavior change:** session keys change, so dApps previously connected under a public suffix will need a one-time reconnect.
- Addresses vultisig/vultisig-windows#4167 (the windows extension consumes this via `@vultisig/lib-utils`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved URL base domain detection to correctly compute registrable domains (eTLD+1) using the Public Suffix List. This prevents incorrect cross-site authorization for hosts under multi-label public suffixes such as `.co.uk`, `vercel.app`, `github.io`, `pages.dev`, and similar.

## Tests
* Added a test suite covering standard hostnames, multi-label public suffixes, ccSLD-style domains, and localhost/IP fallbacks.

## Dependencies
* Added `tldts` as a runtime dependency to support Public Suffix List-based domain parsing.

## Versioning
* Patch version bump for related packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->