### PR TITLE
feat(sdk): add sdk.swap.astroport (Terra Astroport in-chain swap)

### DIFF
--- a/.changeset/sdk-swap-astroport.md
+++ b/.changeset/sdk-swap-astroport.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': minor
+---
+
+Add `sdk.swap.astroport` — `buildAstroportSwap` quotes (read-only `simulate_swap_operations`) and builds an unsigned Astroport router `wasm_execute` envelope for Terra v2 (phoenix-1) in-chain swaps. Pure-crypto: never signs or broadcasts. Ported from mcp-ts. Also exports the helpers `assembleAstroportSwap`, `classifyAstroportAsset`, `computeAstroportMinReceive` and the `ASTROPORT_ROUTER` / `TERRA_LCD` / `TERRA_CHAIN_ID` constants.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -352,6 +352,8 @@ export { CosmosMsgType } from './types'
 // ============================================================================
 
 export type {
+  AstroportSwapResult,
+  BuildAstroportSwapParams,
   Coin,
   CoinKey,
   CoinMetadata,
@@ -367,7 +369,12 @@ export type {
 export {
   abiDecode,
   abiEncode,
+  assembleAstroportSwap,
+  ASTROPORT_ROUTER,
+  buildAstroportSwap,
   chainFeeCoin,
+  classifyAstroportAsset,
+  computeAstroportMinReceive,
   deriveAddressFromKeys,
   evmCall,
   evmCheckAllowance,
@@ -389,6 +396,8 @@ export {
   resolve4ByteSelector,
   resolveEns,
   searchToken,
+  TERRA_CHAIN_ID,
+  TERRA_LCD,
   VerifierClient,
 } from './tools'
 

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -200,6 +200,22 @@ export async function prepareSwapTxFromKeys(...args: unknown[]) {
   return mod.prepareSwapTxFromKeys(...(args as Parameters<typeof mod.prepareSwapTxFromKeys>))
 }
 
+// Astroport in-chain swap (Terra v2 / phoenix-1) — builds an unsigned
+// wasm_execute envelope. Pure-crypto: only @scure/base (bech32), Buffer and
+// fetch, all RN-safe, so a static re-export is fine (no chain-client deps to
+// externalize). The RN consumer (Station / vultiagent-app) needs this to build
+// the signable Terra swap msg; omitting it would force a re-implementation.
+export type { AstroportSwapResult, BuildAstroportSwapParams } from '../../tools/swap/astroport'
+export {
+  assembleAstroportSwap,
+  ASTROPORT_ROUTER,
+  buildAstroportSwap,
+  classifyAstroportAsset,
+  computeAstroportMinReceive,
+  TERRA_CHAIN_ID,
+  TERRA_LCD,
+} from '../../tools/swap/astroport'
+
 // EVM utilities (viem-backed — requires app to install `viem` as a peer dep)
 export {
   abiDecode,

--- a/packages/sdk/src/tools/index.ts
+++ b/packages/sdk/src/tools/index.ts
@@ -9,12 +9,25 @@ export type { Coin, CoinKey, CoinMetadata, KnownCoin, KnownCoinMetadata, TokenMe
 export { chainFeeCoin, getTokenMetadata, knownTokens, knownTokensIndex, searchToken } from './token'
 
 // Swap
-export type { FindSwapQuoteParams, NativeSwapMinAmountIn, SwapQuote } from './swap'
+export type {
+  AstroportSwapResult,
+  BuildAstroportSwapParams,
+  FindSwapQuoteParams,
+  NativeSwapMinAmountIn,
+  SwapQuote,
+} from './swap'
 export {
+  assembleAstroportSwap,
+  ASTROPORT_ROUTER,
+  buildAstroportSwap,
+  classifyAstroportAsset,
+  computeAstroportMinReceive,
   findSwapQuote,
   getNativeSwapDecimals,
   getNativeSwapMinAmountIn,
   NATIVE_SWAP_MIN_OUTBOUND_FEE_MULTIPLIER,
+  TERRA_CHAIN_ID,
+  TERRA_LCD,
 } from './swap'
 
 // Verifier client

--- a/packages/sdk/src/tools/swap/astroport.ts
+++ b/packages/sdk/src/tools/swap/astroport.ts
@@ -1,0 +1,423 @@
+/**
+ * buildAstroportSwap — Astroport router swap on Terra v2 (phoenix-1).
+ *
+ * Builds an unsigned CosmWasm `wasm_execute` envelope against the Astroport
+ * router that swaps `offerAssetDenom` for `askAssetDenom` directly on
+ * phoenix-1 — no Skip / Axelar / IBC. Sub-bridge latency for in-chain
+ * LUNA ↔ ASTRO / ampLUNA / aUSD / etc.
+ *
+ * Pure-crypto: quotes (read-only `simulate_swap_operations`) and builds the
+ * unsigned execute payload. It NEVER signs or broadcasts — the returned
+ * envelope is handed to the Vultisig SDK signing path by the consumer.
+ *
+ * Two execute shapes are produced depending on the offer asset:
+ *
+ *   - Native offer (e.g. `uluna`): direct call to the router with
+ *       msg = { execute_swap_operations: { operations, minimum_receive, to } }
+ *       funds = [{ denom, amount }]
+ *
+ *   - CW20 offer (e.g. an ASTRO contract address): a `Cw20ReceiveMsg`
+ *     envelope through the CW20 contract, which forwards funds to the router.
+ *     The inner execute_swap_operations payload is base64-encoded per the
+ *     CW20 spec:
+ *       contract = CW20_ADDR
+ *       msg = { send: { contract: ROUTER, amount, msg: <base64> } }
+ *       funds = []
+ *
+ * Quote step uses the router's `simulate_swap_operations` smart query. That
+ * endpoint only returns `{ amount }` — commission/spread are pool-level
+ * details the multi-hop router does not expose. We surface what the router
+ * returns and derive `minReceive` = quote × (1 − slippage).
+ *
+ * Route assembly uses `astro_swap` operations exclusively. NativeSwap is a
+ * Terra Classic / market-module construct that does not apply on phoenix-1.
+ * The router auto-routes through pools; if no route exists the simulate query
+ * surfaces a `pair_info ... not found` error cleanly.
+ *
+ * Ported from mcp-ts `src/tools/swap/astroport-swap.ts`. The Skip-fallback,
+ * Blockaid scan-request wrapping, quest-metadata and price-oracle USD
+ * derivation are orchestration concerns and stay in the consumer — they are
+ * intentionally NOT part of this SDK primitive.
+ */
+import { bech32 } from '@scure/base'
+
+// Astroport core deployment on phoenix-1, sourced from
+// astroport-fi/astroport-changelog/terra-2/phoenix-1/core_phoenix.json.
+// Verified on chain: `contract_info.label = "Astroport Router"`. If Astroport
+// ever migrates the router, this constant is the single point of update.
+export const ASTROPORT_ROUTER = 'terra18plp90j0zd596zt3zdsf0w9vvk5ukwlwzwkksxv9mdu8rscat9sqndk5qz'
+export const TERRA_LCD = 'https://terra-lcd.publicnode.com'
+export const TERRA_CHAIN_ID = 'phoenix-1'
+const TERRA_BECH32_PREFIX = 'terra'
+const DEFAULT_SLIPPAGE = 0.01
+// Capped at 5% to align with the Skip swap surface floor. Pre-cap 50% would
+// let thin-pool swaps slip a user out of meaningful value silently.
+const MAX_SLIPPAGE = 0.05
+// Generous gas — multi-hop swaps through 2-3 pools fit under 600k. Matches
+// Astroport's own frontend default.
+const SWAP_GAS = 600_000
+
+type AssetInfo = { native_token: { denom: string } } | { token: { contract_addr: string } }
+
+type AstroSwapOperation = {
+  astro_swap: {
+    offer_asset_info: AssetInfo
+    ask_asset_info: AssetInfo
+  }
+}
+
+export type BuildAstroportSwapParams = {
+  /** Sender address on phoenix-1 (terra1...). The vault-derived signer. */
+  fromAddress: string
+  /** Offer asset: native bank denom (`uluna`, `factory/...`, `ibc/...`) or CW20 contract address (`terra1...` 32-byte). */
+  offerAssetDenom: string
+  /** Amount of offer asset in base units (positive integer decimal string). */
+  offerAmount: string
+  /** Ask asset: native bank denom or CW20 contract address (same shape as `offerAssetDenom`). */
+  askAssetDenom: string
+  /** Max slippage as a fraction. Default 0.01 (1%), max 0.05 (5%). */
+  slippageTolerance?: number
+  /** Optional explicit recipient (terra1...). Omit for "send to signer" (safe default). */
+  recipientAddress?: string
+  /** Override LCD endpoint (defaults to {@link TERRA_LCD}). */
+  lcdUrl?: string
+}
+
+/** The unsigned wasm_execute envelope returned by {@link buildAstroportSwap}. */
+export type AstroportSwapResult = {
+  txType: 'wasm_execute'
+  chain: 'Terra'
+  chainId: typeof TERRA_CHAIN_ID
+  fromAddress: string
+  contractAddress: string
+  /** JSON-stringified CosmWasm execute message. */
+  executeMsg: string
+  funds: { denom: string; amount: string }[]
+  gas: number
+  /** Present only when an explicit third-party recipient was supplied. */
+  toAddress?: string
+  recipientMode: 'self' | 'third_party'
+  quote: {
+    offerAsset: string
+    offerAmount: string
+    askAsset: string
+    expectedAskAmount: string
+    minReceive: string
+    slippageTolerance: number
+  }
+  route: {
+    routerContract: string
+    operations: AstroSwapOperation[]
+  }
+}
+
+type SimulateResponse = {
+  data?: { amount?: string }
+}
+
+function trimRequired(value: string, fieldName: string): string {
+  const trimmed = (value ?? '').trim()
+  if (!trimmed) {
+    throw new Error(`${fieldName} is required`)
+  }
+  return trimmed
+}
+
+/**
+ * Validate a phoenix-1 bech32 account/contract address (terra1...). Rejects a
+ * malformed address at build time rather than at sign time.
+ */
+function validateTerraAddress(value: string, fieldName: string): string {
+  const trimmed = trimRequired(value, fieldName)
+
+  let decoded: ReturnType<typeof bech32.decode>
+  try {
+    decoded = bech32.decode(trimmed as `${string}1${string}`)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`invalid ${fieldName}: malformed bech32 encoding (${message})`)
+  }
+
+  if (decoded.prefix !== TERRA_BECH32_PREFIX) {
+    throw new Error(`invalid ${fieldName}: expected ${TERRA_BECH32_PREFIX} prefix, got ${decoded.prefix}`)
+  }
+
+  let payload: Uint8Array
+  try {
+    payload = bech32.fromWords(decoded.words)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`invalid ${fieldName}: malformed bech32 data (${message})`)
+  }
+
+  // 20 bytes = standard account, 32 bytes = CosmWasm contract address.
+  if (payload.length !== 20 && payload.length !== 32) {
+    throw new Error(`invalid ${fieldName}: expected 20- or 32-byte payload, got ${payload.length}`)
+  }
+
+  return trimmed
+}
+
+/**
+ * Classify an asset denom into its Astroport `AssetInfo` shape.
+ *   - `native_token` — Cosmos-SDK bank denom (`uluna`, `factory/...`, `ibc/...`)
+ *   - `token` — CW20 contract address (a 32-byte `terra1...` bech32)
+ *
+ * A `terra1...` prefix is an unambiguous signal that the caller intended a
+ * bech32 contract address. If the string fails bech32 decode it is rejected
+ * loudly (model fabrication) rather than silently treated as a native denom —
+ * native phoenix-1 denoms NEVER start with `terra1`.
+ *
+ * Exported for testing.
+ */
+export function classifyAstroportAsset(denom: string, fieldName: string): AssetInfo {
+  const trimmed = trimRequired(denom, fieldName)
+
+  // bech32 HRP is case-insensitive per BIP-173, so the branch check is too.
+  if (trimmed.toLowerCase().startsWith(`${TERRA_BECH32_PREFIX}1`)) {
+    let decoded: ReturnType<typeof bech32.decode>
+    try {
+      decoded = bech32.decode(trimmed as `${string}1${string}`)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      throw new Error(
+        `invalid ${fieldName}: "${trimmed}" has a terra1 prefix but is not valid bech32 (${message}). ` +
+          `Resolve the contract address, or pass a native bank denom (uluna, factory/..., ibc/...) instead.`
+      )
+    }
+    if (decoded.prefix !== TERRA_BECH32_PREFIX) {
+      throw new Error(`invalid ${fieldName}: expected ${TERRA_BECH32_PREFIX} prefix, got ${decoded.prefix}`)
+    }
+    const payload = bech32.fromWords(decoded.words)
+    if (payload.length === 32) {
+      // Canonicalize to lowercase: cosmwasm `addr_validate` rejects
+      // `TERRA1...` with "address not normalized". bech32.decode already
+      // confirmed case-uniformity, so this is a safe canonical fold.
+      return { token: { contract_addr: trimmed.toLowerCase() } }
+    }
+    if (payload.length === 20) {
+      throw new Error(
+        `invalid ${fieldName}: "${trimmed}" looks like a user account, not a CW20 contract or native denom`
+      )
+    }
+    throw new Error(`invalid ${fieldName}: unexpected bech32 payload length ${payload.length}`)
+  }
+
+  // Native/factory/IBC denom. The LCD is the source of truth (unknown denoms
+  // surface a structured "pair_info ... not found" simulate error).
+  return { native_token: { denom: trimmed } }
+}
+
+function validateAmount(value: string): string {
+  const trimmed = trimRequired(value, 'offerAmount')
+  if (!/^[0-9]+$/.test(trimmed)) {
+    throw new Error(`invalid offerAmount: "${trimmed}" must be a positive integer in base units`)
+  }
+  if (trimmed === '0' || /^0+$/.test(trimmed)) {
+    throw new Error('invalid offerAmount: must be greater than zero')
+  }
+  return trimmed
+}
+
+function validateSlippage(value: number | undefined): number {
+  const slip = value ?? DEFAULT_SLIPPAGE
+  if (!Number.isFinite(slip) || slip < 0 || slip > MAX_SLIPPAGE) {
+    throw new Error(`invalid slippageTolerance: ${slip} (must be in [0, ${MAX_SLIPPAGE}])`)
+  }
+  return slip
+}
+
+/**
+ * quote × (1 − slippage), integer-only via bps to avoid float drift on the
+ * signed payload. 0.01 → 100 bps; 0 slippage → no haircut.
+ *
+ * Exported for testing.
+ */
+export function computeAstroportMinReceive(quoteAmount: string, slippage: number): string {
+  const quote = BigInt(quoteAmount)
+  const slippageBps = BigInt(Math.round(slippage * 10_000))
+  const numerator = quote * (10_000n - slippageBps)
+  return (numerator / 10_000n).toString()
+}
+
+/**
+ * Assemble the unsigned Astroport router operations + execute envelope without
+ * the network round-trip. Exposed so callers (and tests) can build the payload
+ * deterministically given a quote they already hold.
+ *
+ * Exported for testing.
+ */
+export function assembleAstroportSwap(params: BuildAstroportSwapParams, quoteAmount: string): AstroportSwapResult {
+  const from = validateTerraAddress(params.fromAddress, 'fromAddress')
+  // Only carry an explicit `to` into the inner msg when the caller passes
+  // `recipientAddress`. Astroport's router treats a missing `to` as "send to
+  // the message sender" — the vault-derived signer, the safe default. Never
+  // default `to` to `fromAddress` (a prompt-injected sender could redirect
+  // proceeds).
+  const explicitRecipient = params.recipientAddress
+    ? validateTerraAddress(params.recipientAddress, 'recipientAddress')
+    : undefined
+  const offerAmount = validateAmount(params.offerAmount)
+  const slippage = validateSlippage(params.slippageTolerance)
+  if (!/^[0-9]+$/.test(quoteAmount)) {
+    throw new Error(`invalid quoteAmount: "${quoteAmount}"`)
+  }
+
+  const offerAsset = classifyAstroportAsset(params.offerAssetDenom, 'offerAssetDenom')
+  const askAsset = classifyAstroportAsset(params.askAssetDenom, 'askAssetDenom')
+
+  const operations: AstroSwapOperation[] = [
+    {
+      astro_swap: {
+        offer_asset_info: offerAsset,
+        ask_asset_info: askAsset,
+      },
+    },
+  ]
+
+  const minReceive = computeAstroportMinReceive(quoteAmount, slippage)
+
+  const executeSwapOperations: {
+    operations: AstroSwapOperation[]
+    minimum_receive: string
+    to?: string
+  } = {
+    operations,
+    minimum_receive: minReceive,
+  }
+  if (explicitRecipient !== undefined) {
+    executeSwapOperations.to = explicitRecipient
+  }
+  const innerExecute = { execute_swap_operations: executeSwapOperations }
+
+  let contractAddress: string
+  let executeMsg: object
+  let funds: { denom: string; amount: string }[]
+
+  if ('native_token' in offerAsset) {
+    contractAddress = ASTROPORT_ROUTER
+    executeMsg = innerExecute
+    funds = [{ denom: offerAsset.native_token.denom, amount: offerAmount }]
+  } else {
+    // CW20 offer: forward funds to the router via Cw20ReceiveMsg. The inner
+    // execute_swap_operations payload is base64-encoded per CW20 spec — the
+    // router's `Receive` handler decodes and dispatches.
+    contractAddress = offerAsset.token.contract_addr
+    const innerB64 = Buffer.from(JSON.stringify(innerExecute), 'utf8').toString('base64')
+    executeMsg = {
+      send: {
+        contract: ASTROPORT_ROUTER,
+        amount: offerAmount,
+        msg: innerB64,
+      },
+    }
+    funds = []
+  }
+
+  return {
+    txType: 'wasm_execute',
+    chain: 'Terra',
+    chainId: TERRA_CHAIN_ID,
+    fromAddress: from,
+    contractAddress,
+    executeMsg: JSON.stringify(executeMsg),
+    funds,
+    gas: SWAP_GAS,
+    // Surface the recipient signal at the top level so the approval layer does
+    // not have to decode the nested (possibly base64'd) execute_msg.
+    ...(explicitRecipient
+      ? { toAddress: explicitRecipient, recipientMode: 'third_party' as const }
+      : { recipientMode: 'self' as const }),
+    quote: {
+      offerAsset: params.offerAssetDenom,
+      offerAmount,
+      askAsset: params.askAssetDenom,
+      expectedAskAmount: quoteAmount,
+      minReceive,
+      slippageTolerance: slippage,
+    },
+    route: {
+      routerContract: ASTROPORT_ROUTER,
+      operations,
+    },
+  }
+}
+
+/**
+ * Query the Astroport router's `simulate_swap_operations` smart endpoint to
+ * obtain the expected ask amount for the given operations. Read-only.
+ */
+async function querySimulate(lcdUrl: string, operations: AstroSwapOperation[], offerAmount: string): Promise<string> {
+  const simulateQuery = JSON.stringify({
+    simulate_swap_operations: { offer_amount: offerAmount, operations },
+  })
+  const simulateB64 = Buffer.from(simulateQuery, 'utf8').toString('base64')
+  const url = `${lcdUrl}/cosmwasm/wasm/v1/contract/${ASTROPORT_ROUTER}/smart/${simulateB64}`
+
+  const response = await fetch(url, {
+    method: 'GET',
+    signal: AbortSignal.timeout(15_000),
+  })
+  if (!response.ok) {
+    // Body verbatim — preserve `code`/`message`/`details` for the caller. A
+    // missing pool surfaces here as "pair_info ... not found".
+    const body = await response.text()
+    throw new Error(`HTTP ${response.status}: ${body}`)
+  }
+  const json = (await response.json()) as SimulateResponse
+  const amount = json.data?.amount
+  if (!amount || !/^[0-9]+$/.test(amount)) {
+    throw new Error(`astroport simulate returned malformed amount: ${JSON.stringify(json)}`)
+  }
+  return amount
+}
+
+/**
+ * Build an unsigned Astroport router swap on Terra v2 (phoenix-1).
+ *
+ * Quotes via the router's read-only `simulate_swap_operations` smart query,
+ * then assembles the unsigned `wasm_execute` envelope. Does NOT sign or
+ * broadcast.
+ *
+ * @example
+ * ```ts
+ * const swap = await buildAstroportSwap({
+ *   fromAddress: 'terra1...',
+ *   offerAssetDenom: 'uluna',
+ *   offerAmount: '1000000',
+ *   askAssetDenom: 'terra1...astro-cw20...',
+ *   slippageTolerance: 0.01,
+ * })
+ * // swap.executeMsg is ready to be signed/broadcast by the Vultisig SDK
+ * ```
+ */
+export async function buildAstroportSwap(params: BuildAstroportSwapParams): Promise<AstroportSwapResult> {
+  // Validate inputs eagerly so a bad request fails before the network call.
+  validateTerraAddress(params.fromAddress, 'fromAddress')
+  const offerAmount = validateAmount(params.offerAmount)
+  validateSlippage(params.slippageTolerance)
+
+  const offerAsset = classifyAstroportAsset(params.offerAssetDenom, 'offerAssetDenom')
+  const askAsset = classifyAstroportAsset(params.askAssetDenom, 'askAssetDenom')
+  const operations: AstroSwapOperation[] = [
+    {
+      astro_swap: {
+        offer_asset_info: offerAsset,
+        ask_asset_info: askAsset,
+      },
+    },
+  ]
+
+  const lcdUrl = params.lcdUrl ?? TERRA_LCD
+  let quoteAmount: string
+  try {
+    quoteAmount = await querySimulate(lcdUrl, operations, offerAmount)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    throw new Error(
+      `astroport simulate_swap_operations failed for ${params.offerAssetDenom} → ${params.askAssetDenom}: ${message}`
+    )
+  }
+
+  return assembleAstroportSwap(params, quoteAmount)
+}

--- a/packages/sdk/src/tools/swap/astroport.ts
+++ b/packages/sdk/src/tools/swap/astroport.ts
@@ -155,7 +155,12 @@ function validateTerraAddress(value: string, fieldName: string): string {
     throw new Error(`invalid ${fieldName}: expected 20- or 32-byte payload, got ${payload.length}`)
   }
 
-  return trimmed
+  // Canonicalize to lowercase. bech32.decode confirmed case-uniformity above, so
+  // this is a safe canonical fold. CosmWasm `addr_validate` rejects an uppercase
+  // `TERRA1...` (or `to`) with "address not normalized" at execute time; folding
+  // here keeps the built `fromAddress` / inner `to` execute-ready, matching the
+  // CW20 contract-address normalization in classifyAstroportAsset.
+  return trimmed.toLowerCase()
 }
 
 /**

--- a/packages/sdk/src/tools/swap/index.ts
+++ b/packages/sdk/src/tools/swap/index.ts
@@ -6,3 +6,15 @@ export {
   NATIVE_SWAP_MIN_OUTBOUND_FEE_MULTIPLIER,
 } from '@vultisig/core-chain/swap/native/minimum/getNativeSwapMinAmountIn'
 export { getNativeSwapDecimals } from '@vultisig/core-chain/swap/native/utils/getNativeSwapDecimals'
+
+// Astroport in-chain swap (Terra v2 / phoenix-1) — builds unsigned wasm_execute
+export type { AstroportSwapResult, BuildAstroportSwapParams } from './astroport'
+export {
+  assembleAstroportSwap,
+  ASTROPORT_ROUTER,
+  buildAstroportSwap,
+  classifyAstroportAsset,
+  computeAstroportMinReceive,
+  TERRA_CHAIN_ID,
+  TERRA_LCD,
+} from './astroport'

--- a/packages/sdk/tests/unit/tools/swap/astroport.test.ts
+++ b/packages/sdk/tests/unit/tools/swap/astroport.test.ts
@@ -20,6 +20,13 @@ const RECIPIENT = 'terra1zdpgj8am5nqqvht927k3etljyl6a52kwqup0je'
 const VALOPER = 'terravaloper1qv9pzxqlyckngw6zf9g9whn9d3eh4qvghu0hpp'
 const VALCONS = 'terravalcons1qv9pzxqlyckngw6zf9g9whn9d3eh4qvgr0utdq'
 
+// Pin the canonical Astroport router as a LITERAL so a corrupted ASTROPORT_ROUTER
+// constant (funds → wrong/attacker contract) fails this assertion. Asserting only
+// against the imported symbol mutates both sides of the equality and stays green.
+// Verified on phoenix-1: contract_info.label = "Astroport Router", and matches
+// astroport-changelog terra-2/phoenix-1/core_phoenix.json `router_address`.
+const ASTROPORT_ROUTER_LITERAL = 'terra18plp90j0zd596zt3zdsf0w9vvk5ukwlwzwkksxv9mdu8rscat9sqndk5qz'
+
 const base: BuildAstroportSwapParams = {
   fromAddress: VAULT,
   offerAssetDenom: 'uluna',
@@ -82,6 +89,9 @@ describe('assembleAstroportSwap (native offer)', () => {
     expect(result.chain).toBe('Terra')
     expect(result.chainId).toBe('phoenix-1')
     expect(result.contractAddress).toBe(ASTROPORT_ROUTER)
+    // Pin the literal too — a corrupted ASTROPORT_ROUTER constant would still
+    // satisfy the symbol-equality above (both sides mutate together).
+    expect(result.contractAddress).toBe(ASTROPORT_ROUTER_LITERAL)
     expect(result.funds).toEqual([{ denom: 'uluna', amount: '1000000' }])
     expect(result.gas).toBe(600_000)
   })
@@ -116,6 +126,7 @@ describe('assembleAstroportSwap (CW20 offer)', () => {
     expect(result.funds).toEqual([])
     const msg = JSON.parse(result.executeMsg)
     expect(msg.send.contract).toBe(ASTROPORT_ROUTER)
+    expect(msg.send.contract).toBe(ASTROPORT_ROUTER_LITERAL)
     expect(msg.send.amount).toBe('1000000')
     const inner = JSON.parse(Buffer.from(msg.send.msg, 'base64').toString('utf8'))
     expect(inner.execute_swap_operations.minimum_receive).toBe('495000')
@@ -128,6 +139,23 @@ describe('assembleAstroportSwap (explicit recipient)', () => {
     expect(result.recipientMode).toBe('third_party')
     expect(result.toAddress).toBe(RECIPIENT)
     expect(JSON.parse(result.executeMsg).execute_swap_operations.to).toBe(RECIPIENT)
+  })
+})
+
+describe('assembleAstroportSwap (address normalization)', () => {
+  it('canonicalizes an uppercase explicit recipient to lowercase in the inner `to`', () => {
+    // bech32 accepts an all-uppercase address (same payload) but CosmWasm
+    // `addr_validate` rejects a non-normalized `to` at execute time. Fold to
+    // lowercase so the built envelope is execute-ready, matching the CW20
+    // contract-address normalization.
+    const result = assembleAstroportSwap({ ...base, recipientAddress: RECIPIENT.toUpperCase() }, '500000')
+    expect(result.toAddress).toBe(RECIPIENT)
+    expect(JSON.parse(result.executeMsg).execute_swap_operations.to).toBe(RECIPIENT)
+  })
+
+  it('canonicalizes an uppercase fromAddress to lowercase', () => {
+    const result = assembleAstroportSwap({ ...base, fromAddress: VAULT.toUpperCase() }, '500000')
+    expect(result.fromAddress).toBe(VAULT)
   })
 })
 

--- a/packages/sdk/tests/unit/tools/swap/astroport.test.ts
+++ b/packages/sdk/tests/unit/tools/swap/astroport.test.ts
@@ -12,6 +12,13 @@ import {
 const VAULT = 'terra1dcegyrekltswvyy0xy69ydgxn9x8x32zdtapd8' // 20-byte account
 const ASTRO_CW20 = 'terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26' // 32-byte CW20 contract
 const RECIPIENT = 'terra1zdpgj8am5nqqvht927k3etljyl6a52kwqup0je'
+// Validator operator / consensus keys on phoenix-1. These are NOT spendable
+// accounts — funds routed to them (or swap proceeds pinned to them) are
+// unrecoverable. mcp-ts guards these via assertNotValidatorHrp(); the SDK port
+// relies on the exact `decoded.prefix === 'terra'` check rejecting the distinct
+// `terravaloper` / `terravalcons` HRPs. Pin that equivalence so it can't drift.
+const VALOPER = 'terravaloper1qv9pzxqlyckngw6zf9g9whn9d3eh4qvghu0hpp'
+const VALCONS = 'terravalcons1qv9pzxqlyckngw6zf9g9whn9d3eh4qvgr0utdq'
 
 const base: BuildAstroportSwapParams = {
   fromAddress: VAULT,
@@ -130,6 +137,34 @@ describe('assembleAstroportSwap validation', () => {
     expect(() =>
       assembleAstroportSwap({ ...base, fromAddress: 'cosmos1dcegyrekltswvyy0xy69ydgxn9x8x32zt08p08' }, '500000')
     ).toThrow(/expected terra prefix/)
+  })
+
+  it('rejects a validator operator / consensus sender (valoper / valcons HRP)', () => {
+    // Fund-safety equivalence with mcp-ts assertNotValidatorHrp(): the exact
+    // `terra`-prefix check must reject the distinct validator HRPs. A valoper /
+    // valcons sender is not a spendable account.
+    expect(() => assembleAstroportSwap({ ...base, fromAddress: VALOPER }, '500000')).toThrow(/expected terra prefix/)
+    expect(() => assembleAstroportSwap({ ...base, fromAddress: VALCONS }, '500000')).toThrow(/expected terra prefix/)
+  })
+
+  it('rejects a validator operator / consensus explicit recipient (proceed-redirect guard)', () => {
+    // The explicit-recipient path runs the same validateTerraAddress guard, so
+    // swap proceeds can never be pinned to a valoper/valcons (or any non-terra)
+    // address even when an explicit recipient is supplied.
+    expect(() => assembleAstroportSwap({ ...base, recipientAddress: VALOPER }, '500000')).toThrow(
+      /expected terra prefix/
+    )
+    expect(() =>
+      assembleAstroportSwap({ ...base, recipientAddress: 'cosmos1dcegyrekltswvyy0xy69ydgxn9x8x32zt08p08' }, '500000')
+    ).toThrow(/expected terra prefix/)
+  })
+
+  it('rejects a malformed quote amount (no signed payload built from garbage)', () => {
+    // The quote feeds minimum_receive on the signed envelope. A non-integer
+    // quote must fail closed rather than silently produce a degenerate floor.
+    expect(() => assembleAstroportSwap(base, '12.5')).toThrow(/invalid quoteAmount/)
+    expect(() => assembleAstroportSwap(base, '')).toThrow(/invalid quoteAmount/)
+    expect(() => assembleAstroportSwap(base, 'abc')).toThrow(/invalid quoteAmount/)
   })
 
   it('rejects a zero / non-integer offer amount', () => {

--- a/packages/sdk/tests/unit/tools/swap/astroport.test.ts
+++ b/packages/sdk/tests/unit/tools/swap/astroport.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  assembleAstroportSwap,
+  ASTROPORT_ROUTER,
+  type BuildAstroportSwapParams,
+  classifyAstroportAsset,
+  computeAstroportMinReceive,
+} from '../../../../src/tools/swap/astroport'
+
+// Real phoenix-1 addresses for shape assertions.
+const VAULT = 'terra1dcegyrekltswvyy0xy69ydgxn9x8x32zdtapd8' // 20-byte account
+const ASTRO_CW20 = 'terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26' // 32-byte CW20 contract
+const RECIPIENT = 'terra1zdpgj8am5nqqvht927k3etljyl6a52kwqup0je'
+
+const base: BuildAstroportSwapParams = {
+  fromAddress: VAULT,
+  offerAssetDenom: 'uluna',
+  offerAmount: '1000000',
+  askAssetDenom: ASTRO_CW20,
+  slippageTolerance: 0.01,
+}
+
+describe('classifyAstroportAsset', () => {
+  it('classifies a native bank denom as native_token', () => {
+    expect(classifyAstroportAsset('uluna', 'offer')).toEqual({
+      native_token: { denom: 'uluna' },
+    })
+  })
+
+  it('classifies factory and ibc denoms as native_token', () => {
+    expect(classifyAstroportAsset('factory/terra1abc/shr', 'offer')).toEqual({
+      native_token: { denom: 'factory/terra1abc/shr' },
+    })
+    expect(classifyAstroportAsset('ibc/ABCDEF', 'offer')).toEqual({
+      native_token: { denom: 'ibc/ABCDEF' },
+    })
+  })
+
+  it('classifies a 32-byte terra1 bech32 as a CW20 token (canonicalized lowercase)', () => {
+    expect(classifyAstroportAsset(ASTRO_CW20.toUpperCase(), 'ask')).toEqual({
+      token: { contract_addr: ASTRO_CW20 },
+    })
+  })
+
+  it('rejects a terra1-prefixed string that is not valid bech32 (no silent native fallback)', () => {
+    expect(() => classifyAstroportAsset('terra1notvalidbech32!!!', 'offer')).toThrow(/not valid bech32/)
+  })
+
+  it('rejects a 20-byte account masquerading as a swap asset', () => {
+    expect(() => classifyAstroportAsset(VAULT, 'offer')).toThrow(/user account/)
+  })
+})
+
+describe('computeAstroportMinReceive', () => {
+  it('applies integer-only bps haircut', () => {
+    // 1_000_000 * (1 - 0.01) = 990_000
+    expect(computeAstroportMinReceive('1000000', 0.01)).toBe('990000')
+  })
+
+  it('no haircut at zero slippage', () => {
+    expect(computeAstroportMinReceive('123456789', 0)).toBe('123456789')
+  })
+
+  it('5% cap haircut', () => {
+    expect(computeAstroportMinReceive('1000000', 0.05)).toBe('950000')
+  })
+})
+
+describe('assembleAstroportSwap (native offer)', () => {
+  const result = assembleAstroportSwap(base, '500000')
+
+  it('builds a direct router execute with funds for a native offer', () => {
+    expect(result.txType).toBe('wasm_execute')
+    expect(result.chain).toBe('Terra')
+    expect(result.chainId).toBe('phoenix-1')
+    expect(result.contractAddress).toBe(ASTROPORT_ROUTER)
+    expect(result.funds).toEqual([{ denom: 'uluna', amount: '1000000' }])
+    expect(result.gas).toBe(600_000)
+  })
+
+  it('encodes execute_swap_operations with a single astro_swap hop', () => {
+    const msg = JSON.parse(result.executeMsg)
+    expect(msg.execute_swap_operations.operations[0].astro_swap).toEqual({
+      offer_asset_info: { native_token: { denom: 'uluna' } },
+      ask_asset_info: { token: { contract_addr: ASTRO_CW20 } },
+    })
+    expect(msg.execute_swap_operations.minimum_receive).toBe('495000') // 500000 * 0.99
+  })
+
+  it('defaults to self recipient (no `to` field, recipientMode self)', () => {
+    expect(result.recipientMode).toBe('self')
+    expect(result.toAddress).toBeUndefined()
+    expect(JSON.parse(result.executeMsg).execute_swap_operations.to).toBeUndefined()
+  })
+
+  it('surfaces a quote block matching the simulate amount', () => {
+    expect(result.quote.expectedAskAmount).toBe('500000')
+    expect(result.quote.minReceive).toBe('495000')
+    expect(result.quote.slippageTolerance).toBe(0.01)
+  })
+})
+
+describe('assembleAstroportSwap (CW20 offer)', () => {
+  const result = assembleAstroportSwap({ ...base, offerAssetDenom: ASTRO_CW20, askAssetDenom: 'uluna' }, '500000')
+
+  it('wraps execute_swap_operations in a base64 Cw20ReceiveMsg send envelope', () => {
+    expect(result.contractAddress).toBe(ASTRO_CW20)
+    expect(result.funds).toEqual([])
+    const msg = JSON.parse(result.executeMsg)
+    expect(msg.send.contract).toBe(ASTROPORT_ROUTER)
+    expect(msg.send.amount).toBe('1000000')
+    const inner = JSON.parse(Buffer.from(msg.send.msg, 'base64').toString('utf8'))
+    expect(inner.execute_swap_operations.minimum_receive).toBe('495000')
+  })
+})
+
+describe('assembleAstroportSwap (explicit recipient)', () => {
+  it('sets toAddress + third_party mode and inner `to` when a recipient is given', () => {
+    const result = assembleAstroportSwap({ ...base, recipientAddress: RECIPIENT }, '500000')
+    expect(result.recipientMode).toBe('third_party')
+    expect(result.toAddress).toBe(RECIPIENT)
+    expect(JSON.parse(result.executeMsg).execute_swap_operations.to).toBe(RECIPIENT)
+  })
+})
+
+describe('assembleAstroportSwap validation', () => {
+  it('rejects a non-terra sender prefix', () => {
+    // A valid cosmos1 bech32 — decodes fine but the wrong HRP for phoenix-1.
+    expect(() =>
+      assembleAstroportSwap({ ...base, fromAddress: 'cosmos1dcegyrekltswvyy0xy69ydgxn9x8x32zt08p08' }, '500000')
+    ).toThrow(/expected terra prefix/)
+  })
+
+  it('rejects a zero / non-integer offer amount', () => {
+    expect(() => assembleAstroportSwap({ ...base, offerAmount: '0' }, '500000')).toThrow(/greater than zero/)
+    expect(() => assembleAstroportSwap({ ...base, offerAmount: '1.5' }, '500000')).toThrow(/base units/)
+  })
+
+  it('rejects slippage above the 5% cap', () => {
+    expect(() => assembleAstroportSwap({ ...base, slippageTolerance: 0.1 }, '500000')).toThrow(/slippageTolerance/)
+  })
+})

--- a/scripts/receipts/swap_astroport.mjs
+++ b/scripts/receipts/swap_astroport.mjs
@@ -1,0 +1,50 @@
+/**
+ * Runnable receipt for sdk.swap.astroport (Terra Astroport in-chain swap).
+ *
+ * Hits the LIVE phoenix-1 LCD (terra-lcd.publicnode.com) to quote a real
+ * uluna → ASTRO swap via the Astroport router's simulate_swap_operations
+ * smart query, then builds and prints the UNSIGNED wasm_execute envelope.
+ *
+ * NO signing, NO broadcast — pure quote + build.
+ *
+ *   node --import tsx scripts/receipts/swap_astroport.mjs
+ */
+import { buildAstroportSwap } from '../../packages/sdk/src/tools/swap/astroport.ts'
+
+// Live ASTRO CW20 on phoenix-1.
+const ASTRO_CW20 =
+  'terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26'
+// Dummy vault sender (valid terra1 bech32 — never funded, never signed).
+const VAULT = 'terra1dcegyrekltswvyy0xy69ydgxn9x8x32zdtapd8'
+
+const params = {
+  fromAddress: VAULT,
+  offerAssetDenom: 'uluna',
+  offerAmount: '1000000', // 1 LUNA
+  askAssetDenom: ASTRO_CW20,
+  slippageTolerance: 0.01,
+}
+
+console.log('=== sdk.swap.astroport receipt (LIVE phoenix-1 LCD) ===')
+console.log('params:', JSON.stringify(params, null, 2))
+
+const result = await buildAstroportSwap(params)
+
+console.log('\n--- unsigned wasm_execute envelope ---')
+console.log(JSON.stringify(result, null, 2))
+
+console.log('\n--- decoded execute_msg ---')
+console.log(JSON.stringify(JSON.parse(result.executeMsg), null, 2))
+
+// Light assertions so a broken build fails the receipt loudly.
+if (result.txType !== 'wasm_execute') throw new Error('txType mismatch')
+if (result.contractAddress !== params.askAssetDenom && result.funds.length !== 1)
+  throw new Error('native offer should carry funds')
+if (BigInt(result.quote.minReceive) > BigInt(result.quote.expectedAskAmount))
+  throw new Error('minReceive must be <= expectedAskAmount')
+if (result.recipientMode !== 'self')
+  throw new Error('expected self recipient default')
+
+console.log('\nOK: live quote =', result.quote.expectedAskAmount, 'uASTRO base units')
+console.log('OK: min_receive (1% slippage) =', result.quote.minReceive)
+console.log('OK: built unsigned envelope, no broadcast.')


### PR DESCRIPTION
## what

Adds `sdk.swap.astroport` — `buildAstroportSwap` quotes (read-only `simulate_swap_operations` on the live phoenix-1 LCD) and builds an **unsigned** Astroport router `wasm_execute` envelope for Terra v2 in-chain swaps (LUNA ↔ ASTRO / ampLUNA / aUSD / etc).

Pure-crypto primitive: it quotes + builds-unsigned, and **never signs or broadcasts**. The returned envelope is handed to the SDK signing path by the consumer.

Two execute shapes, picked by the offer asset:
- **Native offer** (`uluna`, `factory/...`, `ibc/...`): direct router call with `funds`.
- **CW20 offer** (`terra1...` 32-byte contract): base64 `Cw20ReceiveMsg.send` envelope through the CW20, funds forwarded to the router.

Fund-safety carried over from the mcp-ts original:
- `terra1...`-prefixed denom that fails bech32 decode is **rejected loudly** (model fabrication) instead of silently falling through to `native_token`.
- 20-byte `terra1...` (a user account) is rejected as a swap asset.
- explicit `recipientAddress` is the only path that sets the inner `to` — a missing `to` means "router sends to the signer" (the safe default), so a prompt-injected `fromAddress` can't redirect proceeds. Surfaced top-level as `recipientMode: 'self' | 'third_party'` so the approval layer needn't decode the nested base64.
- `minReceive` is integer-only bps math (no float drift on the signed payload); slippage capped at 5%.

## why

Part of the mcp-ts/backend → SDK code-as-action consolidation. The mcp-ts `build_astroport_swap` tool's crypto core (address validation, asset classification, route assembly, min-receive math, unsigned envelope) becomes a reusable SDK primitive. The orchestration-only concerns — Skip-fallback, Blockaid scan-request wrapping, quest-metadata, price-oracle USD derivation — intentionally stay in the consumer.

## consumers unblocked

- **mcp-ts** `build_astroport_swap` can drop its hand-rolled bech32/asset/min-receive logic and wrap `sdk.swap.astroport`.
- **agent-backend** and **Station/Windows** get the same in-chain Terra swap builder without re-implementing the Astroport wire format.

## RECEIPT

Live quote against phoenix-1 (`terra-lcd.publicnode.com`), real `simulate_swap_operations`, builds the unsigned envelope, no broadcast:

```
$ node --import tsx scripts/receipts/swap_astroport.mjs

=== sdk.swap.astroport receipt (LIVE phoenix-1 LCD) ===
params: {
  "fromAddress": "terra1dcegyrekltswvyy0xy69ydgxn9x8x32zdtapd8",
  "offerAssetDenom": "uluna",
  "offerAmount": "1000000",
  "askAssetDenom": "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26",
  "slippageTolerance": 0.01
}

--- unsigned wasm_execute envelope ---
{
  "txType": "wasm_execute",
  "chain": "Terra",
  "chainId": "phoenix-1",
  "fromAddress": "terra1dcegyrekltswvyy0xy69ydgxn9x8x32zdtapd8",
  "contractAddress": "terra18plp90j0zd596zt3zdsf0w9vvk5ukwlwzwkksxv9mdu8rscat9sqndk5qz",
  "executeMsg": "{\"execute_swap_operations\":{\"operations\":[{\"astro_swap\":{\"offer_asset_info\":{\"native_token\":{\"denom\":\"uluna\"}},\"ask_asset_info\":{\"token\":{\"contract_addr\":\"terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26\"}}}}],\"minimum_receive\":\"6706674\"}}",
  "funds": [{ "denom": "uluna", "amount": "1000000" }],
  "gas": 600000,
  "recipientMode": "self",
  "quote": {
    "offerAsset": "uluna",
    "offerAmount": "1000000",
    "askAsset": "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26",
    "expectedAskAmount": "6774419",
    "minReceive": "6706674",
    "slippageTolerance": 0.01
  }
}

OK: live quote = 6774419 uASTRO base units
OK: min_receive (1% slippage) = 6706674
OK: built unsigned envelope, no broadcast.
```

Quality gates (worktree off `origin/main`):

```
$ yarn workspace @vultisig/sdk typecheck   # 0 errors
$ yarn workspace @vultisig/sdk test tests/unit/tools/swap/astroport.test.ts
  Test Files  111 passed (111)
       Tests  1527 passed (1527)
```

The unit test covers native + CW20 offer shapes, the base64 `Cw20ReceiveMsg` envelope, explicit-recipient `to`, the fund-safety rejections (fabricated `terra1`, 20-byte account, wrong HRP, zero/non-integer amount, slippage > 5%), and the bps min-receive math.

🤖 Generated with [Claude Code](https://claude.com/claude-code)