### PR TITLE
fix(solana): surface the on-chain rejection reason on broadcast

### DIFF
--- a/.changeset/solana-broadcast-onchain-reason.md
+++ b/.changeset/solana-broadcast-onchain-reason.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/sdk': patch
+---
+
+Solana broadcast: surface the on-chain rejection reason. When `sendTransaction` is rejected at preflight, the RPC returns the actionable detail in `data.err` / `data.logs` (the program logs), which web3.js exposes via `SendTransactionError.logs` while leaving the bare `.message` ("failed to send transaction") uninformative. The broadcast resolver now folds those program logs into the thrown error's message (preserving the original error as `cause`), so consumers reading the top-level message see *why* the network rejected the transaction — "insufficient lamports", a custom program error, a failed instruction — instead of just that it failed.

--- a/packages/core/chain/tx/broadcast/resolvers/solana.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/solana.test.ts
@@ -1,3 +1,4 @@
+import { SendTransactionError } from '@solana/web3.js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
@@ -53,17 +54,40 @@ describe('broadcastSolanaTx', () => {
   })
 
   it('verifies by hash when standard RPC rejects after JITO acceptance', async () => {
-    const rpcError = new Error('already processed')
+    const rpcError = new Error('blockhash not found')
     mocks.sendRawTransaction.mockRejectedValue(rpcError)
     mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
 
     await broadcastSolanaTx({ chain: Chain.Solana, tx })
 
+    // A non-SendTransactionError is forwarded verbatim — nothing to hoist.
     expect(mocks.verifyBroadcastByHash).toHaveBeenCalledWith({
       chain: Chain.Solana,
       tx,
       error: rpcError,
     })
+  })
+
+  it('hoists SendTransactionError program logs into the verified error message', async () => {
+    const sendError = new SendTransactionError({
+      action: 'send',
+      signature: 'sig',
+      transactionMessage: 'Transaction simulation failed: custom program error: 0x1',
+      logs: [
+        'Program 11111111111111111111111111111111 invoke [1]',
+        'Program 11111111111111111111111111111111 failed: insufficient lamports',
+      ],
+    })
+    mocks.sendRawTransaction.mockRejectedValue(sendError)
+    mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+
+    await broadcastSolanaTx({ chain: Chain.Solana, tx })
+
+    const { error } = mocks.verifyBroadcastByHash.mock.calls[0][0]
+    expect(error).toBeInstanceOf(Error)
+    expect(error.cause).toBe(sendError)
+    expect(error.message).toContain('Transaction simulation failed')
+    expect(error.message).toContain('insufficient lamports')
   })
 
   it('treats a duplicate-signature rejection as an idempotent success', async () => {

--- a/packages/core/chain/tx/broadcast/resolvers/solana.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/solana.ts
@@ -1,3 +1,4 @@
+import { SendTransactionError } from '@solana/web3.js'
 import { OtherChain } from '@vultisig/core-chain/Chain'
 import { getSolanaClient } from '@vultisig/core-chain/chains/solana/client'
 import { sendJitoTransaction } from '@vultisig/core-chain/chains/solana/jito'
@@ -6,6 +7,30 @@ import base58 from 'bs58'
 
 import { BroadcastTxResolver } from '../resolver'
 import { verifyBroadcastByHash } from '../verifyBroadcastByHash'
+
+/**
+ * Hoists the on-chain rejection reason into a Solana send error's message.
+ *
+ * On a preflight rejection the RPC returns the actionable detail in
+ * `data.err` / `data.logs` (the program logs), which `web3.js` exposes via
+ * `SendTransactionError.logs`. The bare `.message` ("failed to send
+ * transaction") hides it, so any consumer reading only the top-level message
+ * loses the reason. Fold the program logs into the message — preserving the
+ * original error as `cause` — so the real reason ("insufficient lamports",
+ * "custom program error: 0x1", a failed instruction) reaches the surface.
+ */
+const withSolanaBroadcastReason = (error: unknown): unknown => {
+  if (!(error instanceof SendTransactionError)) {
+    return error
+  }
+
+  const { logs } = error
+  if (!logs || logs.length === 0) {
+    return error
+  }
+
+  return new Error([error.message, ...logs].join('\n'), { cause: error })
+}
 
 export const broadcastSolanaTx: BroadcastTxResolver<OtherChain.Solana> = async ({ chain, tx }) => {
   const rawTransaction = base58.decode(tx.encoded)
@@ -48,6 +73,10 @@ export const broadcastSolanaTx: BroadcastTxResolver<OtherChain.Solana> = async (
     if (isInError(error, 'already been processed', 'AlreadyProcessed')) {
       return
     }
-    await verifyBroadcastByHash({ chain, tx, error })
+    await verifyBroadcastByHash({
+      chain,
+      tx,
+      error: withSolanaBroadcastReason(error),
+    })
   }
 }


### PR DESCRIPTION
## Problem

When a Solana `sendTransaction` is rejected at **preflight**, the RPC returns the actionable detail in `data.err` / `data.logs` (the program logs). web3.js exposes those via `SendTransactionError.logs`, but leaves the bare `.message` as an uninformative `"failed to send transaction"`. Any consumer reading only the top-level message — e.g. an error screen that shows `extractErrorMsg(error)` — lost the real reason (`insufficient lamports`, a custom program error, a failed instruction).

## Fix

The Solana broadcast resolver now folds the program logs into the thrown error's `message` (preserving the original error as `cause`) before it propagates through `verifyBroadcastByHash`. The on-chain reason reaches the surface for **every** consumer of `@vultisig/core-chain`, not just one UI.

- Only `SendTransactionError` instances with non-empty `logs` are rewrapped; anything else (including the `already been processed` / `AlreadyProcessed` idempotent-success path) is untouched and forwarded verbatim.
- The reviewed-and-accepted broadcast-layer trade-off for `AlreadyProcessed` is unchanged.

## Tests

`resolvers/solana.test.ts` — added a case asserting program logs are hoisted into the verified error message with `cause` preserved, and pinned that a non-`SendTransactionError` is forwarded verbatim. Full solana broadcast suite: 7/7 pass. core typecheck + lint + format clean.

## Release

Changeset bumps `@vultisig/core-chain` and `@vultisig/sdk` (bundled-source guard passes).

## Companion

UI/headline half of the same issue lives in `vultisig-windows#4253` (keysign broadcast errors headlined as on-chain instead of device-timeout). That repo's fix is self-contained against the currently published packages; this PR makes the reason richer at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Solana broadcast failures now include clearer on-chain rejection details in the error message, making RPC preflight rejections easier to understand.
  * When transaction sending fails, the original error is still preserved as the underlying cause.
  * Improved handling so non-specific RPC errors continue to be passed through unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->