### PR TITLE
feat(sdk): add sdk.validate.chainPrefix + sdk.address.classify/isValidFor

### DIFF
--- a/packages/sdk/scripts/receipts/validate_chain_prefix.mjs
+++ b/packages/sdk/scripts/receipts/validate_chain_prefix.mjs
@@ -1,0 +1,62 @@
+/**
+ * Runnable receipt for sdk.validate.chainPrefix + sdk.address.classify/isValidFor.
+ *
+ * Pure FORMAT validation — no network, no signing. Classifies real mainnet
+ * addresses to their chain family and flags an osmo-address-claimed-as-ethereum
+ * HRP mismatch (the fund-safety case ported from the Go agent backend).
+ *
+ * Run:
+ *   node --import tsx packages/sdk/scripts/receipts/validate_chain_prefix.mjs
+ */
+
+import { address, validate } from '../../src/utils/addressValidation.ts'
+
+const KNOWN = [
+  { label: 'ethereum (vitalik.eth)', addr: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045' },
+  { label: 'osmosis', addr: 'osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyat' },
+  { label: 'solana', addr: '7EYnhQoR9YM3N7UoaKRoA44Uy8JeaZV3qyouov87awMs' },
+  { label: 'bitcoin (bech32)', addr: 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq' },
+]
+
+console.log('=== sdk.address.classify (real mainnet addresses) ===')
+for (const { label, addr } of KNOWN) {
+  console.log(
+    `  ${label.padEnd(22)} -> ${address.classify(addr).padEnd(8)} (${addr.slice(0, 10)}…)`
+  )
+}
+
+console.log('\n=== sdk.validate.chainPrefix — mismatch detection ===')
+const osmoOnEth = validate.chainPrefix(
+  'osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyat',
+  'ethereum'
+)
+console.log('  osmo address claimed as ethereum:')
+console.log('   ', JSON.stringify(osmoOnEth))
+
+const ethOnEth = validate.chainPrefix(
+  '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+  'ethereum'
+)
+console.log('  eth address on ethereum:')
+console.log('   ', JSON.stringify(ethOnEth))
+
+console.log('\n=== assertions ===')
+const checks = [
+  ['osmo->cosmos', address.classify('osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyat') === 'cosmos'],
+  ['eth->evm', address.classify('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045') === 'evm'],
+  ['sol->solana', address.classify('7EYnhQoR9YM3N7UoaKRoA44Uy8JeaZV3qyouov87awMs') === 'solana'],
+  ['btc->btc', address.classify('bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq') === 'btc'],
+  ['osmo-as-eth is mismatch', osmoOnEth.valid === false && osmoOnEth.reason === 'mismatch'],
+  ['eth-on-eth is match', ethOnEth.valid === true && ethOnEth.reason === 'match'],
+]
+let ok = true
+for (const [name, pass] of checks) {
+  console.log(`  ${pass ? 'PASS' : 'FAIL'}  ${name}`)
+  if (!pass) ok = false
+}
+
+if (!ok) {
+  console.error('\nRECEIPT FAILED')
+  process.exit(1)
+}
+console.log('\nRECEIPT OK — all checks passed')

--- a/packages/sdk/scripts/receipts/validate_chain_prefix.mjs
+++ b/packages/sdk/scripts/receipts/validate_chain_prefix.mjs
@@ -40,6 +40,16 @@ const ethOnEth = validate.chainPrefix(
 console.log('  eth address on ethereum:')
 console.log('   ', JSON.stringify(ethOnEth))
 
+console.log('\n=== valoper field-aware routing (cosmos staking, ported from Go cosmosValopers) ===')
+const COSMOS_DELEGATOR = 'cosmos1qnk2n4nlkpw9xfqntladh74er2xa62wgas5zg'
+const COSMOS_VALOPER = 'cosmosvaloper1clpqr4nrk4khgkxj78fcwwh6dl3uw4epsluffn'
+const delegatorAsValidator = validate.chainPrefix(COSMOS_DELEGATOR, 'cosmos', 'validator')
+const valoperAsValidator = validate.chainPrefix(COSMOS_VALOPER, 'cosmos', 'validator')
+console.log('  cosmos1… delegator on a validator_address field (must be blocked):')
+console.log('   ', JSON.stringify(delegatorAsValidator))
+console.log('  cosmosvaloper1… operator on a validator_address field (must pass):')
+console.log('   ', JSON.stringify(valoperAsValidator))
+
 console.log('\n=== assertions ===')
 const checks = [
   ['osmo->cosmos', address.classify('osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyat') === 'cosmos'],
@@ -48,6 +58,12 @@ const checks = [
   ['btc->btc', address.classify('bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq') === 'btc'],
   ['osmo-as-eth is mismatch', osmoOnEth.valid === false && osmoOnEth.reason === 'mismatch'],
   ['eth-on-eth is match', ethOnEth.valid === true && ethOnEth.reason === 'match'],
+  // valoper fund-safety: a cosmos1… delegator must NOT pass as a validator, a
+  // cosmosvaloper1… operator MUST pass. Account role keeps account semantics.
+  ['cosmos1 delegator blocked on validator field', delegatorAsValidator.valid === false && delegatorAsValidator.reason === 'mismatch'],
+  ['cosmosvaloper1 operator passes on validator field', valoperAsValidator.valid === true && valoperAsValidator.reason === 'match'],
+  ['valoper rejected under account role', address.isValidFor(COSMOS_VALOPER, 'cosmos') === false],
+  ['valoper string not misread as solana', address.classify(COSMOS_VALOPER) !== 'solana'],
 ]
 let ok = true
 for (const [name, pass] of checks) {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -43,6 +43,23 @@ export type { FiatToAmountParams } from './utils/fiatToAmount'
 export { fiatToAmount, FiatToAmountError } from './utils/fiatToAmount'
 export { normalizeChain, UnknownChainError } from './utils/normalizeChain'
 
+// Pure address-format validation (vault-free, no network, no signing):
+//   sdk.validate.chainPrefix(address, chain) — HRP/format mismatch check
+//   sdk.address.classify(address)            — chain family of an address
+//   sdk.address.isValidFor(address, chain)   — is the format valid for a chain
+// Canonical port of the Go agent-backend chain-prefix / per-family address
+// FORMAT rules (collapses the Go + abt duplicates).
+export {
+  canonicalChainTag,
+  classifyAddress,
+  isAddressValidForChain,
+  isSolanaAddress,
+  supportedChainTags,
+} from './utils/addressFormat'
+export type { AddressFamily, ChainPrefixResult } from './utils/addressValidation'
+export { address, validate } from './utils/addressValidation'
+export { checkChainPrefix } from './utils/chainPrefix'
+
 // ============================================================================
 // PUBLIC API - Station Migration Primitives
 // ============================================================================

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -56,7 +56,7 @@ export {
   isSolanaAddress,
   supportedChainTags,
 } from './utils/addressFormat'
-export type { AddressFamily, ChainPrefixResult } from './utils/addressValidation'
+export type { AddressFamily, AddressRole, ChainPrefixResult } from './utils/addressValidation'
 export { address, validate } from './utils/addressValidation'
 export { checkChainPrefix } from './utils/chainPrefix'
 

--- a/packages/sdk/src/utils/addressFormat.ts
+++ b/packages/sdk/src/utils/addressFormat.ts
@@ -96,6 +96,7 @@ const reSolanaBase58Alphabet = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/
  * Ported from chain_prefix_extractor.go knownBech32HRPs.
  */
 const knownBech32HRPs = [
+  // Account HRPs — verbatim from Go knownBech32HRPs.
   'cosmos1',
   'osmo1',
   'thor1',
@@ -116,6 +117,25 @@ const knownBech32HRPs = [
   'cre1',
   'stars1',
   'juno1',
+  // Validator-operator (valoper) HRPs — Go carries these so a valoper bech32
+  // string that happens to base58-decode to 32 bytes is never misread as a
+  // Solana key. Ported 1:1 from Go knownBech32HRPs (chain_prefix_extractor.go).
+  'cosmosvaloper1',
+  'osmovaloper1',
+  'kujivaloper1',
+  'dydxvaloper1',
+  'akashvaloper1',
+  'stridevaloper1',
+  'terravaloper1',
+  'seivaloper1',
+  'kavavaloper1',
+  'persistencevaloper1',
+  'axelarvaloper1',
+  'secretvaloper1',
+  'starsvaloper1',
+  'junovaloper1',
+  // qbtc is SDK-local (Go's base list lacks it); the qbtc account HRP is part
+  // of chainHRPMap below so we keep it here too for the Solana-decode guard.
   'qbtc1',
 ]
 
@@ -164,6 +184,41 @@ const cosmosHRPByChain: Record<string, string> = {
   stargaze: 'stars',
   juno: 'juno',
   qbtc: 'qbtc',
+}
+
+/**
+ * Cosmos validator-operator (valoper) HRP table: canonical chain tag ->
+ * valoper bech32 HRP. Ported 1:1 from Go `cosmosValopers`
+ * (chain_prefix_extractor.go).
+ *
+ * Staking builds carry the validator address under `validator_address`,
+ * `validator_src_address`, `validator_dst_address` — those fields use the
+ * valoper prefix (`<chain>valoper1…`), NOT the account prefix (`<chain>1…`).
+ * Validating a validator field against the ACCOUNT rule is a fund-safety
+ * regression: it silently passes a `cosmos1…` delegator address where a
+ * validator operator is required, and wrongly rejects a valid
+ * `cosmosvaloper1…` operator address.
+ *
+ * Chains with no public staking validators (thorchain, mayachain, noble,
+ * injective, celestia, crescent, qbtc) are intentionally omitted to match Go
+ * and avoid false-block risk on non-standard/permissioned staking surfaces.
+ */
+const cosmosValoperByChain: Record<string, string> = {
+  cosmos: 'cosmosvaloper',
+  osmosis: 'osmovaloper',
+  kujira: 'kujivaloper',
+  dydx: 'dydxvaloper',
+  akash: 'akashvaloper',
+  stride: 'stridevaloper',
+  terra: 'terravaloper',
+  terraclassic: 'terravaloper',
+  sei: 'seivaloper',
+  kava: 'kavavaloper',
+  persistence: 'persistencevaloper',
+  axelar: 'axelarvaloper',
+  secret: 'secretvaloper',
+  stargaze: 'starsvaloper',
+  juno: 'junovaloper',
 }
 
 /** All cosmos HRP bodies (deduped) for family classification. */
@@ -336,16 +391,44 @@ export function classifyAddress(address: string): AddressFamily {
 }
 
 /**
+ * Address role within a tool call. Mirrors the Go validator's field-aware
+ * routing (chain_prefix_extractor.go):
+ *  - `account`   — a normal account/recipient address (default). Validated
+ *    against the chain's account HRP (`<chain>1…`).
+ *  - `validator` — a validator-operator address (staking `validator_address`,
+ *    `validator_src_address`, `validator_dst_address`). On cosmos chains with a
+ *    valoper HRP, validated against the valoper rule (`<chain>valoper1…`).
+ */
+export type AddressRole = 'account' | 'validator'
+
+/**
  * isAddressValidForChain returns true when `address` is a valid FORMAT for
  * `chain` (HRP / prefix / regex match), false on a format/prefix mismatch, and
  * `undefined` when `chain` has no FORMAT rule in the table (caller cannot
  * decide — same semantics as the backend's `!ok` skip on chainHRPMap).
+ *
+ * When `role === 'validator'` and the (cosmos) chain defines a valoper HRP, the
+ * address is validated against the valoper rule (`<chain>valoper1…`) instead of
+ * the account rule. This ports the Go `cosmosValopers` / `validatorAddressFields`
+ * switch: a staking validator field must carry a `cosmosvaloper1…` operator
+ * address, NOT a `cosmos1…` delegator address. Chains without a valoper entry
+ * fall back to the account rules (matches Go's `effectiveRules = rules` default).
  */
-export function isAddressValidForChain(address: string, chain: string): boolean | undefined {
+export function isAddressValidForChain(
+  address: string,
+  chain: string,
+  role: AddressRole = 'account'
+): boolean | undefined {
   const tag = canonicalChainTag(chain)
   const rules = chainFormatRules[tag]
   if (!rules) return undefined
   const addr = address.trim()
+  if (role === 'validator') {
+    const valoperHRP = cosmosValoperByChain[tag]
+    if (valoperHRP) {
+      return cosmosHRPRegex(valoperHRP).test(addr)
+    }
+  }
   return rules.some(rule => rule(addr))
 }
 

--- a/packages/sdk/src/utils/addressFormat.ts
+++ b/packages/sdk/src/utils/addressFormat.ts
@@ -1,0 +1,355 @@
+/**
+ * Pure address-format validation primitives.
+ *
+ * Canonical port of the FORMAT rules from the agent backend's
+ * chain-prefix / per-family address validators
+ * (agent-backend internal/service/agent/validator/chain_prefix_extractor.go
+ * and validator/address/*.go) and the abt src/mastra/chainPrefix.ts mirror.
+ *
+ * Scope: FORMAT ONLY — regex shape, bech32 HRP, base58-decode length.
+ * This module answers two questions:
+ *   1. `classifyAddress(addr)` -> which chain family does this address belong to?
+ *   2. `isAddressValidForChain(addr, chain)` -> is this address a valid format
+ *      for the given chain (HRP/prefix match)?
+ *
+ * It deliberately does NOT do:
+ *   - intent-match (does the address match what the user asked for)
+ *   - grounding (is the address present in tool output)
+ *   - prompt-injection / fabrication detection
+ *   - checksum verification (shape-valid is the contract here, same as the
+ *     backend extractors which validate shape, not cryptographic checksum)
+ * Those stay in the agent backend's judgement layer. This is pure crypto
+ * format-validation, RN-safe (bs58 is pure JS), no network, no signing.
+ */
+
+import bs58 from 'bs58'
+
+/**
+ * Coarse chain-family tag. Mirrors the backend `address.Family` enum.
+ * `unknown` is returned when an address matches no known family format.
+ */
+export type AddressFamily =
+  | 'evm'
+  | 'cosmos'
+  | 'solana'
+  | 'btc'
+  | 'bitcoincash'
+  | 'litecoin'
+  | 'dogecoin'
+  | 'dash'
+  | 'sui'
+  | 'ton'
+  | 'tron'
+  | 'xrp'
+  | 'cardano'
+  | 'polkadot'
+  | 'bittensor'
+  | 'zcash'
+  | 'unknown'
+
+// ---------------------------------------------------------------------------
+// FORMAT regexes — ported verbatim from chain_prefix_extractor.go (anchored
+// full-string variants, NOT the \b-bounded scanning regexes from extract.go).
+// ---------------------------------------------------------------------------
+
+/** 0x + exactly 40 hex chars (EVM addresses). */
+const reEVM = /^0x[0-9a-fA-F]{40}$/
+/** bc1... native SegWit + Taproot. */
+const reBTCNativeSegWit = /^bc1[02-9ac-hj-np-z]{25,70}$/
+/** P2PKH (1...) and P2SH (3...) legacy Bitcoin. */
+const reBTCLegacy = /^[13][1-9A-HJ-NP-Za-km-z]{25,34}$/
+/** Bitcoin Cash cashaddr (q/p prefix, 41 chars, optional scheme). */
+const reBCH = /^(?:bitcoincash:)?[qp][a-z0-9]{41}$/
+/** Litecoin bech32 (ltc1...). */
+const reLTCBech32 = /^ltc1[02-9ac-hj-np-z]{25,70}$/
+/** Litecoin legacy (L or M prefix). */
+const reLTCLegacy = /^[LM][1-9A-HJ-NP-Za-km-z]{25,34}$/
+/** Dogecoin (D prefix). */
+const reDOGE = /^D[5-9A-HJ-NP-U][1-9A-HJ-NP-Za-km-z]{25,34}$/
+/** Dash (X prefix). */
+const reDASH = /^X[1-9A-HJ-NP-Za-km-z]{25,34}$/
+/** XRP classic (r + base58, 25-34 chars). */
+const reXRP = /^r[1-9A-HJ-NP-Za-km-z]{24,33}$/
+/** TON user-friendly base64url (EQ.../UQ..., 48 chars). */
+const reTON = /^[EU]Q[A-Za-z0-9_-]{46}$/
+/** Zcash transparent (t1/t3 + base58). */
+const reZcashT = /^t[13][1-9A-HJ-NP-Za-km-z]{32,34}$/
+/** Zcash shielded (zs1 + bech32-like). */
+const reZcashZ = /^zs1[0-9a-z]{75,80}$/
+/** Sui (0x + exactly 64 hex chars). */
+const reSui = /^0x[0-9a-fA-F]{64}$/
+/** Tron mainnet ('T' + 33 base58, 34 chars total). */
+const reTron = /^T[1-9A-HJ-NP-Za-km-z]{33}$/
+/** Polkadot SS58 prefix-0 ('1' + 46-47 base58). */
+const rePolkadot = /^1[1-9A-HJ-NP-Za-km-z]{46,47}$/
+/** Bittensor SS58 prefix-42 ('5' + 46-47 base58). */
+const reBittensor = /^5[1-9A-HJ-NP-Za-km-z]{46,47}$/
+/** Cardano across Shelley + Byron era families. */
+const reCardano =
+  /^(addr1[a-z0-9]{50,}|addr_test1[a-z0-9]{50,}|Ae2[1-9A-HJ-NP-Za-km-z]{50,}|DdzFF[1-9A-HJ-NP-Za-km-z]{50,})$/
+/** base58-alphabet pre-filter (32-44 chars) before the more expensive decode. */
+const reSolanaBase58Alphabet = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/
+
+/**
+ * Well-known bech32 HRPs that, when a base58-decodable string starts with one,
+ * mean it is NOT a Solana key even if it decodes to 32 bytes by coincidence.
+ * Ported from chain_prefix_extractor.go knownBech32HRPs.
+ */
+const knownBech32HRPs = [
+  'cosmos1',
+  'osmo1',
+  'thor1',
+  'maya1',
+  'kujira1',
+  'noble1',
+  'inj1',
+  'celestia1',
+  'dydx1',
+  'akash1',
+  'stride1',
+  'terra1',
+  'sei1',
+  'kava1',
+  'persistence1',
+  'axelar1',
+  'secret1',
+  'cre1',
+  'stars1',
+  'juno1',
+  'qbtc1',
+]
+
+/**
+ * isSolanaAddress mirrors the backend's isSolanaAddress: base58-alphabet
+ * pre-filter, NOT a known bech32 HRP, and base58-decodes to exactly 32 bytes
+ * (Ed25519 key size).
+ */
+export function isSolanaAddress(addr: string): boolean {
+  if (!reSolanaBase58Alphabet.test(addr)) return false
+  for (const hrp of knownBech32HRPs) {
+    if (addr.startsWith(hrp)) return false
+  }
+  try {
+    return bs58.decode(addr).length === 32
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Cosmos-family HRP table: canonical chain tag -> bech32 human-readable part.
+ * Ported from chainHRPMap (cosmosHRP entries) in chain_prefix_extractor.go.
+ * An address valid for one of these is `<hrp>1` + 25-70 bech32 chars.
+ */
+const cosmosHRPByChain: Record<string, string> = {
+  cosmos: 'cosmos',
+  osmosis: 'osmo',
+  thorchain: 'thor',
+  mayachain: 'maya',
+  kujira: 'kujira',
+  noble: 'noble',
+  injective: 'inj',
+  celestia: 'celestia',
+  dydx: 'dydx',
+  akash: 'akash',
+  stride: 'stride',
+  terra: 'terra',
+  terraclassic: 'terra',
+  sei: 'sei',
+  kava: 'kava',
+  persistence: 'persistence',
+  axelar: 'axelar',
+  secret: 'secret',
+  crescent: 'cre',
+  stargaze: 'stars',
+  juno: 'juno',
+  qbtc: 'qbtc',
+}
+
+/** All cosmos HRP bodies (deduped) for family classification. */
+const cosmosHRPs = Array.from(new Set(Object.values(cosmosHRPByChain)))
+
+/** Build the anchored cosmos bech32 regex for a given HRP. */
+function cosmosHRPRegex(hrp: string): RegExp {
+  const escaped = hrp.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`^${escaped}1[0-9a-z]{25,70}$`)
+}
+
+/** True when addr is a valid cosmos bech32 for ANY known HRP. */
+function isAnyCosmosAddress(addr: string): boolean {
+  for (const hrp of cosmosHRPs) {
+    if (cosmosHRPRegex(hrp).test(addr)) return true
+  }
+  return false
+}
+
+// ---------------------------------------------------------------------------
+// Per-chain FORMAT rule table. Maps canonical chain tag -> matcher(s).
+// Ported from chainHRPMap. EVM-family chains share evmRule, etc.
+// ---------------------------------------------------------------------------
+
+type Matcher = (addr: string) => boolean
+const re =
+  (r: RegExp): Matcher =>
+  (addr: string) =>
+    r.test(addr)
+
+const evmRule = re(reEVM)
+
+const evmChains = [
+  'ethereum',
+  'base',
+  'polygon',
+  'bsc',
+  'arbitrum',
+  'optimism',
+  'avalanche',
+  'hyperevm',
+  'hyperliquid',
+  'katana',
+  'plasma',
+  'mantle',
+  'blast',
+  'cronos',
+  'zksync',
+  'linea',
+  'scroll',
+]
+
+/**
+ * chainFormatRules maps a canonical chain tag to the FORMAT rule(s) valid for
+ * that chain. Mirrors chainHRPMap. An address that matches none of a chain's
+ * rules is a format/prefix mismatch for that chain.
+ */
+const chainFormatRules: Record<string, Matcher[]> = {
+  // Cosmos family — each chain its own HRP.
+  ...Object.fromEntries(Object.entries(cosmosHRPByChain).map(([chain, hrp]) => [chain, [re(cosmosHRPRegex(hrp))]])),
+  // EVM family — all share 0x + 40 hex.
+  ...Object.fromEntries(evmChains.map(chain => [chain, [evmRule]])),
+  solana: [isSolanaAddress],
+  bitcoin: [re(reBTCNativeSegWit), re(reBTCLegacy)],
+  bitcoincash: [re(reBCH)],
+  litecoin: [re(reLTCBech32), re(reLTCLegacy)],
+  dogecoin: [re(reDOGE)],
+  dash: [re(reDASH)],
+  ripple: [re(reXRP)],
+  ton: [re(reTON)],
+  zcash: [re(reZcashT), re(reZcashZ)],
+  sui: [re(reSui)],
+  tron: [re(reTron)],
+  polkadot: [re(rePolkadot)],
+  bittensor: [re(reBittensor)],
+  cardano: [re(reCardano)],
+}
+
+/**
+ * Aliases -> canonical chain tag understood by chainFormatRules.
+ * Covers the common tickers / nicknames an LLM or caller may pass. Anything
+ * not here is lowercased and looked up directly.
+ */
+const chainAlias: Record<string, string> = {
+  eth: 'ethereum',
+  matic: 'polygon',
+  pol: 'polygon',
+  binance: 'bsc',
+  bnb: 'bsc',
+  bnbchain: 'bsc',
+  arb: 'arbitrum',
+  op: 'optimism',
+  avax: 'avalanche',
+  zk: 'zksync',
+  cronoschain: 'cronos',
+  cro: 'cronos',
+  hype: 'hyperliquid',
+  sol: 'solana',
+  btc: 'bitcoin',
+  bch: 'bitcoincash',
+  ltc: 'litecoin',
+  doge: 'dogecoin',
+  atom: 'cosmos',
+  cosmoshub: 'cosmos',
+  osmo: 'osmosis',
+  thor: 'thorchain',
+  maya: 'mayachain',
+  kuji: 'kujira',
+  inj: 'injective',
+  'terra-classic': 'terraclassic',
+  'terra classic': 'terraclassic',
+  lunc: 'terraclassic',
+  ustc: 'terraclassic',
+  xrp: 'ripple',
+  xrpl: 'ripple',
+  zec: 'zcash',
+  trx: 'tron',
+  dot: 'polkadot',
+  tao: 'bittensor',
+  ada: 'cardano',
+  stars: 'stargaze',
+}
+
+/** Resolve an arbitrary chain string to a canonical tag in chainFormatRules. */
+export function canonicalChainTag(chain: string): string {
+  const key = chain.trim().toLowerCase()
+  return chainAlias[key] ?? key
+}
+
+/**
+ * Ordered family matchers for classification. Order matters: Sui (64-hex) must
+ * be checked BEFORE EVM (40-hex) is irrelevant here since both are anchored
+ * full-string, but cosmos is checked before the generic base58 Solana decode
+ * to avoid a bech32 string coincidentally decoding to 32 bytes.
+ */
+const familyMatchers: Array<{ family: AddressFamily; match: Matcher }> = [
+  { family: 'cosmos', match: isAnyCosmosAddress },
+  { family: 'sui', match: re(reSui) },
+  { family: 'evm', match: re(reEVM) },
+  { family: 'solana', match: isSolanaAddress },
+  { family: 'bitcoincash', match: re(reBCH) },
+  { family: 'litecoin', match: addr => reLTCBech32.test(addr) || reLTCLegacy.test(addr) },
+  { family: 'dogecoin', match: re(reDOGE) },
+  { family: 'dash', match: re(reDASH) },
+  { family: 'btc', match: addr => reBTCNativeSegWit.test(addr) || reBTCLegacy.test(addr) },
+  { family: 'cardano', match: re(reCardano) },
+  { family: 'ton', match: re(reTON) },
+  { family: 'tron', match: re(reTron) },
+  { family: 'xrp', match: re(reXRP) },
+  { family: 'zcash', match: addr => reZcashT.test(addr) || reZcashZ.test(addr) },
+  { family: 'polkadot', match: re(rePolkadot) },
+  { family: 'bittensor', match: re(reBittensor) },
+]
+
+/**
+ * classifyAddress returns the coarse chain family an address's FORMAT belongs
+ * to, or `unknown` when it matches no known family.
+ *
+ * Note: EVM and Sui both use `0x`-hex; they're disambiguated by length
+ * (40 vs 64 hex). Cosmos HRPs and Solana base58 are disambiguated by the
+ * known-HRP guard inside isSolanaAddress.
+ */
+export function classifyAddress(address: string): AddressFamily {
+  const addr = address.trim()
+  if (addr === '') return 'unknown'
+  for (const { family, match } of familyMatchers) {
+    if (match(addr)) return family
+  }
+  return 'unknown'
+}
+
+/**
+ * isAddressValidForChain returns true when `address` is a valid FORMAT for
+ * `chain` (HRP / prefix / regex match), false on a format/prefix mismatch, and
+ * `undefined` when `chain` has no FORMAT rule in the table (caller cannot
+ * decide — same semantics as the backend's `!ok` skip on chainHRPMap).
+ */
+export function isAddressValidForChain(address: string, chain: string): boolean | undefined {
+  const tag = canonicalChainTag(chain)
+  const rules = chainFormatRules[tag]
+  if (!rules) return undefined
+  const addr = address.trim()
+  return rules.some(rule => rule(addr))
+}
+
+/** List of canonical chain tags that have a FORMAT rule (for introspection). */
+export function supportedChainTags(): string[] {
+  return Object.keys(chainFormatRules).sort()
+}

--- a/packages/sdk/src/utils/addressValidation.ts
+++ b/packages/sdk/src/utils/addressValidation.ts
@@ -1,0 +1,49 @@
+/**
+ * Public namespace objects for pure address-format validation.
+ *
+ * Exposes:
+ *   - `validate.chainPrefix(address, chain)` — HRP/format mismatch check
+ *   - `address.classify(address)`            — chain-family of an address format
+ *   - `address.isValidFor(address, chain)`   — is the format valid for a chain
+ *   - `address.supportedChains()`            — chains with a FORMAT rule
+ *
+ * These collapse the duplicated FORMAT rules that previously lived in the Go
+ * agent backend (validator/chain_prefix_extractor.go + validator/address/*.go)
+ * and the abt src/mastra/chainPrefix.ts mirror into one canonical SDK source.
+ *
+ * PURE CRYPTO / FORMAT ONLY — no intent-match, no grounding, no network, no
+ * signing. See addressFormat.ts and chainPrefix.ts for the rule sources.
+ */
+
+import { type AddressFamily, classifyAddress, isAddressValidForChain, supportedChainTags } from './addressFormat'
+import { type ChainPrefixResult, checkChainPrefix } from './chainPrefix'
+
+/**
+ * `validate` namespace — format-validation checks that return structured
+ * results suitable for fund-safety gating before a tx is built.
+ */
+export const validate = {
+  /**
+   * Validate that an address FORMAT matches a claimed chain (HRP/prefix check).
+   * Fails open (`valid: true`, `reason: 'unknown-chain'`) for chains with no
+   * FORMAT rule, mirroring the backend extractor's skip behavior.
+   */
+  chainPrefix: (address: string, chain: string): ChainPrefixResult => checkChainPrefix(address, chain),
+} as const
+
+/**
+ * `address` namespace — coarse classification + per-chain format validity.
+ */
+export const address = {
+  /** Return the chain family an address FORMAT belongs to, or `unknown`. */
+  classify: (addr: string): AddressFamily => classifyAddress(addr),
+  /**
+   * Return true when `addr` is a valid FORMAT for `chain`, false on mismatch,
+   * `undefined` when the chain has no FORMAT rule (caller cannot decide).
+   */
+  isValidFor: (addr: string, chain: string): boolean | undefined => isAddressValidForChain(addr, chain),
+  /** Canonical chain tags that have a FORMAT rule. */
+  supportedChains: (): string[] => supportedChainTags(),
+} as const
+
+export type { AddressFamily, ChainPrefixResult }

--- a/packages/sdk/src/utils/addressValidation.ts
+++ b/packages/sdk/src/utils/addressValidation.ts
@@ -15,7 +15,13 @@
  * signing. See addressFormat.ts and chainPrefix.ts for the rule sources.
  */
 
-import { type AddressFamily, classifyAddress, isAddressValidForChain, supportedChainTags } from './addressFormat'
+import {
+  type AddressFamily,
+  type AddressRole,
+  classifyAddress,
+  isAddressValidForChain,
+  supportedChainTags,
+} from './addressFormat'
 import { type ChainPrefixResult, checkChainPrefix } from './chainPrefix'
 
 /**
@@ -27,8 +33,14 @@ export const validate = {
    * Validate that an address FORMAT matches a claimed chain (HRP/prefix check).
    * Fails open (`valid: true`, `reason: 'unknown-chain'`) for chains with no
    * FORMAT rule, mirroring the backend extractor's skip behavior.
+   *
+   * Pass `role: 'validator'` for cosmos staking validator-operator fields
+   * (`validator_address`, …) so the address is checked against the valoper HRP
+   * (`<chain>valoper1…`) instead of the account HRP — mirrors the Go validator's
+   * field-aware routing (cosmosValopers). Defaults to `'account'`.
    */
-  chainPrefix: (address: string, chain: string): ChainPrefixResult => checkChainPrefix(address, chain),
+  chainPrefix: (address: string, chain: string, role: AddressRole = 'account'): ChainPrefixResult =>
+    checkChainPrefix(address, chain, role),
 } as const
 
 /**
@@ -40,10 +52,14 @@ export const address = {
   /**
    * Return true when `addr` is a valid FORMAT for `chain`, false on mismatch,
    * `undefined` when the chain has no FORMAT rule (caller cannot decide).
+   *
+   * Pass `role: 'validator'` for cosmos staking validator-operator addresses so
+   * the check uses the valoper HRP (`<chain>valoper1…`). Defaults to `'account'`.
    */
-  isValidFor: (addr: string, chain: string): boolean | undefined => isAddressValidForChain(addr, chain),
+  isValidFor: (addr: string, chain: string, role: AddressRole = 'account'): boolean | undefined =>
+    isAddressValidForChain(addr, chain, role),
   /** Canonical chain tags that have a FORMAT rule. */
   supportedChains: (): string[] => supportedChainTags(),
 } as const
 
-export type { AddressFamily, ChainPrefixResult }
+export type { AddressFamily, AddressRole, ChainPrefixResult }

--- a/packages/sdk/src/utils/chainPrefix.ts
+++ b/packages/sdk/src/utils/chainPrefix.ts
@@ -16,7 +16,7 @@
  * No network, no signing.
  */
 
-import { canonicalChainTag, classifyAddress, isAddressValidForChain } from './addressFormat'
+import { type AddressRole, canonicalChainTag, classifyAddress, isAddressValidForChain } from './addressFormat'
 
 /** Result of a chain-prefix check. */
 export type ChainPrefixResult = {
@@ -52,11 +52,17 @@ export type ChainPrefixResult = {
  * chain is absent from the HRP map) so this never over-blocks a legitimate
  * address on a chain the SDK doesn't yet have a format rule for.
  *
+ * When `role === 'validator'` the address is checked against the chain's
+ * valoper HRP (cosmos staking validator fields), mirroring the Go validator's
+ * field-aware routing. Defaults to `'account'`.
+ *
  * @example
  * checkChainPrefix('osmo1...', 'ethereum').valid // false (HRP mismatch)
  * checkChainPrefix('0xabc...40hex', 'ethereum').valid // true
+ * checkChainPrefix('cosmos1...', 'cosmos', 'validator').valid // false (needs cosmosvaloper1)
+ * checkChainPrefix('cosmosvaloper1...', 'cosmos', 'validator').valid // true
  */
-export function checkChainPrefix(address: string, chain: string): ChainPrefixResult {
+export function checkChainPrefix(address: string, chain: string, role: AddressRole = 'account'): ChainPrefixResult {
   const addr = (address ?? '').trim()
   const canonicalChain = canonicalChainTag(chain ?? '')
   const detectedFamily = classifyAddress(addr)
@@ -72,7 +78,7 @@ export function checkChainPrefix(address: string, chain: string): ChainPrefixRes
     }
   }
 
-  const formatValid = isAddressValidForChain(addr, chain)
+  const formatValid = isAddressValidForChain(addr, chain, role)
   if (formatValid === undefined) {
     // No FORMAT rule for this chain — cannot decide, fail open.
     return {

--- a/packages/sdk/src/utils/chainPrefix.ts
+++ b/packages/sdk/src/utils/chainPrefix.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure chain-prefix / HRP mismatch validation.
+ *
+ * Canonical port of the FORMAT-mismatch detection in
+ * agent-backend chain_prefix_extractor.go (checkSingleChain) and the
+ * abt src/mastra/chainPrefix.ts mirror.
+ *
+ * Fund-safety motivation (verbatim from the Go source): a `cosmos1...`
+ * address on a Terra v2 build call would pass a grounding check (the user
+ * typed it) yet would lose funds — Terra only routes `terra1...` HRP
+ * addresses. This primitive catches the FORMAT/HRP mismatch between a chain
+ * tag and an address, BEFORE any tx is built or signed.
+ *
+ * Scope: PURE FORMAT validation. It does NOT do intent-match, grounding, or
+ * fabrication detection — those stay in the agent backend's judgement layer.
+ * No network, no signing.
+ */
+
+import { canonicalChainTag, classifyAddress, isAddressValidForChain } from './addressFormat'
+
+/** Result of a chain-prefix check. */
+export type ChainPrefixResult = {
+  /** Whether the address FORMAT is valid for the claimed chain. */
+  valid: boolean
+  /** The address that was checked (trimmed). */
+  address: string
+  /** The chain that was claimed (as passed in). */
+  chain: string
+  /** The canonical chain tag the chain resolved to. */
+  canonicalChain: string
+  /**
+   * The chain family the address FORMAT actually belongs to, or `unknown`.
+   * Useful for explaining a mismatch ("you claimed ethereum but this is a
+   * cosmos address").
+   */
+  detectedFamily: ReturnType<typeof classifyAddress>
+  /**
+   * Why the check returned the result it did:
+   *  - `match`       — address format is valid for the chain
+   *  - `mismatch`    — address format does NOT match the chain (fund-safety hit)
+   *  - `unknown-chain` — no FORMAT rule for the chain; cannot decide (valid=true,
+   *    fail-open, mirrors the backend's chainHRPMap `!ok` skip)
+   *  - `empty`       — address or chain was empty
+   */
+  reason: 'match' | 'mismatch' | 'unknown-chain' | 'empty'
+}
+
+/**
+ * checkChainPrefix validates that `address` is a plausible FORMAT for `chain`.
+ *
+ * Fail-open on unknown chains (mirrors the backend extractor's skip when a
+ * chain is absent from the HRP map) so this never over-blocks a legitimate
+ * address on a chain the SDK doesn't yet have a format rule for.
+ *
+ * @example
+ * checkChainPrefix('osmo1...', 'ethereum').valid // false (HRP mismatch)
+ * checkChainPrefix('0xabc...40hex', 'ethereum').valid // true
+ */
+export function checkChainPrefix(address: string, chain: string): ChainPrefixResult {
+  const addr = (address ?? '').trim()
+  const canonicalChain = canonicalChainTag(chain ?? '')
+  const detectedFamily = classifyAddress(addr)
+
+  if (addr === '' || (chain ?? '').trim() === '') {
+    return {
+      valid: false,
+      address: addr,
+      chain,
+      canonicalChain,
+      detectedFamily,
+      reason: 'empty',
+    }
+  }
+
+  const formatValid = isAddressValidForChain(addr, chain)
+  if (formatValid === undefined) {
+    // No FORMAT rule for this chain — cannot decide, fail open.
+    return {
+      valid: true,
+      address: addr,
+      chain,
+      canonicalChain,
+      detectedFamily,
+      reason: 'unknown-chain',
+    }
+  }
+
+  return {
+    valid: formatValid,
+    address: addr,
+    chain,
+    canonicalChain,
+    detectedFamily,
+    reason: formatValid ? 'match' : 'mismatch',
+  }
+}

--- a/packages/sdk/tests/unit/utils/addressValidation.test.ts
+++ b/packages/sdk/tests/unit/utils/addressValidation.test.ts
@@ -15,6 +15,9 @@ const ADDR = {
   sui: '0x0000000000000000000000000000000000000000000000000000000000000002',
   tron: 'TJRabPrwbZy45sbavfcjinPJC18kjpRTv8',
   xrp: 'rDsbeomae4FXwgQTJp9Rs64Qg9vDiTCdBv',
+  // Cosmos delegator (account) vs validator-operator (valoper) addresses.
+  cosmosValoper: 'cosmosvaloper1clpqr4nrk4khgkxj78fcwwh6dl3uw4epsluffn',
+  osmoValoper: 'osmovaloper1clpqr4nrk4khgkxj78fcwwh6dl3uw4epsluffn',
 }
 
 describe('classifyAddress', () => {
@@ -53,6 +56,12 @@ describe('isSolanaAddress', () => {
   it('rejects an EVM address', () => {
     expect(isSolanaAddress(ADDR.eth)).toBe(false)
   })
+  it('rejects valoper bech32 strings via the known-HRP guard (Go parity)', () => {
+    // cosmosvaloper1 / osmovaloper1 are now in knownBech32HRPs (matches Go),
+    // so a valoper string is never misclassified as a Solana key.
+    expect(isSolanaAddress(ADDR.cosmosValoper)).toBe(false)
+    expect(isSolanaAddress(ADDR.osmoValoper)).toBe(false)
+  })
 })
 
 describe('isAddressValidForChain', () => {
@@ -73,6 +82,40 @@ describe('isAddressValidForChain', () => {
   })
   it('returns undefined for a chain with no FORMAT rule', () => {
     expect(isAddressValidForChain(ADDR.eth, 'madeupchain')).toBeUndefined()
+  })
+
+  // Valoper field-aware routing (ported from Go cosmosValopers). A validator
+  // operator address must carry the <chain>valoper1… HRP, not the account HRP.
+  describe("role: 'validator' (cosmos valoper HRP)", () => {
+    it('accepts a cosmosvaloper1 address as a validator field on cosmos', () => {
+      expect(isAddressValidForChain(ADDR.cosmosValoper, 'cosmos', 'validator')).toBe(true)
+    })
+    it('rejects a cosmos1 delegator address on a validator field (fund-safety)', () => {
+      // The whole point of cosmosValopers: a cosmos1… delegator must NOT pass
+      // where a cosmosvaloper1… operator is required.
+      expect(isAddressValidForChain(ADDR.cosmos, 'cosmos', 'validator')).toBe(false)
+    })
+    it('rejects a valoper address on the account role (account rule, not valoper)', () => {
+      expect(isAddressValidForChain(ADDR.cosmosValoper, 'cosmos', 'account')).toBe(false)
+      expect(isAddressValidForChain(ADDR.cosmosValoper, 'cosmos')).toBe(false)
+    })
+    it('routes per-chain valoper HRP (osmovaloper on osmosis, alias-aware)', () => {
+      expect(isAddressValidForChain(ADDR.osmoValoper, 'osmosis', 'validator')).toBe(true)
+      expect(isAddressValidForChain(ADDR.osmoValoper, 'osmo', 'validator')).toBe(true)
+      // wrong-chain valoper HRP is a mismatch
+      expect(isAddressValidForChain(ADDR.cosmosValoper, 'osmosis', 'validator')).toBe(false)
+    })
+    it('terraclassic shares the terravaloper HRP with terra (Go parity)', () => {
+      const terraValoper = 'terravaloper1clpqr4nrk4khgkxj78fcwwh6dl3uw4epsluffn'
+      expect(isAddressValidForChain(terraValoper, 'terra', 'validator')).toBe(true)
+      expect(isAddressValidForChain(terraValoper, 'terraclassic', 'validator')).toBe(true)
+    })
+    it('falls back to account rules for chains with no valoper entry (thorchain)', () => {
+      // thorchain is intentionally omitted from cosmosValopers — validator role
+      // falls back to the account HRP rather than over-blocking.
+      const thorAddr = 'thor1clpqr4nrk4khgkxj78fcwwh6dl3uw4epsluffn'
+      expect(isAddressValidForChain(thorAddr, 'thorchain', 'validator')).toBe(true)
+    })
   })
 })
 
@@ -100,6 +143,16 @@ describe('validate.chainPrefix', () => {
   })
   it('checkChainPrefix is the same function as validate.chainPrefix', () => {
     expect(checkChainPrefix(ADDR.osmo, 'ethereum')).toEqual(validate.chainPrefix(ADDR.osmo, 'ethereum'))
+  })
+  it('validator role flags a cosmos1 delegator passed as a validator address', () => {
+    const r = validate.chainPrefix(ADDR.cosmos, 'cosmos', 'validator')
+    expect(r.valid).toBe(false)
+    expect(r.reason).toBe('mismatch')
+  })
+  it('validator role passes a cosmosvaloper1 operator address', () => {
+    const r = validate.chainPrefix(ADDR.cosmosValoper, 'cosmos', 'validator')
+    expect(r.valid).toBe(true)
+    expect(r.reason).toBe('match')
   })
 })
 

--- a/packages/sdk/tests/unit/utils/addressValidation.test.ts
+++ b/packages/sdk/tests/unit/utils/addressValidation.test.ts
@@ -84,6 +84,18 @@ describe('isAddressValidForChain', () => {
     expect(isAddressValidForChain(ADDR.eth, 'madeupchain')).toBeUndefined()
   })
 
+  // Length-floor enforcement on the cosmos HRP rule (`<hrp>1[0-9a-z]{25,70}`).
+  // A right-HRP-but-too-short string must be rejected — otherwise loosening the
+  // {25,70} floor (e.g. to {1,70}) would silently pass truncated/garbage
+  // addresses for every cosmos chain. Mirrors the Go cosmosHRP regex floor.
+  it('rejects a too-short cosmos-prefixed string (HRP matches, body below floor)', () => {
+    expect(isAddressValidForChain('cosmos1abc', 'cosmos')).toBe(false)
+    expect(isAddressValidForChain('osmo1abc', 'osmosis')).toBe(false)
+  })
+  it('rejects a too-short valoper string under the validator role', () => {
+    expect(isAddressValidForChain('cosmosvaloper1abc', 'cosmos', 'validator')).toBe(false)
+  })
+
   // Valoper field-aware routing (ported from Go cosmosValopers). A validator
   // operator address must carry the <chain>valoper1… HRP, not the account HRP.
   describe("role: 'validator' (cosmos valoper HRP)", () => {

--- a/packages/sdk/tests/unit/utils/addressValidation.test.ts
+++ b/packages/sdk/tests/unit/utils/addressValidation.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+
+import { classifyAddress, isAddressValidForChain, isSolanaAddress } from '../../../src/utils/addressFormat'
+import { address, validate } from '../../../src/utils/addressValidation'
+import { checkChainPrefix } from '../../../src/utils/chainPrefix'
+
+// Real, well-known mainnet addresses (public — never funded by this test).
+const ADDR = {
+  eth: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045', // vitalik.eth
+  osmo: 'osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyat',
+  cosmos: 'cosmos1z0qrq605sjgcqpylfl4aa6s90x738j7m32g9j2',
+  sol: '7EYnhQoR9YM3N7UoaKRoA44Uy8JeaZV3qyouov87awMs', // canonical example pubkey
+  btcBech32: 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq',
+  btcLegacy: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa', // genesis coinbase
+  sui: '0x0000000000000000000000000000000000000000000000000000000000000002',
+  tron: 'TJRabPrwbZy45sbavfcjinPJC18kjpRTv8',
+  xrp: 'rDsbeomae4FXwgQTJp9Rs64Qg9vDiTCdBv',
+}
+
+describe('classifyAddress', () => {
+  it.each([
+    [ADDR.eth, 'evm'],
+    [ADDR.osmo, 'cosmos'],
+    [ADDR.cosmos, 'cosmos'],
+    [ADDR.sol, 'solana'],
+    [ADDR.btcBech32, 'btc'],
+    [ADDR.btcLegacy, 'btc'],
+    [ADDR.sui, 'sui'],
+    [ADDR.tron, 'tron'],
+    [ADDR.xrp, 'xrp'],
+  ])('classifies %s as %s', (addr, family) => {
+    expect(classifyAddress(addr)).toBe(family)
+  })
+
+  it('returns unknown for garbage', () => {
+    expect(classifyAddress('not-an-address')).toBe('unknown')
+    expect(classifyAddress('')).toBe('unknown')
+  })
+
+  it('disambiguates EVM (40 hex) from Sui (64 hex)', () => {
+    expect(classifyAddress(ADDR.eth)).toBe('evm')
+    expect(classifyAddress(ADDR.sui)).toBe('sui')
+  })
+})
+
+describe('isSolanaAddress', () => {
+  it('accepts a 32-byte base58 pubkey', () => {
+    expect(isSolanaAddress(ADDR.sol)).toBe(true)
+  })
+  it('rejects a cosmos bech32 string that is base58-alphabet-ish', () => {
+    expect(isSolanaAddress(ADDR.osmo)).toBe(false)
+  })
+  it('rejects an EVM address', () => {
+    expect(isSolanaAddress(ADDR.eth)).toBe(false)
+  })
+})
+
+describe('isAddressValidForChain', () => {
+  it('accepts EVM address on ethereum / base / arbitrum (shared 0x rule)', () => {
+    expect(isAddressValidForChain(ADDR.eth, 'ethereum')).toBe(true)
+    expect(isAddressValidForChain(ADDR.eth, 'base')).toBe(true)
+    expect(isAddressValidForChain(ADDR.eth, 'arbitrum')).toBe(true)
+  })
+  it('rejects an osmo address claimed on ethereum (HRP mismatch)', () => {
+    expect(isAddressValidForChain(ADDR.osmo, 'ethereum')).toBe(false)
+  })
+  it('rejects a cosmos1 address on terra (wrong HRP, fund-safety)', () => {
+    expect(isAddressValidForChain(ADDR.cosmos, 'terra')).toBe(false)
+  })
+  it('accepts osmo address on osmosis (and via osmo alias)', () => {
+    expect(isAddressValidForChain(ADDR.osmo, 'osmosis')).toBe(true)
+    expect(isAddressValidForChain(ADDR.osmo, 'osmo')).toBe(true)
+  })
+  it('returns undefined for a chain with no FORMAT rule', () => {
+    expect(isAddressValidForChain(ADDR.eth, 'madeupchain')).toBeUndefined()
+  })
+})
+
+describe('validate.chainPrefix', () => {
+  it('flags an osmo address claimed as ethereum as a mismatch', () => {
+    const r = validate.chainPrefix(ADDR.osmo, 'ethereum')
+    expect(r.valid).toBe(false)
+    expect(r.reason).toBe('mismatch')
+    expect(r.detectedFamily).toBe('cosmos')
+    expect(r.canonicalChain).toBe('ethereum')
+  })
+  it('passes a real EVM address on ethereum', () => {
+    const r = validate.chainPrefix(ADDR.eth, 'eth')
+    expect(r.valid).toBe(true)
+    expect(r.reason).toBe('match')
+  })
+  it('fails open (valid) for an unknown chain', () => {
+    const r = validate.chainPrefix(ADDR.eth, 'madeupchain')
+    expect(r.valid).toBe(true)
+    expect(r.reason).toBe('unknown-chain')
+  })
+  it('reports empty for blank input', () => {
+    expect(validate.chainPrefix('', 'ethereum').reason).toBe('empty')
+    expect(validate.chainPrefix(ADDR.eth, '').reason).toBe('empty')
+  })
+  it('checkChainPrefix is the same function as validate.chainPrefix', () => {
+    expect(checkChainPrefix(ADDR.osmo, 'ethereum')).toEqual(validate.chainPrefix(ADDR.osmo, 'ethereum'))
+  })
+})
+
+describe('address namespace', () => {
+  it('exposes classify / isValidFor / supportedChains', () => {
+    expect(address.classify(ADDR.sol)).toBe('solana')
+    expect(address.isValidFor(ADDR.eth, 'ethereum')).toBe(true)
+    expect(address.supportedChains()).toContain('ethereum')
+    expect(address.supportedChains()).toContain('osmosis')
+  })
+})


### PR DESCRIPTION
## what

Adds pure address-format validation primitives to the SDK:

- `sdk.validate.chainPrefix(address, chain)` — HRP/prefix mismatch check (the `cosmos1`-on-terra fund-safety case). Returns a structured `ChainPrefixResult` (`valid`, `reason`, `detectedFamily`, `canonicalChain`). Fails open on chains with no FORMAT rule, mirroring the backend extractor's skip behavior, so it never over-blocks.
- `sdk.address.classify(address)` — coarse chain family of an address format (`evm` / `cosmos` / `solana` / `btc` / `sui` / `tron` / `xrp` / `cardano` / `polkadot` / `bittensor` / `zcash` / ...).
- `sdk.address.isValidFor(address, chain)` — per-family format validity (`true` / `false` / `undefined` when the chain has no rule).

Plus the underlying named exports (`classifyAddress`, `isAddressValidForChain`, `isSolanaAddress`, `canonicalChainTag`, `supportedChainTags`, `checkChainPrefix`).

## why

These FORMAT rules were duplicated across the Go agent backend (`validator/chain_prefix_extractor.go` + `validator/address/*.go`) and the abt `src/mastra/chainPrefix.ts` mirror. This is the canonical, single-source SDK port so mcp-ts / the backend can route through the SDK instead of re-declaring per-chain regex/bech32/base58 tables (the cross-repo drift root cause).

The load-bearing fund-safety case: a `cosmos1...` address on a Terra v2 build call passes a grounding check (the user typed it) yet would lose funds — Terra only routes `terra1...` HRP addresses. `validate.chainPrefix` catches that HRP/FORMAT mismatch BEFORE any tx is built or signed.

## scope (PURE CRYPTO / FORMAT ONLY)

FORMAT validation only: regex shape, bech32 HRP, base58-decode length (`bs58`, RN-safe pure JS). It deliberately does NOT do intent-match, grounding, fabrication / prompt-injection detection, or checksum verification — those stay in the agent backend's judgement layer. No network, no signing, no broadcast.

## consumers unblocked

- agent-backend: collapse the Go `chainHRPMap` + per-family extractors' FORMAT rules onto one SDK source.
- abt: retire the `src/mastra/chainPrefix.ts` mirror.
- mcp-ts: a pre-build HRP/format gate without re-implementing the tables.

## receipt

```
$ node --import tsx packages/sdk/scripts/receipts/validate_chain_prefix.mjs

=== sdk.address.classify (real mainnet addresses) ===
  ethereum (vitalik.eth) -> evm      (0xd8dA6BF2…)
  osmosis                -> cosmos   (osmo1z0qrq…)
  solana                 -> solana   (7EYnhQoR9Y…)
  bitcoin (bech32)       -> btc      (bc1qar0srr…)

=== sdk.validate.chainPrefix — mismatch detection ===
  osmo address claimed as ethereum:
    {"valid":false,"address":"osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyat","chain":"ethereum","canonicalChain":"ethereum","detectedFamily":"cosmos","reason":"mismatch"}
  eth address on ethereum:
    {"valid":true,"address":"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045","chain":"ethereum","canonicalChain":"ethereum","detectedFamily":"evm","reason":"match"}

=== assertions ===
  PASS  osmo->cosmos
  PASS  eth->evm
  PASS  sol->solana
  PASS  btc->btc
  PASS  osmo-as-eth is mismatch
  PASS  eth-on-eth is match

RECEIPT OK — all checks passed
```

Also: `yarn workspace @vultisig/sdk typecheck` exit 0, 0 errors. `yarn workspace @vultisig/sdk test` 1535 passed (25 new in `addressValidation.test.ts`). eslint + prettier clean.

Part of the mcp-ts/backend -> SDK code-as-action consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Comprehensive address format validation and classification utilities now available in SDK
  * Support for validating addresses across multiple blockchain networks (Cosmos, EVM, Solana, Bitcoin, and others)
  * Chain prefix validation to detect mismatches between claimed and actual addresses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->