### PR TITLE
feat(cli): sign Polymarket flat-tx-builder outputs like the mobile app

### DIFF
--- a/.changeset/cli-polymarket-build-tx-signing.md
+++ b/.changeset/cli-polymarket-build-tx-signing.md
@@ -1,0 +1,26 @@
+---
+"@vultisig/cli": patch
+---
+
+feat(cli): sign Polymarket flat-tx-builder outputs like the mobile app
+
+The headless CLI now signs the Polymarket flat-transaction builders
+(`polymarket_deposit` approve/wrap and `polymarket_setup_trading`) the same way
+the mobile app does — by reading the flat `{chain, chain_id, to, value, data}`
+envelope off the `tool-output-available` channel for an allowlist and feeding it
+into the existing `onTxReady → storeServerTransaction → sign` pipeline. The only
+intended difference from mobile is that the CLI auto-signs (under `--yes` / a
+cached password) instead of asking for a device tap.
+
+These tools deliberately do not set `producesCalldata` (so the backend emits no
+`tx_ready` frame for them); this is a CLI-only consumer of the flat envelope
+that is already on the wire, with zero agent-backend / mcp-ts change.
+
+- Guards every non-transaction result (`no_op`, `insufficient_usdce`, errors,
+  wrong/disagreeing chain) so only a real flat tx is ever signed.
+- Maps the bundled deposit approve→wrap envelope (`needs_approval` +
+  `approval_tx`) onto the executor's existing two-leg machinery so the approve
+  is confirmed (receipt-wait) before the wrap — never shipped as a single tx.
+- Enforces first-wins per turn so a second signable frame in one turn can never
+  silently overwrite (and drop) the first.
+- A parity test pins the CLI allowlist to the mcp-ts m7 source of truth.

--- a/clients/cli/src/agent/__tests__/client.test.ts
+++ b/clients/cli/src/agent/__tests__/client.test.ts
@@ -343,7 +343,7 @@ describe('AgentClient.sendMessageStream', () => {
     it('fires onTxReady with a multi-leg {approvalTxArgs,txArgs} for a bundled deposit wrap', async () => {
       const onTxReady = vi.fn()
       const ONRAMP = '0x1234567890abcdef1234567890abcdef12345678'
-      const WRAP_DATA = '0xea598cb0' + '0'.repeat(184)
+      const WRAP_DATA = '0x62355638' + '0'.repeat(192)
       globalThis.fetch = mockFetchSSE(
         outputFrame('polymarket_deposit', {
           chain: 'Polygon',

--- a/clients/cli/src/agent/__tests__/client.test.ts
+++ b/clients/cli/src/agent/__tests__/client.test.ts
@@ -299,6 +299,83 @@ describe('AgentClient.sendMessageStream', () => {
     expect(onToolProgress).not.toHaveBeenCalled()
   })
 
+  // Design B: the CLI signs Polymarket flat-tx-builder outputs the way mobile
+  // does, by reading the flat tx off the tool-output-available channel for an
+  // allowlist and feeding the EXISTING onTxReady pipeline. These tools don't set
+  // producesCalldata (no tx_ready frame), so this is the only sign trigger.
+  describe('build-tx bridge: tool-output-available → onTxReady', () => {
+    const USDC_E = '0x2791bca1f2de4661ed88a30c99a7a9449aa84174'
+    const APPROVE_DATA = '0x095ea7b3' + '0'.repeat(120)
+
+    function outputFrame(toolName: string, output: object): string[] {
+      return [
+        `data: ${JSON.stringify({ type: 'tool-input-start', toolCallId: 'tc-pm', toolName })}\n\n`,
+        `data: ${JSON.stringify({ type: 'tool-output-available', toolCallId: 'tc-pm', output })}\n\n`,
+        'data: {"type":"finish"}\n\n',
+      ]
+    }
+
+    it('fires onTxReady with a wrapped {chain,chain_id,tx} for an allowlisted flat envelope', async () => {
+      const onTxReady = vi.fn()
+      globalThis.fetch = mockFetchSSE(
+        outputFrame('polymarket_setup_trading', {
+          chain: 'Polygon',
+          chain_id: '137',
+          to: USDC_E,
+          value: '0',
+          data: APPROVE_DATA,
+          action: 'approve',
+        })
+      )
+
+      const client = new AgentClient('http://example.com')
+      await client.sendMessageStream('c1', { public_key: 'pk', content: 'approve' }, { onTxReady })
+
+      expect(onTxReady).toHaveBeenCalledTimes(1)
+      expect(onTxReady.mock.calls[0][0]).toMatchObject({
+        __buildTx: true,
+        chain: 'Polygon',
+        chain_id: '137',
+        tx: { to: USDC_E, value: '0', data: APPROVE_DATA },
+      })
+    })
+
+    it('does NOT fire onTxReady for a no_op envelope (guard)', async () => {
+      const onTxReady = vi.fn()
+      globalThis.fetch = mockFetchSSE(
+        outputFrame('polymarket_setup_trading', {
+          chain: 'Polygon',
+          chain_id: '137',
+          action: 'no_op',
+          message: 'All spenders approved.',
+        })
+      )
+
+      const client = new AgentClient('http://example.com')
+      await client.sendMessageStream('c1', { public_key: 'pk', content: 'approve' }, { onTxReady })
+
+      expect(onTxReady).not.toHaveBeenCalled()
+    })
+
+    it('does NOT fire onTxReady for a tool outside the allowlist', async () => {
+      const onTxReady = vi.fn()
+      globalThis.fetch = mockFetchSSE(
+        outputFrame('polymarket_place_bet', {
+          chain: 'Polygon',
+          chain_id: '137',
+          to: USDC_E,
+          value: '0',
+          data: APPROVE_DATA,
+        })
+      )
+
+      const client = new AgentClient('http://example.com')
+      await client.sendMessageStream('c1', { public_key: 'pk', content: 'bet' }, { onTxReady })
+
+      expect(onTxReady).not.toHaveBeenCalled()
+    })
+  })
+
   // cat4-cli-supported-surfaces: the backend emits data-balance_summary when
   // the client advertised "balance_summary" in supported_surfaces. Previously
   // this v1 part routed to the 'ignore' bucket (client.ts:421) and the card was

--- a/clients/cli/src/agent/__tests__/client.test.ts
+++ b/clients/cli/src/agent/__tests__/client.test.ts
@@ -340,6 +340,36 @@ describe('AgentClient.sendMessageStream', () => {
       })
     })
 
+    it('fires onTxReady with a multi-leg {approvalTxArgs,txArgs} for a bundled deposit wrap', async () => {
+      const onTxReady = vi.fn()
+      const ONRAMP = '0x1234567890abcdef1234567890abcdef12345678'
+      const WRAP_DATA = '0xea598cb0' + '0'.repeat(184)
+      globalThis.fetch = mockFetchSSE(
+        outputFrame('polymarket_deposit', {
+          chain: 'Polygon',
+          chain_id: '137',
+          to: ONRAMP,
+          value: '0',
+          data: WRAP_DATA,
+          gas_limit: '250000',
+          action: 'wrap_usdce_to_pusd',
+          needs_approval: true,
+          approval_tx: { to: USDC_E, data: APPROVE_DATA, value: '0' },
+        })
+      )
+
+      const client = new AgentClient('http://example.com')
+      await client.sendMessageStream('c1', { public_key: 'pk', content: 'deposit' }, { onTxReady })
+
+      expect(onTxReady).toHaveBeenCalledTimes(1)
+      expect(onTxReady.mock.calls[0][0]).toMatchObject({
+        __buildTx: true,
+        chain: 'Polygon',
+        approvalTxArgs: { tx: { to: USDC_E, data: APPROVE_DATA } },
+        txArgs: { tx: { to: ONRAMP, data: WRAP_DATA, gas_limit: '250000' } },
+      })
+    })
+
     it('does NOT fire onTxReady for a no_op envelope (guard)', async () => {
       const onTxReady = vi.fn()
       globalThis.fetch = mockFetchSSE(

--- a/clients/cli/src/agent/__tests__/executor.buildtx.test.ts
+++ b/clients/cli/src/agent/__tests__/executor.buildtx.test.ts
@@ -23,7 +23,7 @@ import {
 const USDC_E = '0x2791bca1f2de4661ed88a30c99a7a9449aa84174'
 const ONRAMP = '0x1234567890abcdef1234567890abcdef12345678'
 const APPROVE_DATA = '0x095ea7b3' + '0'.repeat(120)
-const WRAP_DATA = '0xea598cb0' + '0'.repeat(184)
+const WRAP_DATA = '0x62355638' + '0'.repeat(192)
 
 function createMockVault(): VaultBase {
   return {

--- a/clients/cli/src/agent/__tests__/executor.buildtx.test.ts
+++ b/clients/cli/src/agent/__tests__/executor.buildtx.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Design B end-to-end: a Polymarket flat-tx-builder tool output, lifted by
+ * `buildTxReadyFromToolOutput`, must traverse the EXISTING executor signing
+ * pipeline unchanged:
+ *   - single flat envelope → single-leg `signServerTx` (extractNestedTx finds `tx`);
+ *   - bundled approve+wrap → `signMultiLeg` (approve → receipt-wait → wrap).
+ *
+ * This pins the wrapping shape against the real executor so a future change to
+ * `extractNestedTx` / `storeServerTransaction` / `getPendingSummary` that would
+ * break Polymarket signing fails here.
+ */
+import type { VaultBase } from '@vultisig/sdk'
+import { Chain } from '@vultisig/sdk'
+import { describe, expect, it, vi } from 'vitest'
+
+import { AgentExecutor, extractNestedTx } from '../executor'
+import {
+  buildTxReadyFromToolOutput,
+  POLYMARKET_DEPOSIT_TOOL,
+  POLYMARKET_SETUP_TRADING_TOOL,
+} from '../polymarketTxOutput'
+
+const USDC_E = '0x2791bca1f2de4661ed88a30c99a7a9449aa84174'
+const ONRAMP = '0x1234567890abcdef1234567890abcdef12345678'
+const APPROVE_DATA = '0x095ea7b3' + '0'.repeat(120)
+const WRAP_DATA = '0xea598cb0' + '0'.repeat(184)
+
+function createMockVault(): VaultBase {
+  return {
+    name: 'mock-vault',
+    id: 'vault-mock-1',
+    type: 'secure',
+    chains: [Chain.Ethereum, Chain.Polygon],
+    isEncrypted: false,
+    balances: vi.fn().mockResolvedValue({}),
+    address: vi.fn().mockResolvedValue('0xsender'),
+    balance: vi.fn().mockResolvedValue({ decimals: 6, symbol: 'USDC.e' }),
+    getTxStatus: vi.fn().mockResolvedValue({ status: 'success' }),
+  } as unknown as VaultBase
+}
+
+function setupTradingApprove() {
+  return { chain: 'Polygon', chain_id: '137', to: USDC_E, value: '0', data: APPROVE_DATA, action: 'approve' }
+}
+function depositWrapBundled() {
+  return {
+    chain: 'Polygon',
+    chain_id: '137',
+    to: ONRAMP,
+    value: '0',
+    data: WRAP_DATA,
+    gas_limit: '250000',
+    action: 'wrap_usdce_to_pusd',
+    needs_approval: true,
+    approval_tx: { to: USDC_E, data: APPROVE_DATA, value: '0' },
+  }
+}
+
+describe('build-tx bridge → executor single-leg', () => {
+  it('wrapped flat envelope is recognized by extractNestedTx via `tx`', () => {
+    const wrapped = buildTxReadyFromToolOutput(POLYMARKET_SETUP_TRADING_TOOL, setupTradingApprove())
+    expect(wrapped).not.toBeNull()
+    const nested = extractNestedTx(wrapped)
+    expect(nested).toMatchObject({ to: USDC_E, value: '0', data: APPROVE_DATA })
+  })
+
+  it('storeServerTransaction buffers it and getPendingSummary names the contract + action', () => {
+    const executor = new AgentExecutor(createMockVault())
+    const wrapped = buildTxReadyFromToolOutput(POLYMARKET_SETUP_TRADING_TOOL, setupTradingApprove())
+    expect(executor.storeServerTransaction(wrapped)).toBe(true)
+    expect(executor.hasPendingTransaction()).toBe(true)
+    const summary = executor.getPendingSummary()
+    expect(summary).toContain('contract call on Polygon')
+    expect(summary).toContain(USDC_E)
+    expect(summary).toContain('[approve]')
+    // single-leg: not flagged multi-leg
+    expect(summary).not.toContain('2 transactions')
+  })
+
+  it('signs via single-leg signServerTx (not multi-leg)', async () => {
+    const executor = new AgentExecutor(createMockVault())
+    const signServerTx = vi.spyOn(executor as any, 'signServerTx').mockImplementation(async (envelope: any) => ({
+      tx_hash: '0xhash',
+      chain: 'Polygon',
+      status: 'pending',
+      explorer_url: 'https://polygonscan.com/tx/0xhash',
+      _to: extractNestedTx(envelope)?.to,
+    }))
+
+    const wrapped = buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, {
+      ...setupTradingApprove(),
+      to: USDC_E,
+    })
+    expect(executor.storeServerTransaction(wrapped)).toBe(true)
+    const recent = await executor.signTxFromBuffer('call-1')
+
+    expect(recent.success).toBe(true)
+    expect(signServerTx).toHaveBeenCalledTimes(1)
+    // the envelope handed to signServerTx exposes the flat tx under `tx`
+    const env = signServerTx.mock.calls[0][0] as any
+    expect(extractNestedTx(env)).toMatchObject({ to: USDC_E, data: APPROVE_DATA })
+  })
+})
+
+describe('build-tx bridge → executor multi-leg (bundled approve+wrap)', () => {
+  it('buffers two legs (approve, main) with nested tx each', () => {
+    const executor = new AgentExecutor(createMockVault())
+    const wrapped = buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, depositWrapBundled())
+    expect(executor.storeServerTransaction(wrapped)).toBe(true)
+    const legs = (executor as any).pendingLegs as Array<{ kind: string; txArgs: any }>
+    expect(legs).toHaveLength(2)
+    expect(legs[0].kind).toBe('approve')
+    expect(legs[0].txArgs.tx.to).toBe(USDC_E)
+    expect(legs[1].kind).toBe('main')
+    expect(legs[1].txArgs.tx.to).toBe(ONRAMP)
+  })
+
+  it('getPendingSummary shows the wrap destination + the bundled approval leg', () => {
+    const executor = new AgentExecutor(createMockVault())
+    const wrapped = buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, depositWrapBundled())
+    executor.storeServerTransaction(wrapped)
+    const summary = executor.getPendingSummary()
+    expect(summary).toContain('contract call on Polygon')
+    expect(summary).toContain(ONRAMP)
+    expect(summary).toContain('2 transactions')
+    expect(summary).toContain('[wrap_usdce_to_pusd]')
+  })
+
+  it('sequences approve → receipt-wait → wrap', async () => {
+    const executor = new AgentExecutor(createMockVault())
+    const order: string[] = []
+    vi.spyOn(executor as any, 'signServerTx').mockImplementation(async (envelope: any) => {
+      const to = extractNestedTx(envelope)?.to
+      order.push(to)
+      return {
+        tx_hash: to === USDC_E ? '0xapprove' : '0xwrap',
+        chain: 'Polygon',
+        status: 'pending',
+        explorer_url: `https://polygonscan.com/tx/${to}`,
+      }
+    })
+    const receipt = vi.spyOn(executor as any, 'waitForEvmReceipt').mockResolvedValue(undefined)
+
+    const wrapped = buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, depositWrapBundled())
+    expect(executor.storeServerTransaction(wrapped)).toBe(true)
+    const recent = await executor.signTxFromBuffer('call-1')
+
+    expect(recent.success).toBe(true)
+    expect(order).toEqual([USDC_E, ONRAMP])
+    expect(receipt).toHaveBeenCalledTimes(1)
+    expect(recent.data?.approval_tx_hash).toBe('0xapprove')
+    expect(recent.data?.tx_hash).toBe('0xwrap')
+  })
+
+  it('fails closed: a receipt timeout holds back the wrap leg', async () => {
+    const executor = new AgentExecutor(createMockVault())
+    const signServerTx = vi.spyOn(executor as any, 'signServerTx').mockImplementation(async (envelope: any) => ({
+      tx_hash: extractNestedTx(envelope)?.to === USDC_E ? '0xapprove' : '0xwrap',
+      chain: 'Polygon',
+      status: 'pending',
+      explorer_url: 'https://polygonscan.com/tx/x',
+    }))
+    vi.spyOn(executor as any, 'waitForEvmReceipt').mockRejectedValue(new Error('receipt timeout'))
+
+    const wrapped = buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, depositWrapBundled())
+    executor.storeServerTransaction(wrapped)
+    const recent = await executor.signTxFromBuffer('call-1')
+
+    expect(recent.success).toBe(false)
+    // only the approve leg was ever signed; the wrap never broadcast
+    expect(signServerTx).toHaveBeenCalledTimes(1)
+  })
+})

--- a/clients/cli/src/agent/__tests__/polymarketTxOutput.parity.test.ts
+++ b/clients/cli/src/agent/__tests__/polymarketTxOutput.parity.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Parity guard: the CLI's flat-tx-builder allowlist vs the mcp-ts source of truth.
+ *
+ * The CLI signs Polymarket flat-tx-builder outputs the way the mobile app does
+ * (mobile routes them via `BUILD_TX_EXACT_TOOLS`). To stop the CLI allowlist
+ * from silently drifting from mcp-ts, this test mirrors the mcp-ts m7 contract
+ * list and pins the DOCUMENTED relationship between the two.
+ *
+ * The two sets are deliberately NOT identical, for two concrete reasons:
+ *
+ *  1. `polymarket_place_bet` is in the m7 list but is an EIP-712 *off-chain
+ *     signature* (a CTF-Exchange order + CLOB auth challenge), NOT flat EVM
+ *     calldata. It is signed via a different path and MUST stay out of the
+ *     CLI's flat-calldata allowlist.
+ *
+ *  2. `polymarket_deposit` is flat EVM calldata (USDC.e approve + wrap) and is
+ *     the primary multi-step signing case, but it is ABSENT from the m7 list
+ *     (m7 enumerates off-chain-signable tools; deposit emits ordinary on-chain
+ *     txs). It MUST be in the CLI allowlist.
+ *
+ * So:  CLI_BUILD_TX_TOOL_NAMES  ==  (m7 OFF_CHAIN_SIGNABLE − place_bet) + deposit
+ *
+ * This is a MIRROR, not a cross-repo import (mcp-ts is a separate repo). If
+ * mcp-ts changes its m7 list, sync `MCP_TS_OFF_CHAIN_SIGNABLE_TOOL_NAMES` below
+ * and re-derive — this test then forces a conscious reconciliation instead of a
+ * silent divergence. Source of truth:
+ *   mcp-ts src/lib/__tests__/m7_contract.test.ts  (OFF_CHAIN_SIGNABLE_TOOL_NAMES)
+ *   mcp-ts src/tools/polymarket/polymarket-tools.ts (BUILD_TX_EXACT_TOOLS routing)
+ */
+import { describe, expect, it } from 'vitest'
+
+import { CLI_BUILD_TX_TOOL_NAMES } from '../polymarketTxOutput'
+
+/**
+ * Verbatim mirror of mcp-ts `m7_contract.test.ts` OFF_CHAIN_SIGNABLE_TOOL_NAMES
+ * (commit-pinned by review). Keep this in sync by hand; the assertions below
+ * break loudly if the derived CLI set no longer matches.
+ */
+const MCP_TS_OFF_CHAIN_SIGNABLE_TOOL_NAMES = ['polymarket_place_bet', 'polymarket_setup_trading'] as const
+
+/** m7 tools that sign EIP-712 / off-chain payloads, NOT flat EVM calldata. */
+const EIP712_OFFCHAIN_ONLY = new Set<string>(['polymarket_place_bet'])
+
+/** Flat-calldata builders that emit ordinary on-chain txs and are (correctly)
+ *  absent from the off-chain-signable m7 list, but must still be CLI-signable. */
+const FLAT_CALLDATA_NOT_IN_M7 = ['polymarket_deposit'] as const
+
+describe('CLI_BUILD_TX_TOOL_NAMES parity with mcp-ts m7', () => {
+  it('equals (m7 off-chain-signable − EIP-712-only) + flat-calldata-not-in-m7', () => {
+    const expected = new Set<string>([
+      ...MCP_TS_OFF_CHAIN_SIGNABLE_TOOL_NAMES.filter(name => !EIP712_OFFCHAIN_ONLY.has(name)),
+      ...FLAT_CALLDATA_NOT_IN_M7,
+    ])
+    expect(new Set(CLI_BUILD_TX_TOOL_NAMES)).toEqual(expected)
+  })
+
+  it('NEVER includes polymarket_place_bet (EIP-712 off-chain, not flat calldata)', () => {
+    expect(CLI_BUILD_TX_TOOL_NAMES.has('polymarket_place_bet')).toBe(false)
+  })
+
+  it('NEVER includes polymarket_setup_deposit_wallet (EIP-712 Batch via sign_typed_data)', () => {
+    expect(CLI_BUILD_TX_TOOL_NAMES.has('polymarket_setup_deposit_wallet')).toBe(false)
+  })
+
+  it('includes both flat-calldata builders (deposit + setup_trading)', () => {
+    expect(CLI_BUILD_TX_TOOL_NAMES.has('polymarket_deposit')).toBe(true)
+    expect(CLI_BUILD_TX_TOOL_NAMES.has('polymarket_setup_trading')).toBe(true)
+  })
+})

--- a/clients/cli/src/agent/__tests__/polymarketTxOutput.test.ts
+++ b/clients/cli/src/agent/__tests__/polymarketTxOutput.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Design B — Polymarket flat-tx-builder output → signable tx_ready bridge.
+ *
+ * These tests pin the guard + wrapping contract that lets the headless CLI sign
+ * `polymarket_deposit` / `polymarket_setup_trading` outputs the way mobile does:
+ *  - a valid flat envelope → wrapped `{chain,chain_id,tx:{…}}` (executor's
+ *    `extractNestedTx` reads `tx`, NOT a bare top-level `{to,value,data}`);
+ *  - a bundled deposit approve→wrap → multi-leg `{approvalTxArgs,txArgs}` so the
+ *    executor sequences approve→receipt→wrap (closes the funds-regression where
+ *    a lone wrap reverts on a stale allowance);
+ *  - every non-tx result (`no_op`, `insufficient_usdce`, errors) → null (NOT
+ *    signed).
+ *
+ * The wrapped shapes are validated end-to-end against the real executor in
+ * `executor.buildtx.test.ts`.
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildTxReadyFromToolOutput,
+  CLI_BUILD_TX_TOOL_NAMES,
+  POLYMARKET_DEPOSIT_TOOL,
+  POLYMARKET_SETUP_TRADING_TOOL,
+} from '../polymarketTxOutput'
+
+const USDC_E = '0x2791bca1f2de4661ed88a30c99a7a9449aa84174'
+const ONRAMP = '0x1234567890abcdef1234567890abcdef12345678'
+const APPROVE_DATA = '0x095ea7b3' + '0'.repeat(120)
+const WRAP_DATA = '0xea598cb0' + '0'.repeat(184)
+
+/** A realistic `polymarket_setup_trading` approve envelope. */
+function setupTradingApprove() {
+  return {
+    chain: 'Polygon',
+    chain_id: '137',
+    to: USDC_E,
+    value: '0',
+    data: APPROVE_DATA,
+    action: 'approve',
+    maker_address: '0x000000000000000000000000000000000000dEaD',
+    spender_name: 'CTF Exchange',
+  }
+}
+
+/** A realistic `polymarket_deposit` step-1 approve envelope. */
+function depositApprove() {
+  return {
+    chain: 'Polygon',
+    chain_id: '137',
+    to: USDC_E,
+    value: '0',
+    data: APPROVE_DATA,
+    action: 'approve',
+    step: 1,
+    total_steps: 2,
+    next_step: 'wrap',
+  }
+}
+
+/** A realistic `polymarket_deposit` wrap envelope WITHOUT a bundled approval. */
+function depositWrapPlain() {
+  return {
+    chain: 'Polygon',
+    chain_id: '137',
+    to: ONRAMP,
+    value: '0',
+    data: WRAP_DATA,
+    gas_limit: '250000',
+    action: 'wrap_usdce_to_pusd',
+    step: 2,
+    total_steps: 2,
+  }
+}
+
+/** A realistic `polymarket_deposit` wrap envelope WITH a bundled approval leg. */
+function depositWrapBundled() {
+  return {
+    ...depositWrapPlain(),
+    needs_approval: true,
+    approval_tx: { to: USDC_E, data: APPROVE_DATA, value: '0' },
+  }
+}
+
+describe('CLI_BUILD_TX_TOOL_NAMES', () => {
+  it('contains exactly the two flat-calldata Polymarket builders', () => {
+    expect([...CLI_BUILD_TX_TOOL_NAMES].sort()).toEqual([POLYMARKET_DEPOSIT_TOOL, POLYMARKET_SETUP_TRADING_TOOL].sort())
+  })
+})
+
+describe('buildTxReadyFromToolOutput — allowlist gate', () => {
+  it('returns null for a tool not in the allowlist', () => {
+    expect(buildTxReadyFromToolOutput('polymarket_place_bet', setupTradingApprove())).toBeNull()
+    expect(buildTxReadyFromToolOutput('execute_swap', setupTradingApprove())).toBeNull()
+    expect(buildTxReadyFromToolOutput('polymarket_setup_deposit_wallet', setupTradingApprove())).toBeNull()
+  })
+})
+
+describe('buildTxReadyFromToolOutput — valid flat envelopes → single-leg tx', () => {
+  it('wraps a setup_trading approve into {chain,chain_id,tx}', () => {
+    const out = buildTxReadyFromToolOutput(POLYMARKET_SETUP_TRADING_TOOL, setupTradingApprove())
+    expect(out).not.toBeNull()
+    expect(out).toMatchObject({
+      chain: 'Polygon',
+      chain_id: '137',
+      tx: { to: USDC_E, value: '0', data: APPROVE_DATA },
+    })
+    // single-leg: no multi-leg markers
+    expect(out?.approvalTxArgs).toBeUndefined()
+    expect(out?.txArgs).toBeUndefined()
+  })
+
+  it('wraps a deposit approve step into {chain,chain_id,tx}', () => {
+    const out = buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, depositApprove())
+    expect(out).toMatchObject({ chain: 'Polygon', chain_id: '137', tx: { to: USDC_E, data: APPROVE_DATA } })
+    expect(out?.approvalTxArgs).toBeUndefined()
+  })
+
+  it('wraps a plain deposit wrap step and carries the server gas_limit', () => {
+    const out = buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, depositWrapPlain())
+    expect(out).toMatchObject({
+      chain: 'Polygon',
+      chain_id: '137',
+      tx: { to: ONRAMP, value: '0', data: WRAP_DATA, gas_limit: '250000' },
+    })
+    expect(out?.approvalTxArgs).toBeUndefined()
+  })
+
+  it('parses a stringified JSON envelope identically', () => {
+    const out = buildTxReadyFromToolOutput(POLYMARKET_SETUP_TRADING_TOOL, JSON.stringify(setupTradingApprove()))
+    expect(out).toMatchObject({ chain: 'Polygon', tx: { to: USDC_E, data: APPROVE_DATA } })
+  })
+
+  it('defaults a missing value to "0"', () => {
+    const env = setupTradingApprove() as Record<string, unknown>
+    delete env.value
+    const out = buildTxReadyFromToolOutput(POLYMARKET_SETUP_TRADING_TOOL, env)
+    expect(out?.tx).toMatchObject({ value: '0' })
+  })
+
+  it('marks the envelope __buildTx and passes the action through (for the confirm summary)', () => {
+    const out = buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, depositWrapPlain())
+    expect(out?.__buildTx).toBe(true)
+    expect(out?.action).toBe('wrap_usdce_to_pusd')
+  })
+})
+
+describe('buildTxReadyFromToolOutput — bundled approve+wrap → multi-leg', () => {
+  it('maps needs_approval+approval_tx onto approvalTxArgs/txArgs with nested tx', () => {
+    const out = buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, depositWrapBundled())
+    expect(out).not.toBeNull()
+    expect(out).toMatchObject({
+      chain: 'Polygon',
+      chain_id: '137',
+      approvalTxArgs: { chain: 'Polygon', chain_id: '137', tx: { to: USDC_E, value: '0', data: APPROVE_DATA } },
+      txArgs: {
+        chain: 'Polygon',
+        chain_id: '137',
+        tx: { to: ONRAMP, value: '0', data: WRAP_DATA, gas_limit: '250000' },
+      },
+    })
+    // a multi-leg envelope must NOT also carry a single-leg `tx`
+    expect(out?.tx).toBeUndefined()
+  })
+
+  it('FAILS CLOSED: needs_approval=true but approval_tx missing → null (never sign the wrap alone)', () => {
+    const env = { ...depositWrapPlain(), needs_approval: true }
+    expect(buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, env)).toBeNull()
+  })
+
+  it('FAILS CLOSED: needs_approval=true but approval_tx has no calldata → null', () => {
+    const env = { ...depositWrapPlain(), needs_approval: true, approval_tx: { to: USDC_E, value: '0' } }
+    expect(buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, env)).toBeNull()
+  })
+
+  it('FAILS CLOSED: needs_approval=true but main wrap tx missing data → null', () => {
+    const env = {
+      chain: 'Polygon',
+      chain_id: '137',
+      to: ONRAMP,
+      value: '0',
+      needs_approval: true,
+      approval_tx: { to: USDC_E, data: APPROVE_DATA, value: '0' },
+    }
+    expect(buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, env)).toBeNull()
+  })
+})
+
+describe('buildTxReadyFromToolOutput — non-tx envelopes are NEVER signed (the guard)', () => {
+  it('rejects setup_trading no_op (no to/data)', () => {
+    const noOp = {
+      chain: 'Polygon',
+      chain_id: '137',
+      action: 'no_op',
+      approved_spenders: ['CTF Exchange', 'Neg Risk CTF Exchange'],
+      message: 'All Polymarket V2 spenders are already approved.',
+    }
+    expect(buildTxReadyFromToolOutput(POLYMARKET_SETUP_TRADING_TOOL, noOp)).toBeNull()
+  })
+
+  it('rejects deposit insufficient_usdce (no to/data, has error)', () => {
+    const insufficient = {
+      action: 'insufficient_usdce',
+      required: '5.00',
+      balance: '1.00',
+      error: 'EOA holds 1.00 USDC.e but 5.00 is required.',
+    }
+    expect(buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, insufficient)).toBeNull()
+  })
+
+  it('rejects an explicit error envelope', () => {
+    expect(buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, { status: 'error', error: 'boom' })).toBeNull()
+  })
+
+  it('rejects empty calldata "0x"', () => {
+    const env = { ...setupTradingApprove(), data: '0x' }
+    expect(buildTxReadyFromToolOutput(POLYMARKET_SETUP_TRADING_TOOL, env)).toBeNull()
+  })
+
+  it('rejects a non-0x / malformed `to`', () => {
+    const env = { ...setupTradingApprove(), to: 'not-an-address' }
+    expect(buildTxReadyFromToolOutput(POLYMARKET_SETUP_TRADING_TOOL, env)).toBeNull()
+  })
+
+  it('rejects an envelope with neither chain nor chain_id', () => {
+    const env = { to: USDC_E, value: '0', data: APPROVE_DATA }
+    expect(buildTxReadyFromToolOutput(POLYMARKET_SETUP_TRADING_TOOL, env)).toBeNull()
+  })
+
+  it('rejects when chain is present but chain_id is missing', () => {
+    const env = { chain: 'Polygon', to: USDC_E, value: '0', data: APPROVE_DATA }
+    expect(buildTxReadyFromToolOutput(POLYMARKET_SETUP_TRADING_TOOL, env)).toBeNull()
+  })
+
+  it('rejects when chain and chain_id disagree (wrong-chain routing guard)', () => {
+    // chain says Polygon but chain_id is Ethereum's — never sign on the wrong chain.
+    const env = { ...setupTradingApprove(), chain_id: '1' }
+    expect(buildTxReadyFromToolOutput(POLYMARKET_SETUP_TRADING_TOOL, env)).toBeNull()
+  })
+
+  it('rejects a chain outside the Polymarket EVM allowlist', () => {
+    const env = { ...setupTradingApprove(), chain: 'Ethereum', chain_id: '1' }
+    expect(buildTxReadyFromToolOutput(POLYMARKET_SETUP_TRADING_TOOL, env)).toBeNull()
+  })
+
+  it('rejects a malformed value (non-integer) rather than signing it', () => {
+    // a malformed value must not reach BigInt(); the leg defaults value to '0'
+    const env = { ...setupTradingApprove(), value: 'not-a-number' }
+    const out = buildTxReadyFromToolOutput(POLYMARKET_SETUP_TRADING_TOOL, env)
+    expect(out?.tx).toMatchObject({ value: '0' })
+  })
+
+  it('rejects non-object output', () => {
+    expect(buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, null)).toBeNull()
+    expect(buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, undefined)).toBeNull()
+    expect(buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, 'not json')).toBeNull()
+    expect(buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, 42)).toBeNull()
+    expect(buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, [setupTradingApprove()])).toBeNull()
+  })
+})

--- a/clients/cli/src/agent/__tests__/polymarketTxOutput.test.ts
+++ b/clients/cli/src/agent/__tests__/polymarketTxOutput.test.ts
@@ -26,7 +26,7 @@ import {
 const USDC_E = '0x2791bca1f2de4661ed88a30c99a7a9449aa84174'
 const ONRAMP = '0x1234567890abcdef1234567890abcdef12345678'
 const APPROVE_DATA = '0x095ea7b3' + '0'.repeat(120)
-const WRAP_DATA = '0xea598cb0' + '0'.repeat(184)
+const WRAP_DATA = '0x62355638' + '0'.repeat(192)
 
 /** A realistic `polymarket_setup_trading` approve envelope. */
 function setupTradingApprove() {
@@ -177,6 +177,20 @@ describe('buildTxReadyFromToolOutput — bundled approve+wrap → multi-leg', ()
     expect(out?.tx).toBeUndefined()
   })
 
+  it('routes a TRUTHY non-boolean needs_approval (1) through the bundled multi-leg path', () => {
+    // hardening: a non-boolean-truthy needs_approval must NOT fall through to
+    // signing the wrap alone against a stale allowance.
+    const env = { ...depositWrapBundled(), needs_approval: 1 }
+    const out = buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, env)
+    expect(out?.approvalTxArgs).toMatchObject({ tx: { to: USDC_E, data: APPROVE_DATA } })
+    expect(out?.txArgs).toMatchObject({ tx: { to: ONRAMP, data: WRAP_DATA } })
+  })
+
+  it('FAILS CLOSED: truthy needs_approval (1) but approval_tx missing → null (never the lone wrap)', () => {
+    const env = { ...depositWrapPlain(), needs_approval: 1 }
+    expect(buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, env)).toBeNull()
+  })
+
   it('FAILS CLOSED: needs_approval=true but approval_tx missing → null (never sign the wrap alone)', () => {
     const env = { ...depositWrapPlain(), needs_approval: true }
     expect(buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, env)).toBeNull()
@@ -184,6 +198,15 @@ describe('buildTxReadyFromToolOutput — bundled approve+wrap → multi-leg', ()
 
   it('FAILS CLOSED: needs_approval=true but approval_tx has no calldata → null', () => {
     const env = { ...depositWrapPlain(), needs_approval: true, approval_tx: { to: USDC_E, value: '0' } }
+    expect(buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, env)).toBeNull()
+  })
+
+  it('FAILS CLOSED: needs_approval=true but approval_tx carries an error marker → null', () => {
+    const env = {
+      ...depositWrapPlain(),
+      needs_approval: true,
+      approval_tx: { to: USDC_E, data: APPROVE_DATA, value: '0', error: 'simulated approve failure' },
+    }
     expect(buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, env)).toBeNull()
   })
 
@@ -226,8 +249,24 @@ describe('buildTxReadyFromToolOutput — non-tx envelopes are NEVER signed (the 
     expect(buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, { status: 'error', error: 'boom' })).toBeNull()
   })
 
+  it('rejects status:"error" even with a well-formed tx and no top-level error key', () => {
+    // isolates the `status === 'error'` branch from the `'error' in env` branch
+    const env = { ...setupTradingApprove(), status: 'error' }
+    expect(buildTxReadyFromToolOutput(POLYMARKET_SETUP_TRADING_TOOL, env)).toBeNull()
+  })
+
+  it('rejects when chain_id is present but chain is absent', () => {
+    const env = { chain_id: '137', to: USDC_E, value: '0', data: APPROVE_DATA }
+    expect(buildTxReadyFromToolOutput(POLYMARKET_SETUP_TRADING_TOOL, env)).toBeNull()
+  })
+
   it('rejects empty calldata "0x"', () => {
     const env = { ...setupTradingApprove(), data: '0x' }
+    expect(buildTxReadyFromToolOutput(POLYMARKET_SETUP_TRADING_TOOL, env)).toBeNull()
+  })
+
+  it('rejects odd-length (non-whole-byte) calldata', () => {
+    const env = { ...setupTradingApprove(), data: '0x095ea7b3a' } // 9 hex nibbles
     expect(buildTxReadyFromToolOutput(POLYMARKET_SETUP_TRADING_TOOL, env)).toBeNull()
   })
 

--- a/clients/cli/src/agent/__tests__/polymarketTxOutput.test.ts
+++ b/clients/cli/src/agent/__tests__/polymarketTxOutput.test.ts
@@ -137,6 +137,21 @@ describe('buildTxReadyFromToolOutput — valid flat envelopes → single-leg tx'
     expect(out?.tx).toMatchObject({ value: '0' })
   })
 
+  it('normalizes a malformed value to "0" (never reaches BigInt as-is)', () => {
+    // The tx is still signed (to+data are valid); only the malformed value is
+    // sanitized to '0' so executor's BigInt(value) can't throw / over-send.
+    const env = { ...setupTradingApprove(), value: 'not-a-number' }
+    const out = buildTxReadyFromToolOutput(POLYMARKET_SETUP_TRADING_TOOL, env)
+    expect(out?.tx).toMatchObject({ to: USDC_E, value: '0', data: APPROVE_DATA })
+  })
+
+  it('drops a malformed gas_limit (so the SDK estimates instead of throwing)', () => {
+    const env = { ...depositWrapPlain(), gas_limit: '250000 wei' }
+    const out = buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, env)
+    expect(out?.tx).toMatchObject({ to: ONRAMP, data: WRAP_DATA })
+    expect((out?.tx as Record<string, unknown>)?.gas_limit).toBeUndefined()
+  })
+
   it('marks the envelope __buildTx and passes the action through (for the confirm summary)', () => {
     const out = buildTxReadyFromToolOutput(POLYMARKET_DEPOSIT_TOOL, depositWrapPlain())
     expect(out?.__buildTx).toBe(true)
@@ -240,13 +255,6 @@ describe('buildTxReadyFromToolOutput — non-tx envelopes are NEVER signed (the 
   it('rejects a chain outside the Polymarket EVM allowlist', () => {
     const env = { ...setupTradingApprove(), chain: 'Ethereum', chain_id: '1' }
     expect(buildTxReadyFromToolOutput(POLYMARKET_SETUP_TRADING_TOOL, env)).toBeNull()
-  })
-
-  it('rejects a malformed value (non-integer) rather than signing it', () => {
-    // a malformed value must not reach BigInt(); the leg defaults value to '0'
-    const env = { ...setupTradingApprove(), value: 'not-a-number' }
-    const out = buildTxReadyFromToolOutput(POLYMARKET_SETUP_TRADING_TOOL, env)
-    expect(out?.tx).toMatchObject({ value: '0' })
   })
 
   it('rejects non-object output', () => {

--- a/clients/cli/src/agent/__tests__/sessionBuildTxFirstWins.test.ts
+++ b/clients/cli/src/agent/__tests__/sessionBuildTxFirstWins.test.ts
@@ -49,6 +49,7 @@ function makeHarness(txReadyPayloads: unknown[]) {
     onTxStatus: vi.fn(),
     onError: vi.fn(),
     onDone: vi.fn(),
+    onNotification: vi.fn(),
     requestPassword: vi.fn(async () => 'pw'),
     requestConfirmation: vi.fn(async () => true),
   }
@@ -74,7 +75,7 @@ function makeHarness(txReadyPayloads: unknown[]) {
     withAuthRetry: <T>(fn: () => Promise<T>) => fn(),
   }
   const run = () => (AgentSession.prototype as any).processMessageLoop.call(fakeThis, 'deposit $5', ui, 1)
-  return { run, storeServerTransaction, signTxFromBuffer }
+  return { run, storeServerTransaction, signTxFromBuffer, ui }
 }
 
 // Derived from the REAL bridge (not hand-written literals) so a shape change in
@@ -99,20 +100,24 @@ const TX_B = buildTxReadyFromToolOutput(POLYMARKET_SETUP_TRADING_TOOL, {
 })
 
 describe('processMessageLoop — first-wins for signable tx_ready (C1)', () => {
-  it('buffers + signs exactly once when a single tx_ready arrives', async () => {
+  it('buffers + signs exactly once when a single tx_ready arrives (no deferral notice)', async () => {
     const h = makeHarness([TX_A])
     await h.run()
     expect(h.storeServerTransaction).toHaveBeenCalledTimes(1)
     expect(h.storeServerTransaction).toHaveBeenCalledWith(TX_A)
     expect(h.signTxFromBuffer).toHaveBeenCalledTimes(1)
+    expect(h.ui.onNotification).not.toHaveBeenCalled()
   })
 
-  it('keeps the FIRST and drops the second when two tx_ready arrive in one turn', async () => {
+  it('keeps the FIRST, drops the second, and REPORTS the deferral when two arrive in one turn', async () => {
     const h = makeHarness([TX_A, TX_B])
     await h.run()
     // second frame never reaches the executor — no silent overwrite
     expect(h.storeServerTransaction).toHaveBeenCalledTimes(1)
     expect(h.storeServerTransaction).toHaveBeenCalledWith(TX_A)
     expect(h.signTxFromBuffer).toHaveBeenCalledTimes(1)
+    // the drop is reported (not silent under --yes), addressing the cross-model
+    // finding that a dropped distinct frame must not vanish unreported
+    expect(h.ui.onNotification).toHaveBeenCalledTimes(1)
   })
 })

--- a/clients/cli/src/agent/__tests__/sessionBuildTxFirstWins.test.ts
+++ b/clients/cli/src/agent/__tests__/sessionBuildTxFirstWins.test.ts
@@ -1,0 +1,99 @@
+// C1 regression: first-wins enforcement for signable tx_ready frames in a turn.
+//
+// The executor buffers a single 'latest' slot and signs it once after the
+// stream. The Design B build-tx bridge can surface a SECOND signable frame in
+// one turn (if the model chains two flat-builder calls). Without a guard the
+// second would overwrite the first and silently leave it unsigned. The session's
+// onTxReady must keep the FIRST and drop the rest — never a partial/wrong sign.
+//
+// Driven through processMessageLoop with a minimal `this`, mirroring
+// sessionTxConfirm/sessionConfirmGate.
+import { describe, expect, it, vi } from 'vitest'
+
+import { AgentSession } from '../session'
+import type { RecentAction } from '../types'
+
+function makeHarness(txReadyPayloads: unknown[]) {
+  const storeServerTransaction = vi.fn(() => true)
+  const signTxFromBuffer = vi.fn(
+    async () =>
+      ({
+        tool: 'sign_tx',
+        success: true,
+        data: { tx_hash: '0xfeed', chain: 'Polygon', explorer_url: 'https://x/1' },
+      }) as RecentAction
+  )
+  const client = {
+    sendMessageStream: vi.fn(async (_conv: string, _request: any, callbacks: any) => {
+      // Fire all payloads on the first turn only; later turns are plain text.
+      if (client.sendMessageStream.mock.calls.length === 1) {
+        for (const p of txReadyPayloads) callbacks.onTxReady(p)
+      }
+      return { message: { content: 'ok' }, fullText: '', transactions: [], disconnected: false }
+    }),
+  }
+  const executor = {
+    storeServerTransaction,
+    setPassword: vi.fn(),
+    getPendingSummary: () => 'contract call on Polygon to 0xR',
+    signTxFromBuffer,
+    clearPendingTransaction: vi.fn(),
+  }
+  const ui = {
+    onTextDelta: vi.fn(),
+    onToolCall: vi.fn(),
+    onToolResult: vi.fn(),
+    onAssistantMessage: vi.fn(),
+    onSuggestions: vi.fn(),
+    onTxStatus: vi.fn(),
+    onError: vi.fn(),
+    onDone: vi.fn(),
+    requestPassword: vi.fn(async () => 'pw'),
+    requestConfirmation: vi.fn(async () => true),
+  }
+  const fakeThis: any = {
+    conversationId: 'conv-1',
+    publicKey: 'pk-test',
+    cachedContext: { addresses: {} },
+    config: { password: 'pw', askMode: true, verbose: false },
+    pendingToolResults: [],
+    abortController: null,
+    client,
+    executor,
+    vault: undefined,
+    txConfirmPollIntervalMs: 0,
+    txConfirmMaxPolls: 1,
+    processMessageLoop: (AgentSession.prototype as any).processMessageLoop,
+    runPasswordGatedTool: (AgentSession.prototype as any).runPasswordGatedTool,
+    dispatchClientSideTool: (AgentSession.prototype as any).dispatchClientSideTool,
+    renderEchoedBalanceCard: (AgentSession.prototype as any).renderEchoedBalanceCard,
+    confirmBroadcastedTx: (AgentSession.prototype as any).confirmBroadcastedTx,
+    emitAndConfirmTx: (AgentSession.prototype as any).emitAndConfirmTx,
+    txConfirmSleep: (AgentSession.prototype as any).txConfirmSleep,
+    withAuthRetry: <T>(fn: () => Promise<T>) => fn(),
+  }
+  const run = () => (AgentSession.prototype as any).processMessageLoop.call(fakeThis, 'deposit $5', ui, 1)
+  return { run, storeServerTransaction, signTxFromBuffer }
+}
+
+const TX_A = { __buildTx: true, chain: 'Polygon', chain_id: '137', tx: { to: '0xA', value: '0', data: '0xaa' } }
+const TX_B = { __buildTx: true, chain: 'Polygon', chain_id: '137', tx: { to: '0xB', value: '0', data: '0xbb' } }
+
+describe('processMessageLoop — first-wins for signable tx_ready (C1)', () => {
+  it('buffers + signs exactly once when a single tx_ready arrives', async () => {
+    const h = makeHarness([TX_A])
+    await h.run()
+    expect(h.storeServerTransaction).toHaveBeenCalledTimes(1)
+    expect(h.storeServerTransaction).toHaveBeenCalledWith(TX_A)
+    expect(h.signTxFromBuffer).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the FIRST and drops the second when two tx_ready arrive in one turn', async () => {
+    const h = makeHarness([TX_A, TX_B])
+    await h.run()
+    // second frame never reaches the executor — no silent overwrite
+    expect(h.storeServerTransaction).toHaveBeenCalledTimes(1)
+    expect(h.storeServerTransaction).toHaveBeenCalledWith(TX_A)
+    expect(h.signTxFromBuffer).toHaveBeenCalledTimes(1)
+  })
+})

--- a/clients/cli/src/agent/__tests__/sessionBuildTxFirstWins.test.ts
+++ b/clients/cli/src/agent/__tests__/sessionBuildTxFirstWins.test.ts
@@ -10,6 +10,7 @@
 // sessionTxConfirm/sessionConfirmGate.
 import { describe, expect, it, vi } from 'vitest'
 
+import { buildTxReadyFromToolOutput, POLYMARKET_SETUP_TRADING_TOOL } from '../polymarketTxOutput'
 import { AgentSession } from '../session'
 import type { RecentAction } from '../types'
 
@@ -76,8 +77,26 @@ function makeHarness(txReadyPayloads: unknown[]) {
   return { run, storeServerTransaction, signTxFromBuffer }
 }
 
-const TX_A = { __buildTx: true, chain: 'Polygon', chain_id: '137', tx: { to: '0xA', value: '0', data: '0xaa' } }
-const TX_B = { __buildTx: true, chain: 'Polygon', chain_id: '137', tx: { to: '0xB', value: '0', data: '0xbb' } }
+// Derived from the REAL bridge (not hand-written literals) so a shape change in
+// buildTxReadyFromToolOutput is exercised on the session's onTxReady path too.
+const USDC_E = '0x2791bca1f2de4661ed88a30c99a7a9449aa84174'
+const SPENDER = '0x4bfb41d5b3570defd03c39a9a4d8de6bd8b8982e'
+const TX_A = buildTxReadyFromToolOutput(POLYMARKET_SETUP_TRADING_TOOL, {
+  chain: 'Polygon',
+  chain_id: '137',
+  to: USDC_E,
+  value: '0',
+  data: '0x095ea7b3' + '0'.repeat(120),
+  action: 'approve',
+})
+const TX_B = buildTxReadyFromToolOutput(POLYMARKET_SETUP_TRADING_TOOL, {
+  chain: 'Polygon',
+  chain_id: '137',
+  to: SPENDER,
+  value: '0',
+  data: '0x095ea7b3' + '1'.repeat(120),
+  action: 'approve',
+})
 
 describe('processMessageLoop — first-wins for signable tx_ready (C1)', () => {
   it('buffers + signs exactly once when a single tx_ready arrives', async () => {

--- a/clients/cli/src/agent/client.ts
+++ b/clients/cli/src/agent/client.ts
@@ -5,6 +5,7 @@
  * Supports both JSON and SSE streaming responses.
  */
 import { AgentErrorCode, inferAgentErrorCodeFromMessage, isAgentErrorCode } from './agentErrors'
+import { buildTxReadyFromToolOutput, CLI_BUILD_TX_TOOL_NAMES } from './polymarketTxOutput'
 import type {
   AuthTokenRequest,
   AuthTokenResponse,
@@ -606,7 +607,31 @@ export class AgentClient {
 
     const ok = deriveToolDoneOk(status, parsed.output)
     if (status && toolName) callbacks.onToolProgress?.(toolName, status, label, ok)
+    this.maybeSignBuildTxOutput(status, toolName, parsed.output, callbacks)
     if (status === 'done' && callId) toolNameByCallId.delete(callId)
+  }
+
+  /**
+   * Design B: sign Polymarket flat-tx-builder outputs the way the mobile app
+   * does. These tools deliberately don't set `producesCalldata`, so they emit
+   * NO `tx_ready` frame — their flat `{chain,chain_id,to,value,data}` envelope
+   * only rides the `tool-output-available` channel. When an allowlisted tool
+   * finishes, lift its flat tx into the EXISTING `onTxReady` pipeline. The
+   * bridge guards against non-tx results (`no_op` / `insufficient_usdce`) so
+   * those never reach the signer. The same tool can never also emit a real
+   * `tx_ready` (producesCalldata is OFF), so there is no double-sign path.
+   */
+  private maybeSignBuildTxOutput(
+    status: 'running' | 'done' | undefined,
+    toolName: string | undefined,
+    output: unknown,
+    callbacks: StreamCallbacks
+  ): void {
+    if (status !== 'done' || !toolName || !callbacks.onTxReady || !CLI_BUILD_TX_TOOL_NAMES.has(toolName)) return
+    const txReady = buildTxReadyFromToolOutput(toolName, output)
+    if (!txReady) return
+    if (this.verbose) process.stderr.write(`[SSE:build_tx] ${toolName} → onTxReady (signable flat tx)\n`)
+    callbacks.onTxReady(txReady)
   }
 
   private maybeEmitClientSideToolCall(

--- a/clients/cli/src/agent/executor.ts
+++ b/clients/cli/src/agent/executor.ts
@@ -315,6 +315,26 @@ export class AgentExecutor {
     if (!stored) return null
     const p = stored.payload as any
     const labels = (p?.resolved?.labels ?? {}) as Record<string, string>
+
+    // Design B: Polymarket flat-tx-builder bridge envelopes carry no swap/send
+    // token labels, so the generic summaries below degrade to "send ? to ?".
+    // Summarize the destination contract + value (and the bundled approval leg)
+    // so the confirm gate / `--yes` log always shows what is being signed. Keyed
+    // on the bridge's `__buildTx` marker so existing swap/send summaries are
+    // untouched. These are always contract calls (approve / wrap calldata).
+    if (p?.__buildTx) {
+      const action = typeof p?.action === 'string' && p.action ? ` [${p.action}]` : ''
+      if (p?.__multiLeg) {
+        const wrapTo = (p?.txArgs?.tx?.to as string) || '?'
+        return `contract call on ${stored.chain} to ${wrapTo} (+ token approval — 2 transactions)${action}`
+      }
+      const flat = (p?.tx ?? {}) as Record<string, unknown>
+      const to = typeof flat.to === 'string' ? flat.to : '?'
+      const valueRaw = typeof flat.value === 'string' ? flat.value : '0'
+      const valuePart = valueRaw && valueRaw !== '0' ? ` value ${valueRaw}` : ''
+      return `contract call on ${stored.chain} to ${to}${valuePart}${action}`
+    }
+
     const isSwap = !!(p?.approvalTxArgs || p?.swap_tx || labels.quote_summary || labels.to_token_symbol)
     if (isSwap) {
       // quote_summary already embeds the provider ("… via kyber"); only append

--- a/clients/cli/src/agent/polymarketTxOutput.ts
+++ b/clients/cli/src/agent/polymarketTxOutput.ts
@@ -1,0 +1,201 @@
+/**
+ * Polymarket flat-tx-builder output → signable `tx_ready` bridge (Design B).
+ *
+ * The headless CLI signs Polymarket flat-tx-builder tool outputs the SAME way
+ * the mobile app does. Mobile reads the flat transaction envelope an allowlisted
+ * tool emits and routes it through its `BUILD_TX_EXACT_TOOLS` sign path; this
+ * module is the CLI's peer: it reads the flat envelope off the
+ * `tool-output-available` SSE channel and feeds it into the EXISTING
+ * `onTxReady → storeServerTransaction → signTxFromBuffer` pipeline unchanged.
+ * The only intended difference from mobile is that the CLI auto-signs (under
+ * `--yes` / a cached password) instead of asking for a device tap.
+ *
+ * Why this is necessary (and safe):
+ *  - These tools deliberately do NOT set `producesCalldata` (kept OFF per the
+ *    mcp-ts m7 contract), so the backend emits NO `tx_ready` frame for them.
+ *    The flat `{chain, chain_id, to, value, data}` envelope is nonetheless
+ *    already on the wire, untouched, in the tool output (the safety seams are
+ *    flag-gated off, so nothing mutates it). This module is the only consumer
+ *    that turns that output into a signable tx — ZERO agent-backend / mcp-ts
+ *    change, ZERO mobile/scheduler blast radius.
+ *  - They are pure calldata builders (no server-side action on call), so signing
+ *    their output is correct — the same contract mobile relies on.
+ *
+ * The `extractNestedTx` helper the executor uses recognises a tx under
+ * `swap_tx | send_tx | tx | txArgs.tx` — NOT a bare top-level `{to,value,data}`.
+ * So a single flat envelope is wrapped as `{chain, chain_id, tx:{…}}`, and the
+ * bundled approve+wrap deposit envelope is mapped onto the executor's existing
+ * two-leg machinery (`approvalTxArgs` + `txArgs`, each carrying a nested `tx`),
+ * which signs approve→wrap with a receipt-wait between legs.
+ */
+import type { TxReadyPayload } from './types'
+
+/** Wrap USDC.e → pUSD (approve + wrap steps), flat calldata. */
+export const POLYMARKET_DEPOSIT_TOOL = 'polymarket_deposit'
+/** Next-missing pUSD spender approval, flat erc20_approve calldata. */
+export const POLYMARKET_SETUP_TRADING_TOOL = 'polymarket_setup_trading'
+
+/**
+ * Allowlist of FLAT-calldata Polymarket builder tools the CLI signs from the
+ * `tool-output-available` channel. Mirrors mobile's `BUILD_TX_EXACT_TOOLS`
+ * (flat-calldata subset). The parity test
+ * (`polymarketTxOutput.parity.test.ts`) pins the documented relationship to the
+ * mcp-ts m7 `OFF_CHAIN_SIGNABLE_TOOL_NAMES` so the two can't silently drift.
+ *
+ * Deliberately EXCLUDED:
+ *  - `polymarket_place_bet` — produces EIP-712 payloads (off-chain signatures),
+ *    NOT flat calldata; signed via a different path. (It IS in the mcp-ts m7
+ *    list, which enumerates off-chain-signable tools, not flat-calldata tools.)
+ *  - `polymarket_setup_deposit_wallet` — its signable output is an EIP-712 Batch
+ *    (typed data), signed via the existing `sign_typed_data` path.
+ */
+export const CLI_BUILD_TX_TOOL_NAMES: ReadonlySet<string> = new Set([
+  POLYMARKET_DEPOSIT_TOOL,
+  POLYMARKET_SETUP_TRADING_TOOL,
+])
+
+/**
+ * Chains the Polymarket flat-tx builders target. Polymarket is Polygon-only, so
+ * this pins the exact `(chain name ⇄ chain_id)` pair the envelope must carry. A
+ * malformed/unexpected envelope (wrong or disagreeing chain fields) is rejected
+ * up front so signing can NEVER be routed to the wrong EVM chain — the executor
+ * resolves chain from the envelope and `chain` (a string) silently wins over
+ * `chain_id` (executor.ts resolveChainFromTxReady / signEvmServerTx), so the
+ * bridge validates both agree before handing anything to the signer. Extend this
+ * map (and the guard test) if a builder ever legitimately targets a new chain.
+ */
+const POLYMARKET_EVM_CHAINS: ReadonlyMap<string, string> = new Map([['Polygon', '137']])
+
+/** Minimal flat EVM tx leg lifted out of a builder envelope. */
+type FlatLeg = { to: string; value: string; data: string; gas_limit?: string }
+
+/** A non-null, non-array plain object, parsing a JSON string if needed. The
+ *  backend forwards an MCP tool result as the already-unmarshalled object under
+ *  `output` (agent.go V1ToolOutputAvailable); we still accept a JSON string so a
+ *  stringified payload is handled identically. */
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value) as unknown
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : null
+    } catch {
+      return null
+    }
+  }
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : null
+}
+
+/** A 0x-prefixed 20-byte EVM address. */
+function isAddress(value: unknown): value is string {
+  return typeof value === 'string' && /^0x[0-9a-fA-F]{40}$/.test(value)
+}
+
+/** Non-empty 0x calldata carrying at least a 4-byte selector. Rejects `'0x'`
+ *  (empty) so a value-only / no-op envelope can never be mistaken for a call. */
+function isCalldata(value: unknown): value is string {
+  return typeof value === 'string' && /^0x[0-9a-fA-F]{8,}$/.test(value)
+}
+
+/** Normalise a tx `value` to a non-negative integer string the SDK can parse
+ *  with `BigInt(value)`. Anything malformed (negative, decimal, non-numeric)
+ *  defaults to `'0'`: the builder tools are always 0-value approve/wrap calls,
+ *  and defaulting low can only ever UNDER-send native value, never over-send,
+ *  while also avoiding a `BigInt()` parse throw at sign time. */
+function normalizeValue(value: unknown): string {
+  if (typeof value === 'number' && Number.isInteger(value) && value >= 0) return String(value)
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (/^(0x[0-9a-fA-F]+|\d+)$/.test(trimmed)) return trimmed
+  }
+  return '0'
+}
+
+/** Optional server gas_limit, as a string, when present and usable. */
+function normalizeGasLimit(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim() !== '') return value
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value)
+  return undefined
+}
+
+/**
+ * Lift a flat tx leg out of an envelope/leg object. Returns null unless BOTH a
+ * real `to` (0x address) and real `data` (≥4-byte calldata) are present — this
+ * is the guard that rejects every non-tx result (`{action:'no_op'}`,
+ * `{action:'insufficient_usdce'}`, error envelopes) so they are NEVER signed.
+ */
+function extractLeg(obj: Record<string, unknown>): FlatLeg | null {
+  if (!isAddress(obj.to) || !isCalldata(obj.data)) return null
+  const leg: FlatLeg = { to: obj.to, value: normalizeValue(obj.value), data: obj.data }
+  const gasLimit = normalizeGasLimit(obj.gas_limit)
+  if (gasLimit !== undefined) leg.gas_limit = gasLimit
+  return leg
+}
+
+/**
+ * Turn an allowlisted Polymarket tool's flat output envelope into a
+ * `tx_ready`-shaped payload the executor can sign, or `null` when the output
+ * carries no signable transaction (so the caller signs nothing).
+ *
+ * Returns null when:
+ *  - `toolName` is not in {@link CLI_BUILD_TX_TOOL_NAMES};
+ *  - the output is not a JSON object;
+ *  - the output is an error / status:error envelope;
+ *  - the output has no valid flat tx (`no_op` / `insufficient_usdce` / missing
+ *    `to`/`data`);
+ *  - the output claims `needs_approval` but carries no usable `approval_tx`
+ *    (fail closed: never sign the wrap leg alone against a stale allowance —
+ *    that is the funds-regression the bundled approve→wrap path exists to avoid).
+ *  - the envelope's `chain` / `chain_id` are missing or disagree, or name a
+ *    chain outside {@link POLYMARKET_EVM_CHAINS} (so signing can never be routed
+ *    to the wrong / a non-EVM chain).
+ */
+export function buildTxReadyFromToolOutput(toolName: string, output: unknown): TxReadyPayload | null {
+  if (!CLI_BUILD_TX_TOOL_NAMES.has(toolName)) return null
+
+  const env = asRecord(output)
+  if (!env) return null
+
+  // Never route an error/no-op envelope into the signer.
+  if (env.status === 'error' || 'error' in env) return null
+
+  const chain = typeof env.chain === 'string' && env.chain !== '' ? env.chain : undefined
+  const chainId =
+    typeof env.chain_id === 'string' && env.chain_id !== ''
+      ? env.chain_id
+      : typeof env.chain_id === 'number' && Number.isFinite(env.chain_id)
+        ? String(env.chain_id)
+        : undefined
+  // Require a known, self-consistent chain. mcp-ts always emits chain:'Polygon'
+  // + chain_id:'137'; reject anything where they're absent or disagree so a
+  // malformed envelope can't sign on the wrong chain (executor lets the `chain`
+  // string silently win over `chain_id`).
+  if (!chain || !chainId || POLYMARKET_EVM_CHAINS.get(chain) !== chainId) return null
+
+  // Passed through for the human-readable confirm-gate summary only (inert to
+  // the executor's signing path); e.g. 'approve' / 'wrap_usdce_to_pusd'.
+  const action = typeof env.action === 'string' && env.action !== '' ? env.action : undefined
+
+  const main = extractLeg(env)
+  if (!main) return null
+
+  // Bundled approve+wrap (deposit wrap step while USDC.e allowance is still
+  // insufficient): map onto the executor's EXISTING two-leg machinery so the
+  // approve is signed+confirmed (receipt-wait) BEFORE the wrap, never shipped as
+  // a single tx. `needs_approval` with a missing/invalid `approval_tx` fails
+  // closed (return null) — signing only the wrap would revert / regress funds.
+  if (env.needs_approval === true) {
+    const approval = asRecord(env.approval_tx)
+    const approveLeg = approval ? extractLeg(approval) : null
+    if (!approveLeg) return null
+    return {
+      __buildTx: true,
+      chain,
+      chain_id: chainId,
+      ...(action ? { action } : {}),
+      approvalTxArgs: { chain, chain_id: chainId, tx: approveLeg },
+      txArgs: { chain, chain_id: chainId, tx: main },
+    }
+  }
+
+  return { __buildTx: true, chain, chain_id: chainId, ...(action ? { action } : {}), tx: main }
+}

--- a/clients/cli/src/agent/polymarketTxOutput.ts
+++ b/clients/cli/src/agent/polymarketTxOutput.ts
@@ -90,10 +90,12 @@ function isAddress(value: unknown): value is string {
   return typeof value === 'string' && /^0x[0-9a-fA-F]{40}$/.test(value)
 }
 
-/** Non-empty 0x calldata carrying at least a 4-byte selector. Rejects `'0x'`
- *  (empty) so a value-only / no-op envelope can never be mistaken for a call. */
+/** Non-empty 0x calldata: whole bytes (even hex length) carrying at least a
+ *  4-byte selector. Rejects `'0x'` (empty), odd-length hex (never valid ABI
+ *  calldata), and any value-only / no-op envelope so it can't be mistaken for a
+ *  call. */
 function isCalldata(value: unknown): value is string {
-  return typeof value === 'string' && /^0x[0-9a-fA-F]{8,}$/.test(value)
+  return typeof value === 'string' && /^0x(?:[0-9a-fA-F]{2}){4,}$/.test(value)
 }
 
 /** Normalise a tx `value` to a non-negative integer string the SDK can parse
@@ -188,9 +190,17 @@ export function buildTxReadyFromToolOutput(toolName: string, output: unknown): T
   // approve is signed+confirmed (receipt-wait) BEFORE the wrap, never shipped as
   // a single tx. `needs_approval` with a missing/invalid `approval_tx` fails
   // closed (return null) — signing only the wrap would revert / regress funds.
-  if (env.needs_approval === true) {
+  // Truthy (not strict `=== true`): a non-boolean-truthy `needs_approval` (e.g.
+  // `1` / `'true'`) must still route through the fail-closed bundled path
+  // (which requires a valid approval_tx or returns null) — never fall through
+  // to signing the wrap leg alone against a stale allowance.
+  if (env.needs_approval) {
     const approval = asRecord(env.approval_tx)
-    const approveLeg = approval ? extractLeg(approval) : null
+    // Re-apply the top-level error gate to the nested approve leg (defense in
+    // depth): an approval_tx carrying an error marker must never be signed even
+    // if it happens to carry a well-formed to/data.
+    if (!approval || approval.status === 'error' || 'error' in approval) return null
+    const approveLeg = extractLeg(approval)
     if (!approveLeg) return null
     return {
       __buildTx: true,

--- a/clients/cli/src/agent/polymarketTxOutput.ts
+++ b/clients/cli/src/agent/polymarketTxOutput.ts
@@ -110,10 +110,15 @@ function normalizeValue(value: unknown): string {
   return '0'
 }
 
-/** Optional server gas_limit, as a string, when present and usable. */
+/** Optional server gas_limit as a non-negative integer string. Digit-guarded
+ *  like {@link normalizeValue} so a malformed value never reaches the executor's
+ *  `BigInt(swapTx.gas_limit)` (executor.ts patchEvmGas) — for the bundled path
+ *  that BigInt throw would land on the MAIN leg, AFTER the approve already
+ *  broadcast. A non-integer / unit-suffixed gas limit is dropped (undefined →
+ *  the SDK estimates gas itself) rather than passed through. */
 function normalizeGasLimit(value: unknown): string | undefined {
-  if (typeof value === 'string' && value.trim() !== '') return value
-  if (typeof value === 'number' && Number.isFinite(value)) return String(value)
+  if (typeof value === 'number' && Number.isInteger(value) && value > 0) return String(value)
+  if (typeof value === 'string' && /^\d+$/.test(value.trim())) return value.trim()
   return undefined
 }
 

--- a/clients/cli/src/agent/session.ts
+++ b/clients/cli/src/agent/session.ts
@@ -538,8 +538,14 @@ export class AgentSession {
         // frames deterministically re-emit on the next turn once their on-chain
         // precondition still holds — fail-safe, never a partial/wrong sign.
         if (serverTxStoredFromStream > 0) {
-          if (this.config.verbose)
-            process.stderr.write('[session] tx_ready ignored: one signable tx already buffered this turn\n')
+          // Unconditional (not verbose-gated): dropping a signable tx is
+          // significant enough to always surface, so it is never silent under
+          // `--yes` / non-verbose. The first frame still signs and the turn
+          // recurses; a dropped distinct frame re-emits next turn when its
+          // on-chain precondition still holds.
+          process.stderr.write(
+            '[session] additional signable tx_ready ignored this turn (one already buffered); it will re-emit next turn if still needed\n'
+          )
           return
         }
         if (this.executor.storeServerTransaction(tx)) {

--- a/clients/cli/src/agent/session.ts
+++ b/clients/cli/src/agent/session.ts
@@ -538,13 +538,25 @@ export class AgentSession {
         // frames deterministically re-emit on the next turn once their on-chain
         // precondition still holds — fail-safe, never a partial/wrong sign.
         if (serverTxStoredFromStream > 0) {
-          // Unconditional (not verbose-gated): dropping a signable tx is
-          // significant enough to always surface, so it is never silent under
-          // `--yes` / non-verbose. The first frame still signs and the turn
-          // recurses; a dropped distinct frame re-emits next turn when its
-          // on-chain precondition still holds.
+          // First-wins: the executor buffers a single 'latest' slot and signs it
+          // once after the stream, so a SECOND signable frame in the same turn
+          // would overwrite (and silently drop) the first. The legacy tx_ready
+          // channel is safe (backend emits ≤1/turn); the Design B build-tx bridge
+          // can surface a second frame if the model chains two flat-builder calls
+          // in one turn. Keep the FIRST (guaranteed forward progress — the
+          // multi-step deposit flow completes across turns via the recursion
+          // below) and REPORT the deferral so it is never silent: the dropped
+          // tool's output stays in the backend conversation, so the frame
+          // re-emerges on the next turn when its on-chain precondition still
+          // holds. We do NOT fail the turn (that risks a no-progress loop if the
+          // model re-emits both frames every turn) and we do NOT overwrite (that
+          // would drop the first, unsigned).
           process.stderr.write(
-            '[session] additional signable tx_ready ignored this turn (one already buffered); it will re-emit next turn if still needed\n'
+            '[session] additional signable tx deferred this turn (one already buffered); it will re-emit next turn if still needed\n'
+          )
+          ui.onNotification?.(
+            'Transaction deferred',
+            'Another signable transaction arrived in the same step; it was deferred and will be offered again on the next step.'
           )
           return
         }

--- a/clients/cli/src/agent/session.ts
+++ b/clients/cli/src/agent/session.ts
@@ -528,6 +528,20 @@ export class AgentSession {
         ui.onSuggestions(suggestions)
       },
       onTxReady: (tx: any) => {
+        // First-wins per turn. The executor buffers a single 'latest' slot and
+        // signs it once after the stream (below), so a SECOND signable tx in the
+        // same turn would overwrite the first and silently leave it unsigned.
+        // The legacy `tx_ready` channel is safe (backend emits ≤1/turn), but the
+        // Design B build-tx bridge can surface a second signable frame if the
+        // model chains two flat-builder calls in one turn. Keep the FIRST and
+        // drop the rest: signing the first recurses (depth+1) and the dropped
+        // frames deterministically re-emit on the next turn once their on-chain
+        // precondition still holds — fail-safe, never a partial/wrong sign.
+        if (serverTxStoredFromStream > 0) {
+          if (this.config.verbose)
+            process.stderr.write('[session] tx_ready ignored: one signable tx already buffered this turn\n')
+          return
+        }
         if (this.executor.storeServerTransaction(tx)) {
           serverTxStoredFromStream++
           if (this.config.password) {
@@ -605,11 +619,12 @@ export class AgentSession {
     // Routed straight to the executor (no Action wrapper); result is
     // pushed onto pendingToolResults and recursed for the next turn.
     //
-    // Backend contract: the agent emits at most one tx_ready per stream
-    // turn. storeServerTransaction overwrites a single 'latest' buffer
-    // slot — if the backend ever emits two tx_ready events in one turn,
-    // only the last would be signed. That is not a currently supported
-    // flow; multi-leg sequences use separate turns via recursion.
+    // One signable tx per turn. storeServerTransaction buffers a single
+    // 'latest' slot; the onTxReady handler above enforces first-wins so a
+    // second signable frame in the same turn can never overwrite (and silently
+    // drop) the first. Multi-leg approve→main sequences run within signMultiLeg;
+    // multi-step flows (e.g. deposit approve then wrap) advance across turns via
+    // the recursion below.
     if (serverTxStoredFromStream > 0) {
       if (this.config.verbose)
         process.stderr.write(

--- a/clients/cli/src/agent/types.ts
+++ b/clients/cli/src/agent/types.ts
@@ -302,6 +302,23 @@ export type TxReadyPayload = {
   swap_tx?: Record<string, unknown>
   send_tx?: Record<string, unknown>
   tx?: Record<string, unknown>
+  /**
+   * Multi-leg (approve + main) envelope legs. The executor's
+   * `storeServerTransaction` buffers both legs and `signMultiLeg` signs the
+   * approve, waits for its receipt, then signs the main leg. Each leg nests its
+   * own flat tx under `.tx`. Populated by the Polymarket build-tx bridge for a
+   * bundled deposit approve→wrap (see `polymarketTxOutput.ts`) and by mcp-ts
+   * `execute_*` envelopes.
+   */
+  approvalTxArgs?: Record<string, unknown>
+  txArgs?: Record<string, unknown>
+  /**
+   * Internal marker: this signable envelope was synthesized by the Polymarket
+   * flat-tx-builder bridge (`polymarketTxOutput.ts`) from a `tool-output-available`
+   * frame, not received on a `tx_ready` channel. Used only to render an accurate
+   * confirm-gate summary (`AgentExecutor.getPendingSummary`); inert to signing.
+   */
+  __buildTx?: boolean
 }
 
 export type TokenSearchResult = {


### PR DESCRIPTION
## Problem

On the headless SDK CLI path, the Polymarket flat-transaction builders —
`polymarket_deposit` (USDC.e → pUSD approve + wrap) and
`polymarket_setup_trading` (pUSD spender approvals) — could not be signed. These
tools deliberately do **not** set `producesCalldata`, so the backend emits no
`tx_ready` frame and the CLI had nothing to sign: the agent just narrated
"confirm in the app" and nothing happened, so a deposit wallet could never be
funded.

The mobile app signs these fine: it reads the flat
`{chain, chain_id, to, value, data}` envelope off the `tool-output-available`
channel for an allowlist (its `BUILD_TX_EXACT_TOOLS` path). That flat envelope is
already on the wire for the CLI too — it was just being read display-only and
discarded.

## Change (CLI-only)

Make the CLI a peer client on that signing path. It reads the same flat envelope
and feeds it into the **existing** `onTxReady → storeServerTransaction → sign`
pipeline. The only difference from mobile is that the CLI auto-signs (under
`--yes` / a cached password) instead of asking for a device tap. No
agent-backend or mcp-ts change.

- New `clients/cli/src/agent/polymarketTxOutput.ts`: the `CLI_BUILD_TX_TOOL_NAMES`
  allowlist + `buildTxReadyFromToolOutput`, wired into `client.ts`
  `handleToolProgress`.
- The executor's `extractNestedTx` reads a tx under `swap_tx|send_tx|tx|txArgs.tx`
  (not a bare top-level `{to,value,data}`), so a flat envelope is wrapped as
  `{chain, chain_id, tx:{…}}`.
- The bundled deposit approve→wrap envelope (`needs_approval` + `approval_tx`) is
  mapped onto the executor's existing two-leg machinery (`approvalTxArgs` +
  `txArgs`), so the approve confirms (receipt-wait) before the wrap — never
  shipped as a single tx.

## Safety

- **Guards** every non-transaction result (`no_op`, `insufficient_usdce`,
  errors, missing/wrong/disagreeing chain) so only a real flat tx is ever signed.
- **First-wins per turn**: a second signable frame in one turn can never silently
  overwrite (and drop) the first; the rest re-emit on the next turn.
- **Confirm summary**: `getPendingSummary` now understands the flat / multi-leg
  shapes, so the confirm gate and `--yes` log always show the destination
  contract + value.
- **Parity test** pins the CLI allowlist to the mcp-ts m7 source of truth, with
  the documented reconciliation (excludes EIP-712 `polymarket_place_bet`;
  includes the flat `polymarket_deposit`).

## Tests

39 new tests across `polymarketTxOutput`, the executor end-to-end signing path
(single-leg + bundled multi-leg, incl. fail-closed on receipt timeout), the
`client.ts` SSE bridge, the session first-wins guard, and the parity test. Full
CLI suite green (440 passing). `typecheck` / `check` (lint/knip/format) green.