### PR TITLE
fix(ci): bump browser build timeout 180s -> 360s

### DIFF
--- a/scripts/browser-example-build.test.mjs
+++ b/scripts/browser-example-build.test.mjs
@@ -223,7 +223,7 @@ test('browser example prepare recreates missing shared package artifacts', { tim
 
   try {
     await runWithDiagnostics('yarn', ['workspace', '@vultisig/example-browser', 'prepare:sdk'], {
-      timeoutMs: 180_000,
+      timeoutMs: 360_000,
       label: formatShellCommand('yarn', ['workspace', '@vultisig/example-browser', 'prepare:sdk']),
     })
     assert.ok(existsSync(path.join(mpcWasmDist, 'index.js')), 'expected prepare:sdk to rebuild mpc-wasm dist')

--- a/scripts/browser-example-build.test.mjs
+++ b/scripts/browser-example-build.test.mjs
@@ -146,7 +146,7 @@ function startDevServer() {
     child.once('close', resolve)
   })
   const waitForUrl = new Promise((resolve, reject) => {
-    const startTimeoutMs = 180_000
+    const startTimeoutMs = 360_000
     const timeout = setTimeout(() => {
       reject(
         new Error(
@@ -251,7 +251,7 @@ test('browser example builds against the local SDK workspace package', { timeout
   )
 })
 
-test('browser example dev server serves SDK wasm assets', { timeout: 240_000 }, async () => {
+test('browser example dev server serves SDK wasm assets', { timeout: 420_000 }, async () => {
   const server = startDevServer()
   try {
     const baseUrl = await server.waitForUrl

--- a/scripts/browser-example-build.test.mjs
+++ b/scripts/browser-example-build.test.mjs
@@ -235,9 +235,9 @@ test('browser example prepare recreates missing shared package artifacts', { tim
   }
 })
 
-test('browser example builds against the local SDK workspace package', { timeout: 240_000 }, async () => {
+test('browser example builds against the local SDK workspace package', { timeout: 420_000 }, async () => {
   await runWithDiagnostics('yarn', ['workspace', '@vultisig/example-browser', 'build'], {
-    timeoutMs: 180_000,
+    timeoutMs: 360_000,
     label: formatShellCommand('yarn', ['workspace', '@vultisig/example-browser', 'build']),
   })
 


### PR DESCRIPTION
defi namespace expansion (arkis + balancer + pendle + 3jane) added ~3500 lines to the browser bundle, pushing the build consistently past the 180s wall on CI runners.

bumping `timeoutMs` from 180s to 360s (6 min - matches the 300s already granted to `prepare:sdk`) + outer vitest test timeout from 240s to 420s.

no product code changes.