### PR TITLE
Fix Maya native swap output decimals

### DIFF
--- a/.changeset/maya-native-output-decimals.md
+++ b/.changeset/maya-native-output-decimals.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/sdk': patch
+---
+
+Normalize native THORChain and MayaChain swap quote output amounts to destination coin base units before SDK quote formatting and near-zero validation.

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -1557,6 +1557,11 @@
       "import": "./dist/swap/native/utils/getNativeSwapDecimals.js",
       "default": "./dist/swap/native/utils/getNativeSwapDecimals.js"
     },
+    "./swap/native/utils/nativeSwapAmountToCoinBaseUnit": {
+      "types": "./dist/swap/native/utils/nativeSwapAmountToCoinBaseUnit.d.ts",
+      "import": "./dist/swap/native/utils/nativeSwapAmountToCoinBaseUnit.js",
+      "default": "./dist/swap/native/utils/nativeSwapAmountToCoinBaseUnit.js"
+    },
     "./swap/native/utils/parseThorchainSwapMemoStreaming": {
       "types": "./dist/swap/native/utils/parseThorchainSwapMemoStreaming.d.ts",
       "import": "./dist/swap/native/utils/parseThorchainSwapMemoStreaming.js",

--- a/packages/core/chain/swap/native/utils/nativeSwapAmountToCoinBaseUnit.test.ts
+++ b/packages/core/chain/swap/native/utils/nativeSwapAmountToCoinBaseUnit.test.ts
@@ -1,0 +1,30 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { describe, expect, it } from 'vitest'
+
+import { nativeSwapAmountToCoinBaseUnit } from './nativeSwapAmountToCoinBaseUnit'
+
+describe('nativeSwapAmountToCoinBaseUnit', () => {
+  it('rebases native-swap protocol output into the destination coin base units', () => {
+    expect(
+      nativeSwapAmountToCoinBaseUnit(54_992n, {
+        chain: Chain.Ethereum,
+        decimals: 18,
+      })
+    ).toBe(549_920_000_000_000n)
+
+    expect(
+      nativeSwapAmountToCoinBaseUnit(89_096_500n, {
+        chain: Chain.Ethereum,
+        id: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+        decimals: 6,
+      })
+    ).toBe(890_965n)
+
+    expect(
+      nativeSwapAmountToCoinBaseUnit(153_853_140_240n, {
+        chain: Chain.MayaChain,
+        decimals: 10,
+      })
+    ).toBe(153_853_140_240n)
+  })
+})

--- a/packages/core/chain/swap/native/utils/nativeSwapAmountToCoinBaseUnit.ts
+++ b/packages/core/chain/swap/native/utils/nativeSwapAmountToCoinBaseUnit.ts
@@ -1,0 +1,18 @@
+import { CoinKey, CoinMetadata } from '@vultisig/core-chain/coin/Coin'
+
+import { getNativeSwapDecimals } from './getNativeSwapDecimals'
+
+type CoinWithDecimals = CoinKey & Pick<CoinMetadata, 'decimals'>
+
+export function rebaseDecimalAmount(value: bigint, fromDecimals: number, toDecimals: number): bigint {
+  if (fromDecimals === toDecimals) {
+    return value
+  }
+  if (toDecimals > fromDecimals) {
+    return value * 10n ** BigInt(toDecimals - fromDecimals)
+  }
+  return value / 10n ** BigInt(fromDecimals - toDecimals)
+}
+
+export const nativeSwapAmountToCoinBaseUnit = (value: bigint, coin: CoinWithDecimals): bigint =>
+  rebaseDecimalAmount(value, getNativeSwapDecimals(coin), coin.decimals)

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -34,7 +34,7 @@ import {
   nativeSwapChains,
   nativeSwapEnabledChainsRecord,
 } from '@vultisig/core-chain/swap/native/NativeSwapChain'
-import { getNativeSwapDecimals } from '@vultisig/core-chain/swap/native/utils/getNativeSwapDecimals'
+import { nativeSwapAmountToCoinBaseUnit } from '@vultisig/core-chain/swap/native/utils/nativeSwapAmountToCoinBaseUnit'
 import { NoSwapRoutesError } from '@vultisig/core-chain/swap/NoSwapRoutesError'
 import { SwapError, SwapErrorCode } from '@vultisig/core-chain/swap/SwapError'
 import { isEmpty } from '@vultisig/lib-utils/array/isEmpty'
@@ -183,17 +183,6 @@ const BPS_DENOMINATOR = 10_000n
 const isWithinPreferenceBand = (outputAmount: bigint, bestOutputAmount: bigint): boolean =>
   outputAmount * BPS_DENOMINATOR >= bestOutputAmount * (BPS_DENOMINATOR - SWAP_QUOTE_PREFERENCE_BAND_BPS)
 
-/** Re-base an integer amount from `fromDecimals` fixed-point to `toDecimals`. */
-function rebaseDecimals(value: bigint, fromDecimals: number, toDecimals: number): bigint {
-  if (fromDecimals === toDecimals) {
-    return value
-  }
-  if (toDecimals > fromDecimals) {
-    return value * 10n ** BigInt(toDecimals - fromDecimals)
-  }
-  return value / 10n ** BigInt(fromDecimals - toDecimals)
-}
-
 /**
  * Comparable destination amount in the destination token's smallest units (same
  * scale as `general.dstAmount`).
@@ -208,9 +197,7 @@ function rebaseDecimals(value: bigint, fromDecimals: number, toDecimals: number)
  */
 function getComparableOutputAmount(q: SwapQuote, to: AccountCoin): bigint {
   if ('native' in q.quote) {
-    const nativePrecision = getNativeSwapDecimals(to)
-    const raw = BigInt(q.quote.native.expected_amount_out)
-    return rebaseDecimals(raw, nativePrecision, to.decimals)
+    return nativeSwapAmountToCoinBaseUnit(BigInt(q.quote.native.expected_amount_out), to)
   }
   return BigInt(q.quote.general.dstAmount)
 }

--- a/packages/sdk/src/vault/services/SwapService.ts
+++ b/packages/sdk/src/vault/services/SwapService.ts
@@ -17,6 +17,7 @@ import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { getTokenMetadata } from '@vultisig/core-chain/coin/token/metadata'
 import { chainsWithTokenMetadataDiscovery } from '@vultisig/core-chain/coin/token/metadata/chains'
 import { getCoinValue } from '@vultisig/core-chain/coin/utils/getCoinValue'
+import { nativeSwapAmountToCoinBaseUnit } from '@vultisig/core-chain/swap/native/utils/nativeSwapAmountToCoinBaseUnit'
 import { findSwapQuote, FindSwapQuoteInput } from '@vultisig/core-chain/swap/quote/findSwapQuote'
 import { SwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
 import { swapEnabledChains } from '@vultisig/core-chain/swap/swapEnabledChains'
@@ -359,9 +360,10 @@ export class SwapService {
     const expiresIn = isNative ? quoteData.native.expiry * 1000 - Date.now() : DEFAULT_QUOTE_EXPIRY_MS
     const expiresAt = Date.now() + Math.min(expiresIn, DEFAULT_QUOTE_EXPIRY_MS)
 
-    // Extract estimated output as bigint
+    // Native swap APIs report output in their protocol precision. SDK consumers
+    // expect the destination coin's base units, matching general provider quotes.
     const estimatedOutput = isNative
-      ? BigInt(quoteData.native.expected_amount_out)
+      ? nativeSwapAmountToCoinBaseUnit(BigInt(quoteData.native.expected_amount_out), toCoin)
       : BigInt(quoteData.general.dstAmount)
 
     // Extract provider name

--- a/packages/sdk/tests/unit/services/SwapService.test.ts
+++ b/packages/sdk/tests/unit/services/SwapService.test.ts
@@ -185,6 +185,57 @@ describe('SwapService', () => {
       })
     })
 
+    it('normalizes Maya native quote output before the near-zero guard', async () => {
+      const { findSwapQuote } = await import('@vultisig/core-chain/swap/quote/findSwapQuote')
+
+      const mockQuote = {
+        quote: {
+          native: {
+            swapChain: 'MayaChain' as const,
+            // Native swap APIs return non-Maya outputs in their 8-decimal protocol
+            // precision. For ETH, SDK callers expect wei (18 decimals).
+            expected_amount_out: '506855',
+            expiry: Math.floor(Date.now() / 1000) + 600,
+            fees: {
+              affiliate: '0',
+              asset: 'ETH',
+              outbound: '100000',
+              total: '100000',
+            },
+            inbound_address: 'maya1inbound',
+            memo: '=:ETH.ETH:0x1234567890abcdef1234567890abcdef12345678',
+            notes: '',
+            outbound_delay_blocks: 0,
+            outbound_delay_seconds: 0,
+            recommended_min_amount_in: '1000000',
+            warning: '',
+          },
+        },
+        discounts: [],
+      }
+
+      vi.mocked(findSwapQuote).mockResolvedValue(mockQuote as any)
+
+      const result = await service.getQuote({
+        fromCoin: {
+          chain: Chain.MayaChain,
+          address: 'maya1sender',
+          ticker: 'CACAO',
+          decimals: 10,
+        },
+        toCoin: {
+          chain: Chain.Ethereum,
+          address: '0x1234567890abcdef1234567890abcdef12345678',
+          ticker: 'ETH',
+          decimals: 18,
+        },
+        amount: 90,
+      })
+
+      expect(result.provider).toBe('mayachain')
+      expect(result.estimatedOutput).toBe(5_068_550_000_000_000n)
+    })
+
     it('should fetch a swap quote for ERC-20 token requiring approval', async () => {
       const { findSwapQuote } = await import('@vultisig/core-chain/swap/quote/findSwapQuote')
       const { getErc20Allowance } = await import('@vultisig/core-chain/chains/evm/erc20/getErc20Allowance')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Native swap quotes now show output amounts in the destination coin’s base units, improving consistency across quote displays.
  * Added extra checks for very small values to avoid misleading near-zero swap outputs.

* **Tests**
  * Added coverage for native swap quote normalization on supported chains, including different decimal formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->