### PR TITLE
fix(lib): default timeout on queryUrl (unbounded fetch perma-loading the send fee row)

### DIFF
--- a/.changeset/queryurl-default-timeout.md
+++ b/.changeset/queryurl-default-timeout.md
@@ -1,0 +1,14 @@
+---
+'@vultisig/lib-utils': patch
+'@vultisig/sdk': patch
+---
+
+Add a 20s default deadline to `queryUrl` (the shared HTTP helper behind
+prices/balances/swap quotes/broadcast/MPC-server calls). An unbounded `fetch`
+against a hung upstream previously wedged the caller forever — a stalled
+`/coingeicko` price proxy made `fiatToAmount -> execute_send` hang and
+perma-loaded the agent send card's "Network fee" row until the app's own 60s
+build-timeout fired. The deadline is implemented with a Hermes-compatible
+`AbortController` + `setTimeout` and only applies when the caller passes no
+`signal`; callers that supply their own `signal` keep owning cancellation. A
+new `timeoutMs` option lets callers override the default.

--- a/packages/lib/utils/query/queryUrl.test.ts
+++ b/packages/lib/utils/query/queryUrl.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, afterEach } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { queryUrl } from './queryUrl'
 
@@ -17,7 +17,7 @@ describe('queryUrl - default timeout (unbounded-fetch perma-load fix)', () => {
       (_url: unknown, init?: RequestInit) =>
         new Promise((_resolve, reject) => {
           init?.signal?.addEventListener('abort', () => reject((init.signal as AbortSignal).reason))
-        }),
+        })
     ) as unknown as typeof fetch
 
     const p = queryUrl('https://api.example.com/coingeicko/api/v3/simple/price')
@@ -32,7 +32,7 @@ describe('queryUrl - default timeout (unbounded-fetch perma-load fix)', () => {
         new Response(JSON.stringify({ ethereum: { usd: 3000 } }), {
           status: 200,
           headers: { 'content-type': 'application/json' },
-        }),
+        })
     ) as unknown as typeof fetch
 
     const res = await queryUrl<{ ethereum: { usd: number } }>('https://api.example.com/x')

--- a/packages/lib/utils/query/queryUrl.test.ts
+++ b/packages/lib/utils/query/queryUrl.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi, afterEach } from 'vitest'
+
+import { queryUrl } from './queryUrl'
+
+const origFetch = global.fetch
+
+afterEach(() => {
+  global.fetch = origFetch
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('queryUrl - default timeout (unbounded-fetch perma-load fix)', () => {
+  it('aborts a hung fetch after the default deadline with a timeout error', async () => {
+    vi.useFakeTimers()
+    global.fetch = vi.fn(
+      (_url: unknown, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => reject((init.signal as AbortSignal).reason))
+        }),
+    ) as unknown as typeof fetch
+
+    const p = queryUrl('https://api.example.com/coingeicko/api/v3/simple/price')
+    const assertion = expect(p).rejects.toThrow(/timed out after 20000ms/i)
+    await vi.advanceTimersByTimeAsync(20_000)
+    await assertion
+  })
+
+  it('returns the parsed JSON when the fetch resolves in time (no false timeout)', async () => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ethereum: { usd: 3000 } }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    ) as unknown as typeof fetch
+
+    const res = await queryUrl<{ ethereum: { usd: number } }>('https://api.example.com/x')
+    expect(res).toEqual({ ethereum: { usd: 3000 } })
+  })
+
+  it('passes a caller-supplied signal through and does NOT apply the default deadline', async () => {
+    const controller = new AbortController()
+    global.fetch = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      expect(init?.signal).toBe(controller.signal)
+      return new Response(JSON.stringify({ ok: 1 }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as unknown as typeof fetch
+
+    const res = await queryUrl<{ ok: number }>('https://api.example.com/x', { signal: controller.signal })
+    expect(res).toEqual({ ok: 1 })
+  })
+})

--- a/packages/lib/utils/query/queryUrl.ts
+++ b/packages/lib/utils/query/queryUrl.ts
@@ -6,7 +6,20 @@ type ResponseType = 'json' | 'text' | 'none'
 type QueryUrlOptions = {
   responseType?: ResponseType
   body?: any
+  /**
+   * Deadline in ms for the DEFAULT-timeout path (only applied when the caller
+   * does not pass its own `signal`). Defaults to DEFAULT_QUERY_TIMEOUT_MS.
+   */
+  timeoutMs?: number
 } & Pick<RequestInit, 'method' | 'headers' | 'signal'>
+
+// Default deadline for any queryUrl call that doesn't bring its own AbortSignal.
+// An unbounded fetch against a hung/slow upstream wedges the caller forever: the
+// `/coingeicko` price proxy stalling is what made fiatToAmount -> execute_send
+// hang and perma-loaded the agent send card's "Network fee" row until the app's
+// own 60s build-timeout fired. 20s matches the SDK's other HTTP timeouts
+// (balance/swap rails) — comfortably above a healthy query, still bounding a hang.
+const DEFAULT_QUERY_TIMEOUT_MS = 20_000
 
 const processBody = (body: any) => {
   if (body === undefined) {
@@ -29,24 +42,44 @@ export function queryUrl<T extends string = string>(
 export function queryUrl<T>(url: string | URL, options?: QueryUrlOptions & { responseType?: 'json' }): Promise<T>
 
 export async function queryUrl<T>(url: string | URL, options: QueryUrlOptions = {}): Promise<T | string | void> {
-  const { responseType = 'json', body, headers, method, signal } = options
+  const { responseType = 'json', body, headers, method, signal, timeoutMs = DEFAULT_QUERY_TIMEOUT_MS } = options
 
-  const response = await fetch(
-    url,
-    withoutUndefinedFields({
-      method: method ?? (body ? 'POST' : 'GET'),
-      headers: withoutUndefinedFields({
-        ...headers,
-        'Content-Type': body ? 'application/json' : undefined,
-      }),
-      body: processBody(body),
-      signal,
-    })
-  )
+  // Hermes-compatible default deadline: `AbortSignal.timeout()` isn't available
+  // on older RN/Hermes runtimes (see sdk tools/gas/utxoFeeRate.ts), so when the
+  // caller doesn't supply its own signal, bound the fetch with
+  // AbortController + setTimeout. Callers that pass `signal` own cancellation
+  // and opt out of the default deadline.
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  let effectiveSignal = signal
+  if (!effectiveSignal) {
+    const controller = new AbortController()
+    timeoutId = setTimeout(
+      () => controller.abort(new Error(`queryUrl: request timed out after ${timeoutMs}ms (${String(url)})`)),
+      timeoutMs
+    )
+    effectiveSignal = controller.signal
+  }
 
-  await assertFetchResponse(response)
+  try {
+    const response = await fetch(
+      url,
+      withoutUndefinedFields({
+        method: method ?? (body ? 'POST' : 'GET'),
+        headers: withoutUndefinedFields({
+          ...headers,
+          'Content-Type': body ? 'application/json' : undefined,
+        }),
+        body: processBody(body),
+        signal: effectiveSignal,
+      })
+    )
 
-  if (responseType !== 'none') {
-    return response[responseType]()
+    await assertFetchResponse(response)
+
+    if (responseType !== 'none') {
+      return response[responseType]()
+    }
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId)
   }
 }


### PR DESCRIPTION
Root-cause fix for the flag-OFF "Network fee row perma-loads → build timed out" bug (companion to mcp-ts #589).

## root cause (sim-reproduced, prod, flag OFF)
A USD send (`$0.10 eth`) → `fiatToAmount` → `getCoinPrices` → `queryCoingeickoPrices` → **`queryUrl`**, which did a bare `fetch()` with **no timeout**. A stalled `/coingeicko` price proxy → fetch never settles → `fiatToAmount` never returns → mcp-ts `execute_send` never emits → the send card spins to the app 60s build-timeout. **Native amounts skip the price fetch** (why `0.0001 eth` resolved, `$0.10 eth` hung).

`queryUrl` is the shared helper behind prices/balances/chain queries — the unbounded-fetch **class** bug.

## fix
20s default deadline when no caller `signal` (Hermes-compatible `AbortController`+`setTimeout`; `AbortSignal.timeout` isn't on older Hermes — see `sdk tools/gas/utxoFeeRate.ts`). Market data still fetched, just bounded. New `timeoutMs` option; signal-passing callers unchanged.

## receipts
3 new tests (hung → aborts 20s w/ timeout error; in-time → resolves; caller signal passes through). lib suite green, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)