### PR TITLE
feat(solana): staking foundation — models + RPC read layer

### DIFF
--- a/.changeset/solana-staking-foundation.md
+++ b/.changeset/solana-staking-foundation.md
@@ -1,0 +1,12 @@
+---
+"@vultisig/core-chain": minor
+"@vultisig/sdk": minor
+---
+
+feat(solana): staking foundation — models + RPC read layer
+
+Phase 1 of Solana native staking. Adds the chain-layer read foundation under
+`@vultisig/core-chain/chains/solana/staking`: config, stake-account/validator
+models (jsonParsed parsing + activation-state derivation), the RPC read layer
+(getVoteAccounts / stake-account scan / epoch / rent / inflation / supply), and
+the withdraw cooldown gate. No UI, no signing, no validator-metadata source.

--- a/packages/core/chain/chains/solana/staking/config.ts
+++ b/packages/core/chain/chains/solana/staking/config.ts
@@ -1,0 +1,83 @@
+/**
+ * Constants for Solana native staking (Stake program) reads.
+ *
+ * The Stake-program account layout and the staker-authority memcmp offset are
+ * protocol facts, not per-chain config, so this is a single flat constant set.
+ *
+ * The min-delegation RPC (`getStakeMinimumDelegation`) is blocked by the
+ * Vultisig proxy. The 1 SOL program minimum delegation is active on mainnet and
+ * is enforced by the Stake program — a delegation below it reverts with
+ * `StakeError.InsufficientDelegation`. Since the RPC is blocked, the delegation
+ * floor uses the documented `minDelegationFloorLamports` constant below plus the
+ * live rent-exempt reserve (active stake = funding − rent, so the funding floor
+ * is 1 SOL + rent).
+ *
+ * Port of iOS `SolanaStakingConfig`.
+ */
+export const solanaStakingConfig = {
+  /**
+   * The on-chain Stake program. Every stake account is owned by this program;
+   * it is also the `programId` argument to the stake-filtered
+   * `getProgramAccounts` scan.
+   */
+  stakeProgramId: 'Stake11111111111111111111111111111111111111',
+
+  /**
+   * Byte size of a fully-initialized stake account (`StakeStateV2`). The
+   * `getProgramAccounts` scan filters on `dataSize: 200` to exclude
+   * uninitialized / rewards-pool accounts before the memcmp narrows to the
+   * owner's accounts.
+   */
+  stakeStateSize: 200,
+
+  /**
+   * Offset of the staker authority pubkey inside the stake-account data, used
+   * as the `memcmp` offset to fetch only a given owner's stake accounts.
+   * Layout: 4-byte state enum discriminant + 8-byte `rentExemptReserve` = 12
+   * bytes precede `Meta.authorized.staker`.
+   */
+  stakerMemcmpOffset: 12,
+
+  /**
+   * Offset of the delegation `voter` (vote account) pubkey inside the
+   * stake-account data. Available for vote-account-scoped scans; the
+   * owner-scoped read uses `stakerMemcmpOffset`.
+   */
+  voterMemcmpOffset: 124,
+
+  /**
+   * Documented substitute for the blocked min-delegation RPC. 1 SOL in
+   * lamports — the historical program minimum. Used together with the live
+   * rent-exempt reserve as the delegation floor.
+   */
+  minDelegationFloorLamports: 1_000_000_000n,
+
+  /** Lamports per SOL (9 decimals). Shared by the staking read/format layer. */
+  lamportsPerSol: 1_000_000_000n,
+
+  /**
+   * Rent-exempt reserve for a 200-byte stake account (`StakeStateV2`), in
+   * lamports. Deterministic from the rent rate + account size, so it serves as
+   * the pre-load default before the live `getMinimumBalanceForRentExemption`
+   * read returns.
+   */
+  rentExemptReserveLamports: 2_282_880n,
+
+  /**
+   * Mainnet schedule: 432,000 slots per epoch (~2 days). Informational — the
+   * live value is read from `getEpochInfo.slotsInEpoch`; this is the documented
+   * fallback for activation/cooldown copy.
+   */
+  slotsPerEpoch: 432_000n,
+
+  /**
+   * `u64::MAX` sentinel the Stake program writes into `deactivationEpoch` while
+   * a delegation is active (not deactivating). Parsed stake accounts carry this
+   * verbatim; the activation-state derivation treats it as "no deactivation
+   * scheduled".
+   */
+  epochSentinel: 18_446_744_073_709_551_615n,
+} as const
+
+/** SOL decimals — used by the staking format layer. */
+export const solDecimals = 9

--- a/packages/core/chain/chains/solana/staking/cooldownGate.test.ts
+++ b/packages/core/chain/chains/solana/staking/cooldownGate.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import { solanaStakingConfig } from './config'
+import { evaluateCooldown } from './cooldownGate'
+import { SolanaStakeAccount } from './models/stakeAccount'
+
+const account = (delegation: SolanaStakeAccount['delegation']): SolanaStakeAccount => ({
+  pubkey: 'S',
+  lamports: 1n,
+  rentExemptReserve: 0n,
+  staker: 's',
+  withdrawer: 'w',
+  delegation,
+})
+
+describe('evaluateCooldown', () => {
+  it('is available with no delegation', () => {
+    expect(evaluateCooldown(account(undefined), 100n)).toEqual({
+      status: 'available',
+    })
+  })
+
+  it('is available for an active (non-deactivating) delegation', () => {
+    const a = account({
+      votePubkey: 'v',
+      activationEpoch: 100n,
+      deactivationEpoch: solanaStakingConfig.epochSentinel,
+      stake: 1n,
+    })
+    expect(evaluateCooldown(a, 150n)).toEqual({ status: 'available' })
+  })
+
+  it('is blocked until the epoch passes the deactivation epoch, unlocking at +1', () => {
+    const a = account({
+      votePubkey: 'v',
+      activationEpoch: 100n,
+      deactivationEpoch: 200n,
+      stake: 1n,
+    })
+    expect(evaluateCooldown(a, 200n)).toEqual({
+      status: 'blocked',
+      unlocksAtEpoch: 201n,
+    })
+  })
+
+  it('is available once the network advances past the deactivation epoch', () => {
+    const a = account({
+      votePubkey: 'v',
+      activationEpoch: 100n,
+      deactivationEpoch: 200n,
+      stake: 1n,
+    })
+    expect(evaluateCooldown(a, 201n)).toEqual({ status: 'available' })
+  })
+})

--- a/packages/core/chain/chains/solana/staking/cooldownGate.ts
+++ b/packages/core/chain/chains/solana/staking/cooldownGate.ts
@@ -1,0 +1,45 @@
+import { isDeactivationSentinel, SolanaStakeAccount } from './models/stakeAccount'
+
+/**
+ * Gates a stake-account withdraw on the deactivation cooldown. After a
+ * deactivate, the stake cools down for ~1 epoch: the lamports become
+ * withdrawable only once the network epoch has advanced PAST the account's
+ * `deactivationEpoch`. Evaluating this before a withdraw keysign avoids
+ * surprising the user with a transaction the Stake program would reject.
+ *
+ * Port of iOS `SolanaEpochCooldownGate`.
+ */
+export type SolanaEpochCooldownState = { status: 'available' } | { status: 'blocked'; unlocksAtEpoch: bigint }
+
+/**
+ * Evaluates whether `account`'s deactivated stake can be withdrawn at
+ * `currentEpoch`. Pure function over the parsed delegation + the live epoch.
+ *
+ * - A non-deactivating account (sentinel `deactivationEpoch`) is `available` —
+ *   there is nothing cooling down.
+ * - A deactivating account unlocks once the network advances past its
+ *   deactivation epoch, i.e. at `deactivationEpoch + 1`.
+ */
+export const evaluateCooldown = (account: SolanaStakeAccount, currentEpoch: bigint): SolanaEpochCooldownState => {
+  const { delegation } = account
+  if (!delegation) {
+    return { status: 'available' }
+  }
+  if (isDeactivationSentinel(delegation)) {
+    return { status: 'available' }
+  }
+  if (currentEpoch > delegation.deactivationEpoch) {
+    return { status: 'available' }
+  }
+  // `deactivationEpoch` is < sentinel here, so +1 is safe.
+  return { status: 'blocked', unlocksAtEpoch: delegation.deactivationEpoch + 1n }
+}
+
+/**
+ * Approximate mainnet epoch length in days. Informational copy only — the
+ * authoritative withdraw gate is `evaluateCooldown`, which uses the live epoch.
+ */
+export const approximateDaysPerEpoch = 2
+
+/** Approximate calendar days for `epochs` epochs of cooldown. */
+export const approximateCooldownDays = (epochs: number): number => Math.max(0, epochs) * approximateDaysPerEpoch

--- a/packages/core/chain/chains/solana/staking/models/stakeAccount.test.ts
+++ b/packages/core/chain/chains/solana/staking/models/stakeAccount.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest'
+
+import { solanaStakingConfig } from '../config'
+import { isDeactivationSentinel, parseStakeAccount, SolanaStakeAccount, stakeActivationState } from './stakeAccount'
+
+const sentinel = solanaStakingConfig.epochSentinel
+
+const parsedInfo = (overrides?: {
+  deactivationEpoch?: string
+  activationEpoch?: string
+  withDelegation?: boolean
+}) => ({
+  meta: {
+    rentExemptReserve: '2282880',
+    authorized: { staker: 'STAKER_PUBKEY', withdrawer: 'WITHDRAWER_PUBKEY' },
+  },
+  stake:
+    overrides?.withDelegation === false
+      ? undefined
+      : {
+          delegation: {
+            voter: 'VOTE_PUBKEY',
+            stake: '5000000000',
+            activationEpoch: overrides?.activationEpoch ?? '100',
+            deactivationEpoch: overrides?.deactivationEpoch ?? sentinel.toString(),
+          },
+        },
+})
+
+describe('parseStakeAccount', () => {
+  it('parses a delegated jsonParsed account, converting u64 strings to bigint', () => {
+    const account = parseStakeAccount({
+      pubkey: 'STAKE_ACCT',
+      lamports: 5_002_282_880n,
+      parsedInfo: parsedInfo(),
+    })
+    expect(account).toEqual<SolanaStakeAccount>({
+      pubkey: 'STAKE_ACCT',
+      lamports: 5_002_282_880n,
+      rentExemptReserve: 2_282_880n,
+      staker: 'STAKER_PUBKEY',
+      withdrawer: 'WITHDRAWER_PUBKEY',
+      delegation: {
+        votePubkey: 'VOTE_PUBKEY',
+        activationEpoch: 100n,
+        deactivationEpoch: sentinel,
+        stake: 5_000_000_000n,
+      },
+    })
+  })
+
+  it('parses an initialized-but-undelegated account (no delegation)', () => {
+    const account = parseStakeAccount({
+      pubkey: 'STAKE_ACCT',
+      lamports: 2_282_880n,
+      parsedInfo: parsedInfo({ withDelegation: false }),
+    })
+    expect(account?.delegation).toBeUndefined()
+    expect(account?.rentExemptReserve).toBe(2_282_880n)
+  })
+
+  it('returns undefined when the account is not a parsed stake account', () => {
+    expect(parseStakeAccount({ pubkey: 'X', lamports: 0n, parsedInfo: undefined })).toBeUndefined()
+  })
+})
+
+describe('isDeactivationSentinel', () => {
+  it('is true for the u64::MAX sentinel and false otherwise', () => {
+    expect(
+      isDeactivationSentinel({
+        votePubkey: 'v',
+        activationEpoch: 1n,
+        deactivationEpoch: sentinel,
+        stake: 1n,
+      })
+    ).toBe(true)
+    expect(
+      isDeactivationSentinel({
+        votePubkey: 'v',
+        activationEpoch: 1n,
+        deactivationEpoch: 200n,
+        stake: 1n,
+      })
+    ).toBe(false)
+  })
+})
+
+describe('stakeActivationState', () => {
+  const account = (delegation: SolanaStakeAccount['delegation']): SolanaStakeAccount => ({
+    pubkey: 'S',
+    lamports: 1n,
+    rentExemptReserve: 0n,
+    staker: 's',
+    withdrawer: 'w',
+    delegation,
+  })
+
+  it('is inactive with no delegation', () => {
+    expect(stakeActivationState(account(undefined), 100n)).toBe('inactive')
+  })
+
+  it('is activating in the delegation epoch (not deactivating)', () => {
+    const a = account({
+      votePubkey: 'v',
+      activationEpoch: 100n,
+      deactivationEpoch: sentinel,
+      stake: 1n,
+    })
+    expect(stakeActivationState(a, 100n)).toBe('activating')
+  })
+
+  it('is active after the activation epoch (not deactivating)', () => {
+    const a = account({
+      votePubkey: 'v',
+      activationEpoch: 100n,
+      deactivationEpoch: sentinel,
+      stake: 1n,
+    })
+    expect(stakeActivationState(a, 101n)).toBe('active')
+  })
+
+  it('is deactivating until the current epoch passes the deactivation epoch', () => {
+    const a = account({
+      votePubkey: 'v',
+      activationEpoch: 100n,
+      deactivationEpoch: 200n,
+      stake: 1n,
+    })
+    expect(stakeActivationState(a, 200n)).toBe('deactivating')
+  })
+
+  it('is inactive once the deactivation epoch has passed', () => {
+    const a = account({
+      votePubkey: 'v',
+      activationEpoch: 100n,
+      deactivationEpoch: 200n,
+      stake: 1n,
+    })
+    expect(stakeActivationState(a, 201n)).toBe('inactive')
+  })
+})

--- a/packages/core/chain/chains/solana/staking/models/stakeAccount.test.ts
+++ b/packages/core/chain/chains/solana/staking/models/stakeAccount.test.ts
@@ -78,6 +78,28 @@ describe('parseStakeAccount', () => {
     ).toBeUndefined()
   })
 
+  it('rejects a delegation object missing its voter instead of treating it as undelegated', () => {
+    expect(
+      parseStakeAccount({
+        pubkey: 'X',
+        lamports: 1n,
+        parsedInfo: {
+          meta: {
+            rentExemptReserve: '2282880',
+            authorized: { staker: 'STAKER_PUBKEY', withdrawer: 'WITHDRAWER_PUBKEY' },
+          },
+          stake: {
+            delegation: {
+              stake: '5000000000',
+              activationEpoch: '100',
+              deactivationEpoch: sentinel.toString(),
+            },
+          },
+        },
+      })
+    ).toBeUndefined()
+  })
+
   it('rejects a delegation with an unparseable numeric field instead of coercing it to 0n', () => {
     expect(
       parseStakeAccount({

--- a/packages/core/chain/chains/solana/staking/models/stakeAccount.test.ts
+++ b/packages/core/chain/chains/solana/staking/models/stakeAccount.test.ts
@@ -62,6 +62,44 @@ describe('parseStakeAccount', () => {
   it('returns undefined when the account is not a parsed stake account', () => {
     expect(parseStakeAccount({ pubkey: 'X', lamports: 0n, parsedInfo: undefined })).toBeUndefined()
   })
+
+  it('rejects a row with a missing authority instead of fabricating an empty one', () => {
+    expect(
+      parseStakeAccount({
+        pubkey: 'X',
+        lamports: 1n,
+        parsedInfo: {
+          meta: {
+            rentExemptReserve: '2282880',
+            authorized: { staker: 'STAKER_PUBKEY' },
+          },
+        },
+      })
+    ).toBeUndefined()
+  })
+
+  it('rejects a delegation with an unparseable numeric field instead of coercing it to 0n', () => {
+    expect(
+      parseStakeAccount({
+        pubkey: 'X',
+        lamports: 1n,
+        parsedInfo: {
+          meta: {
+            rentExemptReserve: '2282880',
+            authorized: { staker: 'STAKER_PUBKEY', withdrawer: 'WITHDRAWER_PUBKEY' },
+          },
+          stake: {
+            delegation: {
+              voter: 'VOTE_PUBKEY',
+              stake: 'not-a-number',
+              activationEpoch: '100',
+              deactivationEpoch: sentinel.toString(),
+            },
+          },
+        },
+      })
+    ).toBeUndefined()
+  })
 })
 
 describe('isDeactivationSentinel', () => {

--- a/packages/core/chain/chains/solana/staking/models/stakeAccount.ts
+++ b/packages/core/chain/chains/solana/staking/models/stakeAccount.ts
@@ -1,0 +1,163 @@
+import { solanaStakingConfig } from '../config'
+
+/**
+ * Parsed Solana stake account — the read-side model the staking UI binds to
+ * (delegation amount, validator, activation state, withdraw authority). One
+ * stake account delegates to exactly one validator; a wallet can hold N.
+ *
+ * Decoded from a `getAccountInfo` / `getProgramAccounts` `jsonParsed` row
+ * (`value.data.parsed.info.{meta,stake}`). The on-chain numbers
+ * (`activationEpoch`, `deactivationEpoch`, `stake`, `rentExemptReserve`) are
+ * serialized as decimal STRINGS in jsonParsed — they're u64 and exceed JSON's
+ * safe-integer range — so they are converted to `bigint` here.
+ *
+ * Port of iOS `SolanaStakeAccount`.
+ */
+
+/**
+ * Activation lifecycle of a stake delegation, derived from the account's
+ * `activationEpoch` / `deactivationEpoch` relative to the current epoch.
+ * Solana stake activates at the next epoch boundary and cools down ~1 epoch
+ * after a deactivate before the funds can be withdrawn.
+ */
+export type SolanaStakeActivationState = 'activating' | 'active' | 'deactivating' | 'inactive'
+
+export type SolanaStakeDelegation = {
+  /** Vote account this stake is delegated to. */
+  votePubkey: string
+  /** Epoch the delegation began activating. */
+  activationEpoch: bigint
+  /**
+   * Epoch the delegation began deactivating, or `epochSentinel` (`u64::MAX`)
+   * while active (the Stake program's "not deactivating" sentinel).
+   */
+  deactivationEpoch: bigint
+  /** Delegated lamports. */
+  stake: bigint
+}
+
+export type SolanaStakeAccount = {
+  /** Stake account address (its own pubkey, not the owner's). */
+  pubkey: string
+  /**
+   * The account's total lamports (delegated stake + rent reserve + any
+   * undelegated lamports).
+   */
+  lamports: bigint
+  /**
+   * Rent-exempt reserve held by the account — not part of the delegated /
+   * withdrawable stake.
+   */
+  rentExemptReserve: bigint
+  /** Authority allowed to delegate / deactivate the stake. */
+  staker: string
+  /** Authority allowed to withdraw the stake. */
+  withdrawer: string
+  /**
+   * The delegation, or `undefined` for an initialized-but-undelegated account
+   * (`parsed.type == "initialized"`, no `stake.delegation`).
+   */
+  delegation?: SolanaStakeDelegation
+}
+
+/** `true` when no deactivation has been scheduled on the delegation. */
+export const isDeactivationSentinel = (delegation: SolanaStakeDelegation): boolean =>
+  delegation.deactivationEpoch === solanaStakingConfig.epochSentinel
+
+/**
+ * Derives the lifecycle state from the current epoch. Pure so the cooldown gate
+ * and the UI share one definition.
+ *
+ * - activating: delegation began this epoch and is not deactivating.
+ * - deactivating: a deactivation was scheduled and the current epoch has not
+ *   yet passed it.
+ * - active: delegated in a prior epoch and not deactivating.
+ * - inactive: no delegation, or the deactivation epoch has passed.
+ */
+export const stakeActivationState = (account: SolanaStakeAccount, currentEpoch: bigint): SolanaStakeActivationState => {
+  const { delegation } = account
+  if (!delegation) {
+    return 'inactive'
+  }
+
+  if (!isDeactivationSentinel(delegation)) {
+    // A deactivation is scheduled. Still cooling down until the current epoch
+    // passes the deactivation epoch; inactive afterwards.
+    return currentEpoch <= delegation.deactivationEpoch ? 'deactivating' : 'inactive'
+  }
+
+  // No deactivation scheduled — activating in its first epoch, active after.
+  return currentEpoch <= delegation.activationEpoch ? 'activating' : 'active'
+}
+
+// MARK: - jsonParsed wire decoding
+
+/**
+ * Mirrors the `jsonParsed` Stake-program account `info` shape. u64 fields arrive
+ * as decimal strings (or numbers); `toBigInt` coerces both.
+ */
+type ParsedStakeInfo = {
+  meta?: {
+    rentExemptReserve?: string | number
+    authorized?: { staker?: string; withdrawer?: string }
+  }
+  stake?: {
+    delegation?: {
+      voter?: string
+      stake?: string | number
+      activationEpoch?: string | number
+      deactivationEpoch?: string | number
+    }
+  }
+}
+
+const toBigInt = (value: string | number | undefined): bigint => {
+  if (value === undefined) {
+    return 0n
+  }
+  try {
+    return BigInt(typeof value === 'number' ? Math.trunc(value) : value)
+  } catch {
+    return 0n
+  }
+}
+
+/**
+ * Builds the model from a decoded jsonParsed Stake-program account. Returns
+ * `undefined` when the account is not a parsed stake account (e.g. a non-stake
+ * program account or a base64/dataSliced row with no `parsed` tree).
+ */
+export const parseStakeAccount = ({
+  pubkey,
+  lamports,
+  parsedInfo,
+}: {
+  pubkey: string
+  lamports: bigint
+  parsedInfo: ParsedStakeInfo | undefined
+}): SolanaStakeAccount | undefined => {
+  const meta = parsedInfo?.meta
+  if (!meta?.authorized) {
+    return undefined
+  }
+
+  const delegationInfo = parsedInfo?.stake?.delegation
+  let delegation: SolanaStakeDelegation | undefined
+  if (delegationInfo?.voter) {
+    delegation = {
+      votePubkey: delegationInfo.voter,
+      activationEpoch: toBigInt(delegationInfo.activationEpoch),
+      deactivationEpoch: toBigInt(delegationInfo.deactivationEpoch),
+      stake: toBigInt(delegationInfo.stake),
+    }
+  }
+
+  return {
+    pubkey,
+    lamports,
+    rentExemptReserve: toBigInt(meta.rentExemptReserve),
+    staker: meta.authorized.staker ?? '',
+    withdrawer: meta.authorized.withdrawer ?? '',
+    delegation,
+  }
+}

--- a/packages/core/chain/chains/solana/staking/models/stakeAccount.ts
+++ b/packages/core/chain/chains/solana/staking/models/stakeAccount.ts
@@ -111,14 +111,14 @@ type ParsedStakeInfo = {
   }
 }
 
-const toBigInt = (value: string | number | undefined): bigint => {
+const toBigInt = (value: string | number | undefined): bigint | undefined => {
   if (value === undefined) {
-    return 0n
+    return undefined
   }
   try {
     return BigInt(typeof value === 'number' ? Math.trunc(value) : value)
   } catch {
-    return 0n
+    return undefined
   }
 }
 
@@ -136,28 +136,42 @@ export const parseStakeAccount = ({
   lamports: bigint
   parsedInfo: ParsedStakeInfo | undefined
 }): SolanaStakeAccount | undefined => {
+  // Reject partially-malformed payloads rather than coercing them into
+  // fabricated zero/empty values — a bogus `0n` stake or empty authority would
+  // surface downstream as wrong balances or a falsely inactive/available state.
   const meta = parsedInfo?.meta
-  if (!meta?.authorized) {
+  if (!meta?.authorized?.staker || !meta.authorized.withdrawer) {
+    return undefined
+  }
+
+  const rentExemptReserve = toBigInt(meta.rentExemptReserve)
+  if (rentExemptReserve === undefined) {
     return undefined
   }
 
   const delegationInfo = parsedInfo?.stake?.delegation
   let delegation: SolanaStakeDelegation | undefined
   if (delegationInfo?.voter) {
+    const activationEpoch = toBigInt(delegationInfo.activationEpoch)
+    const deactivationEpoch = toBigInt(delegationInfo.deactivationEpoch)
+    const stake = toBigInt(delegationInfo.stake)
+    if (activationEpoch === undefined || deactivationEpoch === undefined || stake === undefined) {
+      return undefined
+    }
     delegation = {
       votePubkey: delegationInfo.voter,
-      activationEpoch: toBigInt(delegationInfo.activationEpoch),
-      deactivationEpoch: toBigInt(delegationInfo.deactivationEpoch),
-      stake: toBigInt(delegationInfo.stake),
+      activationEpoch,
+      deactivationEpoch,
+      stake,
     }
   }
 
   return {
     pubkey,
     lamports,
-    rentExemptReserve: toBigInt(meta.rentExemptReserve),
-    staker: meta.authorized.staker ?? '',
-    withdrawer: meta.authorized.withdrawer ?? '',
+    rentExemptReserve,
+    staker: meta.authorized.staker,
+    withdrawer: meta.authorized.withdrawer,
     delegation,
   }
 }

--- a/packages/core/chain/chains/solana/staking/models/stakeAccount.ts
+++ b/packages/core/chain/chains/solana/staking/models/stakeAccount.ts
@@ -151,7 +151,12 @@ export const parseStakeAccount = ({
 
   const delegationInfo = parsedInfo?.stake?.delegation
   let delegation: SolanaStakeDelegation | undefined
-  if (delegationInfo?.voter) {
+  if (delegationInfo) {
+    // A delegation object with no `voter` is a malformed row, not an
+    // undelegated account — reject it rather than fabricating "inactive".
+    if (!delegationInfo.voter) {
+      return undefined
+    }
     const activationEpoch = toBigInt(delegationInfo.activationEpoch)
     const deactivationEpoch = toBigInt(delegationInfo.deactivationEpoch)
     const stake = toBigInt(delegationInfo.stake)

--- a/packages/core/chain/chains/solana/staking/models/validator.ts
+++ b/packages/core/chain/chains/solana/staking/models/validator.ts
@@ -25,8 +25,14 @@ export type SolanaValidator = {
   votePubkey: string
   /** The validator's identity (node) pubkey. */
   nodePubkey: string
-  /** Total active stake delegated to this validator, in lamports. */
-  activatedStake: bigint
+  /**
+   * Total active stake delegated to this validator, in lamports. Sourced from
+   * `getVoteAccounts`, which serializes it as a JSON number — so for very large
+   * validators this is already an approximate (>2^53) value. Kept as `number`
+   * rather than dressed up as an exact `bigint`; it drives sort / voting-power
+   * display only, never balance math.
+   */
+  activatedStake: number
   /** Commission percentage (0–100) the validator takes from rewards. */
   commission: number
   /** Whether this vote account has voted in the current epoch. */

--- a/packages/core/chain/chains/solana/staking/models/validator.ts
+++ b/packages/core/chain/chains/solana/staking/models/validator.ts
@@ -1,0 +1,70 @@
+/**
+ * A validator row from `getVoteAccounts` plus an optional metadata enrichment
+ * struct (name / logo / APY / score) populated by the metadata-provider seam.
+ * The base row is decoded straight off the RPC; `ValidatorMetadata` starts
+ * empty so the read layer can ship before the enrichment source is wired.
+ *
+ * Port of iOS `SolanaValidator` / `ValidatorMetadata`.
+ */
+
+/**
+ * Off-chain enrichment for a validator. All optional — populated from a
+ * metadata source; the base read layer leaves it empty.
+ */
+export type ValidatorMetadata = {
+  name?: string
+  logoUrl?: string
+  /** Estimated APY as a fraction (e.g. 0.067 for 6.7%). */
+  apyEstimate?: number
+  /** A 0–100 quality score from the metadata source. */
+  score?: number
+}
+
+export type SolanaValidator = {
+  /** Vote account address — the delegation target a stake account points at. */
+  votePubkey: string
+  /** The validator's identity (node) pubkey. */
+  nodePubkey: string
+  /** Total active stake delegated to this validator, in lamports. */
+  activatedStake: bigint
+  /** Commission percentage (0–100) the validator takes from rewards. */
+  commission: number
+  /** Whether this vote account has voted in the current epoch. */
+  epochVoteAccount: boolean
+  /**
+   * `true` when the validator is in the delinquent set (not voting). Carried
+   * from which `getVoteAccounts` bucket the row came from, not the wire.
+   */
+  isDelinquent: boolean
+  /** Enrichment from the metadata provider — name, logo, APY estimate, score. */
+  metadata: ValidatorMetadata
+}
+
+/**
+ * `prefix…suffix` form of a base58 pubkey for compact display. Returns the
+ * input unchanged when it is too short to truncate meaningfully.
+ */
+export const truncatedPubkey = (pubkey: string, prefix = 4, suffix = 4): string =>
+  pubkey.length > prefix + suffix + 1 ? `${pubkey.slice(0, prefix)}…${pubkey.slice(-suffix)}` : pubkey
+
+/**
+ * Name to show in the picker: the enriched metadata name when present,
+ * otherwise a truncated vote pubkey. Keeps the display layer independent of
+ * whether the metadata provider returned anything.
+ */
+export const validatorDisplayName = (validator: SolanaValidator): string => {
+  const name = validator.metadata.name?.trim()
+  if (name) {
+    return name
+  }
+  return truncatedPubkey(validator.votePubkey)
+}
+
+/**
+ * The validator logo URL, or `undefined` when no metadata source supplied one —
+ * the display layer then renders a deterministic placeholder.
+ */
+export const validatorLogoUrl = (validator: SolanaValidator): string | undefined => {
+  const raw = validator.metadata.logoUrl?.trim()
+  return raw ? raw : undefined
+}

--- a/packages/core/chain/chains/solana/staking/rpc.ts
+++ b/packages/core/chain/chains/solana/staking/rpc.ts
@@ -25,7 +25,9 @@ export const fetchSolanaValidators = async (): Promise<SolanaValidator[]> => {
   const toValidator = (account: (typeof current)[number], isDelinquent: boolean): SolanaValidator => ({
     votePubkey: account.votePubkey,
     nodePubkey: account.nodePubkey,
-    activatedStake: BigInt(Math.trunc(account.activatedStake)),
+    // `activatedStake` arrives from the RPC as a JSON number — keep it as-is
+    // rather than minting a falsely-exact bigint from an already-lossy value.
+    activatedStake: account.activatedStake,
     commission: account.commission,
     epochVoteAccount: account.epochVoteAccount,
     isDelinquent,
@@ -115,9 +117,14 @@ export const fetchSolanaInflationRate = async (): Promise<number> => {
   return total
 }
 
-/** Total SOL supply in lamports — the denominator for the staked fraction. */
-export const fetchSolanaTotalSupply = async (): Promise<bigint> => {
+/**
+ * Total SOL supply in lamports — the denominator for the staked fraction in the
+ * APY fallback. `getSupply` returns a JSON number that exceeds 2^53, so it is
+ * already approximate; kept as `number` (the ratio it feeds only needs ~2dp),
+ * not minted into a falsely-exact bigint.
+ */
+export const fetchSolanaTotalSupply = async (): Promise<number> => {
   const client = getSolanaClient()
   const { value } = await client.getSupply()
-  return BigInt(Math.trunc(value.total))
+  return value.total
 }

--- a/packages/core/chain/chains/solana/staking/rpc.ts
+++ b/packages/core/chain/chains/solana/staking/rpc.ts
@@ -1,0 +1,123 @@
+import { PublicKey } from '@solana/web3.js'
+
+import { getSolanaClient } from '../client'
+import { solanaStakingConfig } from './config'
+import { parseStakeAccount, SolanaStakeAccount } from './models/stakeAccount'
+import { SolanaValidator } from './models/validator'
+
+/**
+ * Read-side Solana RPC for native staking. Thin wrappers over the shared
+ * `@solana/web3.js` connection (`getSolanaClient`) so the staking read layer
+ * stays one call away from the rest of the Solana chain code.
+ *
+ * Port of the Solana staking reads in iOS `SolanaService` / `SolanaAPI`.
+ */
+
+/**
+ * Lists every validator from `getVoteAccounts`, tagging each with the
+ * delinquent flag derived from its bucket (`current` vs `delinquent`). The base
+ * metadata is left empty — the metadata-provider seam enriches it later.
+ */
+export const fetchSolanaValidators = async (): Promise<SolanaValidator[]> => {
+  const client = getSolanaClient()
+  const { current, delinquent } = await client.getVoteAccounts()
+
+  const toValidator = (account: (typeof current)[number], isDelinquent: boolean): SolanaValidator => ({
+    votePubkey: account.votePubkey,
+    nodePubkey: account.nodePubkey,
+    activatedStake: BigInt(Math.trunc(account.activatedStake)),
+    commission: account.commission,
+    epochVoteAccount: account.epochVoteAccount,
+    isDelinquent,
+    metadata: {},
+  })
+
+  return [...current.map(a => toValidator(a, false)), ...delinquent.map(a => toValidator(a, true))]
+}
+
+/**
+ * Fetches the owner's stake accounts via a Stake-program `getProgramAccounts`
+ * scan filtered on `dataSize: 200` (fully-initialized stake accounts) and a
+ * memcmp on the staker authority at offset 12. Uncached at the call site — the
+ * staking view must reflect just-submitted txs and newly accrued rewards.
+ */
+export const fetchSolanaStakeAccounts = async (owner: string): Promise<SolanaStakeAccount[]> => {
+  const client = getSolanaClient()
+  const rows = await client.getParsedProgramAccounts(new PublicKey(solanaStakingConfig.stakeProgramId), {
+    filters: [
+      { dataSize: solanaStakingConfig.stakeStateSize },
+      { memcmp: { offset: solanaStakingConfig.stakerMemcmpOffset, bytes: owner } },
+    ],
+  })
+
+  return rows.flatMap(({ pubkey, account }) => {
+    const { data } = account
+    if (!('parsed' in data)) {
+      return []
+    }
+    const parsed = parseStakeAccount({
+      pubkey: pubkey.toBase58(),
+      lamports: BigInt(account.lamports),
+      parsedInfo: data.parsed?.info,
+    })
+    return parsed ? [parsed] : []
+  })
+}
+
+/**
+ * Fetches a single stake account's parsed state by address. Used by the
+ * unstake / withdraw / move flows that operate on a known account.
+ */
+export const fetchSolanaStakeAccount = async (pubkey: string): Promise<SolanaStakeAccount | undefined> => {
+  const client = getSolanaClient()
+  const { value } = await client.getParsedAccountInfo(new PublicKey(pubkey))
+  if (!value || !('parsed' in value.data)) {
+    return undefined
+  }
+  return parseStakeAccount({
+    pubkey,
+    lamports: BigInt(value.lamports),
+    parsedInfo: value.data.parsed?.info,
+  })
+}
+
+export type SolanaEpochInfo = {
+  epoch: bigint
+  slotIndex: bigint
+  slotsInEpoch: bigint
+}
+
+/** Current epoch info — drives activation-state derivation and cooldown copy. */
+export const fetchSolanaEpochInfo = async (): Promise<SolanaEpochInfo> => {
+  const client = getSolanaClient()
+  const info = await client.getEpochInfo()
+  return {
+    epoch: BigInt(info.epoch),
+    slotIndex: BigInt(info.slotIndex),
+    slotsInEpoch: BigInt(info.slotsInEpoch),
+  }
+}
+
+/**
+ * The rent-exempt reserve for a 200-byte stake account, in lamports. The new
+ * stake account must be funded with this on top of the delegated amount.
+ */
+export const fetchSolanaRentReserve = async (): Promise<bigint> => {
+  const client = getSolanaClient()
+  const lamports = await client.getMinimumBalanceForRentExemption(solanaStakingConfig.stakeStateSize)
+  return BigInt(lamports)
+}
+
+/** Network inflation rate (total) — drives the on-chain APY fallback. */
+export const fetchSolanaInflationRate = async (): Promise<number> => {
+  const client = getSolanaClient()
+  const { total } = await client.getInflationRate()
+  return total
+}
+
+/** Total SOL supply in lamports — the denominator for the staked fraction. */
+export const fetchSolanaTotalSupply = async (): Promise<bigint> => {
+  const client = getSolanaClient()
+  const { value } = await client.getSupply()
+  return BigInt(Math.trunc(value.total))
+}

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -680,6 +680,31 @@
       "import": "./dist/chains/solana/spl/getSplAssociatedAccount.js",
       "default": "./dist/chains/solana/spl/getSplAssociatedAccount.js"
     },
+    "./chains/solana/staking/config": {
+      "types": "./dist/chains/solana/staking/config.d.ts",
+      "import": "./dist/chains/solana/staking/config.js",
+      "default": "./dist/chains/solana/staking/config.js"
+    },
+    "./chains/solana/staking/cooldownGate": {
+      "types": "./dist/chains/solana/staking/cooldownGate.d.ts",
+      "import": "./dist/chains/solana/staking/cooldownGate.js",
+      "default": "./dist/chains/solana/staking/cooldownGate.js"
+    },
+    "./chains/solana/staking/models/stakeAccount": {
+      "types": "./dist/chains/solana/staking/models/stakeAccount.d.ts",
+      "import": "./dist/chains/solana/staking/models/stakeAccount.js",
+      "default": "./dist/chains/solana/staking/models/stakeAccount.js"
+    },
+    "./chains/solana/staking/models/validator": {
+      "types": "./dist/chains/solana/staking/models/validator.d.ts",
+      "import": "./dist/chains/solana/staking/models/validator.js",
+      "default": "./dist/chains/solana/staking/models/validator.js"
+    },
+    "./chains/solana/staking/rpc": {
+      "types": "./dist/chains/solana/staking/rpc.d.ts",
+      "import": "./dist/chains/solana/staking/rpc.js",
+      "default": "./dist/chains/solana/staking/rpc.js"
+    },
     "./chains/sui/buildTransactionFromJson": {
       "types": "./dist/chains/sui/buildTransactionFromJson.d.ts",
       "import": "./dist/chains/sui/buildTransactionFromJson.js",


### PR DESCRIPTION
**Phase 1** of Solana native staking — parity with iOS #4659 (iOS PR vultisig/vultisig-ios#4665).

Tracking sub-issue: vultisig/vultisig-windows#4234 · Epic: vultisig/vultisig-windows#4222

Pure chain-layer foundation under `@vultisig/core-chain/chains/solana/staking`. **No UI, no signing, no validator-metadata source** — those land in later phases. Phase 1 is chain-layer only (mirrors iOS #4665), so it ships as this SDK PR alone; the windows app consumes it once published.

### What's here
- **`config`** — Stake-program id; `dataSize:200` + staker `memcmp` offset 12 for the owner-scoped stake scan; rent-exempt reserve; 1-SOL min-delegation floor (`getStakeMinimumDelegation` is blocked by the Vultisig proxy, so a documented constant substitutes); `u64::MAX` deactivation sentinel.
- **`models/stakeAccount`** — `jsonParsed` parsing and pure activation-state derivation (`activating` / `active` / `deactivating` / `inactive`). u64 fields are `bigint` so the deactivation sentinel (2⁶⁴−1) is representable.
- **`models/validator`** — decoded `getVoteAccounts` row plus an empty `ValidatorMetadata` enrichment seam (populated by the Phase 2 provider) and display fallbacks (truncated vote pubkey when unnamed).
- **`rpc`** — `getVoteAccounts`, `getProgramAccounts` (stake scan), `getAccountInfo` (jsonParsed), `getEpochInfo`, `getMinimumBalanceForRentExemption`, inflation, supply — over the shared Solana client.
- **`cooldownGate`** — pure withdraw-cooldown evaluation over the parsed delegation + the live epoch.

### Tests
- `stakeAccount.test.ts` — jsonParsed parse (u64→bigint), activation-state boundaries, deactivation sentinel.
- `cooldownGate.test.ts` — available/blocked withdraw evaluation, unlock at `deactivationEpoch + 1`.

### Notes
- Caching (per the iOS service TTLs) lives in the consumer's react-query layer, not here.
- Exports map regenerated to include only these five Phase 1 modules.
- Changeset bumps `@vultisig/core-chain` + `@vultisig/sdk` (minor) so consumers (incl. windows) get a new tarball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Solana staking foundation for reading stake accounts, validator data, and epoch/rent/supply details.
  * Introduced activation lifecycle modeling plus a withdraw cooldown gate using on-chain delegation epochs.
  * Added new public import entrypoints for Solana staking configuration, models, cooldown gating, and RPC reads.
* **Bug Fixes**
  * Improved handling of undelegated accounts, deactivation sentinel logic, and strict validation of parsed stake fields.
* **Tests**
  * Added Vitest coverage for stake-account parsing and cooldown gate unlock behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->