### PR TITLE
feat(solana): staking APY resolver

### DIFF
--- a/.changeset/solana-staking-apy-resolver.md
+++ b/.changeset/solana-staking-apy-resolver.md
@@ -1,0 +1,15 @@
+---
+"@vultisig/core-chain": minor
+"@vultisig/sdk": minor
+---
+
+feat(solana): staking APY resolver
+
+Phase 6 of Solana native staking. Adds `resolveValidatorApy` under
+`@vultisig/core-chain/chains/solana/staking/apyResolver`, which drives the
+per-validator APY on the DeFi stake rows. Two sources, in order: the Stakewiz
+`apy_estimate` passthrough (network-measured, commission-net) from the Phase 2
+metadata seam, then an on-chain fallback derived from the network inflation rate
+and the fraction of supply staked, net of the validator's commission, compounded
+over the epochs-per-year. Returns `undefined` when neither yields a positive
+value so the view hides the APY row.

--- a/packages/core/chain/chains/solana/staking/apyResolver.test.ts
+++ b/packages/core/chain/chains/solana/staking/apyResolver.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { onChainApy, resolveValidatorApy } from './apyResolver'
-import { SolanaValidator } from './models/validator'
+import { networkActivatedStake, SolanaValidator } from './models/validator'
 
 const validator = (overrides?: Partial<SolanaValidator>): SolanaValidator => ({
   votePubkey: 'V',
@@ -14,12 +14,16 @@ const validator = (overrides?: Partial<SolanaValidator>): SolanaValidator => ({
   ...overrides,
 })
 
+// Network total activated stake for the 50%-staked scenario (supply 2e12).
+const networkStaked = 1_000_000_000_000
+
 describe('resolveValidatorApy', () => {
   it('prefers the Stakewiz metadata estimate when present', () => {
     const apy = resolveValidatorApy({
       validator: validator({ metadata: { apyEstimate: 0.072 } }),
       inflationRate: 0.08,
       totalSupplyLamports: 2_000_000_000_000,
+      totalActivatedStake: networkStaked,
     })
     expect(apy).toBe(0.072)
   })
@@ -29,8 +33,26 @@ describe('resolveValidatorApy', () => {
       validator: validator(),
       inflationRate: 0.08,
       totalSupplyLamports: 2_000_000_000_000, // 50% staked
+      totalActivatedStake: networkStaked,
     })
     expect(apy).toBeGreaterThan(0)
+    // Sane range — the fallback must use the NETWORK total, not a single
+    // validator's stake (which would collapse fractionStaked and explode APY).
+    expect(apy).toBeLessThan(1)
+  })
+
+  it('uses the network total, not the validator stake, for the fallback', () => {
+    // A validator holding a tiny slice of a large network: its own
+    // `activatedStake` as the denominator would yield an absurd APY; the
+    // network total keeps it sane.
+    const apy = resolveValidatorApy({
+      validator: validator({ activatedStake: 1_000_000_000 }),
+      inflationRate: 0.08,
+      totalSupplyLamports: 2_000_000_000_000,
+      totalActivatedStake: networkStaked,
+    })
+    expect(apy).toBeGreaterThan(0)
+    expect(apy).toBeLessThan(1)
   })
 
   it('returns undefined when neither source yields a value', () => {
@@ -39,8 +61,25 @@ describe('resolveValidatorApy', () => {
         validator: validator(),
         inflationRate: undefined,
         totalSupplyLamports: undefined,
+        totalActivatedStake: networkStaked,
       })
     ).toBeUndefined()
+  })
+})
+
+describe('networkActivatedStake', () => {
+  it('sums activated stake across the validator set', () => {
+    expect(
+      networkActivatedStake([
+        validator({ activatedStake: 1_000_000_000 }),
+        validator({ activatedStake: 2_500_000_000 }),
+        validator({ activatedStake: 0 }),
+      ])
+    ).toBe(3_500_000_000)
+  })
+
+  it('is zero for an empty set', () => {
+    expect(networkActivatedStake([])).toBe(0)
   })
 })
 

--- a/packages/core/chain/chains/solana/staking/apyResolver.test.ts
+++ b/packages/core/chain/chains/solana/staking/apyResolver.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+
+import { onChainApy, resolveValidatorApy } from './apyResolver'
+import { SolanaValidator } from './models/validator'
+
+const validator = (overrides?: Partial<SolanaValidator>): SolanaValidator => ({
+  votePubkey: 'V',
+  nodePubkey: 'N',
+  activatedStake: 1_000_000_000_000,
+  commission: 5,
+  epochVoteAccount: true,
+  isDelinquent: false,
+  metadata: {},
+  ...overrides,
+})
+
+describe('resolveValidatorApy', () => {
+  it('prefers the Stakewiz metadata estimate when present', () => {
+    const apy = resolveValidatorApy({
+      validator: validator({ metadata: { apyEstimate: 0.072 } }),
+      inflationRate: 0.08,
+      totalSupplyLamports: 2_000_000_000_000,
+    })
+    expect(apy).toBe(0.072)
+  })
+
+  it('falls back to the on-chain estimate when there is no metadata APY', () => {
+    const apy = resolveValidatorApy({
+      validator: validator(),
+      inflationRate: 0.08,
+      totalSupplyLamports: 2_000_000_000_000, // 50% staked
+    })
+    expect(apy).toBeGreaterThan(0)
+  })
+
+  it('returns undefined when neither source yields a value', () => {
+    expect(
+      resolveValidatorApy({
+        validator: validator(),
+        inflationRate: undefined,
+        totalSupplyLamports: undefined,
+      })
+    ).toBeUndefined()
+  })
+})
+
+describe('onChainApy', () => {
+  const base = {
+    inflationRate: 0.08,
+    commission: 0,
+    totalActivatedStake: 1_000_000_000_000,
+    totalSupplyLamports: 2_000_000_000_000, // fraction staked = 0.5
+  }
+
+  it('compounds APR over the epochs-per-year into an APY', () => {
+    // APR = (0.08 / 0.5) * (1 - 0) = 0.16; APY = (1 + 0.16/182)^182 - 1 > APR.
+    const apy = onChainApy(base)
+    expect(apy).toBeGreaterThan(0.16)
+    expect(apy).toBeLessThan(0.2)
+  })
+
+  it('reduces the APY by the validator commission', () => {
+    const noFee = onChainApy(base)
+    const withFee = onChainApy({ ...base, commission: 50 })
+    expect(withFee).toBeLessThan(noFee!)
+  })
+
+  it('returns undefined for missing / non-positive inputs', () => {
+    expect(onChainApy({ ...base, inflationRate: undefined })).toBeUndefined()
+    expect(onChainApy({ ...base, totalSupplyLamports: 0 })).toBeUndefined()
+    expect(onChainApy({ ...base, totalActivatedStake: 0 })).toBeUndefined()
+  })
+})

--- a/packages/core/chain/chains/solana/staking/apyResolver.ts
+++ b/packages/core/chain/chains/solana/staking/apyResolver.ts
@@ -1,0 +1,92 @@
+import { SolanaValidator } from './models/validator'
+
+/**
+ * Resolves a per-validator staking APY (as a fraction, e.g. 0.067 for 6.7%) for
+ * the Solana DeFi stake rows. Two sources, in order:
+ *
+ *   1. Stakewiz `apy_estimate` passthrough — the metadata provider's estimate is
+ *      the preferred, network-measured value (already commission-net).
+ *   2. On-chain fallback — derive APR from the network inflation rate and the
+ *      fraction of supply staked, net of the validator's commission, then
+ *      compound over the epochs-per-year to an APY:
+ *        APR = (inflation / fractionStaked) × (1 − commission)
+ *        APY = (1 + APR / N)^N − 1   (N = epochs per year)
+ *
+ * Returns `undefined` when neither source yields a positive value, and the view
+ * hides the APY row.
+ *
+ * Port of iOS `SolanaStakingAPYResolver`.
+ */
+
+/** Mainnet epoch is ~2 days, so ~182 epochs per year. */
+const epochsPerYear = 182
+
+const clamp01 = (value: number): number => Math.min(1, Math.max(0, value))
+
+/**
+ * `APY = (1 + APR/N)^N − 1` where
+ * `APR = (inflation / fractionStaked) × (1 − commission)`. Returns `undefined`
+ * when any input is missing or collapses the result to zero.
+ */
+export const onChainApy = ({
+  inflationRate,
+  commission,
+  totalActivatedStake,
+  totalSupplyLamports,
+}: {
+  inflationRate: number | undefined
+  commission: number
+  totalActivatedStake: number
+  totalSupplyLamports: number | undefined
+}): number | undefined => {
+  if (
+    inflationRate === undefined ||
+    inflationRate <= 0 ||
+    totalSupplyLamports === undefined ||
+    totalSupplyLamports <= 0 ||
+    totalActivatedStake <= 0
+  ) {
+    return undefined
+  }
+
+  const fractionStaked = totalActivatedStake / totalSupplyLamports
+  if (fractionStaked <= 0) {
+    return undefined
+  }
+
+  const commissionFraction = clamp01(commission / 100)
+  const apr = (inflationRate / fractionStaked) * (1 - commissionFraction)
+  if (apr <= 0) {
+    return undefined
+  }
+
+  const apy = (1 + apr / epochsPerYear) ** epochsPerYear - 1
+  return Number.isFinite(apy) && apy > 0 ? apy : undefined
+}
+
+/**
+ * Resolves the APY fraction for `validator`. `metadataApy` is the Stakewiz
+ * passthrough when present; `inflationRate` / `totalSupplyLamports` drive the
+ * on-chain fallback. `totalActivatedStake` defaults to the validator's own
+ * activated stake.
+ */
+export const resolveValidatorApy = ({
+  validator,
+  inflationRate,
+  totalSupplyLamports,
+}: {
+  validator: SolanaValidator
+  inflationRate: number | undefined
+  totalSupplyLamports: number | undefined
+}): number | undefined => {
+  const metadataApy = validator.metadata.apyEstimate
+  if (metadataApy !== undefined && metadataApy > 0) {
+    return metadataApy
+  }
+  return onChainApy({
+    inflationRate,
+    commission: validator.commission,
+    totalActivatedStake: validator.activatedStake,
+    totalSupplyLamports,
+  })
+}

--- a/packages/core/chain/chains/solana/staking/apyResolver.ts
+++ b/packages/core/chain/chains/solana/staking/apyResolver.ts
@@ -65,19 +65,27 @@ export const onChainApy = ({
 }
 
 /**
- * Resolves the APY fraction for `validator`. `metadataApy` is the Stakewiz
- * passthrough when present; `inflationRate` / `totalSupplyLamports` drive the
- * on-chain fallback. `totalActivatedStake` defaults to the validator's own
- * activated stake.
+ * Resolves the APY fraction for `validator`. The Stakewiz `apyEstimate` is the
+ * preferred value when present; otherwise the on-chain fallback derives it from
+ * `inflationRate`, `totalSupplyLamports`, and `totalActivatedStake`.
+ *
+ * `totalActivatedStake` is the NETWORK-wide total activated stake (the
+ * `fractionStaked` denominator numerator), NOT this validator's own
+ * `activatedStake` — feeding a single validator's stake would collapse
+ * `fractionStaked` and explode the APY. Compute it once from the full validator
+ * set via `networkActivatedStake` and pass it in (mirrors iOS, which threads the
+ * summed validator-set stake through as `totalActivatedStake`).
  */
 export const resolveValidatorApy = ({
   validator,
   inflationRate,
   totalSupplyLamports,
+  totalActivatedStake,
 }: {
   validator: SolanaValidator
   inflationRate: number | undefined
   totalSupplyLamports: number | undefined
+  totalActivatedStake: number
 }): number | undefined => {
   const metadataApy = validator.metadata.apyEstimate
   if (metadataApy !== undefined && metadataApy > 0) {
@@ -86,7 +94,7 @@ export const resolveValidatorApy = ({
   return onChainApy({
     inflationRate,
     commission: validator.commission,
-    totalActivatedStake: validator.activatedStake,
+    totalActivatedStake,
     totalSupplyLamports,
   })
 }

--- a/packages/core/chain/chains/solana/staking/models/validator.ts
+++ b/packages/core/chain/chains/solana/staking/models/validator.ts
@@ -47,6 +47,17 @@ export type SolanaValidator = {
 }
 
 /**
+ * Network-wide total activated stake (lamports), summed across the validator
+ * set — the `fractionStaked` numerator for the on-chain APY fallback. This is
+ * the value `resolveValidatorApy` expects as `totalActivatedStake`; passing a
+ * single validator's `activatedStake` would collapse the fraction and explode
+ * the APY. Sums current and delinquent validators alike (all carry stake), so
+ * pass the full set returned by `fetchSolanaValidators`.
+ */
+export const networkActivatedStake = (validators: SolanaValidator[]): number =>
+  validators.reduce((sum, validator) => sum + validator.activatedStake, 0)
+
+/**
  * `prefix…suffix` form of a base58 pubkey for compact display. Returns the
  * input unchanged when it is too short to truncate meaningfully.
  */

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -680,6 +680,11 @@
       "import": "./dist/chains/solana/spl/getSplAssociatedAccount.js",
       "default": "./dist/chains/solana/spl/getSplAssociatedAccount.js"
     },
+    "./chains/solana/staking/apyResolver": {
+      "types": "./dist/chains/solana/staking/apyResolver.d.ts",
+      "import": "./dist/chains/solana/staking/apyResolver.js",
+      "default": "./dist/chains/solana/staking/apyResolver.js"
+    },
     "./chains/solana/staking/config": {
       "types": "./dist/chains/solana/staking/config.d.ts",
       "import": "./dist/chains/solana/staking/config.js",


### PR DESCRIPTION
**Phase 6** (SDK part) of Solana native staking — parity with iOS #4664.

Tracking sub-issue: vultisig/vultisig-windows#4242 · Epic: vultisig/vultisig-windows#4222.

Adds `resolveValidatorApy` under `chains/solana/staking/apyResolver` — the per-validator APY for the DeFi stake rows. Two sources, in order:
1. **Stakewiz `apy_estimate` passthrough** — the Phase 2 metadata seam's network-measured, commission-net estimate.
2. **On-chain fallback** — `APR = (inflation / fractionStaked) × (1 − commission)`, compounded over the epochs-per-year into an APY.

Returns `undefined` when neither yields a positive value, so the view hides the APY row.

### Tests
`apyResolver.test.ts` — metadata passthrough, on-chain fallback + compounding, commission reduces APY, and undefined on missing/non-positive inputs.

### Notes
- Consumes the `number`-typed `activatedStake` / supply from the read layer (no false-precision bigint).
- Changeset bumps `@vultisig/core-chain` + `@vultisig/sdk` (minor). The windows DeFi view wires the APY display once this publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)