### PR TITLE
feat(core-chain): TON nominator-pool staking support

### DIFF
--- a/.changeset/ton-nominator-staking.md
+++ b/.changeset/ton-nominator-staking.md
@@ -1,0 +1,6 @@
+---
+"@vultisig/core-chain": minor
+"@vultisig/core-mpc": patch
+---
+
+Add TON nominator-pool staking support. `@vultisig/core-chain` gains a tonapi staking client (`chains/ton/staking`) — pool list, computed pool info, and account nominator positions — plus per-implementation deposit/withdraw comment resolution (`whales` → `Deposit`/`Withdraw`, `tf` → `d`/`w`), pool eligibility/capacity filters, and a `tonAddressToBounceable` helper that normalizes raw `0:` pool addresses to the bounceable `EQ…` form. `@vultisig/core-mpc` now forces TON transfers bounceable for any staking comment (via `isTonStakingComment`), so a rejected pool deposit/withdraw bounces back instead of being absorbed.

--- a/.changeset/ton-nominator-staking.md
+++ b/.changeset/ton-nominator-staking.md
@@ -1,6 +1,7 @@
 ---
 "@vultisig/core-chain": minor
 "@vultisig/core-mpc": patch
+"@vultisig/sdk": minor
 ---
 
 Add TON nominator-pool staking support. `@vultisig/core-chain` gains a tonapi staking client (`chains/ton/staking`) — pool list, computed pool info, and account nominator positions — plus per-implementation deposit/withdraw comment resolution (`whales` → `Deposit`/`Withdraw`, `tf` → `d`/`w`), pool eligibility/capacity filters, and a `tonAddressToBounceable` helper that normalizes raw `0:` pool addresses to the bounceable `EQ…` form. `@vultisig/core-mpc` now forces TON transfers bounceable for any staking comment (via `isTonStakingComment`), so a rejected pool deposit/withdraw bounces back instead of being absorbed.

--- a/packages/core/chain/chains/ton/address.ts
+++ b/packages/core/chain/chains/ton/address.ts
@@ -1,3 +1,4 @@
+import { Address } from '@ton/core'
 import { fromBase64 } from '@vultisig/lib-utils/fromBase64'
 
 /** Converts base64url encoding to standard base64 so `Buffer.from` can decode it. */
@@ -16,4 +17,20 @@ export const tonAddressToRaw = (userFriendlyAddress: string): string => {
   const hash = decoded.subarray(2, 34).toString('hex')
 
   return `${workchain}:${hash}`
+}
+
+/**
+ * Converts a raw TON address (`workchain:hex`) to the bounceable user-friendly
+ * form (`EQ…`). Staking-API pool addresses arrive in raw `0:` form, which the
+ * signer treats as non-bounceable — sending a deposit non-bounceable risks the
+ * pool absorbing (losing) a rejected transfer instead of bouncing it back, so
+ * pool destinations MUST be normalized to the bounceable form first. Inputs
+ * already in user-friendly form are returned re-encoded as bounceable.
+ */
+export const tonAddressToBounceable = (address: string): string => {
+  const parsed = address.includes(':')
+    ? Address.parseRaw(address)
+    : Address.parse(address)
+
+  return parsed.toString({ bounceable: true, testOnly: false, urlSafe: true })
 }

--- a/packages/core/chain/chains/ton/address.ts
+++ b/packages/core/chain/chains/ton/address.ts
@@ -28,9 +28,7 @@ export const tonAddressToRaw = (userFriendlyAddress: string): string => {
  * already in user-friendly form are returned re-encoded as bounceable.
  */
 export const tonAddressToBounceable = (address: string): string => {
-  const parsed = address.includes(':')
-    ? Address.parseRaw(address)
-    : Address.parse(address)
+  const parsed = address.includes(':') ? Address.parseRaw(address) : Address.parse(address)
 
   return parsed.toString({ bounceable: true, testOnly: false, urlSafe: true })
 }

--- a/packages/core/chain/chains/ton/staking.test.ts
+++ b/packages/core/chain/chains/ton/staking.test.ts
@@ -6,8 +6,8 @@ import {
   isTonNominatorImplementation,
   isTonStakingComment,
   tonPoolHasCapacity,
-  TonStakingPool,
   tonStakingDepositComment,
+  TonStakingPool,
   tonStakingWithdrawComment,
 } from './staking'
 
@@ -60,9 +60,7 @@ describe('TON nominator pool eligibility', () => {
   })
 
   it('treats missing/zero max nominators as having capacity', () => {
-    expect(
-      tonPoolHasCapacity({ ...basePool, currentNominators: undefined })
-    ).toBe(true)
+    expect(tonPoolHasCapacity({ ...basePool, currentNominators: undefined })).toBe(true)
     expect(tonPoolHasCapacity({ ...basePool, maxNominators: 0 })).toBe(true)
   })
 
@@ -79,9 +77,7 @@ describe('TON nominator pool eligibility', () => {
   it('is stakeable only when verified, nominator, and with capacity', () => {
     expect(isStakeableTonPool(basePool)).toBe(true)
     expect(isStakeableTonPool({ ...basePool, verified: false })).toBe(false)
-    expect(
-      isStakeableTonPool({ ...basePool, implementation: 'liquidTF' })
-    ).toBe(false)
+    expect(isStakeableTonPool({ ...basePool, implementation: 'liquidTF' })).toBe(false)
     expect(
       isStakeableTonPool({
         ...basePool,

--- a/packages/core/chain/chains/ton/staking.test.ts
+++ b/packages/core/chain/chains/ton/staking.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+
+import { tonAddressToBounceable, tonAddressToRaw } from './address'
+import {
+  isStakeableTonPool,
+  isTonNominatorImplementation,
+  isTonStakingComment,
+  tonPoolHasCapacity,
+  TonStakingPool,
+  tonStakingDepositComment,
+  tonStakingWithdrawComment,
+} from './staking'
+
+const basePool: TonStakingPool = {
+  address: '0:abc',
+  name: 'Pool',
+  apy: 5,
+  minStake: 50_000_000_000n,
+  verified: true,
+  currentNominators: 10,
+  maxNominators: 40,
+  implementation: 'whales',
+}
+
+describe('TON staking comments', () => {
+  it('maps deposit comments per implementation', () => {
+    expect(tonStakingDepositComment('whales')).toBe('Deposit')
+    expect(tonStakingDepositComment('tf')).toBe('d')
+  })
+
+  it('maps withdraw comments per implementation', () => {
+    expect(tonStakingWithdrawComment('whales')).toBe('Withdraw')
+    expect(tonStakingWithdrawComment('tf')).toBe('w')
+  })
+
+  it('returns undefined for unsupported / unknown implementations', () => {
+    expect(tonStakingDepositComment('liquidTF')).toBeUndefined()
+    expect(tonStakingWithdrawComment('liquidTF')).toBeUndefined()
+    expect(tonStakingDepositComment(undefined)).toBeUndefined()
+    expect(tonStakingDepositComment('something-new')).toBeUndefined()
+  })
+
+  it('recognises all four staking comments (for the bounceable-send guard)', () => {
+    for (const memo of ['d', 'w', 'Deposit', 'Withdraw']) {
+      expect(isTonStakingComment(memo)).toBe(true)
+    }
+    expect(isTonStakingComment(' Deposit ')).toBe(true)
+    expect(isTonStakingComment('Stake')).toBe(false)
+    expect(isTonStakingComment('gm')).toBe(false)
+    expect(isTonStakingComment(undefined)).toBe(false)
+  })
+})
+
+describe('TON nominator pool eligibility', () => {
+  it('recognises only whales and tf as nominator implementations', () => {
+    expect(isTonNominatorImplementation('whales')).toBe(true)
+    expect(isTonNominatorImplementation('tf')).toBe(true)
+    expect(isTonNominatorImplementation('liquidTF')).toBe(false)
+    expect(isTonNominatorImplementation(undefined)).toBe(false)
+  })
+
+  it('treats missing/zero max nominators as having capacity', () => {
+    expect(
+      tonPoolHasCapacity({ ...basePool, currentNominators: undefined })
+    ).toBe(true)
+    expect(tonPoolHasCapacity({ ...basePool, maxNominators: 0 })).toBe(true)
+  })
+
+  it('reports no capacity when full', () => {
+    expect(
+      tonPoolHasCapacity({
+        ...basePool,
+        currentNominators: 40,
+        maxNominators: 40,
+      })
+    ).toBe(false)
+  })
+
+  it('is stakeable only when verified, nominator, and with capacity', () => {
+    expect(isStakeableTonPool(basePool)).toBe(true)
+    expect(isStakeableTonPool({ ...basePool, verified: false })).toBe(false)
+    expect(
+      isStakeableTonPool({ ...basePool, implementation: 'liquidTF' })
+    ).toBe(false)
+    expect(
+      isStakeableTonPool({
+        ...basePool,
+        currentNominators: 40,
+        maxNominators: 40,
+      })
+    ).toBe(false)
+  })
+})
+
+describe('tonAddressToBounceable', () => {
+  it('round-trips an EQ address through raw back to bounceable EQ', () => {
+    const friendly = 'EQDAFuDWly4z3eA16Ej_JHpoL6CcXdt0IRUrODKKsu60HYMi'
+    const raw = tonAddressToRaw(friendly)
+
+    expect(raw.startsWith('0:')).toBe(true)
+    expect(tonAddressToBounceable(raw)).toBe(friendly)
+  })
+
+  it('re-encodes an already user-friendly address as bounceable', () => {
+    const friendly = 'EQDAFuDWly4z3eA16Ej_JHpoL6CcXdt0IRUrODKKsu60HYMi'
+
+    expect(tonAddressToBounceable(friendly)).toBe(friendly)
+  })
+})

--- a/packages/core/chain/chains/ton/staking.ts
+++ b/packages/core/chain/chains/ton/staking.ts
@@ -1,0 +1,238 @@
+import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+
+/**
+ * Public TonAPI host. The staking endpoints (`/v2/staking/*`) are served
+ * exclusively by `tonapi.io` — the Vultisig `/ton` proxy fronts toncenter v3,
+ * which has no staking routes — so we hit tonapi.io directly. The extension's
+ * wildcard https host permission covers it.
+ */
+const tonApiPublicUrl = 'https://tonapi.io'
+
+/**
+ * tonapi `implementation` values that are genuine **nominator pools** — the
+ * only ones the text-comment deposit/withdraw mechanism can stake into.
+ * `liquidTF` (Tonstakers) mints a jetton instead and is excluded; unknown
+ * implementations are treated as non-nominator (excluded).
+ */
+export const tonNominatorImplementations = ['whales', 'tf'] as const
+
+export type TonNominatorImplementation = (typeof tonNominatorImplementations)[number]
+
+export const isTonNominatorImplementation = (
+  implementation: string | undefined
+): implementation is TonNominatorImplementation =>
+  !!implementation && (tonNominatorImplementations as readonly string[]).includes(implementation)
+
+/**
+ * The deposit/withdraw text comments a TON nominator-pool contract expects.
+ * Each pool *implementation* uses a DIFFERENT word — sending the wrong one is
+ * rejected on-chain (exit code 72). These are contract protocol tokens, NOT
+ * user-facing UI: never translate them.
+ *
+ * The Whales pool repo README's "Stake" is stale and rejected by the live
+ * pools; the verified on-chain word is "Deposit".
+ */
+const tonStakingDepositComments: Record<TonNominatorImplementation, string> = {
+  tf: 'd',
+  whales: 'Deposit',
+}
+
+const tonStakingWithdrawComments: Record<TonNominatorImplementation, string> = {
+  tf: 'w',
+  whales: 'Withdraw',
+}
+
+/** Deposit comment for a pool implementation, or `undefined` if unsupported (block the action). */
+export const tonStakingDepositComment = (implementation: string | undefined): string | undefined =>
+  isTonNominatorImplementation(implementation) ? tonStakingDepositComments[implementation] : undefined
+
+/** Withdraw comment for a pool implementation, or `undefined` if unsupported (block the action). */
+export const tonStakingWithdrawComment = (implementation: string | undefined): string | undefined =>
+  isTonNominatorImplementation(implementation) ? tonStakingWithdrawComments[implementation] : undefined
+
+const tonStakingComments = new Set<string>([
+  ...Object.values(tonStakingDepositComments),
+  ...Object.values(tonStakingWithdrawComments),
+])
+
+/**
+ * Whether a memo is a nominator-pool deposit/withdraw comment (`d`/`w`/`Deposit`
+ * /`Withdraw`). The signer uses this to force the transfer bounceable: a pool
+ * deposit/withdraw sent non-bounceable can be absorbed (lost) by the pool
+ * instead of bounced back if rejected.
+ */
+export const isTonStakingComment = (memo: string | undefined): boolean =>
+  !!memo && tonStakingComments.has(memo.trim())
+
+/**
+ * Processing-commission buffer (nanotons) added on top of a pool's `min_stake`
+ * for the minimum acceptable deposit. Depositing exactly the minimum is
+ * rejected; the pool needs ~1 TON headroom for its processing commission.
+ */
+export const tonStakingDepositBuffer = 1_000_000_000n
+
+/**
+ * Amount (nanotons) accompanying a withdraw message — the pool's 0.2 TON
+ * withdraw fee. The pool returns the full staked balance separately; sending
+ * more (e.g. 1 TON) fails.
+ */
+export const tonStakingWithdrawFee = 200_000_000n
+
+/**
+ * Conservative network-fee reserve (nanotons ≈ 0.05 TON) held back from the
+ * spendable balance when sizing a stake deposit or checking the unstake fee is
+ * affordable. Larger than the bare base fee because the text-comment cell adds
+ * compute; matches the iOS reserve.
+ */
+export const tonStakingFeeReserve = 50_000_000n
+
+type RawTonStakingPoolEntry = {
+  address: string
+  name: string
+  apy: number
+  min_stake: number
+  verified: boolean
+  current_nominators?: number
+  max_nominators?: number
+  implementation?: string
+  cycle_end?: number
+}
+
+/**
+ * A staking-pool list entry. `address` is the raw `0:` pool contract address,
+ * `apy` is a percentage (e.g. `13.27` = 13.27%), and `minStake` is in nanotons.
+ */
+export type TonStakingPool = {
+  address: string
+  name: string
+  apy: number
+  minStake: bigint
+  verified: boolean
+  currentNominators?: number
+  maxNominators?: number
+  implementation?: string
+  cycleEnd?: number
+}
+
+const mapPoolEntry = (entry: RawTonStakingPoolEntry): TonStakingPool => ({
+  address: entry.address,
+  name: entry.name,
+  apy: entry.apy,
+  minStake: BigInt(Math.trunc(entry.min_stake)),
+  verified: entry.verified,
+  currentNominators: entry.current_nominators,
+  maxNominators: entry.max_nominators,
+  implementation: entry.implementation,
+  cycleEnd: entry.cycle_end,
+})
+
+/** Whether a pool has room for another nominator (pools at capacity reject new stakes). */
+export const tonPoolHasCapacity = (pool: TonStakingPool): boolean => {
+  const { currentNominators, maxNominators } = pool
+  if (currentNominators === undefined || maxNominators === undefined || maxNominators <= 0) {
+    return true
+  }
+  return currentNominators < maxNominators
+}
+
+/**
+ * Whether a pool is a verified nominator pool with capacity — i.e. one the
+ * picker should surface and a stake can succeed into.
+ */
+export const isStakeableTonPool = (pool: TonStakingPool): boolean =>
+  pool.verified && isTonNominatorImplementation(pool.implementation) && tonPoolHasCapacity(pool)
+
+/**
+ * Fetches all verified TON staking pools from tonapi (`/v2/staking/pools`).
+ * Includes every implementation; callers filter to stakeable nominator pools
+ * via `isStakeableTonPool`.
+ */
+export const getTonStakingPools = async (): Promise<TonStakingPool[]> => {
+  const url = `${tonApiPublicUrl}/v2/staking/pools?include_unverified=false`
+  const { pools } = await queryUrl<{ pools: RawTonStakingPoolEntry[] }>(url)
+
+  return pools.map(mapPoolEntry)
+}
+
+type RawTonStakingPoolInfo = {
+  address?: string
+  name?: string
+  apy?: number
+  min_stake?: number
+  implementation?: string
+  cycle_end?: number
+}
+
+/**
+ * Computed info for a single pool (`/v2/staking/pool/{address}`). All fields
+ * are optional so a partial/changed response degrades gracefully. `apy` is a
+ * percentage; `cycleEnd` is the Unix second the current validation cycle ends.
+ */
+export type TonStakingPoolInfo = {
+  address?: string
+  name?: string
+  apy?: number
+  minStake?: bigint
+  implementation?: string
+  cycleEnd?: number
+}
+
+/** Fetches computed pool metadata (name, APY, implementation, cycle end). */
+export const getTonStakingPoolInfo = async (
+  poolAddress: string
+): Promise<TonStakingPoolInfo | undefined> => {
+  const url = `${tonApiPublicUrl}/v2/staking/pool/${poolAddress}`
+  const { pool } = await queryUrl<{ pool?: RawTonStakingPoolInfo }>(url)
+  if (!pool) return undefined
+
+  return {
+    address: pool.address,
+    name: pool.name,
+    apy: pool.apy,
+    minStake: pool.min_stake !== undefined ? BigInt(Math.trunc(pool.min_stake)) : undefined,
+    implementation: pool.implementation,
+    cycleEnd: pool.cycle_end,
+  }
+}
+
+type RawTonNominatorPosition = {
+  pool: string
+  amount: number
+  pending_deposit: number
+  pending_withdraw: number
+  ready_withdraw: number
+}
+
+/**
+ * An account's position in a nominator pool. All amounts are nanotons. `amount`
+ * is the active stake; `pendingDeposit` is a just-placed stake awaiting the
+ * next validation cycle; `pendingWithdraw`/`readyWithdraw` indicate an
+ * in-progress withdrawal (funds locked until the cycle ends).
+ */
+export type TonNominatorPosition = {
+  pool: string
+  amount: bigint
+  pendingDeposit: bigint
+  pendingWithdraw: bigint
+  readyWithdraw: bigint
+}
+
+/**
+ * Fetches an account's nominator-pool positions
+ * (`/v2/staking/nominator/{accountId}/pools`) — the authoritative source for
+ * staked positions. `accountId` accepts the user-friendly wallet address.
+ */
+export const getTonNominatorPools = async (
+  accountId: string
+): Promise<TonNominatorPosition[]> => {
+  const url = `${tonApiPublicUrl}/v2/staking/nominator/${accountId}/pools`
+  const { pools } = await queryUrl<{ pools: RawTonNominatorPosition[] }>(url)
+
+  return pools.map(position => ({
+    pool: position.pool,
+    amount: BigInt(Math.trunc(position.amount)),
+    pendingDeposit: BigInt(Math.trunc(position.pending_deposit)),
+    pendingWithdraw: BigInt(Math.trunc(position.pending_withdraw)),
+    readyWithdraw: BigInt(Math.trunc(position.ready_withdraw)),
+  }))
+}

--- a/packages/core/chain/chains/ton/staking.ts
+++ b/packages/core/chain/chains/ton/staking.ts
@@ -1,5 +1,7 @@
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
+import { tonAddressToBounceable } from './address'
+
 /**
  * Public TonAPI host. The staking endpoints (`/v2/staking/*`) are served
  * exclusively by `tonapi.io` — the Vultisig `/ton` proxy fronts toncenter v3,
@@ -61,8 +63,7 @@ const tonStakingComments = new Set<string>([
  * deposit/withdraw sent non-bounceable can be absorbed (lost) by the pool
  * instead of bounced back if rejected.
  */
-export const isTonStakingComment = (memo: string | undefined): boolean =>
-  !!memo && tonStakingComments.has(memo.trim())
+export const isTonStakingComment = (memo: string | undefined): boolean => !!memo && tonStakingComments.has(memo.trim())
 
 /**
  * Processing-commission buffer (nanotons) added on top of a pool's `min_stake`
@@ -99,8 +100,9 @@ type RawTonStakingPoolEntry = {
 }
 
 /**
- * A staking-pool list entry. `address` is the raw `0:` pool contract address,
- * `apy` is a percentage (e.g. `13.27` = 13.27%), and `minStake` is in nanotons.
+ * A staking-pool list entry. `address` is the bounceable user-friendly (`EQ…`)
+ * pool contract address (normalized from the raw `0:` API form), `apy` is a
+ * percentage (e.g. `13.27` = 13.27%), and `minStake` is in nanotons.
  */
 export type TonStakingPool = {
   address: string
@@ -115,7 +117,10 @@ export type TonStakingPool = {
 }
 
 const mapPoolEntry = (entry: RawTonStakingPoolEntry): TonStakingPool => ({
-  address: entry.address,
+  // Normalize to the bounceable `EQ…` form at the boundary so no caller can
+  // build a staking transfer to a raw/non-bounceable destination (which the
+  // pool would absorb instead of bouncing back on rejection).
+  address: tonAddressToBounceable(entry.address),
   name: entry.name,
   apy: entry.apy,
   minStake: BigInt(Math.trunc(entry.min_stake)),
@@ -178,15 +183,13 @@ export type TonStakingPoolInfo = {
 }
 
 /** Fetches computed pool metadata (name, APY, implementation, cycle end). */
-export const getTonStakingPoolInfo = async (
-  poolAddress: string
-): Promise<TonStakingPoolInfo | undefined> => {
-  const url = `${tonApiPublicUrl}/v2/staking/pool/${poolAddress}`
+export const getTonStakingPoolInfo = async (poolAddress: string): Promise<TonStakingPoolInfo | undefined> => {
+  const url = `${tonApiPublicUrl}/v2/staking/pool/${encodeURIComponent(poolAddress)}`
   const { pool } = await queryUrl<{ pool?: RawTonStakingPoolInfo }>(url)
   if (!pool) return undefined
 
   return {
-    address: pool.address,
+    address: pool.address ? tonAddressToBounceable(pool.address) : undefined,
     name: pool.name,
     apy: pool.apy,
     minStake: pool.min_stake !== undefined ? BigInt(Math.trunc(pool.min_stake)) : undefined,
@@ -207,7 +210,8 @@ type RawTonNominatorPosition = {
  * An account's position in a nominator pool. All amounts are nanotons. `amount`
  * is the active stake; `pendingDeposit` is a just-placed stake awaiting the
  * next validation cycle; `pendingWithdraw`/`readyWithdraw` indicate an
- * in-progress withdrawal (funds locked until the cycle ends).
+ * in-progress withdrawal (funds locked until the cycle ends). `pool` is the
+ * bounceable user-friendly (`EQ…`) pool address (normalized from raw `0:`).
  */
 export type TonNominatorPosition = {
   pool: string
@@ -222,14 +226,12 @@ export type TonNominatorPosition = {
  * (`/v2/staking/nominator/{accountId}/pools`) — the authoritative source for
  * staked positions. `accountId` accepts the user-friendly wallet address.
  */
-export const getTonNominatorPools = async (
-  accountId: string
-): Promise<TonNominatorPosition[]> => {
-  const url = `${tonApiPublicUrl}/v2/staking/nominator/${accountId}/pools`
+export const getTonNominatorPools = async (accountId: string): Promise<TonNominatorPosition[]> => {
+  const url = `${tonApiPublicUrl}/v2/staking/nominator/${encodeURIComponent(accountId)}/pools`
   const { pools } = await queryUrl<{ pools: RawTonNominatorPosition[] }>(url)
 
   return pools.map(position => ({
-    pool: position.pool,
+    pool: tonAddressToBounceable(position.pool),
     amount: BigInt(Math.trunc(position.amount)),
     pendingDeposit: BigInt(Math.trunc(position.pending_deposit)),
     pendingWithdraw: BigInt(Math.trunc(position.pending_withdraw)),

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -720,6 +720,11 @@
       "import": "./dist/chains/ton/messageBody/types.js",
       "default": "./dist/chains/ton/messageBody/types.js"
     },
+    "./chains/ton/staking": {
+      "types": "./dist/chains/ton/staking.d.ts",
+      "import": "./dist/chains/ton/staking.js",
+      "default": "./dist/chains/ton/staking.js"
+    },
     "./chains/tron/config": {
       "types": "./dist/chains/tron/config.d.ts",
       "import": "./dist/chains/tron/config.js",

--- a/packages/core/mpc/keysign/signingInputs/resolvers/ton/index.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/ton/index.ts
@@ -1,3 +1,4 @@
+import { isTonStakingComment } from '@vultisig/core-chain/chains/ton/staking'
 import { isFeeCoin } from '@vultisig/core-chain/coin/utils/isFeeCoin'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { TW } from '@trustwallet/wallet-core'
@@ -15,7 +16,7 @@ export const getTonSigningInputs: SigningInputsResolver<'ton'> = ({ keysignPaylo
   const { expireAt, sequenceNumber, bounceable, sendMaxAmount, jettonAddress, isActiveDestination } =
     getBlockchainSpecificValue(keysignPayload.blockchainSpecific, 'tonSpecific')
 
-  const isStakeOp = !!keysignPayload.memo && ['d', 'w'].includes(keysignPayload.memo.trim())
+  const isStakeOp = isTonStakingComment(keysignPayload.memo)
 
   const signTonMessages =
     keysignPayload.signData?.case === 'signTon' ? keysignPayload.signData.value.tonMessages : undefined


### PR DESCRIPTION
## Summary

Adds the chain/signing layer for native **TON nominator-pool staking** (deposit + withdraw), consumed by the vultisig-windows DeFi/Earn tab. Verified against live on-chain behavior.

### `@vultisig/core-chain`
- New `chains/ton/staking` module (hits `tonapi.io` directly — the Vultisig `/ton` proxy fronts toncenter v3, which has no `/v2/staking/*` routes):
  - `getTonStakingPools()` / `getTonStakingPoolInfo()` / `getTonNominatorPools()`
  - `isStakeableTonPool` / `tonPoolHasCapacity` — verified nominator pools (`whales`, `tf`) with capacity; excludes `liquidTF` (jetton-based) and unknown implementations
  - per-implementation comments: `whales` → `Deposit`/`Withdraw`, `tf` → `d`/`w`; unsupported → `undefined` so callers block the action
  - constants: deposit buffer (+1 TON over `min_stake`), withdraw fee (0.2 TON), conservative fee reserve
- `tonAddressToBounceable()` — normalizes raw `0:` pool addresses to the bounceable `EQ…` form.

### `@vultisig/core-mpc`
- The TON signer now forces transfers **bounceable** for any staking comment via `isTonStakingComment()` (previously only the bare `d`/`w` literals). A pool deposit/withdraw sent non-bounceable can be absorbed (lost) by the pool instead of bounced back, so this closes a fund-safety gap for `whales` pools.

## Why bounceable matters
Pool addresses arrive raw `0:` and must be sent to the bounceable `EQ…` form. A rejected deposit (e.g. below the pool's effective minimum) bounces back to the vault when bounceable, but is **absorbed** when not — so the address normalization + signer guard are both required.

## Tests
`packages/core/chain/chains/ton/staking.test.ts` — pins comment mapping, nominator/capacity filtering (incl. `liquidTF` exclusion), the staking-comment guard, and raw↔bounceable address round-tripping. 10 tests passing (`vitest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TON nominator-pool staking support, including pool discovery, pool details, and account position lookup via TONAPI.
  * Added standardized memo/comment recognition plus nominator pool eligibility and capacity checks.
  * Added helper to normalize raw `0:...` pool addresses to bounceable `EQ...` formatting.

* **Bug Fixes**
  * Improved staking deposit/withdraw memo detection for supported implementations and tightened validation for unsupported values.
  * Ensured TON staking-related transfers consistently use bounceable formatting so rejected deposits/withdrawals bounce back properly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->