### PR TITLE
Fix Solana blockhash broadcast freshness

### DIFF
--- a/.changeset/solana-blockhash-broadcast-retry.md
+++ b/.changeset/solana-blockhash-broadcast-retry.md
@@ -1,0 +1,7 @@
+---
+"@vultisig/core-chain": patch
+"@vultisig/core-mpc": patch
+"@vultisig/sdk": patch
+---
+
+Fetch Solana signing blockhashes at confirmed commitment and retry transient blockhash misses during standard RPC broadcast.

--- a/packages/core/chain/tx/broadcast/resolvers/solana.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/solana.test.ts
@@ -44,6 +44,30 @@ describe('broadcastSolanaTx', () => {
     })
   })
 
+  it('retries transient blockhash misses before accepting the standard RPC relay', async () => {
+    mocks.sendRawTransaction.mockRejectedValueOnce(new Error('Blockhash not found')).mockResolvedValue('rpc-signature')
+
+    await broadcastSolanaTx({ chain: Chain.Solana, tx })
+
+    expect(mocks.sendRawTransaction).toHaveBeenCalledTimes(2)
+    expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
+  })
+
+  it('routes persistent blockhash misses through hash verification after bounded retries', async () => {
+    const rpcError = new Error('BlockhashNotFound')
+    mocks.sendRawTransaction.mockRejectedValue(rpcError)
+    mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+
+    await broadcastSolanaTx({ chain: Chain.Solana, tx })
+
+    expect(mocks.sendRawTransaction).toHaveBeenCalledTimes(3)
+    expect(mocks.verifyBroadcastByHash).toHaveBeenCalledWith({
+      chain: Chain.Solana,
+      tx,
+      error: rpcError,
+    })
+  })
+
   it('falls back to standard RPC when JITO rejects the transaction', async () => {
     mocks.sendJitoTransaction.mockRejectedValue(new Error('jito unavailable'))
 

--- a/packages/core/chain/tx/broadcast/resolvers/solana.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/solana.test.ts
@@ -1,5 +1,5 @@
 import { SendTransactionError } from '@solana/web3.js'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   sendJitoTransaction: vi.fn(),
@@ -33,6 +33,10 @@ describe('broadcastSolanaTx', () => {
     mocks.sendRawTransaction.mockResolvedValue('rpc-signature')
   })
 
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('relays through standard RPC even when JITO accepts the transaction', async () => {
     await broadcastSolanaTx({ chain: Chain.Solana, tx })
 
@@ -45,20 +49,31 @@ describe('broadcastSolanaTx', () => {
   })
 
   it('retries transient blockhash misses before accepting the standard RPC relay', async () => {
+    vi.useFakeTimers()
     mocks.sendRawTransaction.mockRejectedValueOnce(new Error('Blockhash not found')).mockResolvedValue('rpc-signature')
 
-    await broadcastSolanaTx({ chain: Chain.Solana, tx })
+    const promise = broadcastSolanaTx({ chain: Chain.Solana, tx })
+
+    await vi.advanceTimersByTimeAsync(499)
+    expect(mocks.sendRawTransaction).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1)
+    await promise
 
     expect(mocks.sendRawTransaction).toHaveBeenCalledTimes(2)
     expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
   })
 
   it('routes persistent blockhash misses through hash verification after bounded retries', async () => {
+    vi.useFakeTimers()
     const rpcError = new Error('BlockhashNotFound')
     mocks.sendRawTransaction.mockRejectedValue(rpcError)
     mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
 
-    await broadcastSolanaTx({ chain: Chain.Solana, tx })
+    const promise = broadcastSolanaTx({ chain: Chain.Solana, tx })
+
+    await vi.advanceTimersByTimeAsync(1_500)
+    await promise
 
     expect(mocks.sendRawTransaction).toHaveBeenCalledTimes(3)
     expect(mocks.verifyBroadcastByHash).toHaveBeenCalledWith({
@@ -78,7 +93,7 @@ describe('broadcastSolanaTx', () => {
   })
 
   it('verifies by hash when standard RPC rejects after JITO acceptance', async () => {
-    const rpcError = new Error('blockhash not found')
+    const rpcError = new Error('rpc rejected')
     mocks.sendRawTransaction.mockRejectedValue(rpcError)
     mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
 

--- a/packages/core/chain/tx/broadcast/resolvers/solana.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/solana.ts
@@ -9,9 +9,12 @@ import { BroadcastTxResolver } from '../resolver'
 import { verifyBroadcastByHash } from '../verifyBroadcastByHash'
 
 const solanaStandardRpcMaxAttempts = 3
+const solanaStandardRpcRetryDelayMs = 500
 
 const isTransientBlockhashError = (error: unknown) =>
   isInError(error, 'Blockhash not found', 'blockhash not found', 'BlockhashNotFound')
+
+const wait = (durationMs: number) => new Promise(resolve => setTimeout(resolve, durationMs))
 
 /**
  * Hoists the on-chain rejection reason into a Solana send error's message.
@@ -49,6 +52,7 @@ const sendSolanaRawTransaction = async (rawTransaction: Uint8Array) => {
       return
     } catch (error) {
       if (isTransientBlockhashError(error) && attempt < solanaStandardRpcMaxAttempts) {
+        await wait(solanaStandardRpcRetryDelayMs * attempt)
         continue
       }
       throw error

--- a/packages/core/chain/tx/broadcast/resolvers/solana.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/solana.ts
@@ -8,6 +8,11 @@ import base58 from 'bs58'
 import { BroadcastTxResolver } from '../resolver'
 import { verifyBroadcastByHash } from '../verifyBroadcastByHash'
 
+const solanaStandardRpcMaxAttempts = 3
+
+const isTransientBlockhashError = (error: unknown) =>
+  isInError(error, 'Blockhash not found', 'blockhash not found', 'BlockhashNotFound')
+
 /**
  * Hoists the on-chain rejection reason into a Solana send error's message.
  *
@@ -32,6 +37,25 @@ const withSolanaBroadcastReason = (error: unknown): unknown => {
   return new Error([error.message, ...logs].join('\n'), { cause: error })
 }
 
+const sendSolanaRawTransaction = async (rawTransaction: Uint8Array) => {
+  const client = getSolanaClient()
+
+  for (let attempt = 1; attempt <= solanaStandardRpcMaxAttempts; attempt++) {
+    try {
+      await client.sendRawTransaction(rawTransaction, {
+        skipPreflight: false,
+        preflightCommitment: 'confirmed',
+      })
+      return
+    } catch (error) {
+      if (isTransientBlockhashError(error) && attempt < solanaStandardRpcMaxAttempts) {
+        continue
+      }
+      throw error
+    }
+  }
+}
+
 export const broadcastSolanaTx: BroadcastTxResolver<OtherChain.Solana> = async ({ chain, tx }) => {
   const rawTransaction = base58.decode(tx.encoded)
 
@@ -44,12 +68,8 @@ export const broadcastSolanaTx: BroadcastTxResolver<OtherChain.Solana> = async (
     console.warn('[solana] JITO sendTransaction failed, falling back to standard RPC:', err)
   }
 
-  const client = getSolanaClient()
   try {
-    await client.sendRawTransaction(rawTransaction, {
-      skipPreflight: false,
-      preflightCommitment: 'confirmed',
-    })
+    await sendSolanaRawTransaction(rawTransaction)
   } catch (error) {
     // A duplicate-signature error means the node already accepted this exact
     // signed transaction. Treat it as an idempotent success so a headless

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/solana/index.test.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/solana/index.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getDynamicPriorityFeePrice: vi.fn(),
+  getKeysignCoin: vi.fn(),
+  getLatestBlockhash: vi.fn(),
+}))
+
+vi.mock('@vultisig/core-chain/chains/solana/client', () => ({
+  getSolanaClient: () => ({
+    getLatestBlockhash: mocks.getLatestBlockhash,
+  }),
+}))
+
+vi.mock('@vultisig/core-chain/chains/solana/getDynamicPriorityFeePrice', () => ({
+  getDynamicPriorityFeePrice: mocks.getDynamicPriorityFeePrice,
+}))
+
+vi.mock('../../../utils/getKeysignCoin', () => ({
+  getKeysignCoin: mocks.getKeysignCoin,
+}))
+
+import { Chain } from '@vultisig/core-chain/Chain'
+import { getSolanaChainSpecific } from '.'
+
+describe('getSolanaChainSpecific', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getLatestBlockhash.mockResolvedValue({ blockhash: 'confirmed-blockhash' })
+    mocks.getDynamicPriorityFeePrice.mockResolvedValue(123n)
+    mocks.getKeysignCoin.mockReturnValue({
+      address: '7Zb1h3Z4vYtHk1qSQ9HAtpNQJ4T4r1CqWn2zPnyjF4Lt',
+      chain: Chain.Solana,
+    })
+  })
+
+  it('fetches the Solana signing blockhash at confirmed commitment', async () => {
+    const result = await getSolanaChainSpecific({
+      keysignPayload: {
+        toAddress: '',
+      },
+    } as any)
+
+    expect(mocks.getLatestBlockhash).toHaveBeenCalledWith('confirmed')
+    expect(result.recentBlockHash).toBe('confirmed-blockhash')
+  })
+})

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/solana/index.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/solana/index.ts
@@ -21,7 +21,7 @@ export const getSolanaChainSpecific: GetChainSpecificResolver<'solanaSpecific'> 
   const receiver = keysignPayload.toAddress || undefined
   const client = getSolanaClient()
 
-  const recentBlockHash = (await client.getLatestBlockhash()).blockhash
+  const recentBlockHash = (await client.getLatestBlockhash('confirmed')).blockhash
 
   const chainSpecific = create(SolanaSpecificSchema, {
     recentBlockHash,


### PR DESCRIPTION
Closes #4248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Solana standard RPC broadcasting now retries transient “blockhash not found” failures before falling back, improving reliability.
  * Solana key-signing chain details now fetch the latest blockhash using `confirmed` commitment, reducing stale-blockhash errors.

* **Tests**
  * Added unit tests covering Solana blockhash-miss retry behavior (including bounded retries and fallback routing).
  * Added tests verifying `confirmed` commitment usage for Solana chain-specific blockhash fetching.

* **Chores**
  * Updated package versions with patch bumps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->