### PR TITLE
feat(cli): per-chain custom RPC override (--rpc-override + VULTISIG_<CHAIN>_RPC)

### DIFF
--- a/.changeset/sdkcli-rpc-override-cli.md
+++ b/.changeset/sdkcli-rpc-override-cli.md
@@ -3,10 +3,21 @@
 ---
 
 Add per-chain custom RPC override to the CLI. A headless operator can now point
-the SDK's EVM / Cosmos chain ops (balance, quote, broadcast, tx-status) at a
-private node via the repeatable `--rpc-override <chain>:<url>` flag or a
-`VULTISIG_<CHAIN>_RPC` env var (e.g. `VULTISIG_ETHEREUM_RPC`). Overrides are
-applied at SDK init through core-chain's existing `setCustomRpcOverride` engine;
-only EVM and IBC Cosmos chains are eligible and unsupported/unknown/malformed
-specs are ignored with a stderr warning. An optional `--rpc-check` flag probes
-each endpoint for liveness/chain identity at startup.
+chain RPC at a private node via the repeatable `--rpc-override <chain>:<url>`
+flag or a `VULTISIG_<CHAIN>_RPC` env var (e.g. `VULTISIG_ETHEREUM_RPC`).
+Overrides are applied at SDK init through core-chain's existing
+`setCustomRpcOverride` engine, in both command and interactive (`-i`) modes.
+
+Coverage matches what the core-chain resolvers honor: **EVM** chains route every
+op (balance, gas/nonce, broadcast, tx-status) through the override via
+`getEvmRpcUrl`. **Cosmos** chains honor the override on the LCD/REST paths
+(`getCosmosRpcUrl`: fee/min-gas, account info, LCD balance fallback, wasm smart
+queries); the Tendermint-RPC client used for broadcast and tx-status keeps its
+default endpoint by design (a custom RPC is treated as an LCD endpoint — a
+different protocol).
+
+Only EVM and IBC Cosmos chains are eligible; unsupported/unknown/malformed specs
+are ignored with a stderr warning. Multi-word chains resolve from their env
+spelling (`VULTISIG_CRONOS_CHAIN_RPC` → CronosChain). An optional `--rpc-check`
+flag probes each endpoint at startup and aborts on a confirmed wrong-chain
+identity mismatch.

--- a/.changeset/sdkcli-rpc-override-cli.md
+++ b/.changeset/sdkcli-rpc-override-cli.md
@@ -1,0 +1,12 @@
+---
+'@vultisig/cli': patch
+---
+
+Add per-chain custom RPC override to the CLI. A headless operator can now point
+the SDK's EVM / Cosmos chain ops (balance, quote, broadcast, tx-status) at a
+private node via the repeatable `--rpc-override <chain>:<url>` flag or a
+`VULTISIG_<CHAIN>_RPC` env var (e.g. `VULTISIG_ETHEREUM_RPC`). Overrides are
+applied at SDK init through core-chain's existing `setCustomRpcOverride` engine;
+only EVM and IBC Cosmos chains are eligible and unsupported/unknown/malformed
+specs are ignored with a stderr warning. An optional `--rpc-check` flag probes
+each endpoint for liveness/chain identity at startup.

--- a/clients/cli/src/core/__tests__/rpc-overrides.test.ts
+++ b/clients/cli/src/core/__tests__/rpc-overrides.test.ts
@@ -66,12 +66,36 @@ describe('rpc-overrides', () => {
       expect(getCustomRpcOverride(Chain.Polygon)).toBe(sentinel)
     })
 
-    it('lets a CLI flag override the env var for the same chain', () => {
+    it('lets a CLI flag override the env var for the same chain (engine receives the flag URL)', async () => {
       const resolution = resolveRpcOverrides({
         env: { VULTISIG_ETHEREUM_RPC: 'https://from-env.example' },
         specs: ['ethereum:https://from-flag.example'],
       })
       expect(resolution.applied).toEqual([{ chain: Chain.Ethereum, url: 'https://from-flag.example' }])
+
+      // Prove the precedence survives application — the engine must hold the
+      // flag URL, not the env URL.
+      await applyRpcOverrides(resolution)
+      expect(getCustomRpcOverride(Chain.Ethereum)).toBe('https://from-flag.example')
+    })
+
+    it('resolves multi-word chains from their env spelling (separators ignored)', async () => {
+      const resolution = resolveRpcOverrides({
+        env: {
+          VULTISIG_CRONOS_CHAIN_RPC: 'https://cronos.example',
+          VULTISIG_TERRA_CLASSIC_RPC: 'https://terra-classic.example',
+        },
+      })
+      expect(resolution.warnings).toEqual([])
+      const sorted = [...resolution.applied].sort((a, b) => a.chain.localeCompare(b.chain))
+      expect(sorted).toEqual([
+        { chain: Chain.CronosChain, url: 'https://cronos.example' },
+        { chain: Chain.TerraClassic, url: 'https://terra-classic.example' },
+      ])
+
+      await applyRpcOverrides(resolution)
+      expect(getCustomRpcOverride(Chain.CronosChain)).toBe('https://cronos.example')
+      expect(getCustomRpcOverride(Chain.TerraClassic)).toBe('https://terra-classic.example')
     })
 
     it('ignores overrides for chains that do not support custom RPC', () => {

--- a/clients/cli/src/core/__tests__/rpc-overrides.test.ts
+++ b/clients/cli/src/core/__tests__/rpc-overrides.test.ts
@@ -1,0 +1,90 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { clearCustomRpcOverride, getCustomRpcOverride } from '@vultisig/core-chain/chains/customRpc/customRpcOverrides'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { applyRpcOverrides, parseRpcOverrideSpec, resolveRpcOverrides } from '../rpc-overrides'
+
+const RPC_ENV_KEYS = ['VULTISIG_ETHEREUM_RPC', 'VULTISIG_POLYGON_RPC', 'VULTISIG_THORCHAIN_RPC', 'VULTISIG_ETH_RPC']
+
+function clearRpcEnv(): void {
+  for (const key of RPC_ENV_KEYS) delete process.env[key]
+}
+
+function clearAllOverrides(): void {
+  for (const chain of Object.values(Chain)) {
+    clearCustomRpcOverride(chain as Chain)
+  }
+}
+
+describe('rpc-overrides', () => {
+  beforeEach(() => {
+    clearRpcEnv()
+    clearAllOverrides()
+  })
+
+  afterEach(() => {
+    clearRpcEnv()
+    clearAllOverrides()
+  })
+
+  describe('parseRpcOverrideSpec', () => {
+    it('splits on the first colon so the URL scheme/port survive', () => {
+      expect(parseRpcOverrideSpec('ethereum:https://node.example:8545/rpc')).toEqual({
+        chain: 'ethereum',
+        url: 'https://node.example:8545/rpc',
+      })
+    })
+
+    it('returns undefined for a malformed spec', () => {
+      expect(parseRpcOverrideSpec('ethereum')).toBeUndefined()
+      expect(parseRpcOverrideSpec(':https://x')).toBeUndefined()
+      expect(parseRpcOverrideSpec('ethereum:')).toBeUndefined()
+    })
+  })
+
+  describe('resolveRpcOverrides + applyRpcOverrides', () => {
+    it('honors a VULTISIG_<CHAIN>_RPC env override and applies it to the engine', async () => {
+      const sentinel = 'https://sentinel.eth.example/rpc'
+      const resolution = resolveRpcOverrides({ env: { VULTISIG_ETHEREUM_RPC: sentinel } })
+
+      expect(resolution.applied).toEqual([{ chain: Chain.Ethereum, url: sentinel }])
+
+      await applyRpcOverrides(resolution)
+      // The override must reach the engine that getEvmRpcUrl reads from — and
+      // must NOT be the hardcoded public node default.
+      expect(getCustomRpcOverride(Chain.Ethereum)).toBe(sentinel)
+      expect(getCustomRpcOverride(Chain.Ethereum)).not.toContain('llamarpc.com')
+    })
+
+    it('honors a --rpc-override CLI spec (alias resolved)', async () => {
+      const sentinel = 'https://sentinel.poly.example/rpc'
+      const resolution = resolveRpcOverrides({ specs: [`matic:${sentinel}`] })
+
+      expect(resolution.applied).toEqual([{ chain: Chain.Polygon, url: sentinel }])
+
+      await applyRpcOverrides(resolution)
+      expect(getCustomRpcOverride(Chain.Polygon)).toBe(sentinel)
+    })
+
+    it('lets a CLI flag override the env var for the same chain', () => {
+      const resolution = resolveRpcOverrides({
+        env: { VULTISIG_ETHEREUM_RPC: 'https://from-env.example' },
+        specs: ['ethereum:https://from-flag.example'],
+      })
+      expect(resolution.applied).toEqual([{ chain: Chain.Ethereum, url: 'https://from-flag.example' }])
+    })
+
+    it('ignores overrides for chains that do not support custom RPC', () => {
+      const resolution = resolveRpcOverrides({ specs: ['thorchain:https://thor.example'] })
+      expect(resolution.applied).toEqual([])
+      expect(resolution.warnings).toHaveLength(1)
+      expect(resolution.warnings[0]).toMatch(/EVM and IBC Cosmos/)
+    })
+
+    it('ignores unknown chains and malformed specs with a warning', () => {
+      const resolution = resolveRpcOverrides({ specs: ['notachain:https://x.example', 'garbage'] })
+      expect(resolution.applied).toEqual([])
+      expect(resolution.warnings).toHaveLength(2)
+    })
+  })
+})

--- a/clients/cli/src/core/rpc-overrides.ts
+++ b/clients/cli/src/core/rpc-overrides.ts
@@ -7,11 +7,17 @@ import { probeRpcHealth, type RpcHealthResult } from '@vultisig/core-chain/chain
  * CLI wiring for per-chain custom RPC overrides.
  *
  * The override engine (`setCustomRpcOverride`) already lives in core-chain and
- * is honored by the EVM / Cosmos URL resolvers (`getEvmRpcUrl` /
- * `getCosmosRpcUrl`) for all SDK chain ops — balance, quote, broadcast,
- * tx-status. The only gap was a way for a headless CLI operator to set those
- * overrides; this module resolves them from `--rpc-override <chain>:<url>`
- * flags and `VULTISIG_<CHAIN>_RPC` env vars and applies them at SDK init.
+ * is honored by the EVM / Cosmos URL resolvers. The only gap was a way for a
+ * headless CLI operator to set those overrides; this module resolves them from
+ * `--rpc-override <chain>:<url>` flags and `VULTISIG_<CHAIN>_RPC` env vars and
+ * applies them at SDK init.
+ *
+ * Coverage tracks what the resolvers actually read: EVM chains route every op
+ * (balance, gas/nonce, broadcast, tx-status) through `getEvmRpcUrl`. Cosmos
+ * chains honor the override on the LCD/REST paths (`getCosmosRpcUrl`: fee,
+ * account info, LCD balance fallback, wasm queries); the Tendermint-RPC client
+ * used for Cosmos broadcast / tx-status keeps its default endpoint by design (a
+ * custom RPC is treated as an LCD endpoint — a different protocol).
  *
  * Only EVM and IBC-enabled Cosmos chains accept an override (per
  * `isCustomRpcSupported`); THORChain / MayaChain / UTXO / QBTC are excluded by
@@ -54,16 +60,25 @@ export type RpcOverrideResolution = {
 /** Result of applying an override, including an optional liveness probe. */
 export type AppliedRpcOverride = RpcOverride & { health?: RpcHealthResult }
 
-/** Resolve a user-supplied chain token (enum name or short alias) to a `Chain`. */
+/** Strip `_` / `-` so multi-word chains resolve from env var spelling. */
+const stripSeparators = (value: string): string => value.replace(/[_-]/g, '')
+
+/**
+ * Resolve a user-supplied chain token (enum name or short alias) to a `Chain`.
+ * Separators are ignored on both sides so an env spelling like `CRONOS_CHAIN`
+ * (from `VULTISIG_CRONOS_CHAIN_RPC`) or `TERRA_CLASSIC` resolves to the
+ * separator-free enum value (`CronosChain`, `TerraClassic`).
+ */
 function resolveChainToken(token: string): Chain | undefined {
   const lower = token.trim().toLowerCase()
   if (!lower) return undefined
+  const normalized = stripSeparators(lower)
   for (const value of Object.values(Chain)) {
-    if (typeof value === 'string' && value.toLowerCase() === lower) {
+    if (typeof value === 'string' && stripSeparators(value.toLowerCase()) === normalized) {
       return value as Chain
     }
   }
-  return CHAIN_ALIASES[lower]
+  return CHAIN_ALIASES[lower] ?? CHAIN_ALIASES[normalized]
 }
 
 /**
@@ -78,6 +93,34 @@ export function parseRpcOverrideSpec(spec: string): { chain: string; url: string
   const url = spec.slice(idx + 1).trim()
   if (!chain || !url) return undefined
   return { chain, url }
+}
+
+/**
+ * Read `--rpc-override <spec>` (repeatable) and `--rpc-check` straight from
+ * argv. Interactive mode builds its SDK before Commander parses the program,
+ * so it can't read `program.opts()` — it mirrors `server-endpoints`' argv
+ * parsing the same way.
+ */
+export function parseRpcOverrideArgsFromArgv(args: string[]): { specs: string[]; check: boolean } {
+  const specs: string[] = []
+  let check = false
+  const flag = '--rpc-override'
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i]
+    if (arg === '--rpc-check') {
+      check = true
+    } else if (arg === flag) {
+      const next = args[i + 1]
+      if (next && !next.startsWith('-')) {
+        specs.push(next)
+        i += 1
+      }
+    } else if (arg.startsWith(`${flag}=`)) {
+      const value = arg.slice(flag.length + 1)
+      if (value) specs.push(value)
+    }
+  }
+  return { specs, check }
 }
 
 /** Collect `VULTISIG_<CHAIN>_RPC` pairs from an environment map. */

--- a/clients/cli/src/core/rpc-overrides.ts
+++ b/clients/cli/src/core/rpc-overrides.ts
@@ -1,0 +1,155 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { setCustomRpcOverride } from '@vultisig/core-chain/chains/customRpc/customRpcOverrides'
+import { isCustomRpcSupported } from '@vultisig/core-chain/chains/customRpc/customRpcSupportedChains'
+import { probeRpcHealth, type RpcHealthResult } from '@vultisig/core-chain/chains/customRpc/rpcHealthProbe'
+
+/**
+ * CLI wiring for per-chain custom RPC overrides.
+ *
+ * The override engine (`setCustomRpcOverride`) already lives in core-chain and
+ * is honored by the EVM / Cosmos URL resolvers (`getEvmRpcUrl` /
+ * `getCosmosRpcUrl`) for all SDK chain ops — balance, quote, broadcast,
+ * tx-status. The only gap was a way for a headless CLI operator to set those
+ * overrides; this module resolves them from `--rpc-override <chain>:<url>`
+ * flags and `VULTISIG_<CHAIN>_RPC` env vars and applies them at SDK init.
+ *
+ * Only EVM and IBC-enabled Cosmos chains accept an override (per
+ * `isCustomRpcSupported`); THORChain / MayaChain / UTXO / QBTC are excluded by
+ * construction and any override targeting them is ignored with a warning. The
+ * Rujira / THORChain `--rpc` subcommand flag is a separate, command-scoped
+ * endpoint override and is unaffected by this module.
+ */
+
+const ENV_PREFIX = 'VULTISIG_'
+const ENV_SUFFIX = '_RPC'
+
+/**
+ * Lowercased aliases for the common EVM chains an operator is likely to type.
+ * Mirrors the alias set used by the agent's `resolveChain`, scoped to the
+ * override-eligible chains. Exact (case-insensitive) `Chain` enum names always
+ * win first, so this only needs the short forms.
+ */
+const CHAIN_ALIASES: Record<string, Chain> = {
+  eth: Chain.Ethereum,
+  bnb: Chain.BSC,
+  bsc: Chain.BSC,
+  avax: Chain.Avalanche,
+  matic: Chain.Polygon,
+  poly: Chain.Polygon,
+  arb: Chain.Arbitrum,
+  op: Chain.Optimism,
+  atom: Chain.Cosmos,
+}
+
+/** A single resolved + validated override ready to apply. */
+export type RpcOverride = { chain: Chain; url: string }
+
+export type RpcOverrideResolution = {
+  /** Overrides that resolved to a supported chain, de-duped (flag beats env). */
+  applied: RpcOverride[]
+  /** Human-readable reasons individual specs were ignored. */
+  warnings: string[]
+}
+
+/** Result of applying an override, including an optional liveness probe. */
+export type AppliedRpcOverride = RpcOverride & { health?: RpcHealthResult }
+
+/** Resolve a user-supplied chain token (enum name or short alias) to a `Chain`. */
+function resolveChainToken(token: string): Chain | undefined {
+  const lower = token.trim().toLowerCase()
+  if (!lower) return undefined
+  for (const value of Object.values(Chain)) {
+    if (typeof value === 'string' && value.toLowerCase() === lower) {
+      return value as Chain
+    }
+  }
+  return CHAIN_ALIASES[lower]
+}
+
+/**
+ * Parse a `--rpc-override` spec of the form `<chain>:<url>`. Splits on the
+ * FIRST colon only, so the `https://` in the URL is preserved. Returns
+ * `undefined` for a malformed spec (missing chain or url).
+ */
+export function parseRpcOverrideSpec(spec: string): { chain: string; url: string } | undefined {
+  const idx = spec.indexOf(':')
+  if (idx <= 0) return undefined
+  const chain = spec.slice(0, idx).trim()
+  const url = spec.slice(idx + 1).trim()
+  if (!chain || !url) return undefined
+  return { chain, url }
+}
+
+/** Collect `VULTISIG_<CHAIN>_RPC` pairs from an environment map. */
+function collectEnvSpecs(env: NodeJS.ProcessEnv): { chain: string; url: string; envKey: string }[] {
+  const out: { chain: string; url: string; envKey: string }[] = []
+  for (const [key, value] of Object.entries(env)) {
+    if (!key.startsWith(ENV_PREFIX) || !key.endsWith(ENV_SUFFIX)) continue
+    const chain = key.slice(ENV_PREFIX.length, key.length - ENV_SUFFIX.length)
+    const url = value?.trim()
+    if (!chain || !url) continue
+    out.push({ chain, url, envKey: key })
+  }
+  return out
+}
+
+/**
+ * Resolve overrides from CLI specs and environment variables. Env is ingested
+ * first and CLI flags second, so a `--rpc-override` flag overrides the env var
+ * for the same chain. Unknown / unsupported / malformed specs are dropped with
+ * a warning rather than throwing, so a stray override never aborts a command.
+ */
+export function resolveRpcOverrides(args: { specs?: string[]; env?: NodeJS.ProcessEnv } = {}): RpcOverrideResolution {
+  const env = args.env ?? process.env
+  const warnings: string[] = []
+  const byChain = new Map<Chain, string>()
+
+  const ingest = (rawChain: string, url: string, source: string): void => {
+    const chain = resolveChainToken(rawChain)
+    if (!chain) {
+      warnings.push(`Ignoring ${source}: unknown chain "${rawChain}"`)
+      return
+    }
+    if (!isCustomRpcSupported(chain)) {
+      warnings.push(
+        `Ignoring ${source}: custom RPC overrides are only supported for EVM and IBC Cosmos chains (got ${chain})`
+      )
+      return
+    }
+    byChain.set(chain, url)
+  }
+
+  for (const { chain, url, envKey } of collectEnvSpecs(env)) {
+    ingest(chain, url, envKey)
+  }
+  for (const spec of args.specs ?? []) {
+    const parsed = parseRpcOverrideSpec(spec)
+    if (!parsed) {
+      warnings.push(`Ignoring malformed --rpc-override "${spec}" (expected <chain>:<url>)`)
+      continue
+    }
+    ingest(parsed.chain, parsed.url, `--rpc-override ${spec}`)
+  }
+
+  const applied = [...byChain.entries()].map(([chain, url]) => ({ chain, url }))
+  return { applied, warnings }
+}
+
+/**
+ * Apply resolved overrides into the in-memory override mirror. When `probe` is
+ * set, each endpoint is checked for liveness / chain identity and the result is
+ * attached so the caller can warn on an unreachable or wrong-chain endpoint.
+ * Probing never blocks application — the override is set regardless.
+ */
+export async function applyRpcOverrides(
+  resolution: RpcOverrideResolution,
+  opts: { probe?: boolean } = {}
+): Promise<AppliedRpcOverride[]> {
+  const results: AppliedRpcOverride[] = []
+  for (const { chain, url } of resolution.applied) {
+    setCustomRpcOverride(chain, url)
+    const health = opts.probe ? await probeRpcHealth({ chain, url }) : undefined
+    results.push(health ? { chain, url, health } : { chain, url })
+  }
+  return results
+}

--- a/clients/cli/src/index.ts
+++ b/clients/cli/src/index.ts
@@ -59,7 +59,7 @@ import {
 } from './commands'
 import { cachePassword, createPasswordCallback } from './core'
 import { EXIT_CODE_DESCRIPTIONS } from './core/errors'
-import { applyRpcOverrides, resolveRpcOverrides } from './core/rpc-overrides'
+import { applyRpcOverrides, parseRpcOverrideArgsFromArgv, resolveRpcOverrides } from './core/rpc-overrides'
 import { parseServerEndpointOverridesFromArgv, resolveServerEndpoints } from './core/server-endpoints'
 import { findChainByName } from './interactive'
 import { ShellSession } from './interactive'
@@ -203,6 +203,32 @@ async function findVaultByNameOrId(sdk: Vultisig, nameOrId: string): Promise<Vau
   return null
 }
 
+/**
+ * Resolve + apply per-chain custom RPC overrides (from `--rpc-override` flags
+ * and `VULTISIG_<CHAIN>_RPC` env) before the SDK does any networking. Shared by
+ * the command path (`init`) and interactive mode so both honor the override.
+ * Diagnostics go to stderr so they never corrupt the stdout JSON envelope. When
+ * `--rpc-check` confirms a wrong-chain endpoint, abort rather than risk
+ * broadcasting a fund-moving tx to a node serving a different chain.
+ */
+async function applyConfiguredRpcOverrides(config: { specs?: string[]; check?: boolean }): Promise<void> {
+  const resolution = resolveRpcOverrides({ specs: config.specs })
+  for (const warning of resolution.warnings) {
+    console.error(chalk.yellow(warning))
+  }
+  const applied = await applyRpcOverrides(resolution, { probe: !!config.check })
+  for (const entry of applied) {
+    if (entry.health?.status === 'wrongChain') {
+      throw new Error(`Custom RPC for ${entry.chain} serves the wrong chain (rejected by --rpc-check): ${entry.url}`)
+    }
+    if (entry.health && entry.health.status !== 'reachable') {
+      console.error(chalk.yellow(`Custom RPC for ${entry.chain} is ${entry.health.status}: ${entry.url}`))
+    } else if (!isJsonOutput()) {
+      info(`Using custom RPC for ${entry.chain}: ${entry.url}`)
+    }
+  }
+}
+
 async function init(vaultOverride?: string, unlockPassword?: string, passwordTTL?: number): Promise<CLIContext> {
   if (!ctx) {
     // Cache password BEFORE SDK init if provided
@@ -219,21 +245,7 @@ async function init(vaultOverride?: string, unlockPassword?: string, passwordTTL
     }>()
     const serverEndpoints = resolveServerEndpoints(globalOptions)
 
-    // Apply per-chain custom RPC overrides (flags + VULTISIG_<CHAIN>_RPC env)
-    // before the SDK does any networking. Diagnostics go to stderr so they
-    // never corrupt the JSON envelope on stdout.
-    const rpcResolution = resolveRpcOverrides({ specs: globalOptions.rpcOverride })
-    for (const warning of rpcResolution.warnings) {
-      console.error(chalk.yellow(warning))
-    }
-    const appliedRpc = await applyRpcOverrides(rpcResolution, { probe: !!globalOptions.rpcCheck })
-    for (const applied of appliedRpc) {
-      if (applied.health && applied.health.status !== 'reachable') {
-        console.error(chalk.yellow(`Custom RPC for ${applied.chain} is ${applied.health.status}: ${applied.url}`))
-      } else if (!isJsonOutput()) {
-        info(`Using custom RPC for ${applied.chain}: ${applied.url}`)
-      }
-    }
+    await applyConfiguredRpcOverrides({ specs: globalOptions.rpcOverride, check: globalOptions.rpcCheck })
 
     const sdk = new Vultisig({
       onPasswordRequired: createPasswordCallback(),
@@ -1623,6 +1635,8 @@ program
 
 async function startInteractiveMode(): Promise<void> {
   const serverEndpoints = resolveServerEndpoints(parseServerEndpointOverridesFromArgv(process.argv.slice(2)))
+  const rpcArgs = parseRpcOverrideArgsFromArgv(process.argv.slice(2))
+  await applyConfiguredRpcOverrides({ specs: rpcArgs.specs, check: rpcArgs.check })
   const sdk = new Vultisig({
     onPasswordRequired: createPasswordCallback(),
     ...(serverEndpoints ? { serverEndpoints } : {}),

--- a/clients/cli/src/index.ts
+++ b/clients/cli/src/index.ts
@@ -59,6 +59,7 @@ import {
 } from './commands'
 import { cachePassword, createPasswordCallback } from './core'
 import { EXIT_CODE_DESCRIPTIONS } from './core/errors'
+import { applyRpcOverrides, resolveRpcOverrides } from './core/rpc-overrides'
 import { parseServerEndpointOverridesFromArgv, resolveServerEndpoints } from './core/server-endpoints'
 import { findChainByName } from './interactive'
 import { ShellSession } from './interactive'
@@ -130,6 +131,12 @@ program
   .option('-i, --interactive', 'Start interactive shell mode')
   .option('--vault <nameOrId>', 'Specify vault by name or ID')
   .option('--server-url <url>', 'Base Vultisig API URL for FastVault and relay endpoints')
+  .option(
+    '--rpc-override <chain:url>',
+    'Override a chain RPC endpoint, e.g. ethereum:https://my-node (repeatable; EVM + IBC Cosmos chains only). Also via VULTISIG_<CHAIN>_RPC env.',
+    (value: string, prev: string[] = []) => [...prev, value]
+  )
+  .option('--rpc-check', 'Probe custom RPC overrides for liveness/identity at startup')
   .addHelpText(
     'after',
     '\nExit codes:\n' +
@@ -144,6 +151,7 @@ program
       '  VULTISIG_CONFIG_DIR     Override config directory (~/.vultisig)\n' +
       '  VULTISIG_SILENT         Set to 1 for silent mode\n' +
       '  VULTISIG_HTTP_TIMEOUT_MS  Agent-backend request timeout in ms (default 30000)\n' +
+      '  VULTISIG_<CHAIN>_RPC    Override a chain RPC endpoint (e.g. VULTISIG_ETHEREUM_RPC)\n' +
       '  NO_COLOR                Disable colored output'
   )
   .hook('preAction', thisCommand => {
@@ -206,8 +214,26 @@ async function init(vaultOverride?: string, unlockPassword?: string, passwordTTL
 
     const globalOptions = program.opts<{
       serverUrl?: string
+      rpcOverride?: string[]
+      rpcCheck?: boolean
     }>()
     const serverEndpoints = resolveServerEndpoints(globalOptions)
+
+    // Apply per-chain custom RPC overrides (flags + VULTISIG_<CHAIN>_RPC env)
+    // before the SDK does any networking. Diagnostics go to stderr so they
+    // never corrupt the JSON envelope on stdout.
+    const rpcResolution = resolveRpcOverrides({ specs: globalOptions.rpcOverride })
+    for (const warning of rpcResolution.warnings) {
+      console.error(chalk.yellow(warning))
+    }
+    const appliedRpc = await applyRpcOverrides(rpcResolution, { probe: !!globalOptions.rpcCheck })
+    for (const applied of appliedRpc) {
+      if (applied.health && applied.health.status !== 'reachable') {
+        console.error(chalk.yellow(`Custom RPC for ${applied.chain} is ${applied.health.status}: ${applied.url}`))
+      } else if (!isJsonOutput()) {
+        info(`Using custom RPC for ${applied.chain}: ${applied.url}`)
+      }
+    }
 
     const sdk = new Vultisig({
       onPasswordRequired: createPasswordCallback(),


### PR DESCRIPTION
## What

Wires core-chain's existing `setCustomRpcOverride` engine into the CLI, closing backlog fix-12 (per-chain RPC override). A headless operator can point chain RPC at a private node, in both command and interactive (`-i`) modes.

## Interface

- **Flag:** `--rpc-override <chain>:<url>` (global, repeatable), e.g. `--rpc-override ethereum:https://my-node`
- **Env:** `VULTISIG_<CHAIN>_RPC`, e.g. `VULTISIG_ETHEREUM_RPC=https://my-node`. Multi-word chains resolve from their env spelling (`VULTISIG_CRONOS_CHAIN_RPC` → CronosChain).
- **Precedence:** a flag overrides the env var for the same chain.
- **Eligibility:** only EVM and IBC Cosmos chains (`isCustomRpcSupported`). Unknown / unsupported (THORChain, UTXO, QBTC) / malformed specs are ignored with a **stderr** warning — never aborts a command, never corrupts the stdout JSON envelope.
- **Optional `--rpc-check`:** probes each override (`probeRpcHealth`) at startup; **aborts** on a confirmed wrong-chain identity mismatch, warns on unreachable/invalid.

## Coverage (what the override actually reaches)

- **EVM** — every op (balance, gas/nonce, broadcast, tx-status) routes through `getEvmRpcUrl` → fully covered.
- **Cosmos** — the LCD/REST paths (`getCosmosRpcUrl`: fee/min-gas, account info, LCD balance fallback, wasm smart queries). The Tendermint-RPC client used for Cosmos **broadcast and tx-status keeps its default endpoint by design** (a custom RPC is treated as an LCD endpoint — a different protocol; this is pre-existing core-chain behavior, documented in `cosmos/client.ts`).

## Scope

Matches the task file's freshness-narrowed scope (`230626-sdkcli-fix-12-rpc-override.md`): the override engine already exists in core-chain and is honored by the URL resolvers — **the only gap was CLI wiring**. No core-chain change. The Rujira/THORChain `--rpc` subcommand flag is a separate, command-scoped endpoint override and is untouched.

## Tests

`clients/cli/src/core/__tests__/rpc-overrides.test.ts` (8 cases): env override reaches the engine (not the hardcoded default), CLI spec + alias resolution, first-colon URL parsing, flag-beats-env precedence asserted through `applyRpcOverrides`/`getCustomRpcOverride`, multi-word env spelling (CronosChain / TerraClassic), unsupported-chain + unknown + malformed → warnings.

## Review

Ran a 4-lane team review (correctness / security / tests + Codex cross-model). Findings addressed in the 2nd commit: accurate Cosmos coverage wording (Codex HIGH), multi-word env normalization (Codex MEDIUM), interactive-mode wiring (correctness MEDIUM), `--rpc-check` fatal-on-wrongChain (security MEDIUM). Review file kept local.

## Validation

- `yarn workspace @vultisig/cli typecheck` ✅
- Full CLI suite serial — 352 passed ✅
- Prettier (repo config) ✅ · ESLint ✅ · knip ✅
- Changeset: `@vultisig/cli` patch ✅
- Smoke-tested flag/env/alias/multi-word resolution + warning paths end-to-end ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)