### PR TITLE
feat(sdk): add sdk.defi.arkis (lender supply)

### DIFF
--- a/.changeset/wild-arkis-supply.md
+++ b/.changeset/wild-arkis-supply.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': minor
+---
+
+Add `sdk.defi.arkis` — a lender-side **supply** builder for the Arkis protocol on Ethereum. Builds the unsigned 2-step sequence (ERC-20 `approve` → ERC-4626 / Agreement `deposit`) and returns the decoded transactions. Builds UNSIGNED calldata only — never signs, never broadcasts. Also surfaces `resolveArkisPoolKind` (optional on-chain `asset()` probe) and `parseArkisTokenAmount` (exact string-math base-unit parse), exposed via the new `sdk.defi` getter.

--- a/packages/sdk/src/Vultisig.ts
+++ b/packages/sdk/src/Vultisig.ts
@@ -46,6 +46,7 @@ import type { PushNotificationService } from './services/PushNotificationService
 import { type PerformReshareParams, SecureVaultCreationService } from './services/SecureVaultCreationService'
 import { SecureVaultFromSeedphraseService } from './services/SecureVaultFromSeedphraseService'
 import type { Storage } from './storage/types'
+import { type Defi, defi } from './tools/defi'
 import {
   AddressBook,
   AddressBookEntry,
@@ -159,6 +160,16 @@ export class Vultisig extends UniversalEventEmitter<SdkEvents> {
    */
   public get notifications(): PushNotificationService {
     return this.context.pushNotificationService
+  }
+
+  /**
+   * DeFi protocol primitives. Builds UNSIGNED calldata only (e.g.
+   * `sdk.defi.arkis.buildArkisSupplyTx(...)`) — never signs or broadcasts. The
+   * surface is multi-consumer: any affiliate/fee param is injectable and
+   * defaults to neutral/off, with no consumer identity hardcoded.
+   */
+  public get defi(): Defi {
+    return defi
   }
 
   /**

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -393,6 +393,7 @@ export type {
   CoinKey,
   CoinMetadata,
   DecodeFromToolResultInput,
+  Defi,
   Envelope,
   EnvelopeKind,
   FieldDiff,
@@ -420,7 +421,6 @@ export type {
   VaultIdentity,
   Verdict,
 } from './tools'
-export { type Defi, defi } from './tools'
 export {
   abiDecode,
   abiEncode,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -364,6 +364,7 @@ export type {
   TokenMetadataResolver,
   VaultIdentity,
 } from './tools'
+export { type Defi, defi } from './tools'
 export {
   abiDecode,
   abiEncode,

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -211,6 +211,15 @@ export {
   resolveEns,
 } from '../../tools/evm'
 
+// DeFi protocol primitives (build UNSIGNED calldata only). viem-backed and
+// RN-safe — `buildArkisSupplyTx` / `parseArkisTokenAmount` are pure (viem
+// `encodeFunctionData`), and `resolveArkisPoolKind`'s read-only `eth_call`
+// rides the same externalized core-chain EVM client as the evm tools above.
+// The generic entry (src/index.ts) exposes this via the `defi` namespace; the
+// RN allow-list omitted it so RN consumers (Station, Windows ext) couldn't
+// build an unsigned Arkis supply tx and had to drag the Arkis SDK.
+export { type Defi, defi } from '../../tools/defi'
+
 // Cosmos staking + distribution module (LCD queries — read-only,
 // vault-free, generic over every ibcEnabled cosmos chain). Mirrors the
 // generic entry (src/index.ts); the React Native allow-list omitted

--- a/packages/sdk/src/tools/defi/arkis/abi.ts
+++ b/packages/sdk/src/tools/defi/arkis/abi.ts
@@ -1,0 +1,52 @@
+// Arkis lender-side ABIs.
+//
+// Two supply paths are supported, mirroring the production Arkis app:
+//   - ERC-4626 vaults: `deposit(uint256 assets, address receiver)`
+//   - Standard Agreements: `deposit(uint128 amount)`
+//
+// We hand-roll the minimal ABI fragments (viem `encodeFunctionData`) rather
+// than dragging an Arkis SDK — there is no RN/Hermes-safe official package, and
+// the supply surface is a two-call ERC-20-approve + ERC-4626-deposit sequence.
+//
+// Read fragments (`asset`, `maxDeposit`, `decimals`, …) are used only by the
+// optional on-chain resolver helpers; the calldata builder itself is pure.
+
+export const erc4626WriteAbi = [
+  {
+    name: 'deposit',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'assets', type: 'uint256' },
+      { name: 'receiver', type: 'address' },
+    ],
+    outputs: [{ type: 'uint256' }],
+  },
+] as const
+
+export const erc4626ReadAbi = [
+  {
+    name: 'asset',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ type: 'address' }],
+  },
+  {
+    name: 'maxDeposit',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [{ name: 'receiver', type: 'address' }],
+    outputs: [{ type: 'uint256' }],
+  },
+] as const
+
+export const standardAgreementWriteAbi = [
+  {
+    name: 'deposit',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [{ name: 'amount', type: 'uint128' }],
+    outputs: [],
+  },
+] as const

--- a/packages/sdk/src/tools/defi/arkis/addresses.ts
+++ b/packages/sdk/src/tools/defi/arkis/addresses.ts
@@ -1,0 +1,23 @@
+// Arkis published mainnet contract addresses.
+//
+// Pinned from Arkis docs:
+// https://docs.arkis.xyz/home/for-developers/high-level-architecture
+//
+// Lender-side scaffold is Ethereum mainnet only. Hyperliquid L1 wrapper
+// collateral, margin-account vault allocation, direct borrow, and withdrawals
+// are intentionally out of scope here.
+export const ARKIS_OFFICIAL_ADDRESSES = {
+  dispatcher: '0x2f01D7CFfe62673B3D2b680295A2D047F3848e4c',
+  compliance: '0x286496C568368e036062781F807db5ea3E56d3e8',
+  agreementFactoryV2: '0xbbC9c04348E093473C5b176Cb4b103fF706528bf',
+  leverage: '0xe70d11D23F36826C58f30C61B4DeAf0A89a6D837',
+  liquidator: '0x7ad1dd2516F1499852aAEb95a33D7Ec1BA31b5C3',
+  vaultFactory: '0x76D46cb4c5cA64ba5aDCf3376E4BD3B75f0e61D2',
+  vaultMarketplace: '0x1f797CC91BB598AA5aa8bafF1B1aF65f578fbAf2',
+  wrapperFactory: '0xEA623eebd9c5bFd56067e36C89Db0C13e6c70ba8',
+} as const
+
+export const ARKIS_BOOK_URLS = {
+  lend: 'https://arkis-assets.s3.eu-central-1.amazonaws.com/public/Arkis_Lend_Book.csv',
+  borrow: 'https://arkis-assets.s3.eu-central-1.amazonaws.com/public/Arkis_Borrow_Book.csv',
+} as const

--- a/packages/sdk/src/tools/defi/arkis/buildSupplyTx.ts
+++ b/packages/sdk/src/tools/defi/arkis/buildSupplyTx.ts
@@ -1,0 +1,175 @@
+import { encodeFunctionData, erc20Abi, getAddress, isAddress } from 'viem'
+
+import { erc4626WriteAbi, standardAgreementWriteAbi } from './abi'
+import { parseArkisTokenAmount } from './parseTokenAmount'
+
+const MAX_UINT128 = (1n << 128n) - 1n
+const MAX_UINT256 = (1n << 256n) - 1n
+
+/** Which Arkis supply path the target pool uses. */
+export type ArkisPoolKind = 'erc4626_vault' | 'agreement'
+
+/** A single unsigned EVM transaction in the supply sequence. */
+export type ArkisUnsignedTx = {
+  /** Target contract for this leg. */
+  to: `0x${string}`
+  /** Native value — always "0" for the supply flow (ERC-20 path). */
+  value: '0'
+  /** ABI-encoded calldata. */
+  data: `0x${string}`
+  /** Semantic action: `approve` (step 1) or `deposit` (step 2). */
+  action: 'approve' | 'deposit'
+  /** Human-readable description of this leg. */
+  description: string
+}
+
+export type BuildArkisSupplyParams = {
+  /** Arkis Agreement or ERC-4626 Vault address on Ethereum. */
+  poolAddress: string
+  /** ERC-20 token to supply. On ERC-4626 pools this must match `pool.asset()`. */
+  tokenAddress: string
+  /** Sender / receiver address. Shares (4626) mint back to this address. */
+  from: string
+  /**
+   * Which supply path the pool uses. Resolve on-chain via
+   * `resolveArkisPoolKind` (reads `asset()`), or pass explicitly when known.
+   */
+  poolKind: ArkisPoolKind
+  /** Raw base-unit amount (mutually exclusive with `amount` + `decimals`). */
+  amountRaw?: bigint
+  /** Human-readable amount, e.g. "1500.25" (requires `decimals`). */
+  amount?: string
+  /** Token decimals — required when `amount` is provided. */
+  decimals?: number
+  /**
+   * Optional affiliate / referrer tag. Arkis supply has NO on-chain affiliate
+   * slot, so this is a metadata passthrough only (echoed on the result for the
+   * calling consumer). It is INJECTABLE and defaults to undefined (neutral/off)
+   * — the SDK is multi-consumer and never hardcodes any consumer identity.
+   */
+  affiliate?: string
+}
+
+export type BuildArkisSupplyResult = {
+  protocol: 'Arkis'
+  chain: 'Ethereum'
+  chainId: '1'
+  poolKind: ArkisPoolKind
+  poolAddress: `0x${string}`
+  tokenAddress: `0x${string}`
+  from: `0x${string}`
+  receiver: `0x${string}`
+  amountRaw: string
+  /** Echoed affiliate tag (undefined when not supplied — neutral default). */
+  affiliate?: string
+  /** Two-leg unsigned sequence: [approve, deposit]. Never signed/broadcast. */
+  transactions: [ArkisUnsignedTx, ArkisUnsignedTx]
+  instructions: string
+}
+
+function requireAddress(label: string, value: string): `0x${string}` {
+  if (!isAddress(value, { strict: false })) {
+    throw new Error(`invalid "${label}" address: ${value}`)
+  }
+  return getAddress(value)
+}
+
+/**
+ * Build the unsigned 2-step Arkis lender supply sequence (ERC-20 approve →
+ * ERC-4626 / Agreement deposit) on Ethereum.
+ *
+ * PURE: this only encodes calldata via viem `encodeFunctionData`. It performs
+ * NO network I/O and NEVER signs or broadcasts. The caller is responsible for
+ * having resolved the pool kind (see `resolveArkisPoolKind`) and, for ERC-4626
+ * pools, for confirming `tokenAddress === pool.asset()`.
+ *
+ * @example
+ * ```ts
+ * const built = buildArkisSupplyTx({
+ *   poolKind: 'erc4626_vault',
+ *   poolAddress: '0x2222…',
+ *   tokenAddress: '0xA0b8…', // USDC
+ *   from: '0x7099…',
+ *   amount: '1500',
+ *   decimals: 6,
+ * })
+ * // built.transactions = [approve, deposit(assets, receiver)]
+ * ```
+ */
+export const buildArkisSupplyTx = (params: BuildArkisSupplyParams): BuildArkisSupplyResult => {
+  const from = requireAddress('from', params.from)
+  const poolAddress = requireAddress('pool_address', params.poolAddress)
+  const tokenAddress = requireAddress('token_address', params.tokenAddress)
+
+  let rawAmount: bigint
+  if (params.amountRaw !== undefined) {
+    rawAmount = params.amountRaw
+  } else {
+    if (params.amount === undefined || params.decimals === undefined) {
+      throw new Error('provide either `amountRaw`, or both `amount` and `decimals`')
+    }
+    rawAmount = parseArkisTokenAmount(params.amount, params.decimals)
+  }
+
+  if (rawAmount <= 0n) throw new Error('amount must be positive')
+  if (rawAmount > MAX_UINT256) throw new Error('amount overflows uint256')
+  if (params.poolKind === 'agreement' && rawAmount > MAX_UINT128) {
+    throw new Error('amount overflows uint128 required by the Arkis Agreement deposit path')
+  }
+
+  const approveData = encodeFunctionData({
+    abi: erc20Abi,
+    functionName: 'approve',
+    args: [poolAddress, rawAmount],
+  })
+
+  const depositData =
+    params.poolKind === 'erc4626_vault'
+      ? // receiver is fixed to `from` so the scaffold cannot mint shares to an
+        // arbitrary third party.
+        encodeFunctionData({
+          abi: erc4626WriteAbi,
+          functionName: 'deposit',
+          args: [rawAmount, from],
+        })
+      : encodeFunctionData({
+          abi: standardAgreementWriteAbi,
+          functionName: 'deposit',
+          args: [rawAmount],
+        })
+
+  const approveTx: ArkisUnsignedTx = {
+    to: tokenAddress,
+    value: '0',
+    data: approveData,
+    action: 'approve',
+    description: 'Approve the token to the selected Arkis pool on Ethereum (step 1 of 2).',
+  }
+
+  const depositTx: ArkisUnsignedTx = {
+    to: poolAddress,
+    value: '0',
+    data: depositData,
+    action: 'deposit',
+    description:
+      params.poolKind === 'erc4626_vault'
+        ? 'Supply into the Arkis ERC-4626 vault and mint shares back to your own address (step 2 of 2).'
+        : 'Supply into the Arkis Agreement via deposit(uint128) (step 2 of 2).',
+  }
+
+  return {
+    protocol: 'Arkis',
+    chain: 'Ethereum',
+    chainId: '1',
+    poolKind: params.poolKind,
+    poolAddress,
+    tokenAddress,
+    from,
+    receiver: from,
+    amountRaw: rawAmount.toString(),
+    ...(params.affiliate ? { affiliate: params.affiliate } : {}),
+    transactions: [approveTx, depositTx],
+    instructions:
+      'Two-step flow: approve the underlying token to the Arkis pool, then call deposit. Lender-side only on Ethereum — never signs or broadcasts.',
+  }
+}

--- a/packages/sdk/src/tools/defi/arkis/buildSupplyTx.ts
+++ b/packages/sdk/src/tools/defi/arkis/buildSupplyTx.ts
@@ -42,6 +42,16 @@ export type BuildArkisSupplyParams = {
   /** Token decimals — required when `amount` is provided. */
   decimals?: number
   /**
+   * Optional ERC-4626 underlying-asset guard. When provided (e.g. the `asset`
+   * returned by `resolveArkisPoolKind`), the builder enforces
+   * `tokenAddress === expectedAsset` on the `erc4626_vault` path and throws on a
+   * mismatch. This prevents approving + depositing the wrong ERC-20 into a
+   * vault (an allowance-leak / griefing footgun). Ignored on the `agreement`
+   * path. Default off — the builder stays pure; callers that have resolved the
+   * asset should pass it through.
+   */
+  expectedAsset?: string
+  /**
    * Optional affiliate / referrer tag. Arkis supply has NO on-chain affiliate
    * slot, so this is a metadata passthrough only (echoed on the result for the
    * calling consumer). It is INJECTABLE and defaults to undefined (neutral/off)
@@ -100,6 +110,16 @@ export const buildArkisSupplyTx = (params: BuildArkisSupplyParams): BuildArkisSu
   const from = requireAddress('from', params.from)
   const poolAddress = requireAddress('pool_address', params.poolAddress)
   const tokenAddress = requireAddress('token_address', params.tokenAddress)
+
+  // ERC-4626 underlying-asset guard: if the caller resolved the vault's
+  // `asset()` and passed it through, refuse to approve/deposit a mismatched
+  // token (would leak an allowance to the wrong ERC-20 and revert on deposit).
+  if (params.poolKind === 'erc4626_vault' && params.expectedAsset !== undefined) {
+    const expectedAsset = requireAddress('expected_asset', params.expectedAsset)
+    if (expectedAsset !== tokenAddress) {
+      throw new Error(`token_address ${tokenAddress} does not match the Arkis ERC-4626 vault asset() ${expectedAsset}`)
+    }
+  }
 
   let rawAmount: bigint
   if (params.amountRaw !== undefined) {

--- a/packages/sdk/src/tools/defi/arkis/index.ts
+++ b/packages/sdk/src/tools/defi/arkis/index.ts
@@ -1,0 +1,15 @@
+// sdk.defi.arkis — Arkis lender-side supply surface.
+//
+// Builds UNSIGNED Arkis supply calldata only (ERC-20 approve + ERC-4626 /
+// Agreement deposit). Never signs, never broadcasts. Multi-consumer: no
+// affiliate/consumer identity is hardcoded.
+export { ARKIS_BOOK_URLS, ARKIS_OFFICIAL_ADDRESSES } from './addresses'
+export {
+  type ArkisPoolKind,
+  type ArkisUnsignedTx,
+  type BuildArkisSupplyParams,
+  type BuildArkisSupplyResult,
+  buildArkisSupplyTx,
+} from './buildSupplyTx'
+export { parseArkisTokenAmount } from './parseTokenAmount'
+export { resolveArkisPoolKind, type ResolveArkisPoolKindResult } from './resolvePoolKind'

--- a/packages/sdk/src/tools/defi/arkis/parseTokenAmount.ts
+++ b/packages/sdk/src/tools/defi/arkis/parseTokenAmount.ts
@@ -1,0 +1,33 @@
+/**
+ * Parse a human-readable token amount (e.g. "1500" or "2500.25") into its raw
+ * base-unit `bigint` given the token's decimals. String-only math — no float
+ * round-trips, so it is exact for arbitrary precision.
+ *
+ * @throws if the amount is empty, negative, non-numeric, or has more fractional
+ * digits than the token supports.
+ */
+export const parseArkisTokenAmount = (amount: string, decimals: number): bigint => {
+  const trimmed = amount.trim()
+  if (trimmed === '') throw new Error('empty amount')
+  if (trimmed.startsWith('-')) throw new Error('negative amounts not allowed')
+
+  const dotIdx = trimmed.indexOf('.')
+  let wholePart = trimmed
+  let fracPart = ''
+  if (dotIdx !== -1) {
+    wholePart = trimmed.slice(0, dotIdx)
+    fracPart = trimmed.slice(dotIdx + 1)
+    if (fracPart.includes('.')) throw new Error(`invalid amount: multiple decimal points in ${amount}`)
+  }
+  if (wholePart === '') wholePart = '0'
+  if (!/^\d+$/.test(wholePart)) throw new Error(`invalid integer part: ${wholePart}`)
+  if (fracPart && !/^\d+$/.test(fracPart)) throw new Error(`invalid fractional part: ${fracPart}`)
+  if (fracPart.length > decimals) {
+    throw new Error(`too many decimal places (max ${decimals}): ${amount}`)
+  }
+
+  while (fracPart.length < decimals) fracPart += '0'
+  const wholeInt = BigInt(wholePart)
+  const fracInt = fracPart.length > 0 ? BigInt(fracPart) : 0n
+  return wholeInt * 10n ** BigInt(decimals) + fracInt
+}

--- a/packages/sdk/src/tools/defi/arkis/resolvePoolKind.ts
+++ b/packages/sdk/src/tools/defi/arkis/resolvePoolKind.ts
@@ -1,0 +1,40 @@
+import { getEvmClient } from '@vultisig/core-chain/chains/evm/client'
+import { getAddress, isAddress } from 'viem'
+
+import { erc4626ReadAbi } from './abi'
+import type { ArkisPoolKind } from './buildSupplyTx'
+
+export type ResolveArkisPoolKindResult = {
+  kind: ArkisPoolKind
+  /** Underlying asset address for ERC-4626 vaults (undefined for Agreements). */
+  asset?: `0x${string}`
+}
+
+/**
+ * Detect whether an Arkis pool is an ERC-4626 vault or a standard Agreement by
+ * probing `asset()`. A successful read with a valid address ⇒ ERC-4626 vault;
+ * a revert (no `asset()`) ⇒ Agreement.
+ *
+ * Read-only `eth_call` on Ethereum — never mutates state.
+ */
+export const resolveArkisPoolKind = async (poolAddress: string): Promise<ResolveArkisPoolKindResult> => {
+  if (!isAddress(poolAddress, { strict: false })) {
+    throw new Error(`invalid "pool_address" address: ${poolAddress}`)
+  }
+  const normalized = getAddress(poolAddress)
+  const client = getEvmClient('Ethereum')
+
+  try {
+    const asset = (await client.readContract({
+      address: normalized,
+      abi: erc4626ReadAbi,
+      functionName: 'asset',
+    })) as string
+    if (typeof asset === 'string' && isAddress(asset, { strict: false })) {
+      return { kind: 'erc4626_vault', asset: getAddress(asset) }
+    }
+  } catch {
+    // asset() reverted — treat as a standard Agreement.
+  }
+  return { kind: 'agreement' }
+}

--- a/packages/sdk/src/tools/defi/index.ts
+++ b/packages/sdk/src/tools/defi/index.ts
@@ -1,0 +1,15 @@
+// sdk.defi.* — DeFi protocol primitives that BUILD UNSIGNED calldata/msgs only.
+//
+// Each protocol lives under its own namespace (`sdk.defi.<protocol>`). The
+// surface is multi-consumer: any affiliate/fee param is injectable by the
+// caller and defaults to neutral/off — no consumer identity is ever hardcoded.
+import * as arkis from './arkis'
+
+export { arkis }
+
+/** Grouped DeFi namespace exposed as `sdk.defi`. */
+export const defi = {
+  arkis,
+} as const
+
+export type Defi = typeof defi

--- a/packages/sdk/src/tools/index.ts
+++ b/packages/sdk/src/tools/index.ts
@@ -17,6 +17,9 @@ export {
   NATIVE_SWAP_MIN_OUTBOUND_FEE_MULTIPLIER,
 } from './swap'
 
+// DeFi protocol primitives (build UNSIGNED calldata only)
+export { type Defi, defi } from './defi'
+
 // Verifier client
 export { VerifierClient } from './verifier'
 

--- a/packages/sdk/tests/unit/defi-arkis.test.ts
+++ b/packages/sdk/tests/unit/defi-arkis.test.ts
@@ -85,6 +85,44 @@ describe('buildArkisSupplyTx — Agreement path', () => {
 })
 
 describe('buildArkisSupplyTx — ERC-4626 path', () => {
+  it('enforces expectedAsset === tokenAddress when the caller resolved the vault asset', () => {
+    // matching asset → builds fine
+    const ok = buildArkisSupplyTx({
+      poolKind: 'erc4626_vault',
+      poolAddress: ERC4626_POOL,
+      tokenAddress: USDC,
+      from: SENDER,
+      amountRaw: 1_500_000_000n,
+      expectedAsset: getAddress(USDC),
+    })
+    expect(ok.transactions).toHaveLength(2)
+
+    // mismatched asset (different ERC-20) → must throw, never approve the wrong token
+    const OTHER_TOKEN = '0x3333333333333333333333333333333333333333'
+    expect(() =>
+      buildArkisSupplyTx({
+        poolKind: 'erc4626_vault',
+        poolAddress: ERC4626_POOL,
+        tokenAddress: USDC,
+        from: SENDER,
+        amountRaw: 1_500_000_000n,
+        expectedAsset: OTHER_TOKEN,
+      })
+    ).toThrow(/does not match the Arkis ERC-4626 vault asset/)
+
+    // expectedAsset is ignored on the agreement path (no asset() concept)
+    expect(() =>
+      buildArkisSupplyTx({
+        poolKind: 'agreement',
+        poolAddress: POOL,
+        tokenAddress: USDC,
+        from: SENDER,
+        amountRaw: 1n,
+        expectedAsset: OTHER_TOKEN,
+      })
+    ).not.toThrow()
+  })
+
   it('builds approve + deposit(uint256,address) with receiver fixed to self', () => {
     const built = buildArkisSupplyTx({
       poolKind: 'erc4626_vault',

--- a/packages/sdk/tests/unit/defi-arkis.test.ts
+++ b/packages/sdk/tests/unit/defi-arkis.test.ts
@@ -1,0 +1,179 @@
+import { encodeFunctionData, erc20Abi, getAddress } from 'viem'
+import { describe, expect, it } from 'vitest'
+
+import { ARKIS_OFFICIAL_ADDRESSES, buildArkisSupplyTx, parseArkisTokenAmount } from '@/tools/defi/arkis'
+
+const SENDER = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+const POOL = '0x1111111111111111111111111111111111111111'
+const ERC4626_POOL = '0x2222222222222222222222222222222222222222'
+const USDC = '0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+
+describe('parseArkisTokenAmount', () => {
+  it('parses whole and fractional token amounts', () => {
+    expect(parseArkisTokenAmount('1500', 6)).toBe(1_500_000_000n)
+    expect(parseArkisTokenAmount('1500.5', 6)).toBe(1_500_500_000n)
+  })
+
+  it('rejects malformed or overly precise amounts', () => {
+    expect(() => parseArkisTokenAmount('', 6)).toThrow(/empty/)
+    expect(() => parseArkisTokenAmount('-1', 6)).toThrow(/negative/)
+    expect(() => parseArkisTokenAmount('1.1234567', 6)).toThrow(/too many decimal/)
+    expect(() => parseArkisTokenAmount('1.2.3', 6)).toThrow(/decimal points/)
+  })
+})
+
+describe('buildArkisSupplyTx — Agreement path', () => {
+  it('builds approve + deposit(uint128) for a standard Arkis Agreement', () => {
+    const built = buildArkisSupplyTx({
+      poolKind: 'agreement',
+      poolAddress: POOL,
+      tokenAddress: USDC,
+      from: SENDER,
+      amount: '1500',
+      decimals: 6,
+    })
+
+    expect(built.protocol).toBe('Arkis')
+    expect(built.chain).toBe('Ethereum')
+    expect(built.chainId).toBe('1')
+    expect(built.poolKind).toBe('agreement')
+    expect(built.amountRaw).toBe('1500000000')
+    expect(built.transactions).toHaveLength(2)
+
+    const [approveTx, depositTx] = built.transactions
+    expect(approveTx.to).toBe(getAddress(USDC))
+    expect(approveTx.action).toBe('approve')
+    expect(approveTx.value).toBe('0')
+    expect(approveTx.data).toBe(
+      encodeFunctionData({
+        abi: erc20Abi,
+        functionName: 'approve',
+        args: [getAddress(POOL), 1_500_000_000n],
+      })
+    )
+
+    expect(depositTx.to).toBe(getAddress(POOL))
+    expect(depositTx.action).toBe('deposit')
+    expect(depositTx.data).toBe(
+      encodeFunctionData({
+        abi: [
+          {
+            name: 'deposit',
+            type: 'function',
+            stateMutability: 'nonpayable',
+            inputs: [{ name: 'amount', type: 'uint128' }],
+            outputs: [],
+          },
+        ] as const,
+        functionName: 'deposit',
+        args: [1_500_000_000n],
+      })
+    )
+  })
+
+  it('rejects an amount that overflows uint128 on the Agreement path', () => {
+    expect(() =>
+      buildArkisSupplyTx({
+        poolKind: 'agreement',
+        poolAddress: POOL,
+        tokenAddress: USDC,
+        from: SENDER,
+        amountRaw: 1n << 200n,
+      })
+    ).toThrow(/uint128/)
+  })
+})
+
+describe('buildArkisSupplyTx — ERC-4626 path', () => {
+  it('builds approve + deposit(uint256,address) with receiver fixed to self', () => {
+    const built = buildArkisSupplyTx({
+      poolKind: 'erc4626_vault',
+      poolAddress: ERC4626_POOL,
+      tokenAddress: USDC,
+      from: SENDER,
+      amountRaw: 1_500_000_000n,
+    })
+
+    expect(built.poolKind).toBe('erc4626_vault')
+    expect(built.receiver).toBe(getAddress(SENDER))
+
+    const [, depositTx] = built.transactions
+    expect(depositTx.data).toBe(
+      encodeFunctionData({
+        abi: [
+          {
+            name: 'deposit',
+            type: 'function',
+            stateMutability: 'nonpayable',
+            inputs: [
+              { name: 'assets', type: 'uint256' },
+              { name: 'receiver', type: 'address' },
+            ],
+            outputs: [{ type: 'uint256' }],
+          },
+        ] as const,
+        functionName: 'deposit',
+        args: [1_500_000_000n, getAddress(SENDER)],
+      })
+    )
+  })
+})
+
+describe('buildArkisSupplyTx — validation + injectable affiliate', () => {
+  it('rejects bad addresses, zero amounts, and missing amount inputs', () => {
+    expect(() =>
+      buildArkisSupplyTx({
+        poolKind: 'agreement',
+        poolAddress: 'nope',
+        tokenAddress: USDC,
+        from: SENDER,
+        amountRaw: 1n,
+      })
+    ).toThrow(/pool_address/)
+    expect(() =>
+      buildArkisSupplyTx({
+        poolKind: 'agreement',
+        poolAddress: POOL,
+        tokenAddress: USDC,
+        from: SENDER,
+        amountRaw: 0n,
+      })
+    ).toThrow(/positive/)
+    expect(() =>
+      buildArkisSupplyTx({
+        poolKind: 'agreement',
+        poolAddress: POOL,
+        tokenAddress: USDC,
+        from: SENDER,
+      })
+    ).toThrow(/amountRaw.*amount.*decimals/)
+  })
+
+  it('omits affiliate by default (neutral/off) and echoes it when injected', () => {
+    const neutral = buildArkisSupplyTx({
+      poolKind: 'agreement',
+      poolAddress: POOL,
+      tokenAddress: USDC,
+      from: SENDER,
+      amountRaw: 1n,
+    })
+    expect(neutral.affiliate).toBeUndefined()
+
+    const tagged = buildArkisSupplyTx({
+      poolKind: 'agreement',
+      poolAddress: POOL,
+      tokenAddress: USDC,
+      from: SENDER,
+      amountRaw: 1n,
+      affiliate: 'some-consumer',
+    })
+    expect(tagged.affiliate).toBe('some-consumer')
+    // affiliate is metadata only — it must not alter the on-chain calldata.
+    expect(tagged.transactions[0].data).toBe(neutral.transactions[0].data)
+    expect(tagged.transactions[1].data).toBe(neutral.transactions[1].data)
+  })
+
+  it('exposes the published Arkis mainnet addresses', () => {
+    expect(ARKIS_OFFICIAL_ADDRESSES.dispatcher).toBe('0x2f01D7CFfe62673B3D2b680295A2D047F3848e4c')
+  })
+})

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -24,6 +24,15 @@ describe('@vultisig/sdk public exports', () => {
     expect(typeof sdk.fetchNoonUsdcVaultMetrics).toBe('function')
   })
 
+  it('exports the sdk.defi namespace with the Arkis lender supply builder', () => {
+    expect(sdk.defi).toBeDefined()
+    expect(sdk.defi.arkis).toBeDefined()
+    expect(typeof sdk.defi.arkis.buildArkisSupplyTx).toBe('function')
+    expect(typeof sdk.defi.arkis.parseArkisTokenAmount).toBe('function')
+    expect(typeof sdk.defi.arkis.resolveArkisPoolKind).toBe('function')
+    expect(sdk.defi.arkis.ARKIS_OFFICIAL_ADDRESSES.dispatcher).toBe('0x2f01D7CFfe62673B3D2b680295A2D047F3848e4c')
+  })
+
   it('exports Chain enum and VaultBase class (VaultBase carries the prep-only primitives)', () => {
     expect(sdk.Chain).toBeDefined()
     expect(typeof sdk.VaultBase).toBe('function')

--- a/scripts/receipts/defi_arkis.mjs
+++ b/scripts/receipts/defi_arkis.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+// Runnable receipt for sdk.defi.arkis (lender supply).
+//
+// Builds an UNSIGNED Arkis approve+supply transaction sequence for both the
+// ERC-4626 vault path and the standard Agreement path, with sample inputs, and
+// prints the decoded calldata. NO network I/O, NO signing, NO broadcast.
+//
+// Run from the SDK package root:
+//   node --import tsx scripts/receipts/defi_arkis.mjs
+//
+// The build calldata is pure (viem encodeFunctionData), so this is fully
+// deterministic and offline.
+import { decodeFunctionData, erc20Abi } from 'viem'
+
+import { ARKIS_OFFICIAL_ADDRESSES } from '../../packages/sdk/src/tools/defi/arkis/addresses.ts'
+import { buildArkisSupplyTx } from '../../packages/sdk/src/tools/defi/arkis/buildSupplyTx.ts'
+
+const SENDER = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+const VAULT_POOL = '0x2222222222222222222222222222222222222222'
+const AGREEMENT_POOL = '0x1111111111111111111111111111111111111111'
+const USDC = '0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+
+const erc4626DepositAbi = [
+  {
+    name: 'deposit',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'assets', type: 'uint256' },
+      { name: 'receiver', type: 'address' },
+    ],
+    outputs: [{ type: 'uint256' }],
+  },
+]
+const agreementDepositAbi = [
+  {
+    name: 'deposit',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [{ name: 'amount', type: 'uint128' }],
+    outputs: [],
+  },
+]
+
+function decodeLeg(tx) {
+  if (tx.action === 'approve') {
+    const { args } = decodeFunctionData({ abi: erc20Abi, data: tx.data })
+    return `approve(spender=${args[0]}, amount=${args[1].toString()})`
+  }
+  const abi = tx.data.length > 74 ? erc4626DepositAbi : agreementDepositAbi
+  const { args } = decodeFunctionData({ abi, data: tx.data })
+  return args.length === 2
+    ? `deposit(assets=${args[0].toString()}, receiver=${args[1]})`
+    : `deposit(amount=${args[0].toString()})`
+}
+
+function printBuilt(label, built) {
+  console.log(`\n=== ${label} ===`)
+  console.log(`protocol=${built.protocol} chain=${built.chain} chainId=${built.chainId} poolKind=${built.poolKind}`)
+  console.log(`pool=${built.poolAddress} token=${built.tokenAddress} from=${built.from} receiver=${built.receiver}`)
+  console.log(`amountRaw=${built.amountRaw} affiliate=${built.affiliate ?? '(neutral/off)'}`)
+  built.transactions.forEach((tx, i) => {
+    console.log(`  tx[${i}] ${tx.action.toUpperCase()}  to=${tx.to} value=${tx.value}`)
+    console.log(`         decoded: ${decodeLeg(tx)}`)
+    console.log(`         data:    ${tx.data}`)
+  })
+}
+
+console.log('sdk.defi.arkis — UNSIGNED lender supply receipt (no broadcast)')
+console.log(`Arkis dispatcher (official): ${ARKIS_OFFICIAL_ADDRESSES.dispatcher}`)
+
+// 1) ERC-4626 vault path: deposit(assets, receiver), receiver fixed to self.
+printBuilt(
+  'ERC-4626 vault supply — 1500 USDC',
+  buildArkisSupplyTx({
+    poolKind: 'erc4626_vault',
+    poolAddress: VAULT_POOL,
+    tokenAddress: USDC,
+    from: SENDER,
+    amount: '1500',
+    decimals: 6,
+  })
+)
+
+// 2) Standard Agreement path: deposit(uint128).
+printBuilt(
+  'Agreement supply — 2500.25 USDC',
+  buildArkisSupplyTx({
+    poolKind: 'agreement',
+    poolAddress: AGREEMENT_POOL,
+    tokenAddress: USDC,
+    from: SENDER,
+    amount: '2500.25',
+    decimals: 6,
+  })
+)
+
+// 3) Injectable affiliate: metadata-only, must NOT change the calldata.
+const neutral = buildArkisSupplyTx({
+  poolKind: 'agreement',
+  poolAddress: AGREEMENT_POOL,
+  tokenAddress: USDC,
+  from: SENDER,
+  amountRaw: 1_000_000n,
+})
+const tagged = buildArkisSupplyTx({
+  poolKind: 'agreement',
+  poolAddress: AGREEMENT_POOL,
+  tokenAddress: USDC,
+  from: SENDER,
+  amountRaw: 1_000_000n,
+  affiliate: 'example-consumer',
+})
+const calldataUnchanged =
+  neutral.transactions[0].data === tagged.transactions[0].data &&
+  neutral.transactions[1].data === tagged.transactions[1].data
+console.log('\n=== Injectable affiliate (multi-consumer, default off) ===')
+console.log(`neutral.affiliate=${neutral.affiliate ?? '(undefined)'}  tagged.affiliate=${tagged.affiliate}`)
+console.log(`calldata identical regardless of affiliate: ${calldataUnchanged}`)
+
+if (!calldataUnchanged) {
+  console.error('FAIL: affiliate leaked into calldata')
+  process.exit(1)
+}
+console.log('\nOK — unsigned Arkis approve+supply sequences built and decoded. No signing, no broadcast.')


### PR DESCRIPTION
## what

Adds `sdk.defi.arkis` — a lender-side **supply** builder for the Arkis protocol on Ethereum. It builds the unsigned 2-step sequence (ERC-20 `approve` → ERC-4626 / Agreement `deposit`) and returns the decoded transactions. It **BUILDS UNSIGNED calldata ONLY — never signs, never broadcasts. Pure crypto.**

Ported from mcp-ts `build_arkis_supply_liquidity` + reads, reshaped into the SDK `sdk.defi.<protocol>` namespace alongside the existing prep/swap/token surfaces.

New surface:
- `sdk.defi.arkis.buildArkisSupplyTx(params)` — pure (no network I/O), encodes approve + deposit for both pool kinds:
  - ERC-4626 vault: `deposit(uint256 assets, address receiver)` (selector `0x6e553f65`), receiver fixed to `from`
  - Standard Agreement: `deposit(uint128 amount)` (selector `0x54469aea`)
- `sdk.defi.arkis.resolveArkisPoolKind(pool)` — optional on-chain `asset()` probe (read-only `eth_call` via `getEvmClient`)
- `sdk.defi.arkis.parseArkisTokenAmount(amount, decimals)` — exact string-math base-unit parse
- `sdk.defi.arkis.ARKIS_OFFICIAL_ADDRESSES` / `ARKIS_BOOK_URLS`

Also exported top-level as `defi` (+ `Defi` type) and surfaced as the `sdk.defi` getter.

## why

Part of the `sdk.defi.*` DeFi consolidation — moving protocol calldata builders out of mcp-ts and into the multi-consumer SDK so Station, Windows extension, mcp-ts, and the CLI all share one audited primitive.

**Consumers unblocked:** mcp-ts `build_arkis_supply_liquidity`, agent-backend execute flows, and any client that wants an unsigned Arkis supply tx without dragging an Arkis SDK.

## how

HAND-ROLL viem (`encodeFunctionData` + minimal Arkis ABI fragments), per the lib-vs-handroll deep-dive: no RN/Hermes-safe official Arkis package exists, and the supply surface is a 2-call ERC-20-approve + ERC-4626-deposit sequence. viem is already an SDK dep.

Safety notes:
- ERC-4626 deposit `receiver` is fixed to `from` so the scaffold cannot mint shares to a third party.
- The `affiliate` param is **INJECTABLE, defaults to neutral/off**, and is a **metadata-only passthrough** (Arkis supply has no on-chain affiliate slot). It never alters calldata and no consumer identity (`station`, etc.) is hardcoded — the SDK is multi-consumer.
- `buildArkisSupplyTx` is pure; the only network path is the optional `resolveArkisPoolKind` read.

## receipt

`node --import tsx scripts/receipts/defi_arkis.mjs` (from `packages/sdk`) — builds unsigned approve+supply for both pool kinds with sample inputs, decodes the calldata, and asserts the affiliate tag never leaks into calldata. No broadcast.

```
sdk.defi.arkis — UNSIGNED lender supply receipt (no broadcast)
Arkis dispatcher (official): 0x2f01D7CFfe62673B3D2b680295A2D047F3848e4c

=== ERC-4626 vault supply — 1500 USDC ===
protocol=Arkis chain=Ethereum chainId=1 poolKind=erc4626_vault
pool=0x2222…2222 token=0xA0b8…eB48 from=0x7099…79C8 receiver=0x7099…79C8
amountRaw=1500000000 affiliate=(neutral/off)
  tx[0] APPROVE  to=0xA0b8…eB48 value=0
         decoded: approve(spender=0x2222…2222, amount=1500000000)
         data:    0x095ea7b3…0000000059682f00
  tx[1] DEPOSIT  to=0x2222…2222 value=0
         decoded: deposit(assets=1500000000, receiver=0x7099…79C8)
         data:    0x6e553f65…70997970c51812dc3a010c7d01b50e0d17dc79c8

=== Agreement supply — 2500.25 USDC ===
protocol=Arkis chain=Ethereum chainId=1 poolKind=agreement
  tx[1] DEPOSIT  to=0x1111…1111 value=0
         decoded: deposit(amount=2500250000)
         data:    0x54469aea000000…9506c990

=== Injectable affiliate (multi-consumer, default off) ===
neutral.affiliate=(undefined)  tagged.affiliate=example-consumer
calldata identical regardless of affiliate: true

OK — unsigned Arkis approve+supply sequences built and decoded. No signing, no broadcast.
```

Gate:
- `yarn workspace @vultisig/sdk typecheck` → 0 errors (clean baseline on this main; my files add 0 new)
- `yarn workspace @vultisig/sdk test` → **1519 passed** (incl. new `tests/unit/defi-arkis.test.ts` + a `sdk.defi` public-export assertion)
- eslint + prettier (`.config/.prettierrc`) clean on the new files

Part of the sdk.defi.* DeFi consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
