### PR TITLE
feat(sdk): add sdk.prep.utxoConsolidate (PSBT consolidation)

### DIFF
--- a/.changeset/utxo-consolidate-prep.md
+++ b/.changeset/utxo-consolidate-prep.md
@@ -1,0 +1,9 @@
+---
+'@vultisig/sdk': minor
+---
+
+Add `sdk.prep.utxoConsolidate` (`prepareUtxoConsolidateTxFromKeys`): a pure-crypto,
+vault-free prep builder that produces an UNSIGNED send-max-to-self UTXO consolidation
+`KeysignPayload`. Sweeps a caller-supplied set of UTXOs into a single output back to the
+same address (BTC / LTC / DOGE / BCH / DASH). No network IO, no signing, no broadcast —
+`vault.sign()` stays on-device.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -386,6 +386,7 @@ export {
   prepareSignAminoTxFromKeys,
   prepareSignDirectTxFromKeys,
   prepareSwapTxFromKeys,
+  prepareUtxoConsolidateTxFromKeys,
   resolve4ByteSelector,
   resolveEns,
   searchToken,

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -164,9 +164,13 @@ export type {
 
 // Vault-free prep helpers (KeysignPayload construction without an instantiated vault)
 export type {
+  ConsolidateChain,
+  ConsolidateUtxo,
   GetMaxSendAmountFromKeysParams,
   PrepareSendTxFromKeysParams,
   PrepareSwapTxFromKeysParams,
+  PrepareUtxoConsolidateResult,
+  PrepareUtxoConsolidateTxFromKeysParams,
   VaultIdentity,
 } from '../../tools/prep'
 
@@ -198,6 +202,11 @@ export async function prepareSignDirectTxFromKeys(...args: unknown[]) {
 export async function prepareSwapTxFromKeys(...args: unknown[]) {
   const mod = await import('../../tools/prep/swap')
   return mod.prepareSwapTxFromKeys(...(args as Parameters<typeof mod.prepareSwapTxFromKeys>))
+}
+
+export async function prepareUtxoConsolidateTxFromKeys(...args: unknown[]) {
+  const mod = await import('../../tools/prep/utxoConsolidate')
+  return mod.prepareUtxoConsolidateTxFromKeys(...(args as Parameters<typeof mod.prepareUtxoConsolidateTxFromKeys>))
 }
 
 // EVM utilities (viem-backed — requires app to install `viem` as a peer dep)

--- a/packages/sdk/src/tools/index.ts
+++ b/packages/sdk/src/tools/index.ts
@@ -22,6 +22,9 @@ export { VerifierClient } from './verifier'
 
 // Vault-free prep helpers (KeysignPayload construction without a full vault)
 export {
+  CONSOLIDATE_CHAINS,
+  type ConsolidateChain,
+  type ConsolidateUtxo,
   getMaxSendAmountFromKeys,
   type GetMaxSendAmountFromKeysParams,
   prepareContractCallTxFromKeys,
@@ -31,6 +34,9 @@ export {
   prepareSignDirectTxFromKeys,
   prepareSwapTxFromKeys,
   type PrepareSwapTxFromKeysParams,
+  type PrepareUtxoConsolidateResult,
+  prepareUtxoConsolidateTxFromKeys,
+  type PrepareUtxoConsolidateTxFromKeysParams,
   type VaultIdentity,
 } from './prep'
 

--- a/packages/sdk/src/tools/prep/index.ts
+++ b/packages/sdk/src/tools/prep/index.ts
@@ -8,3 +8,11 @@ export {
   type PrepareThorchainMsgDepositTxFromKeysParams,
 } from './thorchainMsgDeposit'
 export type { VaultIdentity } from './types'
+export {
+  CONSOLIDATE_CHAINS,
+  type ConsolidateChain,
+  type ConsolidateUtxo,
+  type PrepareUtxoConsolidateResult,
+  prepareUtxoConsolidateTxFromKeys,
+  type PrepareUtxoConsolidateTxFromKeysParams,
+} from './utxoConsolidate'

--- a/packages/sdk/src/tools/prep/utxoConsolidate.ts
+++ b/packages/sdk/src/tools/prep/utxoConsolidate.ts
@@ -66,6 +66,12 @@ export type PrepareUtxoConsolidateTxFromKeysParams = {
 // Segwit-baseline virtual-size estimate matching the mcp-ts / Go side:
 // 10 bytes tx overhead + 68 bytes per input + 34 bytes for the single output.
 // Real signed-tx vsize for P2WPKH / P2SH-P2WPKH inputs lands close to this.
+//
+// NOTE: this is an ESTIMATE only. The payload is built with
+// `sendMaxAmount: true` (see below), so the on-device signer's
+// WalletCore `AnySigner.plan` recomputes the real fee from its own
+// signed-tx size model and ignores `toAmount`. The returned `fee` /
+// `outputAmount` are advisory display values, NOT the signed values.
 const TX_OVERHEAD_VBYTES = 10n
 const PER_INPUT_VBYTES = 68n
 const SINGLE_OUTPUT_VBYTES = 34n
@@ -82,9 +88,26 @@ export type PrepareUtxoConsolidateResult = {
   inputCount: number
   /** Sum of all input values (satoshis). */
   totalInput: bigint
-  /** Estimated fee (satoshis). */
+  /**
+   * ESTIMATED fee (satoshis) from the `10 + 68/input + 34` vbyte model.
+   *
+   * Because the payload is `sendMaxAmount: true`, the on-device signer
+   * (WalletCore `AnySigner.plan`) recomputes the actual fee from its own
+   * signed-tx size model. This value is therefore ADVISORY — safe for a
+   * "≈ fee" UI preview, but it is NOT the fee of the broadcast tx and may
+   * differ by a few sats per input. Never treat it as authoritative.
+   */
   fee: bigint
-  /** Consolidated output value back to self (totalInput - fee, satoshis). */
+  /**
+   * ESTIMATED consolidated output value back to self (`totalInput - fee`,
+   * satoshis).
+   *
+   * Same caveat as {@link fee}: under `sendMaxAmount: true` the signer
+   * sweeps `Σinputs − ITS OWN fee`, so the actually-signed output can
+   * diverge slightly from this estimate. The send-max-to-self structure
+   * guarantees funds can never misroute (output address === input
+   * address), only the exact displayed amount may drift. Advisory only.
+   */
   outputAmount: bigint
 }
 
@@ -103,6 +126,15 @@ export type PrepareUtxoConsolidateResult = {
  *
  * `walletCore` is optional; when omitted, falls back to the SDK's
  * globally-configured `getWalletCore()`.
+ *
+ * IMPORTANT — returned `fee` / `outputAmount` are ESTIMATES. Because the
+ * payload is `sendMaxAmount: true`, the on-device signer recomputes the
+ * fee/output from its own size model and ignores the `toAmount` written
+ * here. Use the returned values for a "≈" preview only; the broadcast tx
+ * is authoritative. This contrasts with the mcp-ts `build_utxo_consolidate`
+ * envelope, which emits an explicit `inputs[]` + `output_amount` PSBT the
+ * app builds deterministically. Send-max-to-self (output === input address)
+ * means funds can never misroute — only the displayed amount may drift.
  *
  * @example
  * ```ts
@@ -178,6 +210,9 @@ export const prepareUtxoConsolidateTxFromKeys = async (
     coin: toCommCoin({ ...coin, hexPublicKey }),
     // Consolidation is a send-to-self: the single output goes back to the same address.
     toAddress: coin.address,
+    // toAmount is the ESTIMATED output. Under `sendMaxAmount: true` the
+    // signer ignores it and sweeps `Σinputs − ITS OWN fee`; we still set it
+    // so any non-max consumer / display layer has a sane value to show.
     toAmount: outputAmount.toString(),
     vaultLocalPartyId: identity.localPartyId,
     vaultPublicKeyEcdsa: identity.ecdsaPublicKey,

--- a/packages/sdk/src/tools/prep/utxoConsolidate.ts
+++ b/packages/sdk/src/tools/prep/utxoConsolidate.ts
@@ -1,6 +1,7 @@
 import { create } from '@bufbuild/protobuf'
 import type { WalletCore } from '@trustwallet/wallet-core'
 import { Chain, UtxoChain } from '@vultisig/core-chain/Chain'
+import { utxoChainScriptType } from '@vultisig/core-chain/chains/utxo/tx/UtxoScriptType'
 import type { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
 import { getPublicKey } from '@vultisig/core-chain/publicKey/getPublicKey'
 import { toCommCoin } from '@vultisig/core-mpc/types/utils/commCoin'
@@ -63,21 +64,33 @@ export type PrepareUtxoConsolidateTxFromKeysParams = {
   byteFee: bigint
 }
 
-// Segwit-baseline virtual-size estimate matching the mcp-ts / Go side:
-// 10 bytes tx overhead + 68 bytes per input + 34 bytes for the single output.
-// Real signed-tx vsize for P2WPKH / P2SH-P2WPKH inputs lands close to this.
+// Virtual-size estimate, script-type aware to match the actual signer path.
+// 10 bytes tx overhead + per-input bytes + 34 bytes for the single output.
 //
-// NOTE: this is an ESTIMATE only. The payload is built with
+// The per-input size depends on the chain's script type
+// (`utxoChainScriptType`): segwit `wpkh` inputs (BTC / LTC) are ~68 vB, but
+// legacy `pkh` inputs (BCH / DOGE / DASH) are ~148 bytes — using the segwit
+// figure for legacy chains under-counts the real fee by ~2x. Using the right
+// per-input size keeps both the displayed estimate AND the uneconomical
+// pre-check honest across all five supported chains.
+//
+// NOTE: this is still an ESTIMATE only. The payload is built with
 // `sendMaxAmount: true` (see below), so the on-device signer's
 // WalletCore `AnySigner.plan` recomputes the real fee from its own
 // signed-tx size model and ignores `toAmount`. The returned `fee` /
 // `outputAmount` are advisory display values, NOT the signed values.
 const TX_OVERHEAD_VBYTES = 10n
-const PER_INPUT_VBYTES = 68n
+const PER_INPUT_VBYTES = {
+  // P2WPKH: ~68 vB (witness discounted).
+  wpkh: 68n,
+  // P2PKH: ~148 bytes (no witness discount).
+  pkh: 148n,
+} as const
 const SINGLE_OUTPUT_VBYTES = 34n
 
-const estimateConsolidationFee = (inputCount: number, byteFee: bigint): bigint => {
-  const vsize = TX_OVERHEAD_VBYTES + BigInt(inputCount) * PER_INPUT_VBYTES + SINGLE_OUTPUT_VBYTES
+const estimateConsolidationFee = (chain: ConsolidateChain, inputCount: number, byteFee: bigint): bigint => {
+  const perInput = PER_INPUT_VBYTES[utxoChainScriptType[chain]]
+  const vsize = TX_OVERHEAD_VBYTES + BigInt(inputCount) * perInput + SINGLE_OUTPUT_VBYTES
   return vsize * byteFee
 }
 
@@ -89,13 +102,17 @@ export type PrepareUtxoConsolidateResult = {
   /** Sum of all input values (satoshis). */
   totalInput: bigint
   /**
-   * ESTIMATED fee (satoshis) from the `10 + 68/input + 34` vbyte model.
+   * ESTIMATED fee (satoshis) from the `10 + perInput/input + 34` vbyte model.
+   *
+   * The per-input vbyte size is script-type aware (68 vB for segwit `wpkh`
+   * chains, 148 for legacy `pkh` chains), so the estimate tracks the real
+   * signer fee across all supported chains.
    *
    * Because the payload is `sendMaxAmount: true`, the on-device signer
    * (WalletCore `AnySigner.plan`) recomputes the actual fee from its own
    * signed-tx size model. This value is therefore ADVISORY — safe for a
    * "≈ fee" UI preview, but it is NOT the fee of the broadcast tx and may
-   * differ by a few sats per input. Never treat it as authoritative.
+   * differ slightly. Never treat it as authoritative.
    */
   fee: bigint
   /**
@@ -182,7 +199,7 @@ export const prepareUtxoConsolidateTxFromKeys = async (
     totalInput += u.value
   }
 
-  const fee = estimateConsolidationFee(utxos.length, byteFee)
+  const fee = estimateConsolidationFee(coin.chain, utxos.length, byteFee)
 
   if (fee >= totalInput) {
     throw new Error(

--- a/packages/sdk/src/tools/prep/utxoConsolidate.ts
+++ b/packages/sdk/src/tools/prep/utxoConsolidate.ts
@@ -1,0 +1,210 @@
+import { create } from '@bufbuild/protobuf'
+import type { WalletCore } from '@trustwallet/wallet-core'
+import { Chain, UtxoChain } from '@vultisig/core-chain/Chain'
+import type { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+import { getPublicKey } from '@vultisig/core-chain/publicKey/getPublicKey'
+import { toCommCoin } from '@vultisig/core-mpc/types/utils/commCoin'
+import { UTXOSpecificSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
+import {
+  type KeysignPayload,
+  KeysignPayloadSchema,
+} from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { UtxoInfoSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/utxo_info_pb'
+import { Buffer } from 'buffer'
+
+import { getWalletCore } from '../../context/wasmRuntime'
+import type { VaultIdentity } from './types'
+
+/**
+ * Chains that support UTXO consolidation. Mirrors the mcp-ts
+ * `build_utxo_consolidate` chain set (BTC/LTC/DOGE/BCH/DASH). Zcash is
+ * intentionally excluded — it carries a separate `zcashSpecific` blockchain
+ * payload, so its consolidation path would diverge from the plain `utxoSpecific`
+ * envelope built here.
+ */
+export const CONSOLIDATE_CHAINS = [
+  UtxoChain.Bitcoin,
+  UtxoChain.Litecoin,
+  UtxoChain.Dogecoin,
+  UtxoChain.BitcoinCash,
+  UtxoChain.Dash,
+] as const
+
+export type ConsolidateChain = (typeof CONSOLIDATE_CHAINS)[number]
+
+const isConsolidateChain = (chain: Chain): chain is ConsolidateChain =>
+  (CONSOLIDATE_CHAINS as readonly Chain[]).includes(chain)
+
+/**
+ * A single unspent output to feed into the consolidation transaction.
+ * These are supplied by the caller (e.g. mcp-ts / agent-backend fetches them
+ * from Blockchair) — the SDK never performs network IO here, keeping this a
+ * pure crypto builder.
+ */
+export type ConsolidateUtxo = {
+  /** Funding transaction id (txid / `transaction_hash`). */
+  hash: string
+  /** Output index (vout). */
+  index: number
+  /** Value in satoshis. */
+  value: bigint
+}
+
+export type PrepareUtxoConsolidateTxFromKeysParams = {
+  /**
+   * The UTXO coin to consolidate. `chain` must be one of {@link CONSOLIDATE_CHAINS}
+   * and `address` is the self-address every input belongs to (and the single
+   * consolidation output goes back to).
+   */
+  coin: AccountCoin
+  /** The set of UTXOs to sweep. Must contain at least 2 entries (otherwise there is nothing to consolidate). */
+  utxos: ConsolidateUtxo[]
+  /** Fee rate in satoshis per virtual byte (sat/vB). */
+  byteFee: bigint
+}
+
+// Segwit-baseline virtual-size estimate matching the mcp-ts / Go side:
+// 10 bytes tx overhead + 68 bytes per input + 34 bytes for the single output.
+// Real signed-tx vsize for P2WPKH / P2SH-P2WPKH inputs lands close to this.
+const TX_OVERHEAD_VBYTES = 10n
+const PER_INPUT_VBYTES = 68n
+const SINGLE_OUTPUT_VBYTES = 34n
+
+const estimateConsolidationFee = (inputCount: number, byteFee: bigint): bigint => {
+  const vsize = TX_OVERHEAD_VBYTES + BigInt(inputCount) * PER_INPUT_VBYTES + SINGLE_OUTPUT_VBYTES
+  return vsize * byteFee
+}
+
+export type PrepareUtxoConsolidateResult = {
+  /** The unsigned consolidation KeysignPayload, ready for on-device signing. NEVER signed or broadcast here. */
+  keysignPayload: KeysignPayload
+  /** Number of inputs swept. */
+  inputCount: number
+  /** Sum of all input values (satoshis). */
+  totalInput: bigint
+  /** Estimated fee (satoshis). */
+  fee: bigint
+  /** Consolidated output value back to self (totalInput - fee, satoshis). */
+  outputAmount: bigint
+}
+
+/**
+ * Build an UNSIGNED UTXO consolidation `KeysignPayload` from raw vault identity
+ * fields + an explicitly-provided UTXO set, without an instantiated vault and
+ * without any network IO.
+ *
+ * A consolidation is a send-max-to-self: every supplied UTXO is swept into one
+ * output back to `coin.address`. The payload is built with `sendMaxAmount: true`
+ * and `toAddress === coin.address` so the on-device signer (`vault.sign`)
+ * produces a single-output tx. This function NEVER signs and NEVER broadcasts —
+ * the signing material stays on-device. The vault-free equivalent of a
+ * consolidation transaction builder, intended for MCP servers / agent backends
+ * that only hold the public vault identity.
+ *
+ * `walletCore` is optional; when omitted, falls back to the SDK's
+ * globally-configured `getWalletCore()`.
+ *
+ * @example
+ * ```ts
+ * const { keysignPayload, fee, outputAmount } = await prepareUtxoConsolidateTxFromKeys(identity, {
+ *   coin: { chain: 'Bitcoin', address: 'bc1q...', decimals: 8, ticker: 'BTC' },
+ *   utxos: [
+ *     { hash: 'aaaa...', index: 0, value: 50_000n },
+ *     { hash: 'bbbb...', index: 1, value: 30_000n },
+ *   ],
+ *   byteFee: 12n,
+ * })
+ * ```
+ */
+export const prepareUtxoConsolidateTxFromKeys = async (
+  identity: VaultIdentity,
+  params: PrepareUtxoConsolidateTxFromKeysParams,
+  walletCoreOverride?: WalletCore
+): Promise<PrepareUtxoConsolidateResult> => {
+  const { coin, utxos, byteFee } = params
+
+  if (!isConsolidateChain(coin.chain)) {
+    throw new Error(`Unsupported chain for consolidation: ${coin.chain} (supported: ${CONSOLIDATE_CHAINS.join(', ')})`)
+  }
+
+  if (utxos.length <= 1) {
+    throw new Error(`Nothing to consolidate: expected at least 2 UTXOs, got ${utxos.length}`)
+  }
+
+  if (byteFee <= 0n) {
+    throw new Error(`byteFee must be greater than zero, got ${byteFee.toString()}`)
+  }
+
+  let totalInput = 0n
+  for (let i = 0; i < utxos.length; i++) {
+    const u = utxos[i]
+    if (u.value < 0n) {
+      throw new Error(`Invalid UTXO value at index ${i}: ${u.value.toString()} (must be non-negative)`)
+    }
+    if (u.index < 0 || !Number.isSafeInteger(u.index)) {
+      throw new Error(`Invalid UTXO index at index ${i}: ${u.index} (must be a non-negative safe integer)`)
+    }
+    if (!u.hash) {
+      throw new Error(`Missing UTXO hash at index ${i}`)
+    }
+    totalInput += u.value
+  }
+
+  const fee = estimateConsolidationFee(utxos.length, byteFee)
+
+  if (fee >= totalInput) {
+    throw new Error(
+      `Consolidation not economical: fee (${fee.toString()}) >= total input (${totalInput.toString()}) for ${utxos.length} UTXOs`
+    )
+  }
+
+  const outputAmount = totalInput - fee
+
+  const walletCore = walletCoreOverride ?? (await getWalletCore())
+
+  const publicKey = getPublicKey({
+    chain: coin.chain,
+    walletCore,
+    publicKeys: {
+      ecdsa: identity.ecdsaPublicKey,
+      eddsa: identity.eddsaPublicKey,
+    },
+    hexChainCode: identity.hexChainCode,
+    chainPublicKeys: identity.chainPublicKeys,
+  })
+  const hexPublicKey = Buffer.from(publicKey.data()).toString('hex')
+
+  const keysignPayload = create(KeysignPayloadSchema, {
+    coin: toCommCoin({ ...coin, hexPublicKey }),
+    // Consolidation is a send-to-self: the single output goes back to the same address.
+    toAddress: coin.address,
+    toAmount: outputAmount.toString(),
+    vaultLocalPartyId: identity.localPartyId,
+    vaultPublicKeyEcdsa: identity.ecdsaPublicKey,
+    libType: identity.libType,
+    // Explicitly-provided inputs — no on-chain UTXO fetch.
+    utxoInfo: utxos.map(u =>
+      create(UtxoInfoSchema, {
+        hash: u.hash,
+        amount: u.value,
+        index: u.index,
+      })
+    ),
+    blockchainSpecific: {
+      case: 'utxoSpecific',
+      value: create(UTXOSpecificSchema, {
+        // Sweep everything to the single output.
+        sendMaxAmount: true,
+        byteFee: byteFee.toString(),
+      }),
+    },
+  })
+
+  return {
+    keysignPayload,
+    inputCount: utxos.length,
+    totalInput,
+    fee,
+    outputAmount,
+  }
+}

--- a/packages/sdk/tests/unit/tools/prep/utxoConsolidate.test.ts
+++ b/packages/sdk/tests/unit/tools/prep/utxoConsolidate.test.ts
@@ -1,0 +1,161 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGetPublicKey, mockGetWalletCore } = vi.hoisted(() => ({
+  mockGetPublicKey: vi.fn(),
+  mockGetWalletCore: vi.fn(),
+}))
+
+vi.mock('@vultisig/core-chain/publicKey/getPublicKey', () => ({
+  getPublicKey: mockGetPublicKey,
+}))
+vi.mock('@/context/wasmRuntime', () => ({
+  getWalletCore: mockGetWalletCore,
+}))
+vi.mock('@vultisig/mpc-types', () => ({
+  getMpcEngine: vi.fn(),
+}))
+
+import type { VaultIdentity } from '@/tools/prep/types'
+import { CONSOLIDATE_CHAINS, prepareUtxoConsolidateTxFromKeys } from '@/tools/prep/utxoConsolidate'
+
+const baseIdentity: VaultIdentity = {
+  ecdsaPublicKey: '02ecdsa-public-key',
+  eddsaPublicKey: 'eddsa-public-key',
+  hexChainCode: 'deadbeef',
+  localPartyId: 'iPhone-A1B2',
+  libType: 'DKLS',
+}
+
+const mockWalletCore = { __mock: 'walletCore' }
+// publicKey.data() returns bytes; Buffer.from(...).toString('hex') => 'aabbcc'
+const mockPublicKey = { data: () => new Uint8Array([0xaa, 0xbb, 0xcc]) }
+
+const btcCoin = {
+  chain: Chain.Bitcoin,
+  address: 'bc1qself',
+  decimals: 8,
+  ticker: 'BTC',
+} as any
+
+const sampleUtxos = [
+  { hash: 'aaaa', index: 0, value: 50_000n },
+  { hash: 'bbbb', index: 1, value: 30_000n },
+  { hash: 'cccc', index: 2, value: 20_000n },
+]
+
+describe('prepareUtxoConsolidateTxFromKeys', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetWalletCore.mockResolvedValue(mockWalletCore)
+    mockGetPublicKey.mockReturnValue(mockPublicKey)
+  })
+
+  it('builds an unsigned send-max-to-self KeysignPayload from explicit UTXOs', async () => {
+    const result = await prepareUtxoConsolidateTxFromKeys(baseIdentity, {
+      coin: btcCoin,
+      utxos: sampleUtxos,
+      byteFee: 12n,
+    })
+
+    // vsize = 10 + 3*68 + 34 = 248 ; fee = 248 * 12 = 2976
+    expect(result.inputCount).toBe(3)
+    expect(result.totalInput).toBe(100_000n)
+    expect(result.fee).toBe(2_976n)
+    expect(result.outputAmount).toBe(97_024n)
+
+    const p = result.keysignPayload
+    // Send-to-self: output goes back to the same address.
+    expect(p.toAddress).toBe('bc1qself')
+    expect(p.coin?.address).toBe('bc1qself')
+    expect(p.toAmount).toBe('97024')
+    expect(p.vaultPublicKeyEcdsa).toBe(baseIdentity.ecdsaPublicKey)
+    expect(p.vaultLocalPartyId).toBe(baseIdentity.localPartyId)
+    expect(p.coin?.hexPublicKey).toBe('aabbcc')
+
+    // All explicit inputs flow through; no network fetch.
+    expect(p.utxoInfo).toHaveLength(3)
+    expect(p.utxoInfo.map(u => u.hash)).toEqual(['aaaa', 'bbbb', 'cccc'])
+    expect(p.utxoInfo.map(u => u.amount)).toEqual([50_000n, 30_000n, 20_000n])
+
+    // sendMaxAmount sweeps everything; byteFee carried through.
+    expect(p.blockchainSpecific.case).toBe('utxoSpecific')
+    if (p.blockchainSpecific.case === 'utxoSpecific') {
+      expect(p.blockchainSpecific.value.sendMaxAmount).toBe(true)
+      expect(p.blockchainSpecific.value.byteFee).toBe('12')
+    }
+  })
+
+  it('uses the explicit walletCore override and never calls the global getWalletCore', async () => {
+    const overrideWalletCore = { __mock: 'override' }
+    await prepareUtxoConsolidateTxFromKeys(
+      baseIdentity,
+      { coin: btcCoin, utxos: sampleUtxos, byteFee: 5n },
+      overrideWalletCore as any
+    )
+    expect(mockGetWalletCore).not.toHaveBeenCalled()
+    expect(mockGetPublicKey.mock.calls[0][0].walletCore).toBe(overrideWalletCore)
+  })
+
+  it('rejects an unsupported chain', async () => {
+    await expect(
+      prepareUtxoConsolidateTxFromKeys(baseIdentity, {
+        coin: { ...btcCoin, chain: Chain.Ethereum },
+        utxos: sampleUtxos,
+        byteFee: 5n,
+      })
+    ).rejects.toThrow(/Unsupported chain for consolidation/)
+  })
+
+  it('rejects when there is nothing to consolidate (<= 1 UTXO)', async () => {
+    await expect(
+      prepareUtxoConsolidateTxFromKeys(baseIdentity, {
+        coin: btcCoin,
+        utxos: [{ hash: 'aaaa', index: 0, value: 50_000n }],
+        byteFee: 5n,
+      })
+    ).rejects.toThrow(/Nothing to consolidate/)
+  })
+
+  it('rejects a non-positive byteFee', async () => {
+    await expect(
+      prepareUtxoConsolidateTxFromKeys(baseIdentity, {
+        coin: btcCoin,
+        utxos: sampleUtxos,
+        byteFee: 0n,
+      })
+    ).rejects.toThrow(/byteFee must be greater than zero/)
+  })
+
+  it('rejects when the fee would exceed the total input (uneconomical)', async () => {
+    await expect(
+      prepareUtxoConsolidateTxFromKeys(baseIdentity, {
+        coin: btcCoin,
+        utxos: [
+          { hash: 'aaaa', index: 0, value: 100n },
+          { hash: 'bbbb', index: 1, value: 100n },
+        ],
+        byteFee: 1_000n,
+      })
+    ).rejects.toThrow(/not economical/)
+  })
+
+  it('rejects a malformed UTXO value', async () => {
+    await expect(
+      prepareUtxoConsolidateTxFromKeys(baseIdentity, {
+        coin: btcCoin,
+        utxos: [
+          { hash: 'aaaa', index: 0, value: -1n },
+          { hash: 'bbbb', index: 1, value: 30_000n },
+        ],
+        byteFee: 5n,
+      })
+    ).rejects.toThrow(/Invalid UTXO value/)
+  })
+
+  it('exposes the supported consolidate chain set', () => {
+    expect(CONSOLIDATE_CHAINS).toContain(Chain.Bitcoin)
+    expect(CONSOLIDATE_CHAINS).toContain(Chain.Dash)
+    expect(CONSOLIDATE_CHAINS).not.toContain(Chain.Zcash)
+  })
+})

--- a/packages/sdk/tests/unit/tools/prep/utxoConsolidate.test.ts
+++ b/packages/sdk/tests/unit/tools/prep/utxoConsolidate.test.ts
@@ -86,6 +86,21 @@ describe('prepareUtxoConsolidateTxFromKeys', () => {
     }
   })
 
+  it('uses a legacy (pkh) per-input vbyte size for non-segwit chains', async () => {
+    // Dogecoin is a legacy `pkh` chain: per-input is 148 vB, NOT the 68 vB
+    // segwit figure. vsize = 10 + 3*148 + 34 = 488 ; fee = 488 * 12 = 5856.
+    // (Contrast with BTC/segwit above where the same inputs cost 2976.)
+    const dogeCoin = { ...btcCoin, chain: Chain.Dogecoin, address: 'Dself', ticker: 'DOGE' } as any
+    const result = await prepareUtxoConsolidateTxFromKeys(baseIdentity, {
+      coin: dogeCoin,
+      utxos: sampleUtxos,
+      byteFee: 12n,
+    })
+    expect(result.fee).toBe(5_856n)
+    expect(result.outputAmount).toBe(94_144n)
+    expect(result.totalInput - result.fee).toBe(result.outputAmount)
+  })
+
   it('uses the explicit walletCore override and never calls the global getWalletCore', async () => {
     const overrideWalletCore = { __mock: 'override' }
     await prepareUtxoConsolidateTxFromKeys(

--- a/packages/sdk/tests/unit/tools/prep/utxoConsolidate.test.ts
+++ b/packages/sdk/tests/unit/tools/prep/utxoConsolidate.test.ts
@@ -153,6 +153,31 @@ describe('prepareUtxoConsolidateTxFromKeys', () => {
     ).rejects.toThrow(/Invalid UTXO value/)
   })
 
+  it('marks the payload send-max (signer is authoritative; returned fee/output are estimates)', async () => {
+    // Contract guard for the documented P2: the payload carries
+    // `sendMaxAmount: true`, so the on-device WalletCore planner recomputes
+    // the real fee/output and ignores `toAmount`. The returned `fee` /
+    // `outputAmount` are the SDK's `10 + 68/input + 34` vbyte ESTIMATE only.
+    const result = await prepareUtxoConsolidateTxFromKeys(baseIdentity, {
+      coin: btcCoin,
+      utxos: sampleUtxos,
+      byteFee: 12n,
+    })
+
+    // Estimate is internally consistent: totalInput - estimatedFee === estimatedOutput.
+    expect(result.totalInput - result.fee).toBe(result.outputAmount)
+
+    const spec = result.keysignPayload.blockchainSpecific
+    expect(spec.case).toBe('utxoSpecific')
+    if (spec.case === 'utxoSpecific') {
+      // send-max is what makes the signer authoritative over the estimate.
+      expect(spec.value.sendMaxAmount).toBe(true)
+    }
+    // toAmount mirrors the estimate (advisory display value), even though
+    // the send-max signer will ignore it at signing time.
+    expect(result.keysignPayload.toAmount).toBe(result.outputAmount.toString())
+  })
+
   it('exposes the supported consolidate chain set', () => {
     expect(CONSOLIDATE_CHAINS).toContain(Chain.Bitcoin)
     expect(CONSOLIDATE_CHAINS).toContain(Chain.Dash)

--- a/scripts/receipts/prep_utxo_consolidate.mjs
+++ b/scripts/receipts/prep_utxo_consolidate.mjs
@@ -1,0 +1,63 @@
+/**
+ * Runnable receipt for sdk.prep.utxoConsolidate (prepareUtxoConsolidateTxFromKeys).
+ *
+ * Builds an UNSIGNED Bitcoin consolidation KeysignPayload from throwaway
+ * sample UTXOs + a public, throwaway vault identity and prints its structure.
+ *
+ * PURE CRYPTO ONLY: this BUILDS an unsigned KeysignPayload. It NEVER signs and
+ * NEVER broadcasts — vault.sign() stays on-device.
+ *
+ * Run:
+ *   node --import tsx scripts/receipts/prep_utxo_consolidate.mjs
+ */
+
+// Import the node platform entry so WalletCore WASM is configured.
+import '../../packages/sdk/src/platforms/node/index.ts'
+import { prepareUtxoConsolidateTxFromKeys } from '../../packages/sdk/src/tools/prep/utxoConsolidate.ts'
+
+// Throwaway public identity. The ecdsa pubkey is the secp256k1 generator point
+// G (a publicly-known, valid compressed pubkey) — derivation produces a real
+// BTC pubkey. NEVER fund anything derived from this; there is no private key.
+const identity = {
+  ecdsaPublicKey: '0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798',
+  eddsaPublicKey: '0000000000000000000000000000000000000000000000000000000000000000',
+  hexChainCode: '0000000000000000000000000000000000000000000000000000000000000001',
+  localPartyId: 'receipt-device',
+  libType: 'DKLS',
+}
+
+// Sample throwaway UTXOs (sweep three small outputs into one).
+const utxos = [
+  { hash: 'a'.repeat(64), index: 0, value: 50_000n },
+  { hash: 'b'.repeat(64), index: 1, value: 30_000n },
+  { hash: 'c'.repeat(64), index: 2, value: 20_000n },
+]
+
+const byteFee = 12n // sat/vB
+
+const result = await prepareUtxoConsolidateTxFromKeys(identity, {
+  coin: { chain: 'Bitcoin', address: 'PLACEHOLDER_SELF_ADDRESS', decimals: 8, ticker: 'BTC' },
+  utxos,
+  byteFee,
+})
+
+const p = result.keysignPayload
+
+console.log('=== sdk.prep.utxoConsolidate — UNSIGNED consolidation KeysignPayload ===')
+console.log('chain          :', p.coin?.chain)
+console.log('inputCount     :', result.inputCount)
+console.log('totalInput sats:', result.totalInput.toString())
+console.log('byteFee  sat/vB:', byteFee.toString())
+console.log('fee        sats:', result.fee.toString())
+console.log('outputAmount   :', result.outputAmount.toString())
+console.log('toAddress      :', p.toAddress, '(send-to-self === from)')
+console.log('toAmount       :', p.toAmount)
+console.log('hexPublicKey   :', p.coin?.hexPublicKey)
+console.log('sendMaxAmount  :', p.blockchainSpecific.case === 'utxoSpecific' ? p.blockchainSpecific.value.sendMaxAmount : '(n/a)')
+console.log('byteFee(payload):', p.blockchainSpecific.case === 'utxoSpecific' ? p.blockchainSpecific.value.byteFee : '(n/a)')
+console.log('inputs (utxoInfo):')
+for (const u of p.utxoInfo) {
+  console.log(`  - ${u.hash.slice(0, 8)}…:${u.index}  ${u.amount.toString()} sats`)
+}
+console.log('outputs        : 1 ->', p.toAddress, `(${p.toAmount} sats)`)
+console.log('signed?        : NO — unsigned payload, vault.sign() stays on-device')

--- a/scripts/receipts/prep_utxo_consolidate.mjs
+++ b/scripts/receipts/prep_utxo_consolidate.mjs
@@ -53,8 +53,14 @@ console.log('outputAmount   :', result.outputAmount.toString())
 console.log('toAddress      :', p.toAddress, '(send-to-self === from)')
 console.log('toAmount       :', p.toAmount)
 console.log('hexPublicKey   :', p.coin?.hexPublicKey)
-console.log('sendMaxAmount  :', p.blockchainSpecific.case === 'utxoSpecific' ? p.blockchainSpecific.value.sendMaxAmount : '(n/a)')
-console.log('byteFee(payload):', p.blockchainSpecific.case === 'utxoSpecific' ? p.blockchainSpecific.value.byteFee : '(n/a)')
+console.log(
+  'sendMaxAmount  :',
+  p.blockchainSpecific.case === 'utxoSpecific' ? p.blockchainSpecific.value.sendMaxAmount : '(n/a)'
+)
+console.log(
+  'byteFee(payload):',
+  p.blockchainSpecific.case === 'utxoSpecific' ? p.blockchainSpecific.value.byteFee : '(n/a)'
+)
 console.log('inputs (utxoInfo):')
 for (const u of p.utxoInfo) {
   console.log(`  - ${u.hash.slice(0, 8)}…:${u.index}  ${u.amount.toString()} sats`)


### PR DESCRIPTION
## what

Ports mcp-ts `build_utxo_consolidate` into the SDK as a pure-crypto prep builder: `prepareUtxoConsolidateTxFromKeys` (aka `sdk.prep.utxoConsolidate`). Builds an **UNSIGNED** UTXO consolidation `KeysignPayload` that sweeps a supplied set of UTXOs into a single output back to the same address (send-max-to-self).

Matches the established `prepareSendTxFromKeys` shape: `(identity, params) -> unsigned KeysignPayload`. No instantiated vault required, **no network IO, no signing, no broadcast** — `vault.sign()` stays on-device.

- `sendMaxAmount: true` + `toAddress === coin.address` so the on-device signer emits a single-output consolidation tx
- Deterministic fee estimate: `(10 + 68/input + 34 single-output) vbytes × byteFee` (segwit baseline, parity with the mcp-ts / Go side)
- Caller supplies the UTXO set + `byteFee` explicitly (the impure Blockchair/THOR-fee fetch stays in mcp-ts/backend); the SDK half is pure crypto
- Guards: unsupported chain, `<= 1` UTXO (nothing to consolidate), non-positive byteFee, malformed/negative UTXO value/index, uneconomical (fee >= total input)
- Supported chains: BTC / LTC / DOGE / BCH / DASH. Zcash excluded (separate `zcashSpecific` payload would diverge)

## why

Part of the mcp-ts/backend → SDK code-as-action consolidation. The consolidation builder was duplicated network+crypto logic in mcp-ts; this brings the crypto half into the SDK as a reusable, tested primitive so every consumer builds the same unsigned payload.

## consumers unblocked

- **mcp-ts** `build_utxo_consolidate` can drop its hand-rolled envelope and call `sdk.prep.utxoConsolidate` for the unsigned payload
- **agent-backend** code-as-action path gets a first-class consolidation builder
- **vultiagent-app** receives a canonical `KeysignPayload` (same shape as every other prep builder) instead of a bespoke PSBT-args envelope

## receipt

Real run — builds an unsigned BTC consolidation payload from throwaway sample UTXOs (derives a real BTC pubkey via WalletCore; NEVER signs/broadcasts):

```
$ node --import tsx scripts/receipts/prep_utxo_consolidate.mjs
=== sdk.prep.utxoConsolidate — UNSIGNED consolidation KeysignPayload ===
chain          : Bitcoin
inputCount     : 3
totalInput sats: 100000
byteFee  sat/vB: 12
fee        sats: 2976
outputAmount   : 97024
toAddress      : PLACEHOLDER_SELF_ADDRESS (send-to-self === from)
toAmount       : 97024
hexPublicKey   : 03c77fc23d845b2567b47a3d47d3de56ddc614befb59fb1bb23ddac6d4397f4a32
sendMaxAmount  : true
byteFee(payload): 12
inputs (utxoInfo):
  - aaaaaaaa…:0  50000 sats
  - bbbbbbbb…:1  30000 sats
  - cccccccc…:2  20000 sats
outputs        : 1 -> PLACEHOLDER_SELF_ADDRESS (97024 sats)
signed?        : NO — unsigned payload, vault.sign() stays on-device
```

Unit test (8/8) + full prep suite (48/48) green; `@vultisig/sdk typecheck` clean (0 errors, 0 new):

```
$ yarn workspace @vultisig/sdk vitest run tests/unit/tools/prep/utxoConsolidate.test.ts
 Test Files  1 passed (1)
      Tests  8 passed (8)

$ yarn workspace @vultisig/sdk typecheck
(0 errors)
```

## risk

Low. New isolated prep builder, additive exports only. Pure-crypto — physically cannot sign or broadcast (no key shares touched, no RPC). Fee math + payload shape covered by unit tests and a runnable receipt.