### PR TITLE
feat(sdk): add sdk.defi.threeJane (USDC supply)

### DIFF
--- a/.changeset/sdk-defi-threejane.md
+++ b/.changeset/sdk-defi-threejane.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': minor
+---
+
+Add `sdk.defi.threeJane` — the first protocol under the new `sdk.defi.*` surface. Builds the unsigned 2-step Ethereum transaction sequence (ERC-20 approve + `Helper.deposit`) to supply USDC into 3Jane and mint the senior `USD3` or staked junior `sUSD3` share. Build-only / pure-crypto: returns unsigned calldata, performs no network IO, never signs or broadcasts. Also exported from the React Native entry point.

--- a/packages/sdk/scripts/receipts/defi_3jane.mjs
+++ b/packages/sdk/scripts/receipts/defi_3jane.mjs
@@ -1,0 +1,87 @@
+// Runnable receipt: build an UNSIGNED 3Jane USDC supply tx via the SDK and print
+// its structure + decoded calldata. NO signing, NO broadcast, NO network IO.
+//
+// Run (from packages/sdk):  node --import tsx scripts/receipts/defi_3jane.mjs
+// The `tsx` import hook lets this .mjs pull the real builder straight from src.
+import { decodeFunctionData, erc20Abi } from 'viem'
+
+import { buildThreeJaneSupplyUsdc, THREE_JANE_ADDRESSES } from '../../src/tools/defi/threeJane/index.ts'
+
+const helperDepositAbi = [
+  {
+    name: 'deposit',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'assets', type: 'uint256' },
+      { name: 'receiver', type: 'address' },
+      { name: 'hop', type: 'bool' },
+    ],
+    outputs: [{ type: 'uint256' }],
+  },
+]
+
+const SAMPLE = {
+  from: '0x1111111111111111111111111111111111111111',
+  amount: '1500.5',
+  tranche: 'usd3',
+  // receiver omitted -> defaults to `from` (neutral / self-only; no affiliate baked in)
+}
+
+const result = buildThreeJaneSupplyUsdc(SAMPLE)
+
+const [approve, deposit] = result.transactions
+const approveDecoded = decodeFunctionData({ abi: erc20Abi, data: approve.data })
+const depositDecoded = decodeFunctionData({ abi: helperDepositAbi, data: deposit.data })
+
+const json = (v) => JSON.stringify(v, (_k, val) => (typeof val === 'bigint' ? val.toString() : val), 2)
+
+console.log('=== 3Jane USDC supply — UNSIGNED build receipt (no broadcast) ===\n')
+console.log('Inputs:', json(SAMPLE), '\n')
+console.log('Pinned addresses:', json(THREE_JANE_ADDRESSES), '\n')
+console.log('Result summary:')
+console.log(
+  json({
+    chain: result.chain,
+    chainId: result.chainId,
+    protocol: result.protocol,
+    fromSymbol: result.fromSymbol,
+    toSymbol: result.toSymbol,
+    fromAddress: result.fromAddress,
+    receiver: result.receiver,
+    tranche: result.tranche,
+    amountRaw: result.amountRaw,
+    amountUsdc: result.amountUsdc,
+    minDepositUsdc: result.minDepositUsdc,
+    txCount: result.transactions.length,
+  }),
+  '\n',
+)
+
+console.log('--- Step 1: ERC-20 approve (raw + decoded) ---')
+console.log(json({ to: approve.to, value: approve.value, action: approve.action, data: approve.data }))
+console.log('decoded:', json({ fn: approveDecoded.functionName, args: approveDecoded.args }), '\n')
+
+console.log('--- Step 2: 3Jane Helper.deposit (raw + decoded) ---')
+console.log(json({ to: deposit.to, value: deposit.value, action: deposit.action, data: deposit.data }))
+console.log('decoded:', json({ fn: depositDecoded.functionName, args: depositDecoded.args }), '\n')
+
+// Hard assertions so the receipt FAILS loudly if the build ever drifts.
+const assert = (cond, msg) => {
+  if (!cond) {
+    console.error('RECEIPT ASSERTION FAILED:', msg)
+    process.exit(1)
+  }
+}
+assert(result.transactions.length === 2, 'expected exactly 2 unsigned txs')
+assert(approveDecoded.functionName === 'approve', 'step 1 must be approve')
+assert(depositDecoded.functionName === 'deposit', 'step 2 must be Helper.deposit')
+assert(depositDecoded.args[0] === 1_500_500_000n, 'deposit amount must equal parsed raw USDC')
+assert(
+  depositDecoded.args[1].toLowerCase() === SAMPLE.from.toLowerCase(),
+  'receiver must default to the funder',
+)
+assert(depositDecoded.args[2] === false, 'usd3 tranche must set hop=false')
+assert(!json(result).toLowerCase().includes('station'), 'no station/affiliate may be hardcoded')
+
+console.log('OK — unsigned 3Jane supply tx built + decoded, all assertions passed.')

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -352,6 +352,8 @@ export { CosmosMsgType } from './types'
 // ============================================================================
 
 export type {
+  BuildThreeJaneSupplyUsdcParams,
+  BuildThreeJaneSupplyUsdcResult,
   Coin,
   CoinKey,
   CoinMetadata,
@@ -361,6 +363,8 @@ export type {
   KnownCoinMetadata,
   PrepareSendTxFromKeysParams,
   PrepareSwapTxFromKeysParams,
+  ThreeJaneTranche,
+  ThreeJaneTxStep,
   TokenMetadataResolver,
   VaultIdentity,
 } from './tools'
@@ -368,6 +372,7 @@ export {
   abiDecode,
   abiEncode,
   chainFeeCoin,
+  defi,
   deriveAddressFromKeys,
   evmCall,
   evmCheckAllowance,

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -211,6 +211,19 @@ export {
   resolveEns,
 } from '../../tools/evm'
 
+// DeFi protocol integrations (sdk.defi.* — builds UNSIGNED calldata only).
+// Pure viem encoding, no MPC/native deps, so it is RN-safe as a static
+// re-export (mirrors the generic entry). Without this the React Native
+// allow-list omitted the defi namespace and RN consumers (vultiagent-app)
+// could not reach the 3Jane supply builder.
+export { defi } from '../../tools/defi'
+export type {
+  BuildThreeJaneSupplyUsdcParams,
+  BuildThreeJaneSupplyUsdcResult,
+  ThreeJaneTranche,
+  ThreeJaneTxStep,
+} from '../../tools/defi/threeJane'
+
 // Cosmos staking + distribution module (LCD queries — read-only,
 // vault-free, generic over every ibcEnabled cosmos chain). Mirrors the
 // generic entry (src/index.ts); the React Native allow-list omitted

--- a/packages/sdk/src/tools/defi/index.ts
+++ b/packages/sdk/src/tools/defi/index.ts
@@ -1,0 +1,10 @@
+// DeFi protocol integrations under the sdk.defi.* surface.
+// Each protocol builds UNSIGNED calldata only — it never signs or broadcasts.
+import * as threeJane from './threeJane'
+
+/** Aggregated `sdk.defi.*` namespace. */
+export const defi = {
+  threeJane,
+} as const
+
+export * as threeJane from './threeJane'

--- a/packages/sdk/src/tools/defi/threeJane/buildSupplyUsdc.ts
+++ b/packages/sdk/src/tools/defi/threeJane/buildSupplyUsdc.ts
@@ -17,9 +17,9 @@ export const THREE_JANE_ADDRESSES = {
   /** Senior tranche, liquid ERC-4626 share. */
   usd3: '0x056B269Eb1f75477a8666ae8C7fE01b64dD55eCc',
   /** Staked junior tranche, cooldown-gated exits. */
-  susd3: '0xf689555121e529ff0463e191f9bd9d1e496164a7',
+  susd3: '0xf689555121e529Ff0463e191F9Bd9d1E496164a7',
   /** Canonical Ethereum mainnet USDC. */
-  usdc: '0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+  usdc: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
 } as const
 
 const ETHEREUM_CHAIN_ID = 1

--- a/packages/sdk/src/tools/defi/threeJane/buildSupplyUsdc.ts
+++ b/packages/sdk/src/tools/defi/threeJane/buildSupplyUsdc.ts
@@ -1,0 +1,197 @@
+import { encodeFunctionData, erc20Abi, getAddress, isAddress } from 'viem'
+
+/**
+ * 3Jane supplier-side mainnet addresses, pinned from the public docs:
+ * https://docs.3jane.xyz/developers/addresses
+ *
+ * 3Jane is an ERC-4626-style credit money market on Ethereum. The supplier flow
+ * deposits USDC through a Helper contract that mints the senior (USD3) or staked
+ * junior (sUSD3) share back to the depositor.
+ *
+ * Hand-rolled viem (per the DeFi lib-vs-handroll deep-dive: no official RN-safe
+ * SDK exists; ERC-4626 + a 1-fn helper ABI is trivial to encode directly).
+ */
+export const THREE_JANE_ADDRESSES = {
+  /** Helper.deposit(assets, receiver, hop) — supplier entrypoint. */
+  helper: '0x82736F81A56935c8429ADdbDa4aEBec737444505',
+  /** Senior tranche, liquid ERC-4626 share. */
+  usd3: '0x056B269Eb1f75477a8666ae8C7fE01b64dD55eCc',
+  /** Staked junior tranche, cooldown-gated exits. */
+  susd3: '0xf689555121e529ff0463e191f9bd9d1e496164a7',
+  /** Canonical Ethereum mainnet USDC. */
+  usdc: '0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+} as const
+
+const ETHEREUM_CHAIN_ID = 1
+const USDC_DECIMALS = 6
+/** Documented minimum supplier deposit: 1,000 USDC. */
+const MIN_DEPOSIT_RAW = 1_000n * 10n ** BigInt(USDC_DECIMALS)
+const MAX_UINT256 = (1n << 256n) - 1n
+
+const helperDepositAbi = [
+  {
+    name: 'deposit',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'assets', type: 'uint256' },
+      { name: 'receiver', type: 'address' },
+      { name: 'hop', type: 'bool' },
+    ],
+    outputs: [{ type: 'uint256' }],
+  },
+] as const
+
+/** Senior (liquid) or staked junior (cooldown-gated) 3Jane tranche. */
+export type ThreeJaneTranche = 'usd3' | 'susd3'
+
+export type BuildThreeJaneSupplyUsdcParams = {
+  /** Depositor / msg.sender Ethereum address. */
+  from: string
+  /** USDC amount as a decimal string (e.g. "1000", "1500.5"). Max 6 decimals. */
+  amount: string
+  /**
+   * Tranche to mint. `usd3` (default) = senior liquid share; `susd3` = staked
+   * junior share (maps to Helper.deposit hop=true), exits are cooldown-gated.
+   */
+  tranche?: ThreeJaneTranche
+  /**
+   * Share recipient. Injectable so multi-consumer callers can route shares to a
+   * vault / smart-account distinct from the funding address. Defaults to `from`
+   * (the only behaviour the on-chain Helper currently honours — it mints to
+   * msg.sender). No affiliate/fee is hardcoded; this is the sole steerable
+   * recipient knob and it defaults to the depositor (neutral / self-only).
+   */
+  receiver?: string
+}
+
+/** One unsigned EVM transaction step in the supply sequence. */
+export type ThreeJaneTxStep = {
+  to: `0x${string}`
+  value: '0'
+  data: `0x${string}`
+  action: 'approve' | 'deposit'
+  description: string
+}
+
+export type BuildThreeJaneSupplyUsdcResult = {
+  chain: 'Ethereum'
+  chainId: number
+  protocol: '3Jane'
+  provider: '3jane'
+  fromSymbol: 'USDC'
+  toSymbol: 'USD3' | 'sUSD3'
+  fromAddress: `0x${string}`
+  receiver: `0x${string}`
+  tranche: ThreeJaneTranche
+  amountRaw: string
+  amountUsdc: string
+  minDepositUsdc: string
+  /** Unsigned [approve, deposit] sequence. BUILD-ONLY — never signed/broadcast. */
+  transactions: [ThreeJaneTxStep, ThreeJaneTxStep]
+}
+
+/** Parse a decimal USDC string into a raw 6-decimal bigint. */
+export function parseUsdcAmount(s: string): bigint {
+  const trimmed = s.trim()
+  if (trimmed === '') throw new Error('empty amount')
+  if (trimmed.startsWith('-')) throw new Error('negative amounts not allowed')
+
+  const dotIdx = trimmed.indexOf('.')
+  let wholePart = dotIdx === -1 ? trimmed : trimmed.slice(0, dotIdx)
+  let fracPart = dotIdx === -1 ? '' : trimmed.slice(dotIdx + 1)
+
+  if (fracPart.includes('.')) throw new Error(`invalid amount: multiple decimal points in ${s}`)
+  if (wholePart === '') wholePart = '0'
+  if (fracPart.length > USDC_DECIMALS) {
+    throw new Error(`too many decimal places (max ${USDC_DECIMALS} for USDC): ${s}`)
+  }
+  if (!/^\d+$/.test(wholePart)) throw new Error(`invalid integer part: ${wholePart}`)
+  if (fracPart !== '' && !/^\d+$/.test(fracPart)) throw new Error(`invalid fractional part: ${fracPart}`)
+
+  while (fracPart.length < USDC_DECIMALS) fracPart += '0'
+  const fracInt = fracPart === '' ? 0n : BigInt(fracPart)
+  return BigInt(wholePart) * 10n ** BigInt(USDC_DECIMALS) + fracInt
+}
+
+function formatUsdc(raw: bigint): string {
+  const whole = raw / 10n ** BigInt(USDC_DECIMALS)
+  const frac = raw % 10n ** BigInt(USDC_DECIMALS)
+  if (frac === 0n) return whole.toString()
+  const fracStr = frac.toString().padStart(USDC_DECIMALS, '0').replace(/0+$/, '')
+  return `${whole.toString()}.${fracStr}`
+}
+
+/**
+ * Build the unsigned 2-step Ethereum transaction sequence to supply USDC into
+ * 3Jane: (1) ERC-20 approve USDC to the 3Jane Helper, (2) Helper.deposit(...) to
+ * mint USD3 (senior) or sUSD3 (staked junior) back to `receiver`.
+ *
+ * PURE / BUILD-ONLY: returns unsigned calldata. It never signs, never broadcasts,
+ * and performs no network IO. Supplier-side only (no borrow / no sUSD3 exit).
+ */
+export function buildThreeJaneSupplyUsdc(params: BuildThreeJaneSupplyUsdcParams): BuildThreeJaneSupplyUsdcResult {
+  const senderRaw = String(params.from ?? '').trim()
+  if (senderRaw === '') throw new Error('from address is required')
+  if (!isAddress(senderRaw, { strict: false })) throw new Error(`invalid "from" address: ${senderRaw}`)
+  const sender = getAddress(senderRaw)
+
+  const receiverRaw = String(params.receiver ?? senderRaw).trim()
+  if (!isAddress(receiverRaw, { strict: false })) throw new Error(`invalid "receiver" address: ${receiverRaw}`)
+  const receiver = getAddress(receiverRaw)
+
+  const rawAmount = parseUsdcAmount(String(params.amount))
+  if (rawAmount <= 0n) throw new Error('amount must be positive')
+  if (rawAmount < MIN_DEPOSIT_RAW) {
+    throw new Error(`3Jane supplier deposits must be at least ${formatUsdc(MIN_DEPOSIT_RAW)} USDC.`)
+  }
+  if (rawAmount > MAX_UINT256) throw new Error('amount overflows uint256')
+
+  const tranche: ThreeJaneTranche = params.tranche === 'susd3' ? 'susd3' : 'usd3'
+  const hop = tranche === 'susd3'
+
+  const approveData = encodeFunctionData({
+    abi: erc20Abi,
+    functionName: 'approve',
+    args: [getAddress(THREE_JANE_ADDRESSES.helper), rawAmount],
+  })
+
+  const depositData = encodeFunctionData({
+    abi: helperDepositAbi,
+    functionName: 'deposit',
+    args: [rawAmount, receiver, hop],
+  })
+
+  return {
+    chain: 'Ethereum',
+    chainId: ETHEREUM_CHAIN_ID,
+    protocol: '3Jane',
+    provider: '3jane',
+    fromSymbol: 'USDC',
+    toSymbol: hop ? 'sUSD3' : 'USD3',
+    fromAddress: sender,
+    receiver,
+    tranche,
+    amountRaw: rawAmount.toString(),
+    amountUsdc: formatUsdc(rawAmount),
+    minDepositUsdc: formatUsdc(MIN_DEPOSIT_RAW),
+    transactions: [
+      {
+        to: getAddress(THREE_JANE_ADDRESSES.usdc),
+        value: '0',
+        data: approveData,
+        action: 'approve',
+        description: `Approve ${formatUsdc(rawAmount)} USDC to the 3Jane Helper on Ethereum (step 1 of 2).`,
+      },
+      {
+        to: getAddress(THREE_JANE_ADDRESSES.helper),
+        value: '0',
+        data: depositData,
+        action: 'deposit',
+        description: hop
+          ? `Supply ${formatUsdc(rawAmount)} USDC via 3Jane Helper.deposit(..., hop=true) to mint sUSD3 to ${receiver} (step 2 of 2). sUSD3 exits are cooldown-gated.`
+          : `Supply ${formatUsdc(rawAmount)} USDC via 3Jane Helper.deposit(..., hop=false) to mint USD3 to ${receiver} (step 2 of 2).`,
+      },
+    ],
+  }
+}

--- a/packages/sdk/src/tools/defi/threeJane/index.ts
+++ b/packages/sdk/src/tools/defi/threeJane/index.ts
@@ -1,0 +1,7 @@
+export type {
+  BuildThreeJaneSupplyUsdcParams,
+  BuildThreeJaneSupplyUsdcResult,
+  ThreeJaneTranche,
+  ThreeJaneTxStep,
+} from './buildSupplyUsdc'
+export { buildThreeJaneSupplyUsdc, parseUsdcAmount, THREE_JANE_ADDRESSES } from './buildSupplyUsdc'

--- a/packages/sdk/src/tools/index.ts
+++ b/packages/sdk/src/tools/index.ts
@@ -20,6 +20,15 @@ export {
 // Verifier client
 export { VerifierClient } from './verifier'
 
+// DeFi protocol integrations (sdk.defi.* — builds UNSIGNED calldata only)
+export { defi } from './defi'
+export type {
+  BuildThreeJaneSupplyUsdcParams,
+  BuildThreeJaneSupplyUsdcResult,
+  ThreeJaneTranche,
+  ThreeJaneTxStep,
+} from './defi/threeJane'
+
 // Vault-free prep helpers (KeysignPayload construction without a full vault)
 export {
   getMaxSendAmountFromKeys,

--- a/packages/sdk/tests/unit/defi-threejane.test.ts
+++ b/packages/sdk/tests/unit/defi-threejane.test.ts
@@ -1,0 +1,109 @@
+import { decodeFunctionData, erc20Abi, getAddress } from 'viem'
+import { describe, expect, it } from 'vitest'
+
+import { buildThreeJaneSupplyUsdc, parseUsdcAmount, THREE_JANE_ADDRESSES } from '@/tools/defi/threeJane'
+
+const FROM = '0x1111111111111111111111111111111111111111'
+const RECEIVER = '0x2222222222222222222222222222222222222222'
+
+const helperDepositAbi = [
+  {
+    name: 'deposit',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'assets', type: 'uint256' },
+      { name: 'receiver', type: 'address' },
+      { name: 'hop', type: 'bool' },
+    ],
+    outputs: [{ type: 'uint256' }],
+  },
+] as const
+
+describe('parseUsdcAmount', () => {
+  it('parses whole and fractional USDC into 6-decimal raw', () => {
+    expect(parseUsdcAmount('1000')).toBe(1_000_000_000n)
+    expect(parseUsdcAmount('1500.5')).toBe(1_500_500_000n)
+    expect(parseUsdcAmount('0.000001')).toBe(1n)
+  })
+
+  it('rejects bad input', () => {
+    expect(() => parseUsdcAmount('')).toThrow()
+    expect(() => parseUsdcAmount('-5')).toThrow()
+    expect(() => parseUsdcAmount('1.2.3')).toThrow()
+    expect(() => parseUsdcAmount('1.1234567')).toThrow(/too many decimal places/)
+    expect(() => parseUsdcAmount('abc')).toThrow()
+  })
+})
+
+describe('buildThreeJaneSupplyUsdc', () => {
+  it('builds an unsigned [approve, deposit] sequence for the senior tranche', () => {
+    const res = buildThreeJaneSupplyUsdc({ from: FROM, amount: '1000' })
+
+    expect(res.chain).toBe('Ethereum')
+    expect(res.chainId).toBe(1)
+    expect(res.protocol).toBe('3Jane')
+    expect(res.tranche).toBe('usd3')
+    expect(res.toSymbol).toBe('USD3')
+    expect(res.amountRaw).toBe('1000000000')
+    expect(res.transactions).toHaveLength(2)
+
+    const [approve, deposit] = res.transactions
+
+    // step 1: ERC-20 approve to the helper for the exact amount
+    expect(approve.action).toBe('approve')
+    expect(approve.value).toBe('0')
+    expect(getAddress(approve.to)).toBe(getAddress(THREE_JANE_ADDRESSES.usdc))
+    const approveDecoded = decodeFunctionData({ abi: erc20Abi, data: approve.data })
+    expect(approveDecoded.functionName).toBe('approve')
+    expect(getAddress(approveDecoded.args[0] as string)).toBe(getAddress(THREE_JANE_ADDRESSES.helper))
+    expect(approveDecoded.args[1]).toBe(1_000_000_000n)
+
+    // step 2: Helper.deposit(assets, receiver=from, hop=false)
+    expect(deposit.action).toBe('deposit')
+    expect(getAddress(deposit.to)).toBe(getAddress(THREE_JANE_ADDRESSES.helper))
+    const depositDecoded = decodeFunctionData({ abi: helperDepositAbi, data: deposit.data })
+    expect(depositDecoded.functionName).toBe('deposit')
+    expect(depositDecoded.args[0]).toBe(1_000_000_000n)
+    expect(getAddress(depositDecoded.args[1] as string)).toBe(getAddress(FROM))
+    expect(depositDecoded.args[2]).toBe(false)
+  })
+
+  it('sets hop=true and mints sUSD3 for the staked junior tranche', () => {
+    const res = buildThreeJaneSupplyUsdc({ from: FROM, amount: '2000', tranche: 'susd3' })
+    expect(res.toSymbol).toBe('sUSD3')
+    const depositDecoded = decodeFunctionData({ abi: helperDepositAbi, data: res.transactions[1].data })
+    expect(depositDecoded.args[2]).toBe(true)
+  })
+
+  it('routes shares to an injectable receiver distinct from the funder', () => {
+    const res = buildThreeJaneSupplyUsdc({ from: FROM, amount: '1000', receiver: RECEIVER })
+    expect(getAddress(res.receiver)).toBe(getAddress(RECEIVER))
+    expect(getAddress(res.fromAddress)).toBe(getAddress(FROM))
+    const depositDecoded = decodeFunctionData({ abi: helperDepositAbi, data: res.transactions[1].data })
+    expect(getAddress(depositDecoded.args[1] as string)).toBe(getAddress(RECEIVER))
+  })
+
+  it('defaults receiver to the funder (neutral / self-only)', () => {
+    const res = buildThreeJaneSupplyUsdc({ from: FROM, amount: '1000' })
+    expect(getAddress(res.receiver)).toBe(getAddress(FROM))
+  })
+
+  it('enforces the 1,000 USDC minimum deposit', () => {
+    expect(() => buildThreeJaneSupplyUsdc({ from: FROM, amount: '999' })).toThrow(/at least 1000 USDC/)
+  })
+
+  it('rejects an invalid from / receiver address', () => {
+    expect(() => buildThreeJaneSupplyUsdc({ from: 'nope', amount: '1000' })).toThrow(/invalid "from"/)
+    expect(() => buildThreeJaneSupplyUsdc({ from: FROM, amount: '1000', receiver: 'nope' })).toThrow(
+      /invalid "receiver"/
+    )
+  })
+
+  it('does not hardcode any affiliate / station recipient', () => {
+    const res = buildThreeJaneSupplyUsdc({ from: FROM, amount: '5000' })
+    const serialized = JSON.stringify(res).toLowerCase()
+    expect(serialized).not.toContain('station')
+    expect(serialized).not.toContain('affiliate')
+  })
+})

--- a/packages/sdk/tests/unit/defi-threejane.test.ts
+++ b/packages/sdk/tests/unit/defi-threejane.test.ts
@@ -1,4 +1,4 @@
-import { decodeFunctionData, erc20Abi, getAddress } from 'viem'
+import { decodeFunctionData, erc20Abi, getAddress, isAddress } from 'viem'
 import { describe, expect, it } from 'vitest'
 
 import { buildThreeJaneSupplyUsdc, parseUsdcAmount, THREE_JANE_ADDRESSES } from '@/tools/defi/threeJane'
@@ -98,6 +98,28 @@ describe('buildThreeJaneSupplyUsdc', () => {
     expect(() => buildThreeJaneSupplyUsdc({ from: FROM, amount: '1000', receiver: 'nope' })).toThrow(
       /invalid "receiver"/
     )
+  })
+
+  it('pins every protocol address in valid EIP-55 checksum form', () => {
+    // These constants are exported and consumed directly by downstream callers.
+    // strict:true guarantees the mixed-case bytes are a real EIP-55 checksum, so
+    // a future typo in any of these fund-critical hex digits trips the test
+    // instead of silently shipping a wrong recipient.
+    for (const [key, addr] of Object.entries(THREE_JANE_ADDRESSES)) {
+      expect(isAddress(addr, { strict: true }), `${key} (${addr}) must be EIP-55 checksummed`).toBe(true)
+      expect(getAddress(addr), `${key} must already equal its checksum`).toBe(addr)
+    }
+  })
+
+  it('approve spender and deposit target both resolve to the pinned Helper', () => {
+    const res = buildThreeJaneSupplyUsdc({ from: FROM, amount: '1000' })
+    const [approve, deposit] = res.transactions
+    const approveDecoded = decodeFunctionData({ abi: erc20Abi, data: approve.data })
+    // The address USDC is approved to MUST equal the address the deposit is sent
+    // to — otherwise the allowance is granted to a contract that never spends it
+    // (funds stuck) or, worse, a different contract than the user is told.
+    expect(getAddress(approveDecoded.args[0] as string)).toBe(getAddress(deposit.to))
+    expect(getAddress(deposit.to)).toBe(getAddress(THREE_JANE_ADDRESSES.helper))
   })
 
   it('does not hardcode any affiliate / station recipient', () => {


### PR DESCRIPTION
## what

Adds the first protocol under the new `sdk.defi.*` surface: `sdk.defi.threeJane`. It builds the unsigned 2-step Ethereum tx sequence to supply USDC into 3Jane (an ERC-4626-style credit money market):

1. ERC-20 `approve` USDC -> 3Jane Helper
2. `Helper.deposit(assets, receiver, hop)` to mint the senior `USD3` (hop=false) or staked junior `sUSD3` (hop=true) share

Ported from mcp-ts `build_3jane_supply_usdc`, reshaped into a pure SDK builder.

## how

- **Hand-rolled viem** (ERC-4626 + a 1-fn helper ABI) per the lib-vs-handroll deep-dive: no RN-safe official 3Jane SDK exists, so encoding directly with viem's `encodeFunctionData` is the lighter, RN-safe call. No new deps.
- **BUILD-ONLY / pure crypto**: returns unsigned calldata, performs zero network IO, and never signs or broadcasts. Supplier-side only (no borrow, no sUSD3 exit).
- **Injectable recipient, no hardcoded affiliate**: `receiver` is consumer-supplied and defaults to `from` (the only behaviour the on-chain Helper honours — mints to msg.sender). No `station`/affiliate string is baked in — the SDK is multi-consumer. A unit test asserts the serialized output contains neither `station` nor `affiliate`.
- Strict input validation: address checksum, decimal/precision parsing (max 6 dp), positive amount, 1,000 USDC documented minimum, uint256 overflow guard.
- Exposed as the `defi` namespace (`sdk.defi.threeJane.buildThreeJaneSupplyUsdc`) plus flat type re-exports from the package index.

## consumers unblocked

- **agent-backend / mcp-ts**: can drop the bespoke tool wiring and call the SDK builder directly for 3Jane supply calldata.
- **vultiagent-app**: a vault-free path to construct the unsigned approve+deposit pair for the keysign flow.
- Any future `sdk.defi.*` consumer gets a consistent build-only contract.

## test

- `yarn workspace @vultisig/sdk typecheck` -> exit 0, 0 errors (my files add 0 new).
- `vitest` unit test: 9/9 pass.
- Runnable receipt builds + decodes the unsigned calldata with hard assertions: `node --import tsx scripts/receipts/defi_3jane.mjs`.

```
=== 3Jane USDC supply — UNSIGNED build receipt (no broadcast) ===

Inputs: { "from": "0x1111...1111", "amount": "1500.5", "tranche": "usd3" }

Result summary:
{ "chain": "Ethereum", "chainId": 1, "protocol": "3Jane",
  "fromSymbol": "USDC", "toSymbol": "USD3",
  "fromAddress": "0x1111...1111", "receiver": "0x1111...1111",
  "tranche": "usd3", "amountRaw": "1500500000", "amountUsdc": "1500.5",
  "minDepositUsdc": "1000", "txCount": 2 }

--- Step 1: ERC-20 approve (decoded) ---
fn: approve  args: [ 0x82736F81...444505 (Helper), 1500500000 ]
data: 0x095ea7b3...596fd020

--- Step 2: 3Jane Helper.deposit (decoded) ---
fn: deposit  args: [ 1500500000, 0x1111...1111 (receiver=funder), false (hop) ]
data: 0x83df6747...

OK — unsigned 3Jane supply tx built + decoded, all assertions passed.
```

Part of the sdk.defi.* DeFi consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an SDK DeFi integration for 3Jane USDC supply that builds an **unsigned** 2-step flow (USDC approve, then helper deposit).
  * Supports **USD3** and **sUSD3** tranches with receiver routing (receiver defaults to sender).
  * Added strict input validation with normalized, structured build results and step metadata.
  * Exposed the `sdk.defi.threeJane` API (plus types) from both the main and React Native SDK entry points.
* **Tests**
  * Added unit tests covering USDC parsing and transaction-sequence/validation behavior.
* **Documentation**
  * Added a Changeset entry for the new API (`minor` bump).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->