### PR TITLE
Validate native swap expiry and vault

### DIFF
--- a/.changeset/native-swap-expiry-vault.md
+++ b/.changeset/native-swap-expiry-vault.md
@@ -1,0 +1,7 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/core-mpc': patch
+'@vultisig/sdk': patch
+---
+
+Honor native swap quote expiry and validate THORChain inbound vault addresses before broadcasting stale signed swaps.

--- a/packages/core/chain/chains/cosmos/thor/getThorchainInboundAddress.ts
+++ b/packages/core/chain/chains/cosmos/thor/getThorchainInboundAddress.ts
@@ -3,7 +3,7 @@ import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 import { Chain } from '../../../Chain'
 import { cosmosRpcUrl } from '../cosmosRpcUrl'
 
-type ChainInfo = {
+export type ThorchainInboundAddress = {
   address: string
   chain: string
   chain_lp_actions_paused: boolean
@@ -22,4 +22,4 @@ type ChainInfo = {
 
 const thorchainInboundAddressApi = `${cosmosRpcUrl[Chain.THORChain]}/thorchain/inbound_addresses`
 
-export const getThorchainInboundAddress = (): Promise<ChainInfo[]> => queryUrl(thorchainInboundAddressApi)
+export const getThorchainInboundAddress = (): Promise<ThorchainInboundAddress[]> => queryUrl(thorchainInboundAddressApi)

--- a/packages/core/mpc/swap/native/utils/nativeSwapQuoteToSwapPayload.test.ts
+++ b/packages/core/mpc/swap/native/utils/nativeSwapQuoteToSwapPayload.test.ts
@@ -1,0 +1,78 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import type { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+import type { NativeSwapQuote } from '@vultisig/core-chain/swap/native/NativeSwapQuote'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { nativeSwapQuoteToSwapPayload } from './nativeSwapQuoteToSwapPayload'
+
+const fromCoin = {
+  chain: Chain.Bitcoin,
+  ticker: 'BTC',
+  decimals: 8,
+  address: 'bc1qfrom',
+  hexPublicKey: 'abcd',
+} as AccountCoin & { hexPublicKey: string }
+
+const toCoin = {
+  chain: Chain.Ethereum,
+  ticker: 'ETH',
+  decimals: 18,
+  address: '0xto',
+  hexPublicKey: 'abcd',
+} as AccountCoin & { hexPublicKey: string }
+
+const makeQuote = (expiry: number): NativeSwapQuote =>
+  ({
+    swapChain: Chain.THORChain,
+    expected_amount_out: '100000',
+    expiry,
+    fees: {
+      affiliate: '0',
+      asset: 'BTC.BTC',
+      outbound: '0',
+      total: '100',
+    },
+    inbound_address: 'bc1qinbound',
+    memo: '=:ETH.ETH:0xto',
+    notes: '',
+    outbound_delay_blocks: 0,
+    outbound_delay_seconds: 0,
+    recommended_min_amount_in: '0',
+    warning: '',
+  }) as NativeSwapQuote
+
+describe('nativeSwapQuoteToSwapPayload', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('uses the quote expiry instead of minting a fresh window', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000)
+
+    const payload = nativeSwapQuoteToSwapPayload({
+      quote: makeQuote(1_700_000_600),
+      fromCoin,
+      toCoin,
+      amount: 1_000n,
+    })
+
+    expect(payload.case).toBe('thorchainSwapPayload')
+    if (payload.case !== 'thorchainSwapPayload') {
+      throw new Error('Expected THORChain swap payload')
+    }
+    expect(payload.value.expirationTime).toBe(1_700_000_600n)
+  })
+
+  it('rejects expired native swap quotes before signing', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000)
+
+    expect(() =>
+      nativeSwapQuoteToSwapPayload({
+        quote: makeQuote(1_699_999_999),
+        fromCoin,
+        toCoin,
+        amount: 1_000n,
+      })
+    ).toThrow(/expired/)
+  })
+})

--- a/packages/core/mpc/swap/native/utils/nativeSwapQuoteToSwapPayload.ts
+++ b/packages/core/mpc/swap/native/utils/nativeSwapQuoteToSwapPayload.ts
@@ -6,8 +6,6 @@ import { nativeSwapPayloadCase, nativeSwapStreamingInterval } from '@vultisig/co
 import { NativeSwapQuote } from '@vultisig/core-chain/swap/native/NativeSwapQuote'
 import { getNativeSwapDecimals } from '@vultisig/core-chain/swap/native/utils/getNativeSwapDecimals'
 import { parseThorchainSwapMemoStreaming } from '@vultisig/core-chain/swap/native/utils/parseThorchainSwapMemoStreaming'
-import { convertDuration } from '@vultisig/lib-utils/time/convertDuration'
-import { addMinutes } from 'date-fns'
 
 import { CommKeysignSwapPayload } from '../../../keysign/swap/KeysignSwapPayload'
 import { toCommCoin } from '../../../types/utils/commCoin'
@@ -20,7 +18,15 @@ type Input = {
   amount: bigint
 }
 
+const assertQuoteNotExpired = (expirySeconds: number): void => {
+  if (expirySeconds <= Math.floor(Date.now() / 1000)) {
+    throw new Error('Native swap quote is expired; refresh the quote before signing')
+  }
+}
+
 export const nativeSwapQuoteToSwapPayload = ({ quote, fromCoin, amount, toCoin }: Input): CommKeysignSwapPayload => {
+  assertQuoteNotExpired(quote.expiry)
+
   const isAffiliate = !!quote.fees.affiliate && Number(quote.fees.affiliate) > 0
 
   const { streamingInterval, streamingQuantity } =
@@ -43,7 +49,7 @@ export const nativeSwapQuoteToSwapPayload = ({ quote, fromCoin, amount, toCoin }
       routerAddress: quote.router,
       fromAmount: amount.toString(),
       toAmountDecimal: fromChainAmount(quote.expected_amount_out, toDecimals).toFixed(toDecimals),
-      expirationTime: BigInt(Math.round(convertDuration(addMinutes(Date.now(), 15).getTime(), 'ms', 's'))),
+      expirationTime: BigInt(quote.expiry),
       streamingInterval,
       streamingQuantity,
       toAmountLimit: '0',

--- a/packages/sdk/src/vault/services/BroadcastService.ts
+++ b/packages/sdk/src/vault/services/BroadcastService.ts
@@ -13,6 +13,7 @@ import type { WasmProvider } from '../../context/SdkContext'
 import type { Signature } from '../../types'
 import { convertToKeysignSignatures } from '../utils/convertSignature'
 import { VaultError, VaultErrorCode } from '../VaultError'
+import { assertNativeSwapReadyForBroadcast } from './nativeSwapBroadcastGuard'
 
 /**
  * BroadcastService
@@ -61,6 +62,8 @@ export class BroadcastService {
     const { chain, keysignPayload, signature } = params
 
     try {
+      await assertNativeSwapReadyForBroadcast({ chain, keysignPayload })
+
       // Get WalletCore instance via WasmProvider
       const walletCore = await this.wasmProvider.getWalletCore()
 

--- a/packages/sdk/src/vault/services/nativeSwapBroadcastGuard.ts
+++ b/packages/sdk/src/vault/services/nativeSwapBroadcastGuard.ts
@@ -1,0 +1,58 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import {
+  getThorchainInboundAddress,
+  type ThorchainInboundAddress,
+} from '@vultisig/core-chain/chains/cosmos/thor/getThorchainInboundAddress'
+import { nativeSwapChainIds } from '@vultisig/core-chain/swap/native/NativeSwapChain'
+import { getKeysignSwapPayload } from '@vultisig/core-mpc/keysign/swap/getKeysignSwapPayload'
+import type { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+
+type NativeSwapBroadcastGuardInput = {
+  chain: Chain
+  keysignPayload: KeysignPayload
+  getInboundAddresses?: () => Promise<ThorchainInboundAddress[]>
+  now?: () => number
+}
+
+const getNativeSwapChainId = (chain: Chain): string | undefined =>
+  nativeSwapChainIds[chain as keyof typeof nativeSwapChainIds]
+
+export const assertNativeSwapReadyForBroadcast = async ({
+  chain,
+  keysignPayload,
+  getInboundAddresses = getThorchainInboundAddress,
+  now = Date.now,
+}: NativeSwapBroadcastGuardInput): Promise<void> => {
+  const swapPayload = getKeysignSwapPayload(keysignPayload)
+  if (!swapPayload || !('native' in swapPayload)) {
+    return
+  }
+
+  const { native } = swapPayload
+  const currentSeconds = BigInt(Math.floor(now() / 1000))
+
+  if (native.expirationTime > 0n && native.expirationTime <= currentSeconds) {
+    throw new Error('Native swap quote is expired; refresh the quote before broadcasting')
+  }
+
+  if (native.chain !== Chain.THORChain) {
+    return
+  }
+
+  const sourceChainId = getNativeSwapChainId(chain)
+  if (!sourceChainId) {
+    throw new Error(`Cannot validate THORChain inbound vault for unsupported source chain ${chain}`)
+  }
+
+  const activeInboundAddress = (await getInboundAddresses()).find(
+    ({ chain }) => chain.toUpperCase() === sourceChainId
+  )?.address
+
+  if (!activeInboundAddress) {
+    throw new Error(`Cannot validate THORChain inbound vault for source chain ${sourceChainId}`)
+  }
+
+  if (activeInboundAddress.toLowerCase() !== native.vaultAddress.toLowerCase()) {
+    throw new Error('THORChain inbound vault address changed; refresh the swap quote before broadcasting')
+  }
+}

--- a/packages/sdk/tests/unit/vault/services/nativeSwapBroadcastGuard.test.ts
+++ b/packages/sdk/tests/unit/vault/services/nativeSwapBroadcastGuard.test.ts
@@ -1,0 +1,107 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import type { ThorchainInboundAddress } from '@vultisig/core-chain/chains/cosmos/thor/getThorchainInboundAddress'
+import type { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { describe, expect, it, vi } from 'vitest'
+
+import { assertNativeSwapReadyForBroadcast } from '@/vault/services/nativeSwapBroadcastGuard'
+
+const makeInbound = (chain: string, address: string): ThorchainInboundAddress =>
+  ({
+    address,
+    chain,
+  }) as ThorchainInboundAddress
+
+const makeThorchainSwapPayload = ({
+  vaultAddress = 'bc1qactive',
+  expirationTime = 1_700_000_100n,
+}: {
+  vaultAddress?: string
+  expirationTime?: bigint
+} = {}): KeysignPayload =>
+  ({
+    swapPayload: {
+      case: 'thorchainSwapPayload',
+      value: {
+        vaultAddress,
+        expirationTime,
+      },
+    },
+  }) as KeysignPayload
+
+const makeMayachainSwapPayload = (expirationTime = 1_700_000_100n): KeysignPayload =>
+  ({
+    swapPayload: {
+      case: 'mayachainSwapPayload',
+      value: {
+        expirationTime,
+      },
+    },
+  }) as KeysignPayload
+
+describe('assertNativeSwapReadyForBroadcast', () => {
+  it('does nothing for non-swap payloads', async () => {
+    const getInboundAddresses = vi.fn()
+
+    await assertNativeSwapReadyForBroadcast({
+      chain: Chain.Bitcoin,
+      keysignPayload: {} as KeysignPayload,
+      getInboundAddresses,
+    })
+
+    expect(getInboundAddresses).not.toHaveBeenCalled()
+  })
+
+  it('rejects expired native swap payloads before fetching inbound addresses', async () => {
+    const getInboundAddresses = vi.fn()
+
+    await expect(
+      assertNativeSwapReadyForBroadcast({
+        chain: Chain.Bitcoin,
+        keysignPayload: makeThorchainSwapPayload({
+          expirationTime: 1_700_000_000n,
+        }),
+        getInboundAddresses,
+        now: () => 1_700_000_001_000,
+      })
+    ).rejects.toThrow(/expired/)
+
+    expect(getInboundAddresses).not.toHaveBeenCalled()
+  })
+
+  it('checks Maya native swap expiry without fetching THORChain inbound addresses', async () => {
+    const getInboundAddresses = vi.fn()
+
+    await assertNativeSwapReadyForBroadcast({
+      chain: Chain.MayaChain,
+      keysignPayload: makeMayachainSwapPayload(),
+      getInboundAddresses,
+      now: () => 1_700_000_000_000,
+    })
+
+    expect(getInboundAddresses).not.toHaveBeenCalled()
+  })
+
+  it('rejects stale THORChain inbound vault addresses', async () => {
+    await expect(
+      assertNativeSwapReadyForBroadcast({
+        chain: Chain.Bitcoin,
+        keysignPayload: makeThorchainSwapPayload({
+          vaultAddress: 'bc1qold',
+        }),
+        getInboundAddresses: async () => [makeInbound('BTC', 'bc1qactive')],
+        now: () => 1_700_000_000_000,
+      })
+    ).rejects.toThrow(/inbound vault address changed/)
+  })
+
+  it('passes when the THORChain inbound vault still matches the source chain', async () => {
+    await expect(
+      assertNativeSwapReadyForBroadcast({
+        chain: Chain.Bitcoin,
+        keysignPayload: makeThorchainSwapPayload(),
+        getInboundAddresses: async () => [makeInbound('BTC', 'bc1qactive')],
+        now: () => 1_700_000_000_000,
+      })
+    ).resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
Closes #690

## Summary

- Honor native swap quote expiry when creating native swap signing payloads.

- Guard SDK broadcast against expired native swap payloads and stale THORChain inbound vault addresses.

## Verification
- yarn check:ci
- yarn test
- Windows local-tarball install + desktop smoke at http://localhost:34115/ rendered the real portfolio screen; screenshot: /Users/rodion/vultisig/windows/.codex/receipts/sdk-690-windows-desktop-smoke.png
- Windows yarn check fails on current Windows main and with local SDK tarballs due missing locale keys de/es/it/hr/ru/nl/pt/zh/ko.swap_invalid_external_recipient; this is not introduced by the SDK tarballs.


## Coordination

- PR #808 / SDK #688 also edits packages/core/mpc/swap/native/utils/nativeSwapQuoteToSwapPayload.ts and its test. Read-only merge-tree shows conflict markers between the branches, so whichever PR lands second will need explicit conflict resolution; this PR does not merge sibling branch assumptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Native swap quotes now properly honor their expiration times instead of auto-extending them.
  * THORChain swaps now validate inbound vault addresses before broadcasting to prevent stale transaction issues.

* **Tests**
  * Added unit tests for native swap broadcast validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->