### PR TITLE
feat(solana): native-staking transaction builder (byte-parity)

### DIFF
--- a/.changeset/solana-staking-tx-builder.md
+++ b/.changeset/solana-staking-tx-builder.md
@@ -1,0 +1,24 @@
+---
+"@vultisig/core-chain": minor
+"@vultisig/sdk": minor
+---
+
+feat(solana): native-staking transaction builder (byte-parity)
+
+Phase 3 of Solana native staking. Adds the signing core for the delegate flow
+(and the proto for the later unstake / withdraw / move-stake ops) under
+`@vultisig/core-chain/chains/solana/staking/tx`:
+
+- `stakingPayload` — discriminated staking-op intent (delegate / unstake /
+  withdraw / move-stake deactivate + redelegate sub-steps).
+- `buildUnsignedStakingTx` — maps a payload to the wallet-core Solana stake
+  proto (`delegateStakeTransaction` derives the stake account; move-redelegate
+  sets it explicitly), compiles a zero-signature envelope via
+  `TransactionCompiler`, and returns it base64-encoded. This is the MPC
+  byte-parity contract: the initiating device builds these bytes once (pinning
+  the recent blockhash + the derived stake-account address) and relays them via
+  `signSolana.rawTransactions`, so every co-signer signs the identical message.
+
+Adds `long` to core-chain deps (Long-typed proto amount fields). Byte-parity
+tests build delegate / deactivate / withdraw / move-redelegate txs against real
+wallet-core, decode them back, and assert determinism.

--- a/packages/core/chain/chains/solana/staking/tx/buildUnsignedStakingTx.test.ts
+++ b/packages/core/chain/chains/solana/staking/tx/buildUnsignedStakingTx.test.ts
@@ -36,57 +36,71 @@ describe('buildUnsignedStakingTx', () => {
       priorityFeeLimit: 200_000,
     })
 
-  const decode = (base64: string) => {
+  // Decodes the relayed bytes through the same path the SDK signing resolver
+  // uses, and returns the message account keys (base58) so each op can assert
+  // which accounts it touches — a wrong-but-stable proto mapping would
+  // otherwise still decode into "some" transaction and pass.
+  const accountKeysOf = (base64: string): string[] => {
     const coinType = walletCore.CoinType.solana
     const decoded = walletCore.TransactionDecoder.decode(coinType, Buffer.from(base64, 'base64'))
-    return TW.Solana.Proto.DecodingTransactionOutput.decode(decoded)
+    const { transaction } = TW.Solana.Proto.DecodingTransactionOutput.decode(decoded)
+    expect(transaction).toBeTruthy()
+    return transaction?.v0?.accountKeys ?? transaction?.legacy?.accountKeys ?? []
   }
 
-  it('builds a delegate (create+initialize+delegate) tx that decodes back', () => {
-    const base64 = build({
-      op: 'delegate',
-      votePubkey: voteAccount,
-      lamports: 2_000_000_000n,
-    })
-    expect(base64.length).toBeGreaterThan(0)
-    // Round-trips through the same decoder the SDK relay path uses.
-    const { transaction } = decode(base64)
-    expect(transaction).toBeTruthy()
+  // Stake program — present in every native-staking instruction.
+  const stakeProgramId = 'Stake11111111111111111111111111111111111111'
+
+  it('delegate references the validator vote account and derives a fresh stake account', () => {
+    const keys = accountKeysOf(build({ op: 'delegate', votePubkey: voteAccount, lamports: 2_000_000_000n }))
+    expect(keys).toContain(sender)
+    expect(keys).toContain(stakeProgramId)
+    expect(keys).toContain(voteAccount)
+    // delegate omits the stake account so wallet-core derives a NEW one — our
+    // arbitrary fixed `stakeAccount` must not appear.
+    expect(keys).not.toContain(stakeAccount)
   })
 
-  it('builds a deactivate (unstake) tx that decodes back', () => {
-    const base64 = build({ op: 'unstake', stakeAccount })
-    const { transaction } = decode(base64)
-    expect(transaction).toBeTruthy()
+  it('deactivate (unstake) references the existing stake account, not a validator', () => {
+    const keys = accountKeysOf(build({ op: 'unstake', stakeAccount }))
+    expect(keys).toContain(stakeProgramId)
+    expect(keys).toContain(stakeAccount)
+    // Deactivate carries no validator.
+    expect(keys).not.toContain(voteAccount)
   })
 
-  it('builds a withdraw tx that decodes back', () => {
-    const base64 = build({
-      op: 'withdraw',
-      stakeAccount,
-      lamports: 1_000_000_000n,
-    })
-    const { transaction } = decode(base64)
-    expect(transaction).toBeTruthy()
+  it('withdraw references the existing stake account and the recipient (sender)', () => {
+    const keys = accountKeysOf(build({ op: 'withdraw', stakeAccount, lamports: 1_000_000_000n }))
+    expect(keys).toContain(stakeProgramId)
+    expect(keys).toContain(stakeAccount)
+    expect(keys).toContain(sender)
+    expect(keys).not.toContain(voteAccount)
   })
 
-  it('builds a move-stake redelegate tx (explicit stake account) that decodes back', () => {
-    const base64 = build({
-      op: 'moveStakeRedelegate',
-      stakeAccount,
-      votePubkey: voteAccount,
-      lamports: 1_000_000_000n,
-    })
-    const { transaction } = decode(base64)
-    expect(transaction).toBeTruthy()
+  it('move-stake redelegate re-delegates the EXISTING stake account to the validator', () => {
+    const keys = accountKeysOf(
+      build({ op: 'moveStakeRedelegate', stakeAccount, votePubkey: voteAccount, lamports: 1_000_000_000n })
+    )
+    expect(keys).toContain(stakeProgramId)
+    // Unlike a fresh delegate, the existing account is set explicitly...
+    expect(keys).toContain(stakeAccount)
+    // ...and re-delegated to the validator.
+    expect(keys).toContain(voteAccount)
   })
 
-  it('is deterministic for a fixed blockhash + payload (byte parity across devices)', () => {
+  it('is byte-stable for a fixed payload + blockhash (the MPC relay parity contract)', () => {
     const payload = {
       op: 'delegate' as const,
       votePubkey: voteAccount,
       lamports: 2_000_000_000n,
     }
-    expect(build(payload)).toEqual(build(payload))
+    // Pinned known-good encoding — peers sign these exact relayed bytes, so a
+    // change here is an intentional encoding change to review, not noise.
+    const expected =
+      'AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQAICupKbGPinFIKvvVQexMuxfmVR3auvr57kkIe6mkURtIsz4QGrXslwGLXSdJJmKlRZKeSHfnc3Q3XZZuy7iCrGwoGp9UXGSxcUSGMyUw9SvF/WNruCJuh/UTj29mKAAAAAF68hTcsFSGbzOqwW8Xn4U30dQEzTIvP1NCDkX6BLoqLBqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAAGp9UXGTWE0P7tm7NDHRMga+VEKBtXuFZsxTdf9AAAAAah2BelAgULaAeR5s5tuI4eW3FQ9h/GeQpOtNEAAAAAAwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAah2BeRN1QqmDQ3vf4qerJVf1NcinhyK2ikncAAAAAA6KfLEEmpo7Wh9r/unHsIxcpySPvcuWIboAQrWi0zIHYFBwAJA6CGAQAAAAAABwAFAkANAwAIAwABAHwDAAAA6kpsY+KcUgq+9VB7Ey7F+ZVHdq6+vnuSQh7qaRRG0iwgAAAAAAAAAEdmQnoxek1iZThWZDhnWlo4bkUxa0NUOUxEWmtxRFgxAJQ1dwAAAADIAAAAAAAAAAah2BeRN1QqmDQ3vf4qerJVf1NcinhyK2ikncAAAAAACQIBAnQAAAAA6kpsY+KcUgq+9VB7Ey7F+ZVHdq6+vnuSQh7qaRRG0izqSmxj4pxSCr71UHsTLsX5lUd2rr6+e5JCHuppFEbSLAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAkGAQMEBQYABAIAAAAA'
+    const actual = build(payload)
+    expect(actual).toBe(expected)
+    // And rebuilding is deterministic (no timestamps / randomness).
+    expect(build(payload)).toBe(actual)
   })
 })

--- a/packages/core/chain/chains/solana/staking/tx/buildUnsignedStakingTx.test.ts
+++ b/packages/core/chain/chains/solana/staking/tx/buildUnsignedStakingTx.test.ts
@@ -1,0 +1,92 @@
+import { initWasm, TW, WalletCore } from '@trustwallet/wallet-core'
+import { Buffer } from 'buffer'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import { buildUnsignedStakingTx } from './buildUnsignedStakingTx'
+
+// A real mainnet validator vote account + an arbitrary stake account address.
+const voteAccount = '7Np41oeYqPefeNQEHSv1UDhYrehxin3NStpAVL21vNXc'
+const stakeAccount = 'C9uS6ouW9bx3JZ5pZ1Tt5pAhnRfTrwH4q1f2qfQ8XmA'
+const recentBlockHash = 'GfBz1zMbe8Vd8gZZ8nE1kCT9LDZkqDX1tu9q3iJ8q9aD'
+
+describe('buildUnsignedStakingTx', () => {
+  let walletCore: WalletCore
+  // A consistent (sender, pubkey) pair derived from a fixed ed25519 key — the
+  // compiler matches the placeholder signature to the fee-payer's pubkey, so
+  // the two must correspond.
+  let sender: string
+  let hexPublicKey: string
+
+  beforeAll(async () => {
+    walletCore = await initWasm()
+    const privateKey = walletCore.PrivateKey.createWithData(new Uint8Array(32).fill(7))
+    const publicKey = privateKey.getPublicKeyEd25519()
+    hexPublicKey = walletCore.HexCoding.encode(publicKey.data()).replace(/^0x/, '')
+    sender = walletCore.AnyAddress.createWithPublicKey(publicKey, walletCore.CoinType.solana).description()
+  })
+
+  const build = (payload: Parameters<typeof buildUnsignedStakingTx>[0]['payload']) =>
+    buildUnsignedStakingTx({
+      walletCore,
+      payload,
+      sender,
+      hexPublicKey,
+      recentBlockHash,
+      priorityFeePrice: 100_000n,
+      priorityFeeLimit: 200_000,
+    })
+
+  const decode = (base64: string) => {
+    const coinType = walletCore.CoinType.solana
+    const decoded = walletCore.TransactionDecoder.decode(coinType, Buffer.from(base64, 'base64'))
+    return TW.Solana.Proto.DecodingTransactionOutput.decode(decoded)
+  }
+
+  it('builds a delegate (create+initialize+delegate) tx that decodes back', () => {
+    const base64 = build({
+      op: 'delegate',
+      votePubkey: voteAccount,
+      lamports: 2_000_000_000n,
+    })
+    expect(base64.length).toBeGreaterThan(0)
+    // Round-trips through the same decoder the SDK relay path uses.
+    const { transaction } = decode(base64)
+    expect(transaction).toBeTruthy()
+  })
+
+  it('builds a deactivate (unstake) tx that decodes back', () => {
+    const base64 = build({ op: 'unstake', stakeAccount })
+    const { transaction } = decode(base64)
+    expect(transaction).toBeTruthy()
+  })
+
+  it('builds a withdraw tx that decodes back', () => {
+    const base64 = build({
+      op: 'withdraw',
+      stakeAccount,
+      lamports: 1_000_000_000n,
+    })
+    const { transaction } = decode(base64)
+    expect(transaction).toBeTruthy()
+  })
+
+  it('builds a move-stake redelegate tx (explicit stake account) that decodes back', () => {
+    const base64 = build({
+      op: 'moveStakeRedelegate',
+      stakeAccount,
+      votePubkey: voteAccount,
+      lamports: 1_000_000_000n,
+    })
+    const { transaction } = decode(base64)
+    expect(transaction).toBeTruthy()
+  })
+
+  it('is deterministic for a fixed blockhash + payload (byte parity across devices)', () => {
+    const payload = {
+      op: 'delegate' as const,
+      votePubkey: voteAccount,
+      lamports: 2_000_000_000n,
+    }
+    expect(build(payload)).toEqual(build(payload))
+  })
+})

--- a/packages/core/chain/chains/solana/staking/tx/buildUnsignedStakingTx.ts
+++ b/packages/core/chain/chains/solana/staking/tx/buildUnsignedStakingTx.ts
@@ -1,0 +1,124 @@
+import { TW, WalletCore } from '@trustwallet/wallet-core'
+import { Buffer } from 'buffer'
+import Long from 'long'
+
+import { SolanaStakingPayload } from './stakingPayload'
+
+type BuildUnsignedStakingTxInput = {
+  walletCore: WalletCore
+  payload: SolanaStakingPayload
+  /** The signer's Solana address (fee payer / stake authority). */
+  sender: string
+  /** The signer's ed25519 public key, hex-encoded. */
+  hexPublicKey: string
+  recentBlockHash: string
+  priorityFeePrice: bigint
+  priorityFeeLimit: number
+}
+
+const toLong = (value: bigint): Long => Long.fromString(value.toString())
+
+/**
+ * Maps a staking payload to the wallet-core `SigningInput` transaction-type
+ * oneof:
+ *   - delegate:            `delegateStakeTransaction` (stake account omitted →
+ *                          wallet-core derives it; emits create+initialize+
+ *                          delegate in one tx)
+ *   - unstake / move-deactivate: `deactivateStakeTransaction` (existing account)
+ *   - withdraw:            `withdrawTransaction` (existing account + amount)
+ *   - move-redelegate:     `delegateStakeTransaction` with the existing account
+ *                          set EXPLICITLY (re-delegate, don't derive a new one)
+ */
+const transactionTypeFields = (payload: SolanaStakingPayload): Partial<TW.Solana.Proto.ISigningInput> => {
+  switch (payload.op) {
+    case 'delegate':
+      return {
+        delegateStakeTransaction: TW.Solana.Proto.DelegateStake.create({
+          validatorPubkey: payload.votePubkey,
+          value: toLong(payload.lamports),
+        }),
+      }
+    case 'unstake':
+    case 'moveStakeDeactivate':
+      return {
+        deactivateStakeTransaction: TW.Solana.Proto.DeactivateStake.create({
+          stakeAccount: payload.stakeAccount,
+        }),
+      }
+    case 'withdraw':
+      return {
+        withdrawTransaction: TW.Solana.Proto.WithdrawStake.create({
+          stakeAccount: payload.stakeAccount,
+          value: toLong(payload.lamports),
+        }),
+      }
+    case 'moveStakeRedelegate':
+      return {
+        delegateStakeTransaction: TW.Solana.Proto.DelegateStake.create({
+          validatorPubkey: payload.votePubkey,
+          value: toLong(payload.lamports),
+          stakeAccount: payload.stakeAccount,
+        }),
+      }
+  }
+}
+
+/**
+ * Compiles the unsigned staking transaction (zero-signature envelope) and
+ * returns it base64-encoded. This is the byte-parity contract for native
+ * staking: the initiating device builds these bytes once — pinning the recent
+ * blockhash and the wallet-core-derived stake-account address — and relays them
+ * via `SignSolana.rawTransactions`. Every co-signing device then signs the
+ * IDENTICAL message bytes through the raw-transaction path, so no device
+ * rebuilds the input from a non-round-tripped staking payload.
+ *
+ * Port of iOS `SolanaHelper.buildStakingUnsignedTransaction`.
+ */
+export const buildUnsignedStakingTx = ({
+  walletCore,
+  payload,
+  sender,
+  hexPublicKey,
+  recentBlockHash,
+  priorityFeePrice,
+  priorityFeeLimit,
+}: BuildUnsignedStakingTxInput): string => {
+  const input = TW.Solana.Proto.SigningInput.create({
+    v0Msg: true,
+    recentBlockhash: recentBlockHash,
+    sender,
+    priorityFeePrice: TW.Solana.Proto.PriorityFeePrice.create({
+      price: toLong(priorityFeePrice),
+    }),
+    priorityFeeLimit: TW.Solana.Proto.PriorityFeeLimit.create({
+      limit: priorityFeeLimit,
+    }),
+    ...transactionTypeFields(payload),
+  })
+  const inputData = TW.Solana.Proto.SigningInput.encode(input).finish()
+
+  // Compile a zero-signature envelope: a single 64-byte zero signature plus the
+  // signer's public key, exactly as iOS does. The compiler assembles the wire
+  // message with the placeholder signature; peers re-sign the relayed bytes.
+  const signatures = walletCore.DataVector.create()
+  signatures.add(new Uint8Array(64))
+  const publicKeys = walletCore.DataVector.create()
+  publicKeys.add(Buffer.from(hexPublicKey, 'hex'))
+
+  const compiled = walletCore.TransactionCompiler.compileWithSignatures(
+    walletCore.CoinType.solana,
+    inputData,
+    signatures,
+    publicKeys
+  )
+  const output = TW.Solana.Proto.SigningOutput.decode(compiled)
+  if (output.errorMessage) {
+    throw new Error(`solana staking compile failed: ${output.errorMessage}`)
+  }
+
+  // WalletCore emits base58 (the signing input never sets `txEncoding`).
+  // Normalize to base64 — the encoding `SignSolana.rawTransactions` and the
+  // raw-signing path consume.
+  const txBytes = walletCore.Base58.decodeNoCheck(output.encoded)
+  return Buffer.from(txBytes).toString('base64')
+}

--- a/packages/core/chain/chains/solana/staking/tx/stakingPayload.ts
+++ b/packages/core/chain/chains/solana/staking/tx/stakingPayload.ts
@@ -1,0 +1,42 @@
+/**
+ * Carries the Solana staking-operation intent from the build-keysign step into
+ * the byte-parity unsigned-tx builder (wallet-core's Solana stake proto:
+ * delegate / deactivate / withdraw / move-stake).
+ *
+ * A move-stake (redelegate A → B) is a guided, multi-transaction, cross-epoch
+ * flow — Solana has no native redelegate. It decomposes into discrete sub-steps
+ * mapped onto existing wallet-core primitives so the cross-device byte-parity
+ * guarantee holds:
+ *   - `moveStakeDeactivate` → DeactivateStake on the moved account (byte-
+ *     identical to a plain unstake); begins the ~1-epoch cooldown.
+ *   - `moveStakeRedelegate` → DelegateStake the now-inactive moved account to
+ *     validator B, with the existing `stakeAccount` set EXPLICITLY (a fresh
+ *     delegate omits it so wallet-core derives a new account).
+ *   - The Stake-program `Split` instruction (a partial move) is not exposed by
+ *     wallet-core's high-level Solana proto, so only whole-account moves are
+ *     supported.
+ *
+ * Port of iOS `SolanaStakingPayload`.
+ */
+export type SolanaStakingPayload =
+  | { op: 'delegate'; votePubkey: string; lamports: bigint }
+  | { op: 'unstake'; stakeAccount: string }
+  | { op: 'withdraw'; stakeAccount: string; lamports: bigint }
+  | { op: 'moveStakeDeactivate'; stakeAccount: string }
+  | {
+      op: 'moveStakeRedelegate'
+      stakeAccount: string
+      votePubkey: string
+      lamports: bigint
+    }
+
+/** Discriminant union of every Solana staking op type. */
+export const solanaStakingOps = [
+  'delegate',
+  'unstake',
+  'withdraw',
+  'moveStakeDeactivate',
+  'moveStakeRedelegate',
+] as const
+
+export type SolanaStakingOp = (typeof solanaStakingOps)[number]

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -720,6 +720,16 @@
       "import": "./dist/chains/solana/staking/rpc.js",
       "default": "./dist/chains/solana/staking/rpc.js"
     },
+    "./chains/solana/staking/tx/buildUnsignedStakingTx": {
+      "types": "./dist/chains/solana/staking/tx/buildUnsignedStakingTx.d.ts",
+      "import": "./dist/chains/solana/staking/tx/buildUnsignedStakingTx.js",
+      "default": "./dist/chains/solana/staking/tx/buildUnsignedStakingTx.js"
+    },
+    "./chains/solana/staking/tx/stakingPayload": {
+      "types": "./dist/chains/solana/staking/tx/stakingPayload.d.ts",
+      "import": "./dist/chains/solana/staking/tx/stakingPayload.js",
+      "default": "./dist/chains/solana/staking/tx/stakingPayload.js"
+    },
     "./chains/sui/buildTransactionFromJson": {
       "types": "./dist/chains/sui/buildTransactionFromJson.d.ts",
       "import": "./dist/chains/sui/buildTransactionFromJson.js",
@@ -2002,7 +2012,6 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "7z-wasm": "^1.2.0",
     "@bufbuild/protobuf": "^2.12.0",
     "@cosmjs/amino": "^0.39.0",
     "@cosmjs/encoding": "^0.39.0",
@@ -2021,6 +2030,7 @@
     "@trustwallet/wallet-core": "^4.6.15",
     "@vultisig/core-config": "0.9.1",
     "@vultisig/lib-utils": "0.10.3",
+    "7z-wasm": "^1.2.0",
     "bip32": "^5.0.1",
     "bitcoinjs-lib": "^7.0.1",
     "bs58": "^6.0.0",
@@ -2028,6 +2038,7 @@
     "cbor-x": "^1.6.4",
     "date-fns": "^4.4.0",
     "ethers": "^6.17.0",
+    "long": "^5.3.2",
     "tiny-secp256k1": "^2.2.4",
     "viem": "^2.53.1",
     "xrpl": "^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6990,6 +6990,7 @@ __metadata:
     cbor-x: "npm:^1.6.4"
     date-fns: "npm:^4.4.0"
     ethers: "npm:^6.17.0"
+    long: "npm:^5.3.2"
     tiny-secp256k1: "npm:^2.2.4"
     viem: "npm:^2.53.1"
     xrpl: "npm:^5.0.0"


### PR DESCRIPTION
**Phase 3** of Solana native staking — parity with iOS #4661. The signing core for the delegate flow.

Tracking sub-issue: vultisig/vultisig-windows#4239 · Epic: vultisig/vultisig-windows#4222 · Builds on Phase 1 (#900) + Phase 2 (#912), both merged.

### What's here — `chains/solana/staking/tx/`
- **`stakingPayload`** — discriminated staking-op intent: `delegate` / `unstake` / `withdraw` / move-stake `deactivate` + `redelegate` sub-steps. (The whole op set lands here as one cohesive unit; the later phases add only the windows keysign branches + UI for unstake / withdraw / move.)
- **`buildUnsignedStakingTx`** — maps a payload to the wallet-core Solana stake proto (`delegateStakeTransaction` omits the stake account so wallet-core derives it — create+initialize+delegate in one tx; move-redelegate sets the existing account explicitly), compiles a zero-signature envelope via `TransactionCompiler`, and base64-encodes it.

### MPC byte-parity contract
The validator vote pubkey + amount live on the local-only form, so the initiating device builds these bytes **once** — pinning the recent blockhash and the wallet-core-derived stake-account address — and relays them via `signSolana.rawTransactions`. Every co-signing device then signs the **byte-identical** message through the raw-transaction path, so no device rebuilds the input from a non-round-tripped payload.

### Tests
`buildUnsignedStakingTx.test.ts` builds delegate / deactivate / withdraw / move-redelegate txs against **real wallet-core**, decodes them back through the same `TransactionDecoder` the relay path uses, and asserts determinism (byte parity across devices).

### Notes
- Adds `long` to core-chain deps (Long-typed proto amount fields).
- Changeset bumps `@vultisig/core-chain` + `@vultisig/sdk` (minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Solana native staking transaction building for delegate, unstake/deactivate, withdraw, and move-redelegate flows.
  * Introduced deterministic unsigned transaction output with wallet-compatible compilation and decoding.
  * Exposed new staking payload and transaction builder modules for integrations.
* **Bug Fixes**
  * Improved staking amount compatibility for protocol-friendly serialization.
* **Tests**
  * Added coverage to validate decoded staking transaction structure and byte-level determinism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->