### PR TITLE
feat(sdk): add sdk.tx.normalize + sdk.tx.split

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -44,6 +44,17 @@ export { fiatToAmount, FiatToAmountError } from './utils/fiatToAmount'
 export { normalizeChain, UnknownChainError } from './utils/normalizeChain'
 
 // ============================================================================
+// PUBLIC API - Tx Shape Normalization (pure, vault-free)
+// ============================================================================
+
+// Canonicalize a build_* tool result into a signing-ready tx envelope and split
+// multi-tx build results (approve+swap, generic transactions[]) into ordered
+// legs. Ports the normalize/split half of the agent-backend's
+// enrichBuildResult + splitMultiTx; SSE/Redis sequencing stays in the backend.
+export type { NormalizeArgs, NormalizedTx } from './tx'
+export { normalizeTx, splitMultiTx, TxNormalizeError } from './tx'
+
+// ============================================================================
 // PUBLIC API - Station Migration Primitives
 // ============================================================================
 

--- a/packages/sdk/src/tx/index.ts
+++ b/packages/sdk/src/tx/index.ts
@@ -1,0 +1,2 @@
+export type { NormalizeArgs, NormalizedTx } from './normalize'
+export { normalizeTx, splitMultiTx, TxNormalizeError } from './normalize'

--- a/packages/sdk/src/tx/normalize.ts
+++ b/packages/sdk/src/tx/normalize.ts
@@ -1,0 +1,233 @@
+/**
+ * Pure tx-shape normalization + multi-tx splitting.
+ *
+ * Ports the *normalize/split* half of the agent-backend's
+ * `enrichBuildResult` (internal/service/agent/agent.go) and `splitMultiTx`
+ * (internal/service/agent/tx_sequence.go) into a vault-free, side-effect-free
+ * SDK primitive.
+ *
+ * What stays in the backend (NOT ported here):
+ *   - SSE event sequencing (tx_ready emission ordering, pendingTxReadyEvents)
+ *   - Redis sequence storage / pop / peek / drained-marker lifecycle
+ *   - sequence_id / sequence_index / sequence_total injection (per-turn,
+ *     per-user, Redis-scoped — runtime concern, not a pure shape transform)
+ *   - the produces_calldata dispatch gate + any agent-judgement
+ *
+ * This module is PURE: it takes an already-built tool result (JSON) and
+ * returns a canonical tx envelope (`normalizeTx`) or an ordered list of
+ * per-leg envelopes (`splitMultiTx`). It never signs, broadcasts, or reads
+ * chain state.
+ */
+
+/** A parsed JSON object whose values are themselves arbitrary JSON. */
+type JsonObject = Record<string, unknown>
+
+/**
+ * A canonical, signing-ready tx envelope. Always carries the inner tx under one
+ * of `tx` / `swap_tx` / `send_tx`, plus optional chain-routing metadata copied
+ * from the build args / parent envelope. Extra fields ride along unchanged.
+ */
+export type NormalizedTx = JsonObject & {
+  tx?: unknown
+  swap_tx?: unknown
+  send_tx?: unknown
+  chain?: string
+  chain_id?: string
+  from_chain?: string
+  to_chain?: string
+}
+
+/**
+ * Chain-routing args from the originating `build_*` tool call. Mirrors the
+ * `{from_chain, to_chain, chain}` probe in Go `enrichBuildResult`. All optional
+ * — a flat single-chain `build_evm_tx` only carries `chain`.
+ */
+export type NormalizeArgs = {
+  from_chain?: string
+  to_chain?: string
+  chain?: string
+}
+
+/** Thrown when a build result can't be parsed into a tx envelope. */
+export class TxNormalizeError extends Error {
+  override readonly name = 'TxNormalizeError'
+
+  constructor(message: string) {
+    super(message)
+  }
+}
+
+const isJsonObject = (v: unknown): v is JsonObject => typeof v === 'object' && v !== null && !Array.isArray(v)
+
+/**
+ * Parse a build result into a plain object. Accepts either a JSON string (the
+ * raw MCP tool result, mirroring the Go `result string` input) or an
+ * already-parsed object. Throws `TxNormalizeError` on anything that isn't a
+ * JSON object (arrays, primitives, malformed JSON) — the Go code returned nil
+ * here; in TS we surface it so callers don't silently drop a tx.
+ */
+const parseResult = (result: string | JsonObject): JsonObject => {
+  if (isJsonObject(result)) return { ...result }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(result)
+  } catch (e) {
+    throw new TxNormalizeError(`build result is not valid JSON: ${(e as Error).message}`)
+  }
+  if (!isJsonObject(parsed)) {
+    throw new TxNormalizeError('build result is not a JSON object')
+  }
+  return parsed
+}
+
+/**
+ * `execute_*` prep envelopes (mcp-ts#49) are self-describing via `txArgs` +
+ * `stepperConfig` and dispatch on the inner `txArgs.tx_encoding` discriminator.
+ * Wrapping them under `tx` would double-nest and break consumers that switch on
+ * `txArgs.tx_encoding`, so the wrap step is skipped for them.
+ */
+const isExecutePrep = (txMap: JsonObject): boolean => 'txArgs' in txMap && 'stepperConfig' in txMap
+
+/**
+ * Phantom-card guard (vultiagent-app#603 part B): an `execute_*` prep envelope
+ * whose `txArgs` lacks a `tx_encoding` discriminator is structurally malformed —
+ * the client `parseServerTx` cannot route it to any signing branch. The Go code
+ * returned nil here so tx_ready is never emitted; we throw so the caller can
+ * count + drop it explicitly.
+ */
+const assertExecutePrepRoutable = (txMap: JsonObject): void => {
+  const txArgs = txMap['txArgs']
+  const encoding = isJsonObject(txArgs) ? txArgs['tx_encoding'] : undefined
+  if (typeof encoding !== 'string' || encoding === '') {
+    throw new TxNormalizeError('execute_* prep envelope missing txArgs.tx_encoding discriminator (phantom card)')
+  }
+}
+
+/**
+ * Normalize a `build_*` tool result into a canonical tx envelope.
+ *
+ * Mirrors Go `enrichBuildResult`:
+ *   - If the result already carries a nested tx (`swap_tx` / `send_tx` / `tx`),
+ *     or is an `execute_*` prep envelope, it is enriched in place.
+ *   - Otherwise the whole result IS the transaction and gets wrapped under
+ *     `tx` (with `chain` / `chain_id` lifted to the outer level so chain
+ *     resolution keeps working).
+ *   - Chain-routing fields (`from_chain` / `to_chain` / `chain`) are filled
+ *     from `args` when the payload doesn't already carry them.
+ *
+ * Pure: no I/O, no signing, no broadcast. Returns a fresh object.
+ *
+ * @throws {TxNormalizeError} on unparseable input or a non-routable
+ *   `execute_*` prep envelope (phantom card).
+ */
+export const normalizeTx = (result: string | JsonObject, args: NormalizeArgs = {}): NormalizedTx => {
+  let txMap = parseResult(result)
+
+  const executePrep = isExecutePrep(txMap)
+  if (executePrep) {
+    assertExecutePrepRoutable(txMap)
+  }
+
+  const hasNestedTx = 'swap_tx' in txMap || 'send_tx' in txMap || 'tx' in txMap
+
+  // Flat build_* result with no nested tx and not an execute_* prep envelope:
+  // the whole result IS the transaction, wrap it under "tx" and lift chain
+  // metadata to the outer level for downstream chain resolution.
+  if (!executePrep && !hasNestedTx) {
+    const wrapped: JsonObject = { tx: { ...txMap } }
+    if ('chain' in txMap) wrapped['chain'] = txMap['chain']
+    if ('chain_id' in txMap) wrapped['chain_id'] = txMap['chain_id']
+    txMap = wrapped
+  }
+
+  // Enrich with chain-routing info from the originating tool-call args when the
+  // payload doesn't already carry it. from_chain falls back to chain (matches
+  // Go: single-chain ops set from_chain = chain).
+  const { from_chain: argFrom, to_chain: argTo, chain: argChain } = args
+  if (!('from_chain' in txMap)) {
+    if (argFrom) txMap['from_chain'] = argFrom
+    else if (argChain) txMap['from_chain'] = argChain
+  }
+  if (!('chain' in txMap) && argChain) txMap['chain'] = argChain
+  if (!('to_chain' in txMap) && argTo) txMap['to_chain'] = argTo
+
+  return txMap as NormalizedTx
+}
+
+/**
+ * Metadata fields copied from a multi-tx parent onto each split leg so that
+ * `chain` / `chain_id` / `provider` / symbols / addresses / decimals ride along
+ * on every leg. Matches the `metadataKeys` slice in Go `wrapSingleTx`.
+ */
+const LEG_METADATA_KEYS = [
+  'chain',
+  'chain_id',
+  'from_chain',
+  'to_chain',
+  'provider',
+  'from_symbol',
+  'to_symbol',
+  'from_address',
+  'to_address',
+  'from_decimals',
+  'to_decimals',
+] as const
+
+/**
+ * Wrap a single child tx under `txKey` and copy routing metadata from the
+ * parent envelope. Mirrors Go `wrapSingleTx`.
+ */
+const wrapSingleTx = (txKey: string, txData: unknown, parent: JsonObject): NormalizedTx => {
+  const leg: JsonObject = { [txKey]: txData }
+  for (const key of LEG_METADATA_KEYS) {
+    if (key in parent) leg[key] = parent[key]
+  }
+  return leg as NormalizedTx
+}
+
+/**
+ * Split a (possibly multi-) tx build result into an ordered list of per-leg
+ * envelopes. Mirrors Go `splitMultiTx`.
+ *
+ * Two patterns are recognised, in priority order:
+ *   - Pattern 1 (swap-with-approval): top-level `needs_approval === true` with
+ *     both `approval_tx` and `swap_tx` present -> `[approvalLeg, swapLeg]`,
+ *     ordered approval-first. The approval is wrapped under `tx`, the swap
+ *     under `swap_tx`.
+ *   - Pattern 2 (generic): a top-level `transactions` array with length >= 1 ->
+ *     each element wrapped under `tx` with parent metadata copied on. Fires on
+ *     len >= 1 (not > 1) so single-tx canonical responses (Morpho borrow /
+ *     withdraw, etc.) also get per-tx wrapping instead of falling through.
+ *
+ * If neither pattern matches, the result is normalized via {@link normalizeTx}
+ * and returned as a single-element array — a no-op for single-tx callers.
+ *
+ * Pure: no Redis, no sequence_id injection, no SSE. Each leg is a fresh object.
+ *
+ * @throws {TxNormalizeError} on unparseable input.
+ */
+export const splitMultiTx = (result: string | JsonObject, args: NormalizeArgs = {}): NormalizedTx[] => {
+  let parsed: JsonObject
+  try {
+    parsed = parseResult(result)
+  } catch {
+    // Go returns the original payload as a single element on parse failure.
+    // We can only do that if it was already an object; a bad string is fatal.
+    if (isJsonObject(result)) return [result as NormalizedTx]
+    throw new TxNormalizeError('build result is not valid JSON')
+  }
+
+  // Pattern 1: swap with approval.
+  if (parsed['needs_approval'] === true && 'approval_tx' in parsed && 'swap_tx' in parsed) {
+    return [wrapSingleTx('tx', parsed['approval_tx'], parsed), wrapSingleTx('swap_tx', parsed['swap_tx'], parsed)]
+  }
+
+  // Pattern 2: generic transactions array (len >= 1).
+  const txs = parsed['transactions']
+  if (Array.isArray(txs) && txs.length > 0) {
+    return txs.map(child => wrapSingleTx('tx', child, parsed))
+  }
+
+  // Neither pattern: normalize the single tx and return as a 1-element list.
+  return [normalizeTx(parsed, args)]
+}

--- a/packages/sdk/tests/unit/tx/normalize.test.ts
+++ b/packages/sdk/tests/unit/tx/normalize.test.ts
@@ -171,4 +171,83 @@ describe('splitMultiTx', () => {
   it('throws on a malformed JSON string', () => {
     expect(() => splitMultiTx('{broken')).toThrow(TxNormalizeError)
   })
+
+  // --- adversarial invariants (lock Go-parity against future refactors) ---
+
+  it('Pattern 1 (approve+swap) wins over Pattern 2 (transactions[]) when both present', () => {
+    // Mirrors Go splitMultiTx: needs_approval/approval_tx/swap_tx is checked
+    // BEFORE the transactions[] array. If both shapes co-exist on a payload,
+    // the approval-first split must win — never fall through to the generic
+    // array path (which would wrap the WRONG legs under tx and drop the
+    // approval-before-swap ordering).
+    const buildResult = {
+      needs_approval: true,
+      approval_tx: { to: '0xtoken', data: '0x095ea7b3' },
+      swap_tx: { to: '0xrouter', data: '0xfeed' },
+      transactions: [{ to: '0xWRONG_A' }, { to: '0xWRONG_B' }, { to: '0xWRONG_C' }],
+      chain: 'Ethereum',
+    }
+    const legs = splitMultiTx(buildResult)
+    expect(legs).toHaveLength(2)
+    expect(legs[0]['tx']).toEqual({ to: '0xtoken', data: '0x095ea7b3' })
+    expect(legs[1]['swap_tx']).toEqual({ to: '0xrouter', data: '0xfeed' })
+  })
+
+  it('does NOT split on a non-boolean needs_approval (string "true" / number 1)', () => {
+    // Go unmarshals needs_approval into a strict bool; a JSON string "true" or
+    // number 1 fails that unmarshal-and-check, so Pattern 1 never fires. The TS
+    // port must match (strict === true), otherwise a stringly-typed flag would
+    // spuriously fabricate an approval leg.
+    for (const flag of ['true', 1, 'yes'] as const) {
+      const legs = splitMultiTx({
+        needs_approval: flag,
+        approval_tx: { to: '0xtoken' },
+        swap_tx: { to: '0xrouter', data: '0xfeed' },
+        chain: 'Ethereum',
+      })
+      expect(legs).toHaveLength(1)
+      // single passthrough leg keeps its nested swap_tx (normalizeTx no-op)
+      expect(legs[0]['swap_tx']).toEqual({ to: '0xrouter', data: '0xfeed' })
+      expect(legs[0]['tx']).toBeUndefined()
+    }
+  })
+
+  it('preserves order and drops no leg for a 3+ element transactions[] array', () => {
+    // No leg dropped, no reorder — index parity 0,1,2 with parent metadata on
+    // every leg (the contract sequenceTxReady relies on for approval-before-X).
+    const buildResult = {
+      transactions: [
+        { to: '0xa', step: 0 },
+        { to: '0xb', step: 1 },
+        { to: '0xc', step: 2 },
+      ],
+      chain: 'Base',
+      chain_id: '8453',
+      provider: 'morpho',
+    }
+    const legs = splitMultiTx(buildResult)
+    expect(legs).toHaveLength(3)
+    expect(legs.map(l => (l['tx'] as Record<string, unknown>)['step'])).toEqual([0, 1, 2])
+    for (const leg of legs) {
+      expect(leg.chain).toBe('Base')
+      expect(leg.chain_id).toBe('8453')
+      expect(leg.provider).toBe('morpho')
+    }
+  })
+
+  it('does not copy non-metadata keys (e.g. needs_approval) onto split legs', () => {
+    // wrapSingleTx copies ONLY the fixed LEG_METADATA_KEYS list — control flags
+    // like needs_approval / approval_tx must NOT leak onto the wrapped legs, or
+    // a re-split downstream would mis-trigger.
+    const legs = splitMultiTx({
+      needs_approval: true,
+      approval_tx: { to: '0xtoken' },
+      swap_tx: { to: '0xrouter' },
+      chain: 'Ethereum',
+    })
+    for (const leg of legs) {
+      expect(leg['needs_approval']).toBeUndefined()
+      expect(leg['approval_tx']).toBeUndefined()
+    }
+  })
 })

--- a/packages/sdk/tests/unit/tx/normalize.test.ts
+++ b/packages/sdk/tests/unit/tx/normalize.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeTx, splitMultiTx, TxNormalizeError } from '../../../src/tx/normalize'
+
+describe('normalizeTx', () => {
+  it('wraps a flat build_* result under "tx" and lifts chain metadata', () => {
+    const flat = {
+      to: '0xrecipient',
+      value: '0x0',
+      data: '0xabc',
+      chain: 'Ethereum',
+      chain_id: '1',
+    }
+    const out = normalizeTx(flat)
+    expect(out['tx']).toEqual(flat)
+    // chain / chain_id lifted to outer level for downstream resolution
+    expect(out.chain).toBe('Ethereum')
+    expect(out.chain_id).toBe('1')
+  })
+
+  it('leaves a result that already nests swap_tx untouched (only enriches chain)', () => {
+    const nested = { swap_tx: { to: '0xpool', data: '0xdead' } }
+    const out = normalizeTx(nested, { from_chain: 'Ethereum', to_chain: 'THORChain' })
+    expect(out['swap_tx']).toEqual({ to: '0xpool', data: '0xdead' })
+    expect(out['tx']).toBeUndefined() // not double-wrapped
+    expect(out.from_chain).toBe('Ethereum')
+    expect(out.to_chain).toBe('THORChain')
+  })
+
+  it('falls from_chain back to chain when from_chain arg is absent', () => {
+    const out = normalizeTx({ tx: { to: '0x1' } }, { chain: 'Polygon' })
+    expect(out.from_chain).toBe('Polygon')
+    expect(out.chain).toBe('Polygon')
+  })
+
+  it('does not overwrite chain fields already present in the payload', () => {
+    const out = normalizeTx(
+      { tx: { to: '0x1' }, chain: 'Bitcoin', from_chain: 'Bitcoin' },
+      { chain: 'Ethereum', from_chain: 'Ethereum' }
+    )
+    expect(out.chain).toBe('Bitcoin')
+    expect(out.from_chain).toBe('Bitcoin')
+  })
+
+  it('accepts a raw JSON string (the MCP tool result transport)', () => {
+    const out = normalizeTx('{"to":"0x1","chain":"Ethereum"}')
+    expect(out['tx']).toEqual({ to: '0x1', chain: 'Ethereum' })
+    expect(out.chain).toBe('Ethereum')
+  })
+
+  it('passes execute_* prep envelopes through without wrapping when routable', () => {
+    const prep = {
+      txArgs: { tx_encoding: 'evm', to: '0xc' },
+      stepperConfig: { steps: ['sign'] },
+      chain: 'Ethereum',
+    }
+    const out = normalizeTx(prep)
+    // not wrapped under tx — txArgs/tx_encoding preserved
+    expect(out['tx']).toBeUndefined()
+    expect((out['txArgs'] as Record<string, unknown>)['tx_encoding']).toBe('evm')
+  })
+
+  it('throws on an execute_* prep envelope missing tx_encoding (phantom card)', () => {
+    const phantom = {
+      txArgs: { to: '0xc' },
+      stepperConfig: { steps: [] },
+    }
+    expect(() => normalizeTx(phantom)).toThrow(TxNormalizeError)
+  })
+
+  it('throws on malformed JSON and non-object input', () => {
+    expect(() => normalizeTx('{not json')).toThrow(TxNormalizeError)
+    expect(() => normalizeTx('[1,2,3]')).toThrow(TxNormalizeError)
+    expect(() => normalizeTx('"a string"')).toThrow(TxNormalizeError)
+  })
+
+  it('returns a fresh object (no mutation of the input)', () => {
+    const input = { to: '0x1', chain: 'Ethereum' }
+    const out = normalizeTx(input)
+    expect(out).not.toBe(input)
+    expect(input).toEqual({ to: '0x1', chain: 'Ethereum' })
+  })
+})
+
+describe('splitMultiTx', () => {
+  it('splits an approve+swap into ordered [approval, swap] legs with metadata', () => {
+    const buildResult = {
+      needs_approval: true,
+      approval_tx: { to: '0xtoken', data: '0x095ea7b3' },
+      swap_tx: { to: '0xrouter', data: '0xfeed' },
+      provider: 'thorchain',
+      chain: 'Ethereum',
+      from_symbol: 'USDC',
+      to_symbol: 'ETH',
+      from_address: '0xuser',
+    }
+    const legs = splitMultiTx(buildResult)
+    expect(legs).toHaveLength(2)
+
+    // leg 0 = approval, wrapped under tx, approval-first ordering
+    expect(legs[0]['tx']).toEqual({ to: '0xtoken', data: '0x095ea7b3' })
+    expect(legs[0]['swap_tx']).toBeUndefined()
+    expect(legs[0].provider).toBe('thorchain')
+    expect(legs[0].chain).toBe('Ethereum')
+    expect(legs[0].from_symbol).toBe('USDC')
+
+    // leg 1 = swap, wrapped under swap_tx, same metadata copied on
+    expect(legs[1]['swap_tx']).toEqual({ to: '0xrouter', data: '0xfeed' })
+    expect(legs[1]['tx']).toBeUndefined()
+    expect(legs[1].to_symbol).toBe('ETH')
+    expect(legs[1].from_address).toBe('0xuser')
+  })
+
+  it('does NOT split when needs_approval is false', () => {
+    const buildResult = {
+      needs_approval: false,
+      approval_tx: { to: '0xtoken' },
+      swap_tx: { to: '0xrouter', data: '0xfeed' },
+      chain: 'Ethereum',
+    }
+    const legs = splitMultiTx(buildResult)
+    expect(legs).toHaveLength(1)
+    // single leg keeps its nested swap_tx (normalizeTx no-op)
+    expect(legs[0]['swap_tx']).toEqual({ to: '0xrouter', data: '0xfeed' })
+  })
+
+  it('splits a generic transactions[] array, copying parent metadata onto each leg', () => {
+    const buildResult = {
+      transactions: [
+        { to: '0xa', data: '0x1' },
+        { to: '0xb', data: '0x2' },
+      ],
+      chain: 'Ethereum',
+      provider: 'morpho',
+    }
+    const legs = splitMultiTx(buildResult)
+    expect(legs).toHaveLength(2)
+    expect(legs[0]['tx']).toEqual({ to: '0xa', data: '0x1' })
+    expect(legs[1]['tx']).toEqual({ to: '0xb', data: '0x2' })
+    for (const leg of legs) {
+      expect(leg.chain).toBe('Ethereum')
+      expect(leg.provider).toBe('morpho')
+    }
+  })
+
+  it('wraps a single-element transactions[] (len-1 Morpho op) under tx', () => {
+    const buildResult = {
+      transactions: [{ to: '0xa', data: '0x1' }],
+      chain: 'Ethereum',
+    }
+    const legs = splitMultiTx(buildResult)
+    expect(legs).toHaveLength(1)
+    expect(legs[0]['tx']).toEqual({ to: '0xa', data: '0x1' })
+    expect(legs[0].chain).toBe('Ethereum')
+  })
+
+  it('returns a single normalized leg for a plain single-tx build result', () => {
+    const legs = splitMultiTx({ to: '0x1', data: '0xabc', chain: 'Ethereum' })
+    expect(legs).toHaveLength(1)
+    expect(legs[0]['tx']).toEqual({ to: '0x1', data: '0xabc', chain: 'Ethereum' })
+    expect(legs[0].chain).toBe('Ethereum')
+  })
+
+  it('accepts the raw JSON string transport', () => {
+    const legs = splitMultiTx('{"needs_approval":true,"approval_tx":{"to":"0xt"},"swap_tx":{"to":"0xr"}}')
+    expect(legs).toHaveLength(2)
+    expect(legs[0]['tx']).toEqual({ to: '0xt' })
+    expect(legs[1]['swap_tx']).toEqual({ to: '0xr' })
+  })
+
+  it('throws on a malformed JSON string', () => {
+    expect(() => splitMultiTx('{broken')).toThrow(TxNormalizeError)
+  })
+})

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -10,6 +10,12 @@ describe('@vultisig/sdk public exports', () => {
     expect(typeof sdk.UnknownChainError).toBe('function')
   })
 
+  it('exports tx-shape normalization primitives (normalizeTx, splitMultiTx)', () => {
+    expect(typeof sdk.normalizeTx).toBe('function')
+    expect(typeof sdk.splitMultiTx).toBe('function')
+    expect(typeof sdk.TxNormalizeError).toBe('function')
+  })
+
   it('exports findSwapQuote, abiEncode, evmCheckAllowance (already consumed by mcp-ts)', () => {
     expect(typeof sdk.findSwapQuote).toBe('function')
     expect(typeof sdk.abiEncode).toBe('function')

--- a/scripts/receipts/tx_normalize.mjs
+++ b/scripts/receipts/tx_normalize.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * Runnable receipt for sdk.tx.normalize + sdk.tx.split.
+ *
+ * Exercises the pure tx-shape primitives on REAL build-result shapes:
+ *   1. normalizeTx() on a flat build_evm_tx result (wrap under "tx" + lift chain)
+ *   2. normalizeTx() on an execute_* prep envelope (passthrough, no double-nest)
+ *   3. splitMultiTx() on a 2-leg approve+swap build_swap_tx result (ordered legs)
+ *   4. splitMultiTx() on a generic transactions[] array (per-leg metadata copy)
+ *
+ * NO signing, NO broadcast — pure shape transforms. Run from repo root:
+ *   node scripts/receipts/tx_normalize.mjs
+ */
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+import { tsImport } from 'tsx/esm/api'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const modPath = resolve(__dirname, '../../packages/sdk/src/tx/normalize.ts')
+const { normalizeTx, splitMultiTx } = await tsImport(modPath, import.meta.url)
+
+const j = v => JSON.stringify(v, null, 2)
+const hr = t => console.log(`\n${'='.repeat(4)} ${t} ${'='.repeat(4)}`)
+
+// ---------------------------------------------------------------------------
+// 1. normalizeTx: flat build_evm_tx result -> wrapped canonical tx envelope
+// ---------------------------------------------------------------------------
+hr('1. normalizeTx(flat build_evm_tx result)')
+const flatBuild = {
+  to: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+  value: '0x0',
+  data: '0xa9059cbb',
+  gas: '0x5208',
+  chain: 'Ethereum',
+  chain_id: '1',
+}
+const normalized = normalizeTx(flatBuild, { chain: 'Ethereum' })
+console.log('input :', j(flatBuild))
+console.log('output:', j(normalized))
+console.assert(normalized.tx?.data === '0xa9059cbb', 'tx wrapped')
+console.assert(normalized.chain === 'Ethereum', 'chain lifted')
+console.assert(normalized.from_chain === 'Ethereum', 'from_chain enriched from arg')
+
+// ---------------------------------------------------------------------------
+// 2. normalizeTx: execute_* prep envelope passes through untouched
+// ---------------------------------------------------------------------------
+hr('2. normalizeTx(execute_* prep envelope)')
+const prepEnvelope = {
+  txArgs: { tx_encoding: 'evm', to: '0xrouter', data: '0xdeadbeef' },
+  stepperConfig: { steps: ['sign', 'broadcast'] },
+  chain: 'Ethereum',
+}
+const prepOut = normalizeTx(prepEnvelope)
+console.log('output:', j(prepOut))
+console.assert(prepOut.tx === undefined, 'prep NOT double-wrapped under tx')
+console.assert(prepOut.txArgs?.tx_encoding === 'evm', 'tx_encoding discriminator preserved')
+
+// ---------------------------------------------------------------------------
+// 3. splitMultiTx: approve + swap -> ordered [approval, swap] legs
+// ---------------------------------------------------------------------------
+hr('3. splitMultiTx(approve + swap build_swap_tx result)')
+const swapBuild = {
+  needs_approval: true,
+  approval_tx: {
+    to: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', // USDC
+    data: '0x095ea7b3', // approve(spender, amount)
+  },
+  swap_tx: {
+    to: '0x111111125421cA6dc452d289314280a0f8842A65', // 1inch router
+    data: '0x12aa3caf',
+  },
+  provider: 'oneinch',
+  chain: 'Ethereum',
+  from_symbol: 'USDC',
+  to_symbol: 'ETH',
+  from_address: '0xUSER',
+}
+const legs = splitMultiTx(swapBuild)
+console.log(`split into ${legs.length} ordered legs:`)
+legs.forEach((leg, i) => {
+  const kind = leg.tx ? 'approval (tx)' : 'swap (swap_tx)'
+  console.log(`  leg ${i} = ${kind}: ${j(leg)}`)
+})
+console.assert(legs.length === 2, 'two legs')
+console.assert(legs[0].tx?.data === '0x095ea7b3', 'leg 0 = approval first')
+console.assert(legs[1].swap_tx?.data === '0x12aa3caf', 'leg 1 = swap')
+console.assert(legs[0].provider === 'oneinch' && legs[1].provider === 'oneinch', 'metadata copied to both legs')
+
+// ---------------------------------------------------------------------------
+// 4. splitMultiTx: generic transactions[] array -> per-leg envelopes
+// ---------------------------------------------------------------------------
+hr('4. splitMultiTx(generic transactions[] array)')
+const multiBuild = {
+  transactions: [
+    { to: '0xmorpho', data: '0x0001' },
+    { to: '0xmorpho', data: '0x0002' },
+  ],
+  chain: 'Base',
+  provider: 'morpho',
+}
+const genericLegs = splitMultiTx(multiBuild)
+console.log(`split into ${genericLegs.length} legs:`)
+genericLegs.forEach((leg, i) => console.log(`  leg ${i}: ${j(leg)}`))
+console.assert(genericLegs.length === 2, 'two generic legs')
+console.assert(
+  genericLegs.every(l => l.chain === 'Base' && l.provider === 'morpho'),
+  'parent metadata on each leg'
+)
+
+console.log('\nAll receipt assertions passed. (pure shape transforms — no signing, no broadcast)')


### PR DESCRIPTION
## what

Two pure, vault-free tx-shape primitives exported from `@vultisig/sdk`:

- **`normalizeTx(result, args)`** — canonicalize a `build_*` tool result into a signing-ready envelope. Wraps a flat result under `tx` + lifts `chain`/`chain_id` to the outer level, leaves an already-nested `swap_tx`/`send_tx`/`tx` untouched (no double-nest), passes `execute_*` prep envelopes through unchanged, and enriches `from_chain`/`to_chain`/`chain` from the originating tool args (with `from_chain` falling back to `chain`). Throws `TxNormalizeError` on a non-routable `execute_*` prep envelope (phantom-card guard, missing `txArgs.tx_encoding`) and on unparseable input.
- **`splitMultiTx(result, args)`** — split a multi-tx build result into an ordered list of per-leg envelopes:
  - approve+swap (`needs_approval === true` + `approval_tx` + `swap_tx`) -> ordered `[approval, swap]`, approval-first
  - generic `transactions[]` (len >= 1) -> per-leg, with parent metadata (`chain`/`provider`/symbols/addresses/decimals) copied onto each leg
  - otherwise a 1-element `[normalizeTx(...)]` no-op

## why

This is the normalize/split half of the agent-backend's Go `enrichBuildResult` (`internal/service/agent/agent.go`) + `splitMultiTx` (`internal/service/agent/tx_sequence.go`), lifted into the SDK so every consumer shares ONE canonical tx-shape contract instead of each re-deriving it.

What deliberately STAYS in the backend (not ported, not pure): SSE `tx_ready` event sequencing, Redis sequence storage/pop/peek/drained-marker lifecycle, `sequence_id`/`sequence_index`/`sequence_total` injection, and the `produces_calldata` dispatch gate. Those are per-turn/per-user runtime + agent-judgement concerns. This module never signs and never broadcasts.

## consumers unblocked

- **mcp-ts** `execute_*` tools — can normalize their build output through one shared helper before emitting
- **SDK CLI executor** (`storeServerTransaction` reads `.swap_tx || .send_tx || .tx`) — split legs are already in the shape it routes on
- **Windows extension / Station** — same canonical envelope for approve+swap and generic multi-tx flows

## receipt

```
==== 1. normalizeTx(flat build_evm_tx result) ====
output: {
  "tx": { "to": "0xA0b8...eB48", "value": "0x0", "data": "0xa9059cbb", "gas": "0x5208", "chain": "Ethereum", "chain_id": "1" },
  "chain": "Ethereum",
  "chain_id": "1",
  "from_chain": "Ethereum"
}

==== 2. normalizeTx(execute_* prep envelope) ====
output: { "txArgs": { "tx_encoding": "evm", ... }, "stepperConfig": { "steps": ["sign","broadcast"] }, "chain": "Ethereum" }
  (NOT double-wrapped under tx; tx_encoding discriminator preserved)

==== 3. splitMultiTx(approve + swap build_swap_tx result) ====
split into 2 ordered legs:
  leg 0 = approval (tx):  { "tx": { "to": "0xA0b8...eB48", "data": "0x095ea7b3" }, "provider": "oneinch", "chain": "Ethereum", "from_symbol": "USDC", ... }
  leg 1 = swap (swap_tx): { "swap_tx": { "to": "0x1111...2A65", "data": "0x12aa3caf" }, "provider": "oneinch", "chain": "Ethereum", "to_symbol": "ETH", ... }

==== 4. splitMultiTx(generic transactions[] array) ====
split into 2 legs:
  leg 0: { "tx": { "to": "0xmorpho", "data": "0x0001" }, "chain": "Base", "provider": "morpho" }
  leg 1: { "tx": { "to": "0xmorpho", "data": "0x0002" }, "chain": "Base", "provider": "morpho" }

All receipt assertions passed. (pure shape transforms — no signing, no broadcast)
```

Run it yourself: `node scripts/receipts/tx_normalize.mjs`

## testing

- `yarn workspace @vultisig/sdk test` — 1527 passed (incl. new `tests/unit/tx/normalize.test.ts`, both functions + every branch: flat-wrap, nested-passthrough, execute_* prep pass + phantom-card throw, from_chain fallback, no-overwrite, raw-string transport, no-mutation, approve+swap ordering, `needs_approval:false` no-split, generic array len>=1, malformed-JSON throw)
- `yarn workspace @vultisig/sdk typecheck` — 0 errors (these files add 0 new)
- lint + prettier clean

Part of the mcp-ts/backend -> SDK code-as-action consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transaction normalization utilities to the SDK for standardizing transaction payload shapes
  * Support for splitting multi-leg transactions (e.g., approval + swap scenarios) into separate normalized legs
  * New error handling for malformed or invalid transaction inputs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->