### PR TITLE
fix(core-chain): lower terraclassic lunc cosmosGasRecord from 100 to 20 lunc

### DIFF
--- a/.changeset/fix-terraclassic-lunc-send-fee.md
+++ b/.changeset/fix-terraclassic-lunc-send-fee.md
@@ -1,0 +1,12 @@
+---
+"@vultisig/core-chain": patch
+"@vultisig/sdk": patch
+---
+
+Lower `cosmosGasRecord[TerraClassic]` from 100 LUNC to 20 LUNC.
+
+Real on-chain MsgSend cost on columbus-5: ~400k gas x 28.325 uluna/gas ~ 11.33 LUNC.
+The 100 LUNC floor was blocking sends from wallets with 20-100 LUNC balance even when
+the transaction would have succeeded. The new 20 LUNC floor gives a ~1.77x buffer.
+
+Companion to vultisig/agent-backend#1409 and vultisig/mcp-ts#594.

--- a/packages/core/chain/chains/cosmos/cosmosGasLimitRecord.ts
+++ b/packages/core/chain/chains/cosmos/cosmosGasLimitRecord.ts
@@ -41,12 +41,15 @@ export const getCosmosGasLimit = (coin: CoinKey<CosmosChain>): bigint => {
  * writes that the standard SDK gas estimate omits. In practice this adds
  * ~200-800 gas on top of the base delegate cost (~2M), so a 2M limit fails
  * consistently ("out of gas in location: ValuePerByte; gasWanted: 2000000,
- * gasUsed: 200X"). 3M sits safely under the 100 LUNC fee floor at msgCount=1
- * (3M * 28.325 uluna/gas ≈ 84.97 LUNC < 100 LUNC). The msgCount scaling is
- * disabled for TerraClassic: at msgCount>=2, scaled gasWanted would exceed
- * 100 LUNC, causing node rejection when the tx fee amount (cosmosGasRecord
- * [TerraClassic]=100_000_000 uluna) no longer covers gasWanted * gasPrice.
- * Columbus-5 callers must split multi-validator claims into separate txs.
+ * gasUsed: 200X"). 3M needs ~84.97 LUNC at sign time (3M * 28.325 uluna/gas).
+ * That fee is supplied by the CONSUMER's separate per-msg staking fee
+ * (mcp-ts COSMOS_STAKING_FEE_PER_MSG_BASE_UNITS[TerraClassic] = 100 LUNC/msg,
+ * written into the signAmino / signDirect fee) — NOT by
+ * `cosmosGasRecord[TerraClassic]`, which is the native MsgSend fee floor
+ * (20 LUNC) and never governs staking. The msgCount scaling is disabled for
+ * TerraClassic: at msgCount>=2, scaled gasWanted would push the required fee
+ * above the 100 LUNC per-msg staking fee, causing node rejection. Columbus-5
+ * callers must split multi-validator claims into separate txs.
  */
 const cosmosStakingGasLimitRecord: Record<IbcEnabledCosmosChain, bigint> = {
   [Chain.Cosmos]: 350_000n,
@@ -87,9 +90,10 @@ export const getCosmosStakingGasLimit = ({ chain, msgCount = 1 }: GetCosmosStaki
 
   const base = cosmosStakingGasLimitRecord[chain]
 
-  // TerraClassic: fee-floor cap (see comment on cosmosStakingGasLimitRecord).
-  // Scaling would push gasWanted above 100 LUNC at msgCount>=2; single-msg
-  // policy keeps the tx fee within the cosmosGasRecord floor for columbus-5.
+  // TerraClassic: staking-fee cap (see comment on cosmosStakingGasLimitRecord).
+  // Scaling would push the required fee above the consumer's 100 LUNC per-msg
+  // staking fee at msgCount>=2; single-msg policy keeps the tx within that fee
+  // for columbus-5 (independent of the 20 LUNC cosmosGasRecord send floor).
   if (chain === Chain.TerraClassic) return base
 
   const n = BigInt(Math.max(1, msgCount))

--- a/packages/core/chain/chains/cosmos/gas.ts
+++ b/packages/core/chain/chains/cosmos/gas.ts
@@ -12,7 +12,7 @@ export const cosmosGasRecord: Record<IbcEnabledCosmosChain, bigint> = {
   [Chain.Kujira]: defaultGas,
   [Chain.Terra]: defaultGas,
   [Chain.Dydx]: 2500000000000000n,
-  [Chain.TerraClassic]: 100000000n,
+  [Chain.TerraClassic]: 20000000n,
   [Chain.Noble]: 30000n,
   [Chain.Akash]: 200000n,
 }

--- a/packages/sdk/tests/unit/tools/gas/cosmos.test.ts
+++ b/packages/sdk/tests/unit/tools/gas/cosmos.test.ts
@@ -23,10 +23,9 @@ describe('estimateCosmosSwapFeeLabel', () => {
     expect(estimateCosmosSwapFeeLabel(Chain.Osmosis)).toBe('~0.009 OSMO')
   })
 
-  // TerraClassic carries the 100 LUNC sign-time fee. This is the highest-blast
-  // assertion: under-displaying it would badly mislead the user.
-  it('formats the canonical TerraClassic swap fee (100_000_000 uluna = 100 LUNC)', () => {
-    expect(estimateCosmosSwapFeeLabel(Chain.TerraClassic)).toBe('~100 LUNC')
+  // TerraClassic send fee lowered from 100 to 20 LUNC (cosmosGasRecord, real MsgSend ~11 LUNC).
+  it('formats the canonical TerraClassic swap fee (20_000_000 uluna = 20 LUNC)', () => {
+    expect(estimateCosmosSwapFeeLabel(Chain.TerraClassic)).toBe('~20 LUNC')
   })
 
   // Terra (phoenix-1, LUNA) must not be confused with TerraClassic (columbus-5,


### PR DESCRIPTION
## What

Lowers `cosmosGasRecord[Chain.TerraClassic]` from 100_000_000n (100 LUNC) to 20_000_000n (20 LUNC) in `packages/core/chain/chains/cosmos/gas.ts`.

This is the root cause fix. `getCosmosFeeAmount` uses this as the floor: since the live computed fee (~11 LUNC) is below the floor, it always returns the floor. Lowering the floor from 100 to 20 LUNC means the signer now charges 20 LUNC for a bare MsgSend on columbus-5.

## Why

Real on-chain MsgSend cost: ~400k gas x 28.325 uluna/gas ~ 11.33 LUNC. The 100 LUNC floor was blocking sends from wallets with 20-100 LUNC balance even when the tx would have succeeded on-chain:

- User has 50 LUNC, tries to send 10 LUNC
- Old: agent checks 10 + 100 = 110 > 50 -> blocked
- New: agent checks 10 + 20 = 30 < 50 -> passes; signer charges 20 LUNC; user sends 10 LUNC

Note: `cosmosGasRecord` is the FLOOR for sends. For staking, `mcp-ts` uses a separate `COSMOS_STAKING_FEE_PER_MSG_BASE_UNITS.TerraClassic = 100_000_000n` (intentionally kept at 100 LUNC because staking ops use ~1M gas/msg, not ~400k).

## Math

- MsgSend gas limit: 400_000 gas
- columbus-5 min-gas-price: ~28.325 uluna/gas
- Computed fee: ~11.33 LUNC = ~11_330_000 uluna
- New floor: 20 LUNC = 20_000_000 uluna (~1.77x real cost)

## Risk

Low - scoped to TerraClassic sends. Includes changeset for patch bump. All 2265 SDK tests green.

## Companion PRs

- vultisig/agent-backend#1409 - lowers the AB reserve to 20 LUNC
- vultisig/mcp-ts#594 - lowers COSMOS_SEND_FEE_BASE_UNITS['TerraClassic'] to 20 LUNC

🤖 generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Lowered TerraClassic’s minimum send fee estimate, allowing wallet sends to work with smaller LUNC balances.
  * Improved fee calculations and related guidance so TerraClassic transactions show a more accurate expected cost.
* **Tests**
  * Updated fee-label expectations to match the new TerraClassic send estimate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->