### PR TITLE
feat(cardano): attach cip-20 memo via walletcore native auxiliarydata

### DIFF
--- a/.changeset/cardano-native-aux-data.md
+++ b/.changeset/cardano-native-aux-data.md
@@ -1,0 +1,15 @@
+---
+"@vultisig/core-chain": patch
+"@vultisig/core-mpc": patch
+"@vultisig/sdk": patch
+---
+
+refactor(cardano): attach CIP-20 memo via WalletCore native auxiliary_data
+
+Bumps `@trustwallet/wallet-core` to `4.7.0`, which adds the Cardano
+`SigningInput.auxiliary_data` field. The Cardano memo path now hands the
+CIP-20 CBOR straight to WalletCore, which commits its Blake2b-256 hash into
+tx body key 7 and embeds the bytes in the signed transaction — replacing the
+client-side body patching and re-hashing in TypeScript. The chain-specific
+fee estimator prices the WalletCore body as-is (it already carries key 7),
+and the now-unused `patchTxBodyWithAuxHash` helper is removed.

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -2028,7 +2028,7 @@
     "@solana/web3.js": "^1.98.4",
     "@ton/core": "^0.63.1",
     "@ton/crypto": "^3.3.0",
-    "@trustwallet/wallet-core": "^4.6.15",
+    "@trustwallet/wallet-core": "^4.7.0",
     "@vultisig/core-config": "0.9.1",
     "@vultisig/lib-utils": "0.10.3",
     "bip32": "^5.0.1",

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/cardano.test.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/cardano.test.ts
@@ -9,7 +9,7 @@ import { beforeAll, describe, expect, it, vi } from 'vitest'
 import { Chain } from '@vultisig/core-chain/Chain'
 
 import { getCardanoSigningInputs } from '../../signingInputs/resolvers/cardano'
-import { buildCip20AuxData, patchTxBodyWithAuxHash } from '../../../tx/compile/cardano/buildCip20AuxData'
+import { buildCip20AuxData } from '../../../tx/compile/cardano/buildCip20AuxData'
 import { buildSignedCardanoTx } from '../../../tx/compile/cardano/buildSignedCardanoTx'
 import { CardanoChainSpecific } from '../../../types/vultisig/keysign/v1/blockchain_specific_pb'
 import { CoinSchema } from '../../../types/vultisig/keysign/v1/coin_pb'
@@ -107,10 +107,11 @@ const calculateFinalSignedTxFee = async ({
     return CARDANO_A_PARAM * BigInt(signedTx.length) + CARDANO_B_PARAM
   }
 
-  const { auxDataCbor, auxDataHash } = buildCip20AuxData(keysignPayload.memo)
-  const patchedTxBodyCbor = patchTxBodyWithAuxHash(preOutput.data, auxDataHash)
+  // WalletCore already committed the aux hash into the body (key 7) from
+  // SigningInput.auxiliary_data, so use it as-is and embed the aux-data bytes.
+  const { auxDataCbor } = buildCip20AuxData(keysignPayload.memo)
   const signedTx = buildSignedCardanoTx({
-    txBodyCbor: patchedTxBodyCbor,
+    txBodyCbor: preOutput.data,
     publicKey: publicKeyBytes,
     signature,
     auxDataCbor,

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/cardano.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/cardano.ts
@@ -10,7 +10,7 @@ import { TW, type WalletCore } from '@trustwallet/wallet-core'
 
 import { getCardanoSigningInputs } from '../../signingInputs/resolvers/cardano'
 import { KeysignPayload } from '../../../types/vultisig/keysign/v1/keysign_message_pb'
-import { buildCip20AuxData, patchTxBodyWithAuxHash } from '../../../tx/compile/cardano/buildCip20AuxData'
+import { buildCip20AuxData } from '../../../tx/compile/cardano/buildCip20AuxData'
 import { getKeysignAmount } from '../../utils/getKeysignAmount'
 import { GetChainSpecificResolver } from '../resolver'
 
@@ -34,10 +34,12 @@ const getCardanoPricedSize = ({ txBodyCbor, memo }: { txBodyCbor: Uint8Array; me
     return txBodyCbor.length + CARDANO_SIGNED_TX_ENVELOPE_SIZE + 1
   }
 
-  const { auxDataCbor, auxDataHash } = buildCip20AuxData(memo)
-  const patchedTxBodyCbor = patchTxBodyWithAuxHash(txBodyCbor, auxDataHash)
+  // With native auxiliary_data, the WalletCore-produced body already commits
+  // the aux hash at key 7, so price it as-is and add the aux-data bytes that
+  // land as signed-tx element [3].
+  const { auxDataCbor } = buildCip20AuxData(memo)
 
-  return patchedTxBodyCbor.length + CARDANO_SIGNED_TX_ENVELOPE_SIZE + auxDataCbor.length
+  return txBodyCbor.length + CARDANO_SIGNED_TX_ENVELOPE_SIZE + auxDataCbor.length
 }
 
 const estimateCardanoByteFee = async ({

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cardano.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cardano.ts
@@ -6,6 +6,7 @@ import { TW } from '@trustwallet/wallet-core'
 import Long from 'long'
 
 import { getBlockchainSpecificValue } from '../../chainSpecific/KeysignChainSpecific'
+import { buildCip20AuxData } from '../../../tx/compile/cardano/buildCip20AuxData'
 import { SigningInputsResolver } from '../resolver'
 
 /** Encodes a token amount as big-endian bytes for WalletCore's Cardano proto. */
@@ -20,6 +21,11 @@ export const getCardanoSigningInputs: SigningInputsResolver<'cardano'> = ({ keys
 
   const coin = shouldBePresent(keysignPayload.coin)
   const isTokenSend = coin.contractAddress !== ''
+
+  // CIP-20 memo: hand the already-CBOR-encoded auxiliary data to WalletCore,
+  // which commits its Blake2b-256 hash into the tx body (key 7) and embeds the
+  // bytes in the signed transaction. No client-side body patching needed.
+  const auxiliaryData = keysignPayload.memo ? buildCip20AuxData(keysignPayload.memo).auxDataCbor : undefined
 
   const tokenBundle = isTokenSend
     ? (() => {
@@ -47,6 +53,7 @@ export const getCardanoSigningInputs: SigningInputsResolver<'cardano'> = ({ keys
       forceFee: Long.fromString(byteFee.toString()),
     }),
     ttl: Long.fromString(ttl.toString()),
+    auxiliaryData,
 
     utxos: keysignPayload.utxoInfo.map(({ hash, amount, index }) =>
       TW.Cardano.Proto.TxInput.create({

--- a/packages/core/mpc/package.json
+++ b/packages/core/mpc/package.json
@@ -1023,7 +1023,7 @@
     "@mysten/sui": "^2.20.1",
     "@noble/hashes": "^1.8.0",
     "@solana/web3.js": "^1.98.4",
-    "@trustwallet/wallet-core": "^4.6.15",
+    "@trustwallet/wallet-core": "^4.7.0",
     "@vultisig/core-chain": "2.22.0",
     "@vultisig/core-config": "0.9.1",
     "@vultisig/lib-dkls": "0.9.0",

--- a/packages/core/mpc/tx/compile/cardano/buildCip20AuxData.test.ts
+++ b/packages/core/mpc/tx/compile/cardano/buildCip20AuxData.test.ts
@@ -2,7 +2,7 @@ import { blake2b } from '@noble/hashes/blake2b'
 import { decode as cborDecode } from 'cbor-x'
 import { describe, expect, it } from 'vitest'
 
-import { buildCip20AuxData, memoToChunks, patchTxBodyWithAuxHash } from './buildCip20AuxData'
+import { buildCip20AuxData, memoToChunks } from './buildCip20AuxData'
 
 const bytesToHex = (b: Uint8Array): string => Buffer.from(b).toString('hex')
 
@@ -116,43 +116,5 @@ describe('buildCip20AuxData', () => {
     expect(auxDataHash.some(b => b !== 0)).toBe(true)
     // Verify it matches blake2b of the CBOR
     expect(bytesToHex(auxDataHash)).toBe(bytesToHex(blake2b(auxDataCbor, { dkLen: 32 })))
-  })
-})
-
-describe('patchTxBodyWithAuxHash', () => {
-  const DUMMY_HASH = new Uint8Array(32).fill(0xab)
-
-  it('increments the CBOR map count by 1', () => {
-    // a1 02 00 = map(1) { 2: 0 } — minimal Shelley body
-    const body = new Uint8Array([0xa1, 0x02, 0x00])
-    const patched = patchTxBodyWithAuxHash(body, DUMMY_HASH)
-    // First byte should now be a2 = map(2)
-    expect(patched[0]).toBe(0xa2)
-  })
-
-  it('appends key 7 and the aux hash bytes', () => {
-    const body = new Uint8Array([0xa1, 0x02, 0x00])
-    const patched = patchTxBodyWithAuxHash(body, DUMMY_HASH)
-    // After the header (a2) and original body (02 00), we expect:
-    // 07        = uint(7) — the aux_data_hash key
-    // 5820 <32 bytes of 0xab>
-    const hex = bytesToHex(patched)
-    expect(hex.endsWith('07' + '5820' + 'ab'.repeat(32))).toBe(true)
-  })
-
-  it('preserves original map entries verbatim', () => {
-    const body = new Uint8Array([0xa2, 0x00, 0x01, 0x02, 0x03])
-    const patched = patchTxBodyWithAuxHash(body, DUMMY_HASH)
-    // Original bytes (after the header) should appear intact
-    expect(bytesToHex(patched).includes('00010203')).toBe(true)
-  })
-
-  it('throws on empty input', () => {
-    expect(() => patchTxBodyWithAuxHash(new Uint8Array(0), DUMMY_HASH)).toThrow()
-  })
-
-  it('throws if first byte is not a CBOR map', () => {
-    // 0x81 = array(1)
-    expect(() => patchTxBodyWithAuxHash(new Uint8Array([0x81, 0x00]), DUMMY_HASH)).toThrow(/major type/)
   })
 })

--- a/packages/core/mpc/tx/compile/cardano/buildCip20AuxData.ts
+++ b/packages/core/mpc/tx/compile/cardano/buildCip20AuxData.ts
@@ -1,11 +1,5 @@
 import { blake2b } from '@noble/hashes/blake2b'
-import {
-  cborArray,
-  cborBytes,
-  cborMap,
-  cborText,
-  cborUint,
-} from '@vultisig/core-chain/chains/cardano/cip30/cardanoCborPrimitives'
+import { cborArray, cborMap, cborText, cborUint } from '@vultisig/core-chain/chains/cardano/cip30/cardanoCborPrimitives'
 
 /** CIP-20 limits each metadata text chunk to 64 UTF-8 bytes. */
 const MAX_CHUNK_BYTES = 64
@@ -81,64 +75,4 @@ export function buildCip20AuxData(memo: string): {
   const auxDataCbor = cborMap([[cborUint(674), innerMap]])
   const auxDataHash = blake2b(auxDataCbor, { dkLen: 32 })
   return { auxDataCbor, auxDataHash }
-}
-
-/**
- * Re-emit a WalletCore-produced CBOR tx body with an `auxiliary_data_hash`
- * entry (CBOR map key 7) appended.
- *
- * WalletCore emits the tx body as a CBOR map. We avoid a full decode/encode
- * round-trip (which could alter key ordering or integer widths and invalidate
- * the MPC signature) by:
- *   1. Reading the initial CBOR map header byte to extract the current count.
- *   2. Re-emitting the header byte(s) with count+1.
- *   3. Concatenating the original body bytes after the header.
- *   4. Appending `cborUint(7)` + `cborBytes(auxDataHash)`.
- *
- * This works as long as WalletCore never produces a body map with > 23
- * entries (i.e. the count fits in the CBOR one-byte "additional info" form),
- * which is true in practice — current Cardano tx bodies have at most 9 keys.
- */
-export function patchTxBodyWithAuxHash(txBodyCbor: Uint8Array, auxDataHash: Uint8Array): Uint8Array {
-  if (txBodyCbor.length === 0) {
-    throw new Error('patchTxBodyWithAuxHash: empty txBodyCbor')
-  }
-
-  const firstByte = txBodyCbor[0]!
-  const majorType = firstByte >> 5
-  if (majorType !== 5) {
-    throw new Error(`patchTxBodyWithAuxHash: expected CBOR map (major type 5), got major type ${majorType}`)
-  }
-
-  const additionalInfo = firstByte & 0x1f
-  if (additionalInfo >= 24) {
-    // Multi-byte map count — would require a more complex header rewrite.
-    // In practice Cardano tx bodies never exceed 23 entries.
-    throw new Error(
-      `patchTxBodyWithAuxHash: map header uses additional info ${additionalInfo}; only direct-count maps (< 24 entries) are supported`
-    )
-  }
-
-  const oldCount = additionalInfo
-  const newCount = oldCount + 1
-
-  if (newCount >= 24) {
-    throw new Error(
-      `patchTxBodyWithAuxHash: cannot increment map count to ${newCount} (would overflow into two-byte header)`
-    )
-  }
-
-  const newHeader = new Uint8Array([(5 << 5) | newCount])
-  const bodyAfterHeader = txBodyCbor.slice(1)
-  const auxHashEntry = new Uint8Array([...cborUint(7), ...cborBytes(auxDataHash)])
-
-  const totalLen = newHeader.length + bodyAfterHeader.length + auxHashEntry.length
-  const out = new Uint8Array(totalLen)
-  let offset = 0
-  out.set(newHeader, offset)
-  offset += newHeader.length
-  out.set(bodyAfterHeader, offset)
-  offset += bodyAfterHeader.length
-  out.set(auxHashEntry, offset)
-  return out
 }

--- a/packages/core/mpc/tx/compile/compileTx.golden.test.ts
+++ b/packages/core/mpc/tx/compile/compileTx.golden.test.ts
@@ -42,6 +42,7 @@ import {
 } from '../../types/vultisig/keysign/v1/blockchain_specific_pb'
 import { CoinSchema } from '../../types/vultisig/keysign/v1/coin_pb'
 import { KeysignPayloadSchema } from '../../types/vultisig/keysign/v1/keysign_message_pb'
+import { buildCip20AuxData } from './cardano/buildCip20AuxData'
 import { compileTx } from './compileTx'
 
 const ECDSA_PRIVATE_KEY = new Uint8Array(32).fill(1)
@@ -414,8 +415,12 @@ describe('compileTx golden vectors', () => {
       ],
     })
 
+    // Mirror getCardanoSigningInputs: the resolver hands the CIP-20 CBOR to
+    // WalletCore via auxiliary_data, which commits its hash into the body.
+    const { auxDataCbor } = buildCip20AuxData(MEMO)
     const signingInput = TW.Cardano.Proto.SigningInput.create({
       ttl: Long.fromNumber(500_000),
+      auxiliaryData: auxDataCbor,
       transferMessage: TW.Cardano.Proto.Transfer.create({
         toAddress: recipient,
         changeAddress: sender,
@@ -435,7 +440,7 @@ describe('compileTx golden vectors', () => {
     })
     const txInputData = TW.Cardano.Proto.SigningInput.encode(signingInput).finish()
 
-    // Get the hash that MPC must sign (blake2b of the patched body)
+    // Get the hash that MPC must sign (blake2b of the aux-committed body)
     const hashes = getPreSigningHashes({ walletCore, chain: Chain.Cardano, txInputData, keysignPayload })
     const hashHex = hex(hashes[0])
 
@@ -472,24 +477,48 @@ describe('compileTx golden vectors', () => {
     expect(auxDecoded['674']).toBeDefined()
     expect(auxDecoded['674']!['msg']).toEqual([MEMO])
 
-    // Element [0]: tx body — key 7 must be blake2b-256 of the aux data CBOR
-    const bodyBytes = compiledOutput.encoded.slice(
-      // find body bytes: decode the outer array to get element [0] as bytes
-      // use the raw bytes — the body is the first element of the 0x84 array
-      0
-    )
-    // Verify txId = blake2b of the patched body (not the WalletCore body)
+    // Element [0]: tx body must commit blake2b-256(aux data) at key 7. cbor-x
+    // decodes the integer-keyed body map to an object with stringified keys.
+    const body = signedTxArray[0] as Record<string, Uint8Array>
+    expect(hex(body['7']!)).toBe(hex(blake2b(auxDataCbor, { dkLen: 32 })))
+
+    // WalletCore now commits the aux hash natively, so its pre-image data hash
+    // already equals the signed txId — no client-side patching involved.
     const preOutput = TW.TxCompiler.Proto.PreSigningOutput.decode(
       walletCore.TransactionCompiler.preImageHashes(walletCore.CoinType.cardano, txInputData)
     )
-    // The patched body hash should differ from WalletCore's plain dataHash
-    expect(hex(compiledOutput.txId)).not.toBe(hex(preOutput.dataHash))
-    // txId must equal hashes[0] (the hash MPC signed)
     expect(hex(compiledOutput.txId)).toBe(hashHex)
+    expect(hex(compiledOutput.txId)).toBe(hex(preOutput.dataHash))
 
-    // No-memo path is regression-guarded: same fixture without memo
-    const noMemoHashes = getPreSigningHashes({ walletCore, chain: Chain.Cardano, txInputData })
-    expect(hex(noMemoHashes[0])).toBe(hex(preOutput.dataHash))
+    // Regression guard: the same fixture without auxiliary data yields a
+    // different body hash (no key 7), and its signing hash is that plain hash.
+    const noMemoInput = TW.Cardano.Proto.SigningInput.encode(
+      TW.Cardano.Proto.SigningInput.create({
+        ttl: Long.fromNumber(500_000),
+        transferMessage: TW.Cardano.Proto.Transfer.create({
+          toAddress: recipient,
+          changeAddress: sender,
+          amount: Long.fromNumber(1_000_000),
+          forceFee: Long.fromNumber(170_000),
+        }),
+        utxos: [
+          TW.Cardano.Proto.TxInput.create({
+            outPoint: TW.Cardano.Proto.OutPoint.create({
+              txHash: bytesFromHex('11'.repeat(32)),
+              outputIndex: Long.fromNumber(0),
+            }),
+            address: sender,
+            amount: Long.fromNumber(2_000_000),
+          }),
+        ],
+      })
+    ).finish()
+    const noMemoPre = TW.TxCompiler.Proto.PreSigningOutput.decode(
+      walletCore.TransactionCompiler.preImageHashes(walletCore.CoinType.cardano, noMemoInput)
+    )
+    const noMemoHashes = getPreSigningHashes({ walletCore, chain: Chain.Cardano, txInputData: noMemoInput })
+    expect(hex(noMemoHashes[0])).toBe(hex(noMemoPre.dataHash))
+    expect(hex(preOutput.dataHash)).not.toBe(hex(noMemoPre.dataHash))
   })
 
   it('pins the custom Bittensor extrinsic assembly', () => {

--- a/packages/core/mpc/tx/compile/compileTx.ts
+++ b/packages/core/mpc/tx/compile/compileTx.ts
@@ -11,7 +11,7 @@ import { signatureFormats } from '@vultisig/core-chain/signing/SignatureFormat'
 import { assertSignature } from '@vultisig/core-chain/utils/assertSignature'
 
 import { getQBTCSignedTransaction } from '../../chains/cosmos/qbtc/QBTCHelper'
-import { buildCip20AuxData, patchTxBodyWithAuxHash } from './cardano/buildCip20AuxData'
+import { buildCip20AuxData } from './cardano/buildCip20AuxData'
 import { buildSignedCardanoTx } from './cardano/buildSignedCardanoTx'
 import { getBlockchainSpecificValue } from '../../keysign/chainSpecific/KeysignChainSpecific'
 import { KeysignSignature } from '../../keysign/KeysignSignature'
@@ -110,9 +110,10 @@ export const compileTx = ({
   }
 
   if (chain === Chain.Cardano) {
-    // hashes[0] is blake2b-256 of the tx body. When a memo is set,
-    // getPreSigningHashes returns blake2b of the patched body (with aux_data_hash
-    // at key 7) so both signing phase and compile phase agree on the same bytes.
+    // hashes[0] is blake2b-256 of the tx body. When a memo is set, WalletCore
+    // already committed the aux_data_hash into the body (key 7) from
+    // SigningInput.auxiliary_data, so the signing and compile phases agree on
+    // the same bytes without any client-side patching.
     const hash = hashes[0]
     const hashHex = Buffer.from(hash).toString('hex')
 
@@ -129,21 +130,16 @@ export const compileTx = ({
       signatureFormat,
     })
 
-    // Re-derive the tx body (and aux data when memo is set) to wrap it with
-    // the witness set and produce the final signed transaction.
+    // Re-derive the tx body to wrap it with the witness set. WalletCore already
+    // committed the aux_data_hash into this body when a memo was set, so it is
+    // used as-is; the matching aux-data bytes go into element [3] of the tx.
     const preOutput = TW.TxCompiler.Proto.PreSigningOutput.decode(
       walletCore.TransactionCompiler.preImageHashes(getCoinType({ chain, walletCore }), txInputData)
     )
 
     const memo = keysignPayload?.memo
-    let txBodyCbor = preOutput.data
-    let auxDataCbor: Uint8Array | undefined
-
-    if (memo) {
-      const cip20 = buildCip20AuxData(memo)
-      auxDataCbor = cip20.auxDataCbor
-      txBodyCbor = patchTxBodyWithAuxHash(txBodyCbor, cip20.auxDataHash)
-    }
+    const txBodyCbor = preOutput.data
+    const auxDataCbor = memo ? buildCip20AuxData(memo).auxDataCbor : undefined
 
     const spendingKey = new Uint8Array(publicKey.data()).slice(0, 32)
     const encoded = buildSignedCardanoTx({

--- a/packages/core/mpc/tx/preSigningHashes/index.ts
+++ b/packages/core/mpc/tx/preSigningHashes/index.ts
@@ -1,6 +1,5 @@
 import { Chain } from '@vultisig/core-chain/Chain'
 import { fromBinary } from '@bufbuild/protobuf'
-import { blake2b } from '@noble/hashes/blake2b'
 import { decodeBittensorTxInput } from '../../keysign/signingInputs/resolvers/bittensor'
 import { computePreSigningHashes } from '../../keysign/signingInputs/resolvers/bitcoin/sighash'
 import { getQBTCPreSignedImageHash } from '../../chains/cosmos/qbtc/QBTCHelper'
@@ -10,7 +9,6 @@ import { blake2AsU8a } from '@polkadot/util-crypto'
 import { WalletCore } from '@trustwallet/wallet-core'
 import { getBlockchainSpecificValue } from '../../keysign/chainSpecific/KeysignChainSpecific'
 import { getPreSigningOutput } from '../../keysign/preSigningOutput'
-import { buildCip20AuxData, patchTxBodyWithAuxHash } from '../compile/cardano/buildCip20AuxData'
 import { KeysignPayload, KeysignPayloadSchema } from '../../types/vultisig/keysign/v1/keysign_message_pb'
 import { getSwapKitSignBitcoin } from '../swapkitSignBitcoin'
 
@@ -44,16 +42,6 @@ export const getPreSigningHashes = ({ walletCore, txInputData, chain, keysignPay
     const { payload } = decodeBittensorTxInput(txInputData)
     const toSign = payload.length > 256 ? blake2AsU8a(payload, 256) : payload
     return [toSign]
-  }
-
-  // Cardano with memo: the aux-data hash is committed into the tx body, so
-  // the signed bytes differ from the WalletCore body. Patch the body and
-  // return blake2b-256 of the patched bytes — that is what MPC must sign.
-  if (chain === Chain.Cardano && keysignPayload?.memo) {
-    const output = getPreSigningOutput({ walletCore, txInputData, chain })
-    const { auxDataHash } = buildCip20AuxData(keysignPayload.memo)
-    const patchedBody = patchTxBodyWithAuxHash(output.data, auxDataHash)
-    return [blake2b(patchedBody, { dkLen: 32 })]
   }
 
   const output = getPreSigningOutput({

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -193,7 +193,7 @@
     "@solana/web3.js": "^1.98.4",
     "@ton/core": "^0.63.1",
     "@ton/crypto": "^3.3.0",
-    "@trustwallet/wallet-core": "^4.6.15",
+    "@trustwallet/wallet-core": "^4.7.0",
     "@vultisig/lib-dkls": "workspace:*",
     "@vultisig/lib-mldsa": "workspace:*",
     "@vultisig/lib-schnorr": "workspace:*",

--- a/scripts/quality-contracts.mjs
+++ b/scripts/quality-contracts.mjs
@@ -259,7 +259,7 @@ function packedConsumerSmoke(workRoot, tgzPath) {
       2
     ) + '\n'
   )
-  writeFileSync(path.join(consumer, '.yarnrc.yml'), 'nodeLinker: node-modules\n')
+  writeFileSync(path.join(consumer, '.yarnrc.yml'), 'nodeLinker: node-modules\nminPublishTime: 0\n')
 
   const cacheFolder = path.join(repoRoot, '.yarn/cache')
   const env = {
@@ -395,7 +395,7 @@ function packedCliBinSmoke(
       2
     ) + '\n'
   )
-  writeFileSync(path.join(consumer, '.yarnrc.yml'), 'nodeLinker: node-modules\n')
+  writeFileSync(path.join(consumer, '.yarnrc.yml'), 'nodeLinker: node-modules\nminPublishTime: 0\n')
 
   const cacheFolder = path.join(repoRoot, '.yarn/cache')
   const env = {
@@ -458,7 +458,7 @@ function packedMcpBinSmoke(workRoot, tgzPath, sdkTgzPath, clientSharedTgzPath) {
       2
     ) + '\n'
   )
-  writeFileSync(path.join(consumer, '.yarnrc.yml'), 'nodeLinker: node-modules\n')
+  writeFileSync(path.join(consumer, '.yarnrc.yml'), 'nodeLinker: node-modules\nminPublishTime: 0\n')
 
   const cacheFolder = path.join(repoRoot, '.yarn/cache')
   const env = {

--- a/scripts/quality-contracts.mjs
+++ b/scripts/quality-contracts.mjs
@@ -259,7 +259,7 @@ function packedConsumerSmoke(workRoot, tgzPath) {
       2
     ) + '\n'
   )
-  writeFileSync(path.join(consumer, '.yarnrc.yml'), 'nodeLinker: node-modules\nminPublishTime: 0\n')
+  writeFileSync(path.join(consumer, '.yarnrc.yml'), 'nodeLinker: node-modules\nnpmMinimalAgeGate: 0\n')
 
   const cacheFolder = path.join(repoRoot, '.yarn/cache')
   const env = {
@@ -395,7 +395,7 @@ function packedCliBinSmoke(
       2
     ) + '\n'
   )
-  writeFileSync(path.join(consumer, '.yarnrc.yml'), 'nodeLinker: node-modules\nminPublishTime: 0\n')
+  writeFileSync(path.join(consumer, '.yarnrc.yml'), 'nodeLinker: node-modules\nnpmMinimalAgeGate: 0\n')
 
   const cacheFolder = path.join(repoRoot, '.yarn/cache')
   const env = {
@@ -458,7 +458,7 @@ function packedMcpBinSmoke(workRoot, tgzPath, sdkTgzPath, clientSharedTgzPath) {
       2
     ) + '\n'
   )
-  writeFileSync(path.join(consumer, '.yarnrc.yml'), 'nodeLinker: node-modules\nminPublishTime: 0\n')
+  writeFileSync(path.join(consumer, '.yarnrc.yml'), 'nodeLinker: node-modules\nnpmMinimalAgeGate: 0\n')
 
   const cacheFolder = path.join(repoRoot, '.yarn/cache')
   const env = {

--- a/scripts/quality-contracts.mjs
+++ b/scripts/quality-contracts.mjs
@@ -259,7 +259,7 @@ function packedConsumerSmoke(workRoot, tgzPath) {
       2
     ) + '\n'
   )
-  writeFileSync(path.join(consumer, '.yarnrc.yml'), 'nodeLinker: node-modules\nnpmMinimalAgeGate: 0\n')
+  writeFileSync(path.join(consumer, '.yarnrc.yml'), 'nodeLinker: node-modules\n')
 
   const cacheFolder = path.join(repoRoot, '.yarn/cache')
   const env = {
@@ -395,7 +395,7 @@ function packedCliBinSmoke(
       2
     ) + '\n'
   )
-  writeFileSync(path.join(consumer, '.yarnrc.yml'), 'nodeLinker: node-modules\nnpmMinimalAgeGate: 0\n')
+  writeFileSync(path.join(consumer, '.yarnrc.yml'), 'nodeLinker: node-modules\n')
 
   const cacheFolder = path.join(repoRoot, '.yarn/cache')
   const env = {
@@ -458,7 +458,7 @@ function packedMcpBinSmoke(workRoot, tgzPath, sdkTgzPath, clientSharedTgzPath) {
       2
     ) + '\n'
   )
-  writeFileSync(path.join(consumer, '.yarnrc.yml'), 'nodeLinker: node-modules\nnpmMinimalAgeGate: 0\n')
+  writeFileSync(path.join(consumer, '.yarnrc.yml'), 'nodeLinker: node-modules\n')
 
   const cacheFolder = path.join(repoRoot, '.yarn/cache')
   const env = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6032,12 +6032,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@trustwallet/wallet-core@npm:^4.6.15":
-  version: 4.6.15
-  resolution: "@trustwallet/wallet-core@npm:4.6.15"
+"@trustwallet/wallet-core@npm:^4.7.0":
+  version: 4.7.0
+  resolution: "@trustwallet/wallet-core@npm:4.7.0"
   dependencies:
     protobufjs: "npm:>=6.11.3"
-  checksum: 10c0/d1452f9833af2e2ad8d5ad69cdbe77a0ced70f658442727d9266a3e23b1cb3c7addc0acf462f2637599106c2c81f8a1f416c0d5a03446fe4204a00f07c58513d
+  checksum: 10c0/b40814760940e40f2a907364440c70be6b2d2dcdb5be2ef270ffc66909642d07dcdb24d644f750ccabfe5dfd5a8756cce95ae24ea88c442adfaf633b700f6ef3
   languageName: node
   linkType: hard
 
@@ -6980,7 +6980,7 @@ __metadata:
     "@solana/web3.js": "npm:^1.98.4"
     "@ton/core": "npm:^0.63.1"
     "@ton/crypto": "npm:^3.3.0"
-    "@trustwallet/wallet-core": "npm:^4.6.15"
+    "@trustwallet/wallet-core": "npm:^4.7.0"
     "@vultisig/core-config": "npm:0.9.1"
     "@vultisig/lib-utils": "npm:0.10.3"
     bip32: "npm:^5.0.1"
@@ -7013,7 +7013,7 @@ __metadata:
     "@mysten/sui": "npm:^2.20.1"
     "@noble/hashes": "npm:^1.8.0"
     "@solana/web3.js": "npm:^1.98.4"
-    "@trustwallet/wallet-core": "npm:^4.6.15"
+    "@trustwallet/wallet-core": "npm:^4.7.0"
     "@vultisig/core-chain": "npm:2.22.0"
     "@vultisig/core-config": "npm:0.9.1"
     "@vultisig/lib-dkls": "npm:0.9.0"
@@ -7234,7 +7234,7 @@ __metadata:
     "@solana/web3.js": "npm:^1.98.4"
     "@ton/core": "npm:^0.63.1"
     "@ton/crypto": "npm:^3.3.0"
-    "@trustwallet/wallet-core": "npm:^4.6.15"
+    "@trustwallet/wallet-core": "npm:^4.7.0"
     "@types/chrome": "npm:^0.2.0"
     "@types/events": "npm:^3"
     "@types/node": "npm:^26.0.0"


### PR DESCRIPTION
> **DO NOT MERGE before 2026-07-01 07:18 UTC** - see supply-chain note below.

Picks up @Ehsan-saradar's work from #722 and restores the yarn quarantine that was bypassed to unblock CI.

## What

Native CIP-20 auxiliary data support for Cardano transactions via `@trustwallet/wallet-core`'s `auxiliaryData` field (added in 4.7.0). Replaces the fragile manual CBOR-patching approach that previously attached memo data after signing.

- `buildCip20AuxData` - builds the CIP-20 auxiliary data structure
- `keysign/signingInputs/resolvers/cardano.ts` - passes `auxiliaryData` directly into the signing input so wallet-core commits the aux-data hash into the tx body
- `tx/compile/cardano/buildSignedCardanoTx.ts` - embeds the aux-data bytes in the final CBOR envelope

## Supply-chain note

`@trustwallet/wallet-core@4.7.0` was published today at **07:18 UTC 2026-06-30**. Yarn 4's `npmMinimalAgeGate` quarantines packages published within the last 24h as a supply-chain safeguard - exactly the kind of thing we want respected. #722's CI was failing on this and two bypass commits were pushed (`eda74e0c5`, `aec157992`) to work around it.

This PR reverts that bypass (see `27d9e3c1e`) and keeps the quarantine intact. CI will fail on `Lint and Type Check` / `quality:contracts` until the gate clears around **07:18 UTC 2026-07-01**. That's intentional. Do not admin-merge to skip CI.

@Ehsan-saradar - taking this over from your #722, no changes to the actual Cardano code, just cleaning up the CI bypass. You're credited as co-author on the original commits.

## Risk

Low - Cardano only, no impact on other chains.

🤖 reviewed via Claude Code (local /loop hourly poll)