### PR TITLE
Protect native swaps with minimum output limits

### DIFF
--- a/.changeset/native-swap-min-output.md
+++ b/.changeset/native-swap-min-output.md
@@ -1,0 +1,7 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/core-mpc': patch
+'@vultisig/sdk': patch
+---
+
+Apply native THORChain/Maya swap slippage tolerance to quote requests and signed payload limits so native swaps no longer use a zero minimum-output floor.

--- a/packages/core/chain/swap/native/NativeSwapQuote.ts
+++ b/packages/core/chain/swap/native/NativeSwapQuote.ts
@@ -14,6 +14,7 @@ export type NativeSwapQuote = {
   outbound_delay_blocks: number
   outbound_delay_seconds: number
   recommended_min_amount_in: string
+  liquidity_tolerance_bps?: number
   max_streaming_quantity?: number
   slippage_bps?: number
   total_swap_seconds?: number

--- a/packages/core/chain/swap/native/api/getNativeSwapQuote.test.ts
+++ b/packages/core/chain/swap/native/api/getNativeSwapQuote.test.ts
@@ -71,7 +71,44 @@ describe('getNativeSwapQuote', () => {
     expect(queryUrlMock).toHaveBeenCalledTimes(1)
     const url = String(queryUrlMock.mock.calls[0][0])
     expect(url).toContain('streaming_interval=0')
+    expect(url).toContain('liquidity_tolerance_bps=100')
     expect(url).not.toContain('streaming_quantity')
+    expect(quote.liquidity_tolerance_bps).toBe(100)
+  })
+
+  it('THORChain: forwards custom slippage tolerance bps to the quote request', async () => {
+    queryUrlMock.mockResolvedValueOnce({
+      ...baseOkBody,
+      fees: { ...baseOkBody.fees, total_bps: THORCHAIN_STREAMING_SLIPPAGE_THRESHOLD_BPS },
+    })
+
+    const quote = await getNativeSwapQuote({
+      swapChain: Chain.THORChain,
+      destination: ethTo.address,
+      from: btcFrom,
+      to: ethTo,
+      amount: 1,
+      slippageToleranceBps: 250,
+    })
+
+    const url = String(queryUrlMock.mock.calls[0][0])
+    expect(url).toContain('liquidity_tolerance_bps=250')
+    expect(quote.liquidity_tolerance_bps).toBe(250)
+  })
+
+  it('rejects invalid slippage tolerance bps before requesting a quote', async () => {
+    await expect(
+      getNativeSwapQuote({
+        swapChain: Chain.THORChain,
+        destination: ethTo.address,
+        from: btcFrom,
+        to: ethTo,
+        amount: 1,
+        slippageToleranceBps: -1,
+      })
+    ).rejects.toThrow(/slippageToleranceBps/)
+
+    expect(queryUrlMock).not.toHaveBeenCalled()
   })
 
   it('THORChain: skips streaming when total_bps is missing', async () => {
@@ -120,6 +157,7 @@ describe('getNativeSwapQuote', () => {
 
     const streamUrl = String(queryUrlMock.mock.calls[1][0])
     expect(streamUrl).toContain('streaming_interval=1')
+    expect(streamUrl).toContain('liquidity_tolerance_bps=100')
     expect(streamUrl).not.toContain('streaming_quantity')
   })
 

--- a/packages/core/chain/swap/native/api/getNativeSwapQuote.ts
+++ b/packages/core/chain/swap/native/api/getNativeSwapQuote.ts
@@ -21,6 +21,7 @@ type GetNativeSwapQuoteInput = Record<TransferDirection, AccountCoin> & {
   swapChain: NativeSwapChain
   destination: string
   amount: number
+  slippageToleranceBps?: number
   referral?: string
   affiliateBps?: number
   nativeAffiliateConfig?: NativeSwapAffiliateConfig
@@ -33,6 +34,13 @@ type NativeSwapQuoteErrorResponse = {
 type NativeSwapQuoteResponse = Omit<NativeSwapQuote, 'swapChain'>
 
 const THORCHAIN_STREAMING_SWAP_INTERVAL = 1
+export const DEFAULT_NATIVE_SWAP_SLIPPAGE_TOLERANCE_BPS = 100
+
+const assertValidSlippageToleranceBps = (slippageToleranceBps: number): void => {
+  if (!Number.isSafeInteger(slippageToleranceBps) || slippageToleranceBps < 0 || slippageToleranceBps > 10_000) {
+    throw new Error(`slippageToleranceBps must be an integer between 0 and 10000. Received "${slippageToleranceBps}".`)
+  }
+}
 
 const requestNativeSwapQuote = async ({
   swapChain,
@@ -43,6 +51,7 @@ const requestNativeSwapQuote = async ({
   destination,
   streamingInterval,
   streamingQuantity,
+  slippageToleranceBps,
   affiliateBps,
   referral,
   nativeAffiliateConfig,
@@ -55,6 +64,7 @@ const requestNativeSwapQuote = async ({
   destination: string
   streamingInterval: number
   streamingQuantity?: number
+  slippageToleranceBps: number
   affiliateBps?: number
   referral?: string
   nativeAffiliateConfig?: NativeSwapAffiliateConfig
@@ -65,6 +75,7 @@ const requestNativeSwapQuote = async ({
     amount: chainAmount.toString(),
     destination,
     streaming_interval: String(streamingInterval),
+    liquidity_tolerance_bps: String(slippageToleranceBps),
     ...(streamingQuantity !== undefined ? { streaming_quantity: String(streamingQuantity) } : {}),
     ...(affiliateBps !== undefined
       ? buildAffiliateParams({
@@ -101,10 +112,13 @@ export const getNativeSwapQuote = async ({
   from,
   to,
   amount,
+  slippageToleranceBps = DEFAULT_NATIVE_SWAP_SLIPPAGE_TOLERANCE_BPS,
   affiliateBps,
   referral,
   nativeAffiliateConfig,
 }: GetNativeSwapQuoteInput): Promise<NativeSwapQuote> => {
+  assertValidSlippageToleranceBps(slippageToleranceBps)
+
   const [fromAsset, toAsset] = [from, to].map(asset => toNativeSwapAsset(asset))
 
   const fromDecimals = getNativeSwapDecimals(from)
@@ -122,6 +136,7 @@ export const getNativeSwapQuote = async ({
       chainAmount,
       destination,
       streamingInterval: nativeSwapStreamingInterval[swapChain],
+      slippageToleranceBps,
       affiliateBps,
       referral,
       nativeAffiliateConfig,
@@ -130,6 +145,7 @@ export const getNativeSwapQuote = async ({
     return {
       ...assertOkQuote(result, from),
       swapChain,
+      liquidity_tolerance_bps: slippageToleranceBps,
     }
   }
 
@@ -141,6 +157,7 @@ export const getNativeSwapQuote = async ({
     chainAmount,
     destination,
     streamingInterval: nativeSwapStreamingInterval[swapChain],
+    slippageToleranceBps,
     affiliateBps,
     referral,
     nativeAffiliateConfig,
@@ -150,7 +167,7 @@ export const getNativeSwapQuote = async ({
 
   const totalBps = rapid.fees.total_bps
   if (totalBps === undefined || totalBps <= THORCHAIN_STREAMING_SLIPPAGE_THRESHOLD_BPS) {
-    return { ...rapid, swapChain }
+    return { ...rapid, swapChain, liquidity_tolerance_bps: slippageToleranceBps }
   }
 
   const streamingQuantity =
@@ -169,6 +186,7 @@ export const getNativeSwapQuote = async ({
       destination,
       streamingInterval: THORCHAIN_STREAMING_SWAP_INTERVAL,
       streamingQuantity,
+      slippageToleranceBps,
       affiliateBps,
       referral,
       nativeAffiliateConfig,
@@ -176,16 +194,16 @@ export const getNativeSwapQuote = async ({
     streaming = assertOkQuote(streamingRes, from)
   } catch (error) {
     console.warn('[thorchain] streaming quote failed after elevated rapid slippage; using rapid quote', error)
-    return { ...rapid, swapChain }
+    return { ...rapid, swapChain, liquidity_tolerance_bps: slippageToleranceBps }
   }
 
   try {
     if (BigInt(streaming.expected_amount_out) > BigInt(rapid.expected_amount_out)) {
-      return { ...streaming, swapChain }
+      return { ...streaming, swapChain, liquidity_tolerance_bps: slippageToleranceBps }
     }
   } catch {
-    return { ...rapid, swapChain }
+    return { ...rapid, swapChain, liquidity_tolerance_bps: slippageToleranceBps }
   }
 
-  return { ...rapid, swapChain }
+  return { ...rapid, swapChain, liquidity_tolerance_bps: slippageToleranceBps }
 }

--- a/packages/core/chain/swap/quote/findSwapQuote.slippage.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.slippage.test.ts
@@ -72,6 +72,8 @@ describe('findSwapQuote slippage tolerance', () => {
     expect(getLifiSwapQuote).toHaveBeenCalledWith(expect.objectContaining({ slippage: 0.01 }))
     // SwapKit wants percent
     expect(getSwapKitQuote).toHaveBeenCalledWith(expect.objectContaining({ slippage: 1 }))
+    // Native THOR/Maya quote APIs want basis points
+    expect(getNativeSwapQuote).toHaveBeenCalledWith(expect.objectContaining({ slippageToleranceBps: 100 }))
   })
 
   it('leaves each provider on its default when no tolerance is given', async () => {
@@ -81,6 +83,7 @@ describe('findSwapQuote slippage tolerance', () => {
     expect(getKyberSwapQuote).toHaveBeenCalledWith(expect.objectContaining({ slippageTolerance: undefined }))
     expect(getLifiSwapQuote).toHaveBeenCalledWith(expect.objectContaining({ slippage: undefined }))
     expect(getSwapKitQuote).toHaveBeenCalledWith(expect.objectContaining({ slippage: undefined }))
+    expect(getNativeSwapQuote).toHaveBeenCalledWith(expect.objectContaining({ slippageToleranceBps: undefined }))
   })
 
   it.each([-1, NaN, Infinity, -Infinity])('rejects invalid slippage %p before calling any provider', async invalid => {

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -307,17 +307,23 @@ const assertValidCustomRecipient = (recipient: string | undefined, from: Account
 // native unit. `undefined` leaves every provider on its own default (no behaviour
 // change). Extracted from findSwapQuote to keep its cognitive complexity in budget.
 type ProviderSlippage = {
+  nativeBps: number | undefined
   oneInchPercent: number | undefined
   swapKitPercent: number | undefined
   lifiFraction: number | undefined
   kyberBps: number | undefined
 }
-const toProviderSlippage = (slippageTolerance: number | undefined): ProviderSlippage => ({
-  oneInchPercent: slippageTolerance,
-  swapKitPercent: slippageTolerance,
-  lifiFraction: slippageTolerance !== undefined ? slippageTolerance / 100 : undefined,
-  kyberBps: slippageTolerance !== undefined ? Math.round(slippageTolerance * 100) : undefined,
-})
+const toProviderSlippage = (slippageTolerance: number | undefined): ProviderSlippage => {
+  const bps = slippageTolerance !== undefined ? Math.round(slippageTolerance * 100) : undefined
+
+  return {
+    nativeBps: bps,
+    oneInchPercent: slippageTolerance,
+    swapKitPercent: slippageTolerance,
+    lifiFraction: slippageTolerance !== undefined ? slippageTolerance / 100 : undefined,
+    kyberBps: bps,
+  }
+}
 
 export const findSwapQuote = async ({
   from,
@@ -377,6 +383,7 @@ export const findSwapQuote = async ({
     swapKitPercent: swapKitSlippagePercent,
     lifiFraction: lifiSlippageFraction,
     kyberBps: kyberSlippageBps,
+    nativeBps: nativeSlippageBps,
   } = toProviderSlippage(slippageTolerance)
 
   const involvedChains = [from.chain, to.chain]
@@ -399,6 +406,7 @@ export const findSwapQuote = async ({
           from,
           to,
           amount: amountNumber,
+          slippageToleranceBps: nativeSlippageBps,
           referral,
           affiliateBps,
           nativeAffiliateConfig: affiliateConfig?.native,

--- a/packages/core/mpc/swap/native/utils/nativeSwapQuoteToSwapPayload.test.ts
+++ b/packages/core/mpc/swap/native/utils/nativeSwapQuoteToSwapPayload.test.ts
@@ -1,0 +1,83 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import type { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+import type { NativeSwapQuote } from '@vultisig/core-chain/swap/native/NativeSwapQuote'
+import { describe, expect, it } from 'vitest'
+
+import { getNativeSwapToAmountLimit, nativeSwapQuoteToSwapPayload } from './nativeSwapQuoteToSwapPayload'
+
+const fromCoin = {
+  chain: Chain.Bitcoin,
+  ticker: 'BTC',
+  decimals: 8,
+  address: 'bc1qfrom',
+  hexPublicKey: 'abcd',
+} as AccountCoin & { hexPublicKey: string }
+
+const toCoin = {
+  chain: Chain.Ethereum,
+  ticker: 'ETH',
+  decimals: 18,
+  address: '0xto',
+  hexPublicKey: 'abcd',
+} as AccountCoin & { hexPublicKey: string }
+
+const quote = {
+  swapChain: Chain.THORChain,
+  expected_amount_out: '100000',
+  expiry: 1_700_000_000,
+  fees: {
+    affiliate: '0',
+    asset: 'BTC.BTC',
+    outbound: '0',
+    total: '100',
+  },
+  inbound_address: 'bc1qinbound',
+  memo: '=:ETH.ETH:0xto',
+  notes: '',
+  outbound_delay_blocks: 0,
+  outbound_delay_seconds: 0,
+  recommended_min_amount_in: '0',
+  liquidity_tolerance_bps: 250,
+  warning: '',
+} as NativeSwapQuote
+
+describe('nativeSwapQuoteToSwapPayload', () => {
+  it('sets a non-zero minimum output limit from quote tolerance bps', () => {
+    const payload = nativeSwapQuoteToSwapPayload({
+      quote,
+      fromCoin,
+      toCoin,
+      amount: 1_000n,
+    })
+
+    expect(payload.case).toBe('thorchainSwapPayload')
+    if (payload.case !== 'thorchainSwapPayload') {
+      throw new Error('Expected THORChain swap payload')
+    }
+    expect(payload.value.toAmountLimit).toBe('97500')
+  })
+})
+
+describe('getNativeSwapToAmountLimit', () => {
+  it('floors expected output by tolerance basis points', () => {
+    expect(
+      getNativeSwapToAmountLimit({
+        expectedAmountOut: '1000',
+        slippageToleranceBps: 100,
+      })
+    ).toBe('990')
+  })
+
+  it('uses the shared native default when persisted quotes do not include tolerance bps', () => {
+    expect(getNativeSwapToAmountLimit({ expectedAmountOut: '1000' })).toBe('990')
+  })
+
+  it('rejects invalid tolerance bps', () => {
+    expect(() =>
+      getNativeSwapToAmountLimit({
+        expectedAmountOut: '1000',
+        slippageToleranceBps: 10_001,
+      })
+    ).toThrow(/slippageToleranceBps/)
+  })
+})

--- a/packages/core/mpc/swap/native/utils/nativeSwapQuoteToSwapPayload.test.ts
+++ b/packages/core/mpc/swap/native/utils/nativeSwapQuoteToSwapPayload.test.ts
@@ -59,6 +59,15 @@ describe('nativeSwapQuoteToSwapPayload', () => {
 })
 
 describe('getNativeSwapToAmountLimit', () => {
+  it('keeps a non-zero limit for positive outputs when tolerance is below 100%', () => {
+    expect(
+      getNativeSwapToAmountLimit({
+        expectedAmountOut: '1',
+        slippageToleranceBps: 100,
+      })
+    ).toBe('1')
+  })
+
   it('floors expected output by tolerance basis points', () => {
     expect(
       getNativeSwapToAmountLimit({

--- a/packages/core/mpc/swap/native/utils/nativeSwapQuoteToSwapPayload.ts
+++ b/packages/core/mpc/swap/native/utils/nativeSwapQuoteToSwapPayload.ts
@@ -2,6 +2,7 @@ import { create } from '@bufbuild/protobuf'
 import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+import { DEFAULT_NATIVE_SWAP_SLIPPAGE_TOLERANCE_BPS } from '@vultisig/core-chain/swap/native/api/getNativeSwapQuote'
 import { nativeSwapPayloadCase, nativeSwapStreamingInterval } from '@vultisig/core-chain/swap/native/NativeSwapChain'
 import { NativeSwapQuote } from '@vultisig/core-chain/swap/native/NativeSwapQuote'
 import { getNativeSwapDecimals } from '@vultisig/core-chain/swap/native/utils/getNativeSwapDecimals'
@@ -18,6 +19,35 @@ type Input = {
   fromCoin: AccountCoin & { hexPublicKey: string }
   toCoin: AccountCoin & { hexPublicKey: string }
   amount: bigint
+}
+
+const BASIS_POINTS_DENOMINATOR = 10_000n
+
+const assertValidSlippageToleranceBps = (slippageToleranceBps: number): void => {
+  if (
+    !Number.isSafeInteger(slippageToleranceBps) ||
+    slippageToleranceBps < 0 ||
+    slippageToleranceBps > Number(BASIS_POINTS_DENOMINATOR)
+  ) {
+    throw new Error(
+      `slippageToleranceBps must be an integer between 0 and ${BASIS_POINTS_DENOMINATOR}. Received "${slippageToleranceBps}".`
+    )
+  }
+}
+
+export const getNativeSwapToAmountLimit = ({
+  expectedAmountOut,
+  slippageToleranceBps = DEFAULT_NATIVE_SWAP_SLIPPAGE_TOLERANCE_BPS,
+}: {
+  expectedAmountOut: string
+  slippageToleranceBps?: number
+}): string => {
+  assertValidSlippageToleranceBps(slippageToleranceBps)
+
+  const expected = BigInt(expectedAmountOut)
+  const tolerance = BigInt(slippageToleranceBps)
+
+  return ((expected * (BASIS_POINTS_DENOMINATOR - tolerance)) / BASIS_POINTS_DENOMINATOR).toString()
 }
 
 export const nativeSwapQuoteToSwapPayload = ({ quote, fromCoin, amount, toCoin }: Input): CommKeysignSwapPayload => {
@@ -46,7 +76,10 @@ export const nativeSwapQuoteToSwapPayload = ({ quote, fromCoin, amount, toCoin }
       expirationTime: BigInt(Math.round(convertDuration(addMinutes(Date.now(), 15).getTime(), 'ms', 's'))),
       streamingInterval,
       streamingQuantity,
-      toAmountLimit: '0',
+      toAmountLimit: getNativeSwapToAmountLimit({
+        expectedAmountOut: quote.expected_amount_out,
+        slippageToleranceBps: quote.liquidity_tolerance_bps,
+      }),
       isAffiliate,
       fee: quote.fees.total,
     }),

--- a/packages/core/mpc/swap/native/utils/nativeSwapQuoteToSwapPayload.ts
+++ b/packages/core/mpc/swap/native/utils/nativeSwapQuoteToSwapPayload.ts
@@ -46,8 +46,13 @@ export const getNativeSwapToAmountLimit = ({
 
   const expected = BigInt(expectedAmountOut)
   const tolerance = BigInt(slippageToleranceBps)
+  const limit = (expected * (BASIS_POINTS_DENOMINATOR - tolerance)) / BASIS_POINTS_DENOMINATOR
 
-  return ((expected * (BASIS_POINTS_DENOMINATOR - tolerance)) / BASIS_POINTS_DENOMINATOR).toString()
+  if (expected > 0n && tolerance < BASIS_POINTS_DENOMINATOR && limit === 0n) {
+    return '1'
+  }
+
+  return limit.toString()
 }
 
 export const nativeSwapQuoteToSwapPayload = ({ quote, fromCoin, amount, toCoin }: Input): CommKeysignSwapPayload => {


### PR DESCRIPTION
Closes #688

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Native swap slippage tolerance is now configurable with a default of 100 basis points
  * Configured tolerance is applied consistently across quote requests and swap executions

* **Bug Fixes**
  * Native swap minimum-output limits previously hardcoded to zero; now properly reflect the configured slippage tolerance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->