### PR TITLE
fix(terra-classic): align send gas limit with iOS/Android for cross-device co-signing

### DIFF
--- a/.changeset/terraclassic-gas-limit-cross-device.md
+++ b/.changeset/terraclassic-gas-limit-cross-device.md
@@ -1,0 +1,11 @@
+---
+"@vultisig/core-chain": patch
+"@vultisig/sdk": patch
+---
+
+fix(terra-classic): align send gas limit with iOS/Android for cross-device co-signing
+
+Corrects the Terra Classic send gas limit in `cosmosGasLimitRecord` so it matches
+the values used by the iOS and Android clients. When co-signing across devices, a
+mismatched gas limit produces a different transaction hash and the signing session
+fails; aligning the record keeps the payload identical across platforms.

--- a/packages/core/chain/chains/cosmos/cosmosGasLimitRecord.test.ts
+++ b/packages/core/chain/chains/cosmos/cosmosGasLimitRecord.test.ts
@@ -6,7 +6,15 @@ import { getCosmosGasLimit, getCosmosStakingGasLimit } from './cosmosGasLimitRec
 describe('cosmosGasLimitRecord', () => {
   it('keeps existing send gas limits unchanged', () => {
     expect(getCosmosGasLimit({ chain: Chain.Cosmos })).toBe(200_000n)
-    expect(getCosmosGasLimit({ chain: Chain.TerraClassic, id: 'uusd' })).toBe(1_000_000n)
+  })
+
+  it('uses 300000 for every TerraClassic send denom to match iOS/Android SignDoc', () => {
+    // The gas limit is part of the pre-sign image; iOS (TerraHelperStruct)
+    // and Android (CosmosHelper.getChainGasLimit) hardcode 300000 for all
+    // columbus-5 sends, so cross-device co-signing requires the same value
+    // here regardless of denom (uluna, uusd, ...).
+    expect(getCosmosGasLimit({ chain: Chain.TerraClassic, id: 'uluna' })).toBe(300_000n)
+    expect(getCosmosGasLimit({ chain: Chain.TerraClassic, id: 'uusd' })).toBe(300_000n)
   })
 
   it('returns higher staking gas limits and scales bulk reward claim messages', () => {

--- a/packages/core/chain/chains/cosmos/cosmosGasLimitRecord.ts
+++ b/packages/core/chain/chains/cosmos/cosmosGasLimitRecord.ts
@@ -1,6 +1,6 @@
 import { Chain, CosmosChain, IbcEnabledCosmosChain } from '@vultisig/core-chain/Chain'
 
-import { areEqualCoins, CoinKey } from '../../coin/Coin'
+import { CoinKey } from '../../coin/Coin'
 
 const cosmosGasLimitRecord: Record<CosmosChain, bigint> = {
   [Chain.Cosmos]: 200000n,
@@ -10,22 +10,20 @@ const cosmosGasLimitRecord: Record<CosmosChain, bigint> = {
   [Chain.Noble]: 200000n,
   [Chain.Akash]: 200000n,
   [Chain.Terra]: 300000n,
-  // TerraClassic default covers both bank.MsgSend (uluna ~80k) and
-  // ibc.MsgTransfer (~150-200k), with margin for chain load. uusd
-  // (USTC) MsgSend has its own 1M override below for the burn-tax /
-  // treasury post-handler path; IBC `MsgTransfer` is exempt from the
-  // burn tax (per classic-terra/core fee_tax.go::FilterMsgAndComputeTax)
-  // so it falls through to this default.
-  [Chain.TerraClassic]: 400000n,
+  // TerraClassic must stay byte-for-byte in sync with iOS
+  // (TerraHelperStruct.GasLimit) and Android (CosmosHelper.getChainGasLimit)
+  // so cross-device co-signing produces the same SignDoc — the gas limit is
+  // part of the pre-sign image. Both mobile clients hardcode 300000 for
+  // every columbus-5 send denom (uluna, uusd bank denoms, IBC transfers,
+  // wasm), so this is a single value with no per-denom override. The burn
+  // tax on non-uluna bank denoms is carried in the fee AMOUNT (precomputed
+  // upstream), not the gas limit.
+  [Chain.TerraClassic]: 300000n,
   [Chain.THORChain]: 20000000n,
   [Chain.MayaChain]: 2000000000n,
 }
 
 export const getCosmosGasLimit = (coin: CoinKey<CosmosChain>): bigint => {
-  if (areEqualCoins(coin, { chain: Chain.TerraClassic, id: 'uusd' })) {
-    return 1_000_000n
-  }
-
   return cosmosGasLimitRecord[coin.chain]
 }
 

--- a/packages/sdk/tests/unit/tools/gas/cosmos.test.ts
+++ b/packages/sdk/tests/unit/tools/gas/cosmos.test.ts
@@ -96,8 +96,8 @@ describe('getCosmosGasLimit (re-export from core-chain)', () => {
     expect(getCosmosGasLimit({ chain: Chain.Osmosis, id: 'uosmo' })).toBe(300_000n)
   })
 
-  it('applies the TerraClassic uusd burn-tax override (1M)', () => {
-    expect(getCosmosGasLimit({ chain: Chain.TerraClassic, id: 'uusd' })).toBe(1_000_000n)
-    expect(getCosmosGasLimit({ chain: Chain.TerraClassic, id: 'uluna' })).toBe(400_000n)
+  it('uses 300000 for all TerraClassic send denoms (matches iOS/Android SignDoc)', () => {
+    expect(getCosmosGasLimit({ chain: Chain.TerraClassic, id: 'uusd' })).toBe(300_000n)
+    expect(getCosmosGasLimit({ chain: Chain.TerraClassic, id: 'uluna' })).toBe(300_000n)
   })
 })


### PR DESCRIPTION
## Problem

Sending LUNC (and other TerraClassic denoms) between a Windows device and an iOS/Android device fails to complete co-signing. The `preKeysignImage` (pre-sign hash) generated by Windows differs from the one generated by mobile, so the MPC signature can't be assembled.

## Root cause

The fee **gas limit** is serialized into the Cosmos `SignDoc` (`AuthInfo.fee.gas_limit`), which is hashed into the pre-sign image. Everything else in the TerraClassic `SigningInput` was already byte-identical across platforms — only the gas limit differed:

| Platform | Gas limit (TerraClassic send) | Source |
|---|---|---|
| iOS | **300000** | `TerraHelperStruct.GasLimit` |
| Android | **300000** | `CosmosHelper.getChainGasLimit()` |
| Windows (this SDK) | **400000** (and **1_000_000** for `uusd`) ❌ | `cosmosGasLimitRecord` / `getCosmosGasLimit` |

A differing gas limit → different SignDoc → different pre-sign hash → co-signing fails.

## Fix

- `Chain.TerraClassic`: `400000n` → `300000n`
- Removed the `uusd → 1_000_000n` override in `getCosmosGasLimit` (mobile uses 300000 for USTC too, so that override broke cross-device USTC sends identically)
- Removed the now-unused `areEqualCoins` import

Both mobile clients hardcode 300000 for every columbus-5 send denom (uluna, uusd bank denoms, IBC transfers, wasm). The burn tax on non-uluna bank denoms is carried in the fee **amount** (precomputed upstream), not the gas limit, so a single gas value with no per-denom override is correct.

## Tests

Updated the two tests that pinned the old values, then ran them:

- `packages/core/chain/chains/cosmos/cosmosGasLimitRecord.test.ts` — ✅ 5 passed
- `packages/sdk/tests/unit/tools/gas/cosmos.test.ts` — ✅ 13 passed
- SDK typecheck ✅ clean
- ESLint ✅ clean on changed files

## Follow-up (consumer side)

After merge, publish `@vultisig/core-chain` and bump the dependency in `vultisig-windows` to pick up the corrected gas limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized TerraClassic send gas limits so both supported denoms now use the same fixed value.
  * Improved cross-device compatibility by aligning gas-limit behavior with signing expectations, reducing session/signature issues.
* **Tests**
  * Updated unit and suite assertions to reflect the new uniform TerraClassic gas limit.
* **Documentation**
  * Added a release note entry for the TerraClassic gas-limit fix and patch releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->