### PR TITLE
[SPIKE — DO NOT MERGE] deterministic `vultisig polymarket buy` prototype (Path B)

### DIFF
--- a/clients/cli/src/agent/pmSpikeMcp.ts
+++ b/clients/cli/src/agent/pmSpikeMcp.ts
@@ -1,0 +1,136 @@
+/**
+ * ⚠️ SPIKE / THROWAWAY — NOT FOR MERGE ⚠️
+ *
+ * Minimal MCP-over-HTTP (streamable JSON-RPC) client, just enough to drive the
+ * mcp-ts Polymarket build→submit primitives DIRECTLY from the CLI, with the LLM
+ * removed from the loop. This is the deterministic Path-B wiring proof for the
+ * spike documented in
+ *   .claude/knowledge/tasks/010726-spike-protocol-commands-report.md
+ *
+ * We hand-roll the JSON-RPC handshake (initialize → notifications/initialized →
+ * tools/call) over `fetch` rather than pull in `@modelcontextprotocol/sdk` as a
+ * new CLI dependency — a spike shouldn't touch the dependency graph. mcp-ts runs
+ * its `/mcp` transport with `enableJsonResponse: true`, so `tools/call` returns
+ * plain JSON-RPC (not SSE); we still tolerate an SSE-framed body defensively.
+ *
+ * A real implementation would use the official MCP client (session management,
+ * reconnect, cancellation) — see the report's "recommended shape".
+ */
+
+type JsonRpcResult = {
+  jsonrpc: '2.0'
+  id: number
+  result?: unknown
+  error?: { code: number; message: string; data?: unknown }
+}
+
+/** A parsed mcp-ts tool result (the `content[0].text` JSON, already decoded). */
+export type McpToolResult = Record<string, unknown>
+
+export class PmSpikeMcpClient {
+  private readonly baseUrl: string
+  private readonly authToken?: string
+  private sessionId: string | null = null
+  private nextId = 1
+  readonly verbose: boolean
+
+  constructor(baseUrl: string, opts?: { authToken?: string; verbose?: boolean }) {
+    this.baseUrl = baseUrl.replace(/\/+$/, '')
+    this.authToken = opts?.authToken
+    this.verbose = !!opts?.verbose
+  }
+
+  private log(msg: string): void {
+    if (this.verbose) process.stderr.write(`[pm-spike-mcp] ${msg}\n`)
+  }
+
+  private headers(): Record<string, string> {
+    const h: Record<string, string> = {
+      'Content-Type': 'application/json',
+      // mcp-ts's WebStandardStreamableHTTP transport requires BOTH be accepted.
+      Accept: 'application/json, text/event-stream',
+    }
+    if (this.authToken) h.Authorization = `Bearer ${this.authToken}`
+    if (this.sessionId) h['mcp-session-id'] = this.sessionId
+    return h
+  }
+
+  /** Decode a `/mcp` response body, tolerating either raw JSON (enableJsonResponse)
+   *  or an SSE-framed `data:` line carrying the JSON-RPC envelope. */
+  private static decodeBody(raw: string): JsonRpcResult | null {
+    const trimmed = raw.trim()
+    if (!trimmed) return null
+    if (trimmed.startsWith('{')) return JSON.parse(trimmed) as JsonRpcResult
+    // SSE frame: pull the last `data:` line and parse it.
+    const dataLine = trimmed
+      .split('\n')
+      .map(l => l.trim())
+      .filter(l => l.startsWith('data:'))
+      .map(l => l.slice(5).trim())
+      .pop()
+    return dataLine ? (JSON.parse(dataLine) as JsonRpcResult) : null
+  }
+
+  /** Run the initialize handshake and capture the server-assigned session id. */
+  async connect(): Promise<void> {
+    const res = await fetch(`${this.baseUrl}/mcp`, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: this.nextId++,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'vsig-pm-spike', version: '0.0.0' },
+        },
+      }),
+    })
+    if (!res.ok) throw new Error(`MCP initialize failed (${res.status}): ${await res.text()}`)
+    this.sessionId = res.headers.get('mcp-session-id')
+    this.log(`initialized, session=${this.sessionId ?? '(none)'}`)
+
+    // Fire the initialized notification (no id, no response body expected).
+    await fetch(`${this.baseUrl}/mcp`, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized', params: {} }),
+    }).catch(() => undefined)
+  }
+
+  /** Call a tool and return its decoded JSON payload (the `content[0].text` JSON,
+   *  or the structured content). Throws on a JSON-RPC / transport error. */
+  async callTool(name: string, args: Record<string, unknown>): Promise<McpToolResult> {
+    if (!this.sessionId) await this.connect()
+    this.log(`tools/call ${name} ${JSON.stringify(args)}`)
+    const res = await fetch(`${this.baseUrl}/mcp`, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: this.nextId++,
+        method: 'tools/call',
+        params: { name, arguments: args },
+      }),
+    })
+    const raw = await res.text()
+    if (!res.ok) throw new Error(`MCP tools/call ${name} failed (${res.status}): ${raw}`)
+    const decoded = PmSpikeMcpClient.decodeBody(raw)
+    if (!decoded) throw new Error(`MCP tools/call ${name}: empty/unparseable response: ${raw.slice(0, 400)}`)
+    if (decoded.error) throw new Error(`MCP tools/call ${name} error ${decoded.error.code}: ${decoded.error.message}`)
+
+    const result = decoded.result as { content?: Array<{ type: string; text?: string }>; isError?: boolean } | undefined
+    const textPart = result?.content?.find(c => c.type === 'text')?.text
+    if (textPart) {
+      try {
+        return JSON.parse(textPart) as McpToolResult
+      } catch {
+        // A textError() result is plain prose, not JSON — surface it as an error.
+        throw new Error(`MCP tool ${name} returned a text error: ${textPart}`)
+      }
+    }
+    // No text content — return the raw result envelope for the caller to inspect.
+    return (result ?? {}) as McpToolResult
+  }
+}

--- a/clients/cli/src/commands/index.ts
+++ b/clients/cli/src/commands/index.ts
@@ -29,6 +29,10 @@ export { executeSignBytes, signBytes } from './sign'
 export type { BroadcastRawParams, BroadcastRawResult } from './broadcast'
 export { executeBroadcast } from './broadcast'
 
+// ⚠️ SPIKE / THROWAWAY — deterministic Polymarket protocol commands (Path B).
+export type { PolymarketBuyParams } from './polymarket'
+export { executePolymarketBuy } from './polymarket'
+
 // Transaction status command
 export type { TxStatusParams } from './tx-status'
 export { executeTxStatus } from './tx-status'

--- a/clients/cli/src/commands/polymarket.ts
+++ b/clients/cli/src/commands/polymarket.ts
@@ -1,0 +1,185 @@
+/**
+ * ⚠️ SPIKE / THROWAWAY — NOT FOR MERGE ⚠️
+ *
+ * Deterministic Polymarket protocol command (Path B) — prototype of
+ *   vultisig polymarket buy --token-id X --price 0.80 --size 10 [--tif ioc|gtc]
+ *
+ * Proves the wiring for a build→sign→submit flow with the LLM REMOVED:
+ *   1. BUILD   — call mcp-ts `polymarket_place_bet` directly over MCP/HTTP.
+ *                It returns `sign_action.params.payloads` (the Order + ClobAuth
+ *                EIP-712 payloads) and an `order_ref`; the order struct is held
+ *                server-side in the mcp-ts process, keyed by order_ref.
+ *   2. SIGN    — MPC-sign both payloads LOCALLY via the CLI's existing
+ *                AgentExecutor.signTypedData (vault.signBytes → VultiServer co-sign).
+ *   3. SUBMIT  — call mcp-ts `polymarket_submit_order` with order_ref + the two
+ *                signatures. Handles the `needs_fresh_auth` re-sign loop (the L1
+ *                ClobAuth timestamp has a ~180s window).
+ *
+ * See the spike report:
+ *   .claude/knowledge/tasks/010726-spike-protocol-commands-report.md
+ *
+ * STUBS / ASSUMPTIONS (noted in the report):
+ *  - `--token-id` is passed to place_bet as `token_id`, which ASSUMES §A
+ *    (mcp-ts PR #727, branch fix/pm-placebet-token-id) has landed. On current
+ *    mcp-ts `origin/main`, place_bet resolves via (event_slug, outcome) instead,
+ *    so `--event-slug`/`--outcome` are accepted as a fallback to exercise the
+ *    wiring against a stock mcp-ts.
+ *  - `--tif ioc|gtc` is accepted and forwarded as `order_type`, but stock
+ *    place_bet ignores it (always builds a marketable, cross-the-spread order).
+ *    Real IOC/FOK is a §A dependency.
+ */
+import type { VaultBase } from '@vultisig/sdk'
+import { Chain } from '@vultisig/sdk'
+
+import { AgentExecutor } from '../agent/executor'
+import { PmSpikeMcpClient } from '../agent/pmSpikeMcp'
+import type { CommandContext } from '../core'
+import { ensureVaultUnlocked } from '../core'
+import { info, isJsonOutput, outputJson } from '../lib/output'
+
+export type PolymarketBuyParams = {
+  tokenId?: string
+  price?: number
+  size: number
+  tif?: 'ioc' | 'gtc'
+  // §A-missing fallback so the prototype runs against stock mcp-ts main:
+  eventSlug?: string
+  outcome?: string
+  password?: string
+  verbose?: boolean
+}
+
+type SignatureEntry = {
+  id: string
+  signature: string
+  [k: string]: unknown
+}
+
+/** Resolve the mcp-ts base URL for the spike. Defaults to the local dev port. */
+function resolveMcpUrl(): string {
+  return process.env.PM_SPIKE_MCP_URL || process.env.MCP_SERVER_URL || 'http://127.0.0.1:9091'
+}
+
+/**
+ * Deterministic Polymarket BUY — build → MPC-sign → submit, no LLM.
+ */
+export async function executePolymarketBuy(ctx: CommandContext, params: PolymarketBuyParams): Promise<unknown> {
+  const vault = await ctx.ensureActiveVault()
+  await ensureVaultUnlocked(vault, params.password)
+
+  const makerAddress = await vault.address(Chain.Polygon)
+  const mcp = new PmSpikeMcpClient(resolveMcpUrl(), {
+    authToken: process.env.MCP_INBOUND_TOKEN,
+    verbose: params.verbose,
+  })
+
+  // ── 1. BUILD ───────────────────────────────────────────────────────────────
+  // Assemble place_bet args deterministically from the caller's exact params.
+  const buildArgs: Record<string, unknown> = {
+    side: 'buy',
+    maker_address: makerAddress,
+    amount: params.size, // shares
+  }
+  if (params.tokenId) buildArgs.token_id = params.tokenId // §A path
+  if (params.eventSlug) buildArgs.event_slug = params.eventSlug // fallback
+  if (params.outcome) buildArgs.outcome = params.outcome // fallback
+  if (params.price !== undefined) buildArgs.price = params.price
+  if (params.tif) buildArgs.order_type = params.tif // §A-dependent; ignored by stock main
+
+  if (!params.tokenId && !(params.eventSlug && params.outcome)) {
+    throw new Error(
+      'polymarket buy: provide --token-id (requires §A) or, against stock mcp-ts, --event-slug and --outcome.'
+    )
+  }
+
+  info('→ building order via mcp-ts polymarket_place_bet …')
+  const built = await mcp.callTool('polymarket_place_bet', buildArgs)
+
+  if (built.action === 'fund' || built.status === 'needs_funding') {
+    throw new Error(
+      `Deposit wallet underfunded: ${String(built.message ?? 'needs funding')} ` +
+        `(deposit_wallet=${String(built.deposit_wallet ?? '?')})`
+    )
+  }
+  const orderRef = built.order_ref as string | undefined
+  const signAction = built.sign_action as { params?: { payloads?: unknown[] } } | undefined
+  const payloads = signAction?.params?.payloads
+  if (!orderRef || !Array.isArray(payloads) || payloads.length === 0) {
+    throw new Error(`place_bet did not return an order_ref + sign payloads. Got: ${JSON.stringify(built).slice(0, 600)}`)
+  }
+  info(`  order_ref=${orderRef}  ${String(built.summary ?? '')}`)
+
+  // ── 2. SIGN (local MPC) ──────────────────────────────────────────────────────
+  info('→ MPC-signing Order + ClobAuth locally …')
+  const signatures = await signPayloads(vault, ctx, params, payloads)
+  const orderSig = signatures.find(s => s.id === 'order')?.signature
+  let authSig = signatures.find(s => s.id === 'auth')?.signature
+  if (!orderSig || !authSig) {
+    throw new Error(`signing did not yield both order + auth signatures. Got ids: ${signatures.map(s => s.id).join(',')}`)
+  }
+
+  // ── 3. SUBMIT (with fresh-auth re-sign loop) ─────────────────────────────────
+  // Allow ONE re-sign of a stale ClobAuth, then require a terminal result. A
+  // freshly re-signed auth that STILL comes back needs_fresh_auth must fail
+  // loudly rather than fall through to a false "ok" — the order was never
+  // accepted by the CLOB. (Codex signing sanity pass, 2026-07-02.)
+  info('→ submitting to CLOB via mcp-ts polymarket_submit_order …')
+  const MAX_SUBMIT_ATTEMPTS = 2
+  let submitResult: Record<string, unknown> | null = null
+  for (let attempt = 0; attempt < MAX_SUBMIT_ATTEMPTS; attempt++) {
+    const res = await mcp.callTool('polymarket_submit_order', {
+      order_ref: orderRef,
+      order_signature: orderSig,
+      auth_signature: authSig,
+      address: makerAddress,
+    })
+    if (res.status === 'needs_fresh_auth' && res.auth_payload) {
+      if (attempt === MAX_SUBMIT_ATTEMPTS - 1) {
+        // No attempts left — a re-signed auth still stale means we never got a
+        // terminal submit. Do NOT report success.
+        throw new Error('polymarket submit: auth still stale after re-sign — order was not submitted')
+      }
+      // The L1 ClobAuth timestamp went stale; re-sign the fresh payload and retry.
+      info('  auth stale — re-signing fresh ClobAuth …')
+      const fresh = await signPayloads(vault, ctx, params, [res.auth_payload])
+      const freshAuth = fresh.find(s => s.id === 'auth' || s.id === 'default')?.signature
+      if (!freshAuth) throw new Error('could not re-sign fresh ClobAuth payload')
+      authSig = freshAuth
+      continue
+    }
+    submitResult = res
+    break
+  }
+  if (!submitResult) {
+    throw new Error('polymarket submit: no terminal result from polymarket_submit_order')
+  }
+
+  const out = {
+    ok: submitResult.status !== 'error',
+    order_ref: orderRef,
+    maker_address: makerAddress,
+    build_summary: built.summary,
+    submit: submitResult,
+  }
+  if (isJsonOutput()) outputJson(out)
+  else info(`✓ done: ${JSON.stringify(submitResult)}`)
+  return out
+}
+
+/** MPC-sign a payloads array through the CLI's real signing path (AgentExecutor). */
+async function signPayloads(
+  vault: VaultBase,
+  ctx: CommandContext,
+  params: PolymarketBuyParams,
+  payloads: unknown[]
+): Promise<SignatureEntry[]> {
+  const executor = new AgentExecutor(vault, !!params.verbose, vault.publicKeys.ecdsa, ctx.sdk)
+  if (params.password) executor.setPassword(params.password)
+  const action = await executor.signTypedData('pm-spike', { payloads })
+  if (!action.success) {
+    throw new Error(`sign_typed_data failed: ${JSON.stringify(action.data)}`)
+  }
+  const sigs = (action.data as { signatures?: SignatureEntry[] }).signatures
+  if (!sigs || sigs.length === 0) throw new Error('sign_typed_data returned no signatures')
+  return sigs
+}

--- a/clients/cli/src/index.ts
+++ b/clients/cli/src/index.ts
@@ -37,6 +37,7 @@ import {
   executeImport,
   executeInfo,
   executeJoinSecure,
+  executePolymarketBuy,
   executePortfolio,
   executeRename,
   executeRujiraBalance,
@@ -740,6 +741,45 @@ program
         password: options.password,
       })
     })
+  )
+
+// ⚠️ SPIKE / THROWAWAY — deterministic Polymarket protocol commands (Path B).
+// Prototype: build→MPC-sign→submit with the LLM removed. Not for merge.
+const polymarketCmd = program.command('polymarket').description('[SPIKE] Deterministic Polymarket protocol commands')
+polymarketCmd
+  .command('buy')
+  .description('[SPIKE] Build, MPC-sign, and submit a Polymarket buy order deterministically (no LLM)')
+  .option('--token-id <id>', 'CLOB token id to buy (requires §A place_bet token_id support)')
+  .option('--price <price>', 'Limit price per share, 0-1 (omit for marketable)', parseFloat)
+  .requiredOption('--size <shares>', 'Number of outcome shares to buy', parseFloat)
+  .option('--tif <tif>', 'Time-in-force: ioc|gtc (§A-dependent; ignored by stock mcp-ts)')
+  .option('--event-slug <slug>', 'Fallback: event slug (used when --token-id/§A is unavailable)')
+  .option('--outcome <outcome>', 'Fallback: outcome name (paired with --event-slug)')
+  .option('--password <password>', 'Vault password for signing')
+  .action(
+    withExit(
+      async (options: {
+        tokenId?: string
+        price?: number
+        size: number
+        tif?: string
+        eventSlug?: string
+        outcome?: string
+        password?: string
+      }) => {
+        const context = await init(program.opts().vault, options.password)
+        await executePolymarketBuy(context, {
+          tokenId: options.tokenId,
+          price: options.price,
+          size: options.size,
+          tif: options.tif === 'ioc' || options.tif === 'gtc' ? options.tif : undefined,
+          eventSlug: options.eventSlug,
+          outcome: options.outcome,
+          password: options.password,
+          verbose: !!program.opts().verbose,
+        })
+      }
+    )
   )
 
 // Command: Broadcast raw transaction


### PR DESCRIPTION
> ⚠️ **SPIKE / PROTOTYPE — NOT FOR MERGE.** Throwaway exploratory code. Kept as a
> DRAFT to preserve the wiring proof. Do **not** review for merge-readiness.

## What this is
A time-boxed spike proving the wiring for a **deterministic** `vultisig polymarket …`
command family (Path B) that **builds → MPC-signs → submits a Polymarket order with the
LLM removed from the loop**. Prototypes ONE command end-to-end:

```
vultisig polymarket buy --token-id X --price 0.80 --size 10 [--tif ioc|gtc]
```

## Wiring (no LLM)
1. **BUILD** — call mcp-ts `polymarket_place_bet` directly over MCP/HTTP → returns the
   EIP-712 Order + ClobAuth payloads + `order_ref`.
2. **SIGN** — locally via the **existing** `AgentExecutor.signTypedData` (MPC `vault.signBytes`,
   low-S, recover-verify). No new crypto.
3. **SUBMIT** — call `polymarket_submit_order` with `order_ref` + signatures; handles the
   `needs_fresh_auth` re-sign loop.

**Recommended real path: CLI → mcp-ts MCP tools directly** (bypasses both the LLM and
agent-backend). Full analysis, §A dependencies, full-family cost, and go/no-go are in the
spike report (kept OUT of this repo, under `.claude/knowledge/tasks/`).

## Files
- `clients/cli/src/agent/pmSpikeMcp.ts` (new) — minimal MCP-over-HTTP client
- `clients/cli/src/commands/polymarket.ts` (new) — the `buy` command
- `clients/cli/src/index.ts`, `commands/index.ts` — registration

## Validation
- `yarn typecheck`: zero errors in the new files.
- `yarn test:cli`: 401/401 pass.
- End-to-end wiring proven against a mock mcp-ts transport (build → sign(stub) → submit
  incl. fresh-auth loop). Real fill not exercised (no local mcp-ts / funded wallet / geo).
- One local **Codex** signing sanity pass; fixed a false-success on auth exhaustion.

## Known stubs / dependencies
- `--token-id` assumes **§A** (mcp-ts PR #727, `token_id` input) — falls back to
  `--event-slug`/`--outcome` against stock mcp-ts main.
- `--tif` forwarded but ignored by stock `place_bet` (IOC/FOK is §A).
- No changeset (spike, not for publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)