### PR TITLE
Fail closed on native swap missing expiry

### DIFF
--- a/.changeset/soft-native-swaps.md
+++ b/.changeset/soft-native-swaps.md
@@ -1,6 +1,6 @@
 ---
-"@vultisig/core-mpc": patch
+"@vultisig/core-mpc": minor
 "@vultisig/sdk": patch
 ---
 
-Fail closed before broadcasting native swap payloads that do not carry a positive quote expiration, while preserving secured-asset withdrawal deposits.
+Fail closed before broadcasting native swap payloads that do not carry a positive quote expiration, while preserving secured-asset withdrawal deposits with a shared classifier.

--- a/.changeset/soft-native-swaps.md
+++ b/.changeset/soft-native-swaps.md
@@ -1,5 +1,6 @@
 ---
-'@vultisig/sdk': patch
+"@vultisig/core-mpc": patch
+"@vultisig/sdk": patch
 ---
 
-Fail closed before broadcasting native swap payloads that do not carry a positive quote expiration.
+Fail closed before broadcasting native swap payloads that do not carry a positive quote expiration, while preserving secured-asset withdrawal deposits.

--- a/.changeset/soft-native-swaps.md
+++ b/.changeset/soft-native-swaps.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Fail closed before broadcasting native swap payloads that do not carry a positive quote expiration.

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos.test.ts
@@ -162,6 +162,7 @@ describe('getCosmosSigningInputs gas limit', () => {
               contractAddress: '',
               decimals: 8,
             },
+            fromAmount: '10000000',
             vaultAddress: '',
             routerAddress: '',
             expirationTime: 0n,

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos.test.ts
@@ -127,4 +127,103 @@ describe('getCosmosSigningInputs gas limit', () => {
 
     expect(input.fee?.gas.toString()).toBe('20000000')
   })
+
+  it('encodes secured withdrawals with the L1 asset from the auxiliary payload', async () => {
+    // Reference: https://dev.thorchain.org/concepts/secured-assets.html#withdrawing-secured-assets
+    const [input] = await getCosmosSigningInputs({
+      keysignPayload: create(KeysignPayloadSchema, {
+        coin: create(CoinSchema, {
+          chain: Chain.THORChain,
+          ticker: 'RUNE',
+          address: thorSender,
+          decimals: 8,
+          isNativeToken: true,
+          hexPublicKey: publicKeyHex,
+        }),
+        toAddress: '',
+        toAmount: '10000000',
+        memo: 'SECURE-:bc1qp8278yutn09r2wu3jrc8xg2a7hgdgwv2gvsdyw',
+        blockchainSpecific: {
+          case: 'thorchainSpecific',
+          value: create(THORChainSpecificSchema, {
+            accountNumber: 7n,
+            sequence: 3n,
+            fee: 2_000_000n,
+            isDeposit: true,
+            transactionType: TransactionType.UNSPECIFIED,
+          }),
+        },
+        swapPayload: {
+          case: 'thorchainSwapPayload',
+          value: {
+            fromCoin: {
+              chain: Chain.Bitcoin,
+              ticker: 'BTC',
+              contractAddress: '',
+              decimals: 8,
+            },
+            vaultAddress: '',
+            routerAddress: '',
+            expirationTime: 0n,
+          },
+        },
+      }),
+      walletCore,
+    })
+
+    const deposit = input.messages[0]?.thorchainDepositMessage
+    const depositCoin = deposit?.coins?.[0]
+    expect(input.memo).toBe('')
+    expect(deposit).toBeDefined()
+    expect(deposit?.memo).toBe('SECURE-:bc1qp8278yutn09r2wu3jrc8xg2a7hgdgwv2gvsdyw')
+    expect(depositCoin?.asset).toMatchObject({
+      chain: 'BTC',
+      symbol: 'BTC',
+      ticker: 'BTC',
+      secured: true,
+    })
+    expect(depositCoin?.amount).toBe('10000000')
+    expect(depositCoin?.decimals.toString()).toBe('0')
+  })
+
+  it('keeps standard liquidity withdrawals on the native THOR asset path', async () => {
+    const memo = '-:BTC.BTC:10000'
+    const [input] = await getCosmosSigningInputs({
+      keysignPayload: create(KeysignPayloadSchema, {
+        coin: create(CoinSchema, {
+          chain: Chain.THORChain,
+          ticker: 'RUNE',
+          address: thorSender,
+          decimals: 8,
+          isNativeToken: true,
+          hexPublicKey: publicKeyHex,
+        }),
+        toAddress: '',
+        toAmount: '1',
+        memo,
+        blockchainSpecific: {
+          case: 'thorchainSpecific',
+          value: create(THORChainSpecificSchema, {
+            accountNumber: 7n,
+            sequence: 3n,
+            fee: 2_000_000n,
+            isDeposit: true,
+            transactionType: TransactionType.UNSPECIFIED,
+          }),
+        },
+      }),
+      walletCore,
+    })
+
+    const deposit = input.messages[0]?.thorchainDepositMessage
+    const depositCoin = deposit?.coins?.[0]
+    expect(input.memo).toBe(memo)
+    expect(depositCoin?.asset).toMatchObject({
+      chain: 'THOR',
+      symbol: 'RUNE',
+      ticker: 'RUNE',
+      secured: false,
+    })
+    expect(depositCoin?.decimals.toString()).toBe('8')
+  })
 })

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
@@ -15,7 +15,7 @@ import { TW } from '@trustwallet/wallet-core'
 import { AuthInfo, TxBody } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
 import Long from 'long'
 
-import { getKeysignSwapPayload } from '../../../swap/getKeysignSwapPayload'
+import { getKeysignSwapPayload, isSecuredAssetWithdrawal } from '../../../swap/getKeysignSwapPayload'
 import { getKeysignTwPublicKey } from '../../../tw/getKeysignTwPublicKey'
 import { getTwChainId } from '@vultisig/core-chain/chains/evm/tx/tw/getTwChainId'
 import { toTwAddress } from '../../../tw/toTwAddress'
@@ -346,7 +346,8 @@ export const getCosmosSigningInputs: SigningInputsResolver<'cosmos'> = ({ keysig
           (nativeSwapChainIds as Record<string, string>)[assetCoin.chain] ??
           nativeSwapChainIds[chain as VaultBasedCosmosChain]
         const contractAddress = 'contractAddress' in assetCoin ? assetCoin.contractAddress : undefined
-        const isSecuredWithdrawal = memo?.toLowerCase().startsWith('secure-:') || false
+        const isSecuredWithdrawal =
+          !!swapPayload && isSecuredAssetWithdrawal({ chain, keysignPayload, native: swapPayload })
         const rawSymbol =
           contractAddress && contractAddress.trim() ? `${assetCoin.ticker}-${contractAddress}` : assetCoin.ticker
         const assetSymbol = isSecuredWithdrawal ? rawSymbol.toUpperCase() : rawSymbol

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
@@ -25,6 +25,46 @@ import { SigningInputsResolver } from '../../resolver'
 import { CosmosChainSpecific, getCosmosChainSpecific } from './chainSpecific'
 import { getCosmosCoinAmount } from './coinAmount'
 
+const getNativeSwapPayload = (keysignPayload: Parameters<typeof getKeysignSwapPayload>[0]) => {
+  const swapPayload = getKeysignSwapPayload(keysignPayload)
+  if (!swapPayload) {
+    return null
+  }
+
+  return getRecordUnionValue(swapPayload, 'native')
+}
+
+const getThorchainDepositAsset = ({
+  assetCoin,
+  chain,
+  secured,
+}: {
+  assetCoin: {
+    chain: string
+    contractAddress?: string
+    ticker: string
+  }
+  chain: CosmosChain
+  secured: boolean
+}) => {
+  const chainId =
+    (nativeSwapChainIds as Record<string, string>)[assetCoin.chain] ??
+    nativeSwapChainIds[chain as VaultBasedCosmosChain]
+  const { contractAddress } = assetCoin
+  const rawSymbol =
+    typeof contractAddress === 'string' && contractAddress.trim()
+      ? `${assetCoin.ticker}-${contractAddress}`
+      : assetCoin.ticker
+
+  return TW.Cosmos.Proto.THORChainAsset.create({
+    chain: secured ? chainId.toUpperCase() : chainId,
+    symbol: secured ? rawSymbol.toUpperCase() : rawSymbol,
+    ticker: secured ? assetCoin.ticker.toUpperCase() : assetCoin.ticker,
+    synth: false,
+    secured,
+  })
+}
+
 export const getCosmosSigningInputs: SigningInputsResolver<'cosmos'> = ({ keysignPayload, walletCore }) => {
   const chain = getKeysignChain<'cosmos'>(keysignPayload)
   const coin = getKeysignCoin<CosmosChain>(keysignPayload)
@@ -325,16 +365,7 @@ export const getCosmosSigningInputs: SigningInputsResolver<'cosmos'> = ({ keysig
         }
       }
 
-      const getSwapPayload = () => {
-        const swapPayload = getKeysignSwapPayload(keysignPayload)
-        if (!swapPayload) {
-          return null
-        }
-
-        return getRecordUnionValue(swapPayload, 'native')
-      }
-
-      const swapPayload = getSwapPayload()
+      const swapPayload = getNativeSwapPayload(keysignPayload)
 
       if (isDeposit || (swapPayload && coin.chain === chain && swapPayload.chain === chain)) {
         const amountStr = isDeposit ? (keysignPayload.toAmount ?? '0') : swapPayload!.fromAmount
@@ -342,26 +373,10 @@ export const getCosmosSigningInputs: SigningInputsResolver<'cosmos'> = ({ keysig
         const isPositive = +/^[0-9]+$/.test(amountStr) && BigInt(amountStr) > 0n
 
         const assetCoin = swapPayload?.fromCoin ?? coin
-        const assetChainId =
-          (nativeSwapChainIds as Record<string, string>)[assetCoin.chain] ??
-          nativeSwapChainIds[chain as VaultBasedCosmosChain]
-        const contractAddress = 'contractAddress' in assetCoin ? assetCoin.contractAddress : undefined
-        const isSecuredWithdrawal =
-          !!swapPayload && isSecuredAssetWithdrawal({ chain, keysignPayload, native: swapPayload })
-        const rawSymbol =
-          contractAddress && contractAddress.trim() ? `${assetCoin.ticker}-${contractAddress}` : assetCoin.ticker
-        const assetSymbol = isSecuredWithdrawal ? rawSymbol.toUpperCase() : rawSymbol
-        const finalChainId = isSecuredWithdrawal ? assetChainId.toUpperCase() : assetChainId
-        const finalTicker = isSecuredWithdrawal ? assetCoin.ticker.toUpperCase() : assetCoin.ticker
+        const isSecuredWithdrawal = isSecuredAssetWithdrawal({ chain, keysignPayload, native: swapPayload })
 
         const depositCoin = TW.Cosmos.Proto.THORChainCoin.create({
-          asset: TW.Cosmos.Proto.THORChainAsset.create({
-            chain: finalChainId,
-            symbol: assetSymbol,
-            ticker: finalTicker,
-            synth: false,
-            secured: isSecuredWithdrawal,
-          }),
+          asset: getThorchainDepositAsset({ assetCoin, chain, secured: isSecuredWithdrawal }),
           ...(isPositive
             ? {
                 amount: amountStr,

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
@@ -341,14 +341,32 @@ export const getCosmosSigningInputs: SigningInputsResolver<'cosmos'> = ({ keysig
 
         const isPositive = +/^[0-9]+$/.test(amountStr) && BigInt(amountStr) > 0n
 
+        const assetCoin = swapPayload?.fromCoin ?? coin
+        const assetChainId =
+          (nativeSwapChainIds as Record<string, string>)[assetCoin.chain] ??
+          nativeSwapChainIds[chain as VaultBasedCosmosChain]
+        const contractAddress = 'contractAddress' in assetCoin ? assetCoin.contractAddress : undefined
+        const isSecuredWithdrawal = memo?.toLowerCase().startsWith('secure-:') || false
+        const rawSymbol =
+          contractAddress && contractAddress.trim() ? `${assetCoin.ticker}-${contractAddress}` : assetCoin.ticker
+        const assetSymbol = isSecuredWithdrawal ? rawSymbol.toUpperCase() : rawSymbol
+        const finalChainId = isSecuredWithdrawal ? assetChainId.toUpperCase() : assetChainId
+        const finalTicker = isSecuredWithdrawal ? assetCoin.ticker.toUpperCase() : assetCoin.ticker
+
         const depositCoin = TW.Cosmos.Proto.THORChainCoin.create({
           asset: TW.Cosmos.Proto.THORChainAsset.create({
-            chain: nativeSwapChainIds[chain as VaultBasedCosmosChain],
-            symbol: coin.ticker,
-            ticker: coin.ticker,
+            chain: finalChainId,
+            symbol: assetSymbol,
+            ticker: finalTicker,
             synth: false,
+            secured: isSecuredWithdrawal,
           }),
-          ...(isPositive ? { amount: amountStr, decimals: new Long(coin.decimals) } : {}),
+          ...(isPositive
+            ? {
+                amount: amountStr,
+                decimals: new Long(isSecuredWithdrawal ? 0 : assetCoin.decimals),
+              }
+            : {}),
         })
 
         return {

--- a/packages/core/mpc/keysign/swap/getKeysignSwapPayload.ts
+++ b/packages/core/mpc/keysign/swap/getKeysignSwapPayload.ts
@@ -9,10 +9,11 @@ type NativeKeysignSwapPayload = Extract<KeysignSwapPayload, { native: unknown }>
 type IsSecuredAssetWithdrawalInput = {
   chain: Chain
   keysignPayload: KeysignPayload
-  native: NativeKeysignSwapPayload
+  native?: NativeKeysignSwapPayload | null
 }
 
 export const isSecuredAssetWithdrawal = ({ chain, keysignPayload, native }: IsSecuredAssetWithdrawalInput): boolean =>
+  !!native &&
   chain === Chain.THORChain &&
   native.chain === Chain.THORChain &&
   native.expirationTime === 0n &&

--- a/packages/core/mpc/keysign/swap/getKeysignSwapPayload.ts
+++ b/packages/core/mpc/keysign/swap/getKeysignSwapPayload.ts
@@ -4,6 +4,32 @@ import { matchDiscriminatedUnion } from '@vultisig/lib-utils/matchDiscriminatedU
 
 import { KeysignSwapPayload } from './KeysignSwapPayload'
 
+type NativeKeysignSwapPayload = Extract<KeysignSwapPayload, { native: unknown }>['native']
+
+type IsSecuredAssetWithdrawalInput = {
+  chain: Chain
+  keysignPayload: KeysignPayload
+  native: NativeKeysignSwapPayload
+}
+
+export const isSecuredAssetWithdrawal = ({ chain, keysignPayload, native }: IsSecuredAssetWithdrawalInput): boolean =>
+  chain === Chain.THORChain &&
+  native.chain === Chain.THORChain &&
+  native.expirationTime === 0n &&
+  native.vaultAddress === '' &&
+  native.routerAddress === '' &&
+  keysignPayload.toAddress === '' &&
+  !!keysignPayload.memo?.toLowerCase().startsWith('secure-:') &&
+  keysignPayload.blockchainSpecific.case === 'thorchainSpecific' &&
+  keysignPayload.blockchainSpecific.value.isDeposit &&
+  !!native.fromCoin &&
+  native.fromCoin.chain !== Chain.THORChain &&
+  typeof native.fromCoin.ticker === 'string' &&
+  !!native.fromCoin.ticker.trim() &&
+  /^[0-9]+$/.test(native.fromAmount) &&
+  BigInt(native.fromAmount) > 0n &&
+  native.fromAmount === keysignPayload.toAmount
+
 export const getKeysignSwapPayload = ({
   swapPayload,
 }: Pick<KeysignPayload, 'swapPayload'>): KeysignSwapPayload | undefined => {

--- a/packages/rujira/src/__tests__/withdraw.test.ts
+++ b/packages/rujira/src/__tests__/withdraw.test.ts
@@ -288,6 +288,18 @@ describe('RujiraWithdraw', () => {
               isDeposit: true,
             }),
           }),
+          swapPayload: expect.objectContaining({
+            case: 'thorchainSwapPayload',
+            value: expect.objectContaining({
+              vaultAddress: '',
+              routerAddress: '',
+              expirationTime: 0n,
+              fromCoin: expect.objectContaining({
+                chain: 'Bitcoin',
+                ticker: 'BTC',
+              }),
+            }),
+          }),
         }),
         signature: expect.any(Object),
       })

--- a/packages/sdk/src/vault/services/nativeSwapBroadcastGuard.ts
+++ b/packages/sdk/src/vault/services/nativeSwapBroadcastGuard.ts
@@ -8,7 +8,7 @@ import {
   type NativeSwapChain,
   nativeSwapChainIds,
 } from '@vultisig/core-chain/swap/native/NativeSwapChain'
-import { getKeysignSwapPayload } from '@vultisig/core-mpc/keysign/swap/getKeysignSwapPayload'
+import { getKeysignSwapPayload, isSecuredAssetWithdrawal } from '@vultisig/core-mpc/keysign/swap/getKeysignSwapPayload'
 import type { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
@@ -46,27 +46,9 @@ export const assertNativeSwapReadyForBroadcast = async ({
   }
 
   const { native } = swapPayload
-  const isSecuredAssetWithdrawal =
-    chain === Chain.THORChain &&
-    native.chain === Chain.THORChain &&
-    native.expirationTime === 0n &&
-    native.vaultAddress === '' &&
-    native.routerAddress === '' &&
-    keysignPayload.toAddress === '' &&
-    keysignPayload.memo?.toLowerCase().startsWith('secure-:') &&
-    keysignPayload.blockchainSpecific.case === 'thorchainSpecific' &&
-    keysignPayload.blockchainSpecific.value.isDeposit &&
-    !!native.fromCoin &&
-    native.fromCoin.chain !== Chain.THORChain &&
-    typeof native.fromCoin.ticker === 'string' &&
-    !!native.fromCoin.ticker.trim() &&
-    /^[0-9]+$/.test(native.fromAmount) &&
-    BigInt(native.fromAmount) > 0n &&
-    native.fromAmount === keysignPayload.toAmount
-
   // Secured-asset withdrawals use the native payload union as L1 asset metadata,
   // not as a quote. Their MsgDeposit has no quote expiry or inbound vault.
-  if (isSecuredAssetWithdrawal) {
+  if (isSecuredAssetWithdrawal({ chain, keysignPayload, native })) {
     return
   }
 

--- a/packages/sdk/src/vault/services/nativeSwapBroadcastGuard.ts
+++ b/packages/sdk/src/vault/services/nativeSwapBroadcastGuard.ts
@@ -48,7 +48,14 @@ export const assertNativeSwapReadyForBroadcast = async ({
   const { native } = swapPayload
   const currentSeconds = BigInt(Math.floor(now() / 1000))
 
-  if (native.expirationTime > 0n && native.expirationTime <= currentSeconds) {
+  if (native.expirationTime <= 0n) {
+    throw new VaultError(
+      VaultErrorCode.InvalidConfig,
+      'Native swap quote is missing an expiration; refresh the quote before broadcasting'
+    )
+  }
+
+  if (native.expirationTime <= currentSeconds) {
     throw new VaultError(
       VaultErrorCode.InvalidConfig,
       'Native swap quote is expired; refresh the quote before broadcasting'

--- a/packages/sdk/src/vault/services/nativeSwapBroadcastGuard.ts
+++ b/packages/sdk/src/vault/services/nativeSwapBroadcastGuard.ts
@@ -46,9 +46,33 @@ export const assertNativeSwapReadyForBroadcast = async ({
   }
 
   const { native } = swapPayload
+  const isSecuredAssetWithdrawal =
+    chain === Chain.THORChain &&
+    native.chain === Chain.THORChain &&
+    native.expirationTime === 0n &&
+    native.vaultAddress === '' &&
+    native.routerAddress === '' &&
+    keysignPayload.toAddress === '' &&
+    keysignPayload.memo?.toLowerCase().startsWith('secure-:') &&
+    keysignPayload.blockchainSpecific.case === 'thorchainSpecific' &&
+    keysignPayload.blockchainSpecific.value.isDeposit &&
+    !!native.fromCoin &&
+    native.fromCoin.chain !== Chain.THORChain &&
+    typeof native.fromCoin.ticker === 'string' &&
+    !!native.fromCoin.ticker.trim() &&
+    /^[0-9]+$/.test(native.fromAmount) &&
+    BigInt(native.fromAmount) > 0n &&
+    native.fromAmount === keysignPayload.toAmount
+
+  // Secured-asset withdrawals use the native payload union as L1 asset metadata,
+  // not as a quote. Their MsgDeposit has no quote expiry or inbound vault.
+  if (isSecuredAssetWithdrawal) {
+    return
+  }
+
   const currentSeconds = BigInt(Math.floor(now() / 1000))
 
-  if (native.expirationTime <= 0n) {
+  if (typeof native.expirationTime !== 'bigint' || native.expirationTime <= 0n) {
     throw new VaultError(
       VaultErrorCode.InvalidConfig,
       'Native swap quote is missing an expiration; refresh the quote before broadcasting'

--- a/packages/sdk/src/vault/services/nativeSwapBroadcastGuard.ts
+++ b/packages/sdk/src/vault/services/nativeSwapBroadcastGuard.ts
@@ -57,7 +57,7 @@ export const assertNativeSwapReadyForBroadcast = async ({
   if (typeof native.expirationTime !== 'bigint' || native.expirationTime <= 0n) {
     throw new VaultError(
       VaultErrorCode.InvalidConfig,
-      'Native swap quote is missing an expiration; refresh the quote before broadcasting'
+      'Native swap quote has a missing or invalid expiration; refresh the quote before broadcasting'
     )
   }
 

--- a/packages/sdk/tests/unit/vault/services/nativeSwapBroadcastGuard.test.ts
+++ b/packages/sdk/tests/unit/vault/services/nativeSwapBroadcastGuard.test.ts
@@ -69,6 +69,23 @@ describe('assertNativeSwapReadyForBroadcast', () => {
     expect(getInboundAddresses).not.toHaveBeenCalled()
   })
 
+  it('rejects native swap payloads with missing expiration before fetching inbound addresses', async () => {
+    const getInboundAddresses = vi.fn()
+
+    await expect(
+      assertNativeSwapReadyForBroadcast({
+        chain: Chain.Bitcoin,
+        keysignPayload: makeThorchainSwapPayload({
+          expirationTime: 0n,
+        }),
+        getInboundAddresses,
+        now: () => 1_700_000_000_000,
+      })
+    ).rejects.toThrow(/missing an expiration/)
+
+    expect(getInboundAddresses).not.toHaveBeenCalled()
+  })
+
   it('passes when the MayaChain inbound vault still matches the source chain', async () => {
     await expect(
       assertNativeSwapReadyForBroadcast({

--- a/packages/sdk/tests/unit/vault/services/nativeSwapBroadcastGuard.test.ts
+++ b/packages/sdk/tests/unit/vault/services/nativeSwapBroadcastGuard.test.ts
@@ -121,7 +121,7 @@ describe('assertNativeSwapReadyForBroadcast', () => {
         getInboundAddresses,
         now: () => 1_700_000_000_000,
       })
-    ).rejects.toThrow(/missing an expiration/)
+    ).rejects.toThrow(/missing or invalid expiration/)
 
     expect(getInboundAddresses).not.toHaveBeenCalled()
   })
@@ -143,7 +143,7 @@ describe('assertNativeSwapReadyForBroadcast', () => {
         keysignPayload,
         getInboundAddresses,
       })
-    ).rejects.toThrow(/missing an expiration/)
+    ).rejects.toThrow(/missing or invalid expiration/)
 
     expect(getInboundAddresses).not.toHaveBeenCalled()
   })
@@ -235,7 +235,7 @@ describe('assertNativeSwapReadyForBroadcast', () => {
         getInboundAddresses,
         now: () => 1_700_000_000_000,
       })
-    ).rejects.toThrow(/missing an expiration/)
+    ).rejects.toThrow(/missing or invalid expiration/)
 
     expect(getInboundAddresses).not.toHaveBeenCalled()
   })

--- a/packages/sdk/tests/unit/vault/services/nativeSwapBroadcastGuard.test.ts
+++ b/packages/sdk/tests/unit/vault/services/nativeSwapBroadcastGuard.test.ts
@@ -45,11 +45,15 @@ const makeMayachainSwapPayload = ({
     },
   }) as KeysignPayload
 
-const makeSecuredAssetWithdrawalPayload = (
+const makeSecuredAssetWithdrawalPayload = ({
   vaultAddress = '',
   memo = 'SECURE-:bc1qdestination',
-  expirationTime = 0n
-): KeysignPayload =>
+  expirationTime = 0n,
+}: {
+  vaultAddress?: string
+  memo?: string
+  expirationTime?: bigint
+} = {}): KeysignPayload =>
   ({
     toAddress: '',
     toAmount: '10000000',
@@ -167,7 +171,11 @@ describe('assertNativeSwapReadyForBroadcast', () => {
     await expect(
       assertNativeSwapReadyForBroadcast({
         chain: Chain.THORChain,
-        keysignPayload: makeSecuredAssetWithdrawalPayload('thor1stale', 'secure-:bc1qdestination', 1_700_000_100n),
+        keysignPayload: makeSecuredAssetWithdrawalPayload({
+          vaultAddress: 'thor1stale',
+          memo: 'secure-:bc1qdestination',
+          expirationTime: 1_700_000_100n,
+        }),
         getInboundAddresses,
         now: () => 1_700_000_000_000,
       })
@@ -185,7 +193,11 @@ describe('assertNativeSwapReadyForBroadcast', () => {
     await expect(
       assertNativeSwapReadyForBroadcast({
         chain: Chain.THORChain,
-        keysignPayload: makeSecuredAssetWithdrawalPayload('thor1stale', '-:BTC.BTC:10000', 1_700_000_100n),
+        keysignPayload: makeSecuredAssetWithdrawalPayload({
+          vaultAddress: 'thor1stale',
+          memo: '-:BTC.BTC:10000',
+          expirationTime: 1_700_000_100n,
+        }),
         getInboundAddresses,
         now: () => 1_700_000_000_000,
       })

--- a/packages/sdk/tests/unit/vault/services/nativeSwapBroadcastGuard.test.ts
+++ b/packages/sdk/tests/unit/vault/services/nativeSwapBroadcastGuard.test.ts
@@ -45,7 +45,11 @@ const makeMayachainSwapPayload = ({
     },
   }) as KeysignPayload
 
-const makeSecuredAssetWithdrawalPayload = (vaultAddress = '', memo = 'SECURE-:bc1qdestination'): KeysignPayload =>
+const makeSecuredAssetWithdrawalPayload = (
+  vaultAddress = '',
+  memo = 'SECURE-:bc1qdestination',
+  expirationTime = 0n
+): KeysignPayload =>
   ({
     toAddress: '',
     toAmount: '10000000',
@@ -59,7 +63,7 @@ const makeSecuredAssetWithdrawalPayload = (vaultAddress = '', memo = 'SECURE-:bc
       value: {
         vaultAddress,
         routerAddress: '',
-        expirationTime: 0n,
+        expirationTime,
         fromAmount: '10000000',
         fromCoin: {
           chain: Chain.Bitcoin,
@@ -155,31 +159,39 @@ describe('assertNativeSwapReadyForBroadcast', () => {
   })
 
   it('does not exempt a secure-memo payload that carries an inbound vault', async () => {
-    const getInboundAddresses = vi.fn()
+    const getInboundAddresses = vi.fn(async nativeChain => {
+      expect(nativeChain).toBe(Chain.THORChain)
+      return [makeInbound('THOR', 'thor1active')]
+    })
 
     await expect(
       assertNativeSwapReadyForBroadcast({
         chain: Chain.THORChain,
-        keysignPayload: makeSecuredAssetWithdrawalPayload('thor1vault'),
+        keysignPayload: makeSecuredAssetWithdrawalPayload('thor1stale', 'secure-:bc1qdestination', 1_700_000_100n),
         getInboundAddresses,
+        now: () => 1_700_000_000_000,
       })
-    ).rejects.toThrow(/missing an expiration/)
+    ).rejects.toThrow(/inbound vault address changed/)
 
-    expect(getInboundAddresses).not.toHaveBeenCalled()
+    expect(getInboundAddresses).toHaveBeenCalledOnce()
   })
 
   it('does not treat a standard liquidity-withdraw memo as a secured-asset withdrawal', async () => {
-    const getInboundAddresses = vi.fn()
+    const getInboundAddresses = vi.fn(async nativeChain => {
+      expect(nativeChain).toBe(Chain.THORChain)
+      return [makeInbound('THOR', 'thor1active')]
+    })
 
     await expect(
       assertNativeSwapReadyForBroadcast({
         chain: Chain.THORChain,
-        keysignPayload: makeSecuredAssetWithdrawalPayload('', '-:BTC.BTC:10000'),
+        keysignPayload: makeSecuredAssetWithdrawalPayload('thor1stale', '-:BTC.BTC:10000', 1_700_000_100n),
         getInboundAddresses,
+        now: () => 1_700_000_000_000,
       })
-    ).rejects.toThrow(/missing an expiration/)
+    ).rejects.toThrow(/inbound vault address changed/)
 
-    expect(getInboundAddresses).not.toHaveBeenCalled()
+    expect(getInboundAddresses).toHaveBeenCalledOnce()
   })
 
   it('rejects expired Maya native swap payloads before fetching inbound addresses', async () => {

--- a/packages/sdk/tests/unit/vault/services/nativeSwapBroadcastGuard.test.ts
+++ b/packages/sdk/tests/unit/vault/services/nativeSwapBroadcastGuard.test.ts
@@ -45,6 +45,32 @@ const makeMayachainSwapPayload = ({
     },
   }) as KeysignPayload
 
+const makeSecuredAssetWithdrawalPayload = (vaultAddress = '', memo = 'SECURE-:bc1qdestination'): KeysignPayload =>
+  ({
+    toAddress: '',
+    toAmount: '10000000',
+    memo,
+    blockchainSpecific: {
+      case: 'thorchainSpecific',
+      value: { isDeposit: true },
+    },
+    swapPayload: {
+      case: 'thorchainSwapPayload',
+      value: {
+        vaultAddress,
+        routerAddress: '',
+        expirationTime: 0n,
+        fromAmount: '10000000',
+        fromCoin: {
+          chain: Chain.Bitcoin,
+          ticker: 'BTC',
+          contractAddress: '',
+          decimals: 8,
+        },
+      },
+    },
+  }) as KeysignPayload
+
 describe('assertNativeSwapReadyForBroadcast', () => {
   it('does nothing for non-swap payloads', async () => {
     const getInboundAddresses = vi.fn()
@@ -92,13 +118,79 @@ describe('assertNativeSwapReadyForBroadcast', () => {
     expect(getInboundAddresses).not.toHaveBeenCalled()
   })
 
+  it('rejects a native swap payload whose expiration field is absent at runtime', async () => {
+    const getInboundAddresses = vi.fn()
+    const keysignPayload = makeThorchainSwapPayload()
+    if (keysignPayload.swapPayload.case !== 'thorchainSwapPayload') {
+      throw new Error('expected THORChain swap payload')
+    }
+    const native = keysignPayload.swapPayload.value as {
+      expirationTime?: bigint
+    }
+    native.expirationTime = undefined
+
+    await expect(
+      assertNativeSwapReadyForBroadcast({
+        chain: Chain.Bitcoin,
+        keysignPayload,
+        getInboundAddresses,
+      })
+    ).rejects.toThrow(/missing an expiration/)
+
+    expect(getInboundAddresses).not.toHaveBeenCalled()
+  })
+
+  it('allows a secured-asset withdrawal metadata payload without fetching inbound addresses', async () => {
+    const getInboundAddresses = vi.fn()
+
+    await expect(
+      assertNativeSwapReadyForBroadcast({
+        chain: Chain.THORChain,
+        keysignPayload: makeSecuredAssetWithdrawalPayload(),
+        getInboundAddresses,
+      })
+    ).resolves.toBeUndefined()
+
+    expect(getInboundAddresses).not.toHaveBeenCalled()
+  })
+
+  it('does not exempt a secure-memo payload that carries an inbound vault', async () => {
+    const getInboundAddresses = vi.fn()
+
+    await expect(
+      assertNativeSwapReadyForBroadcast({
+        chain: Chain.THORChain,
+        keysignPayload: makeSecuredAssetWithdrawalPayload('thor1vault'),
+        getInboundAddresses,
+      })
+    ).rejects.toThrow(/missing an expiration/)
+
+    expect(getInboundAddresses).not.toHaveBeenCalled()
+  })
+
+  it('does not treat a standard liquidity-withdraw memo as a secured-asset withdrawal', async () => {
+    const getInboundAddresses = vi.fn()
+
+    await expect(
+      assertNativeSwapReadyForBroadcast({
+        chain: Chain.THORChain,
+        keysignPayload: makeSecuredAssetWithdrawalPayload('', '-:BTC.BTC:10000'),
+        getInboundAddresses,
+      })
+    ).rejects.toThrow(/missing an expiration/)
+
+    expect(getInboundAddresses).not.toHaveBeenCalled()
+  })
+
   it('rejects expired Maya native swap payloads before fetching inbound addresses', async () => {
     const getInboundAddresses = vi.fn()
 
     await expect(
       assertNativeSwapReadyForBroadcast({
         chain: Chain.MayaChain,
-        keysignPayload: makeMayachainSwapPayload({ expirationTime: 1_700_000_000n }),
+        keysignPayload: makeMayachainSwapPayload({
+          expirationTime: 1_700_000_000n,
+        }),
         getInboundAddresses,
         now: () => 1_700_000_001_000,
       })

--- a/packages/sdk/tests/unit/vault/services/nativeSwapBroadcastGuard.test.ts
+++ b/packages/sdk/tests/unit/vault/services/nativeSwapBroadcastGuard.test.ts
@@ -28,12 +28,18 @@ const makeThorchainSwapPayload = ({
     },
   }) as KeysignPayload
 
-const makeMayachainSwapPayload = (expirationTime = 1_700_000_100n): KeysignPayload =>
+const makeMayachainSwapPayload = ({
+  vaultAddress = 'dash1active',
+  expirationTime = 1_700_000_100n,
+}: {
+  vaultAddress?: string
+  expirationTime?: bigint
+} = {}): KeysignPayload =>
   ({
     swapPayload: {
       case: 'mayachainSwapPayload',
       value: {
-        vaultAddress: 'dash1active',
+        vaultAddress,
         expirationTime,
       },
     },
@@ -86,6 +92,54 @@ describe('assertNativeSwapReadyForBroadcast', () => {
     expect(getInboundAddresses).not.toHaveBeenCalled()
   })
 
+  it('rejects expired Maya native swap payloads before fetching inbound addresses', async () => {
+    const getInboundAddresses = vi.fn()
+
+    await expect(
+      assertNativeSwapReadyForBroadcast({
+        chain: Chain.MayaChain,
+        keysignPayload: makeMayachainSwapPayload({ expirationTime: 1_700_000_000n }),
+        getInboundAddresses,
+        now: () => 1_700_000_001_000,
+      })
+    ).rejects.toThrow(/expired/)
+
+    expect(getInboundAddresses).not.toHaveBeenCalled()
+  })
+
+  it('rejects missing Maya native swap expiration before fetching inbound addresses', async () => {
+    const getInboundAddresses = vi.fn()
+
+    await expect(
+      assertNativeSwapReadyForBroadcast({
+        chain: Chain.Dash,
+        keysignPayload: makeMayachainSwapPayload({
+          expirationTime: 0n,
+        }),
+        getInboundAddresses,
+        now: () => 1_700_000_000_000,
+      })
+    ).rejects.toThrow(/missing an expiration/)
+
+    expect(getInboundAddresses).not.toHaveBeenCalled()
+  })
+
+  it('rejects stale MayaChain inbound vault addresses', async () => {
+    await expect(
+      assertNativeSwapReadyForBroadcast({
+        chain: Chain.Dash,
+        keysignPayload: makeMayachainSwapPayload({
+          vaultAddress: 'dash1old',
+        }),
+        getInboundAddresses: async nativeChain => {
+          expect(nativeChain).toBe(Chain.MayaChain)
+          return [makeInbound('DASH', 'dash1active')]
+        },
+        now: () => 1_700_000_000_000,
+      })
+    ).rejects.toThrow(/MayaChain inbound vault address changed/)
+  })
+
   it('passes when the MayaChain inbound vault still matches the source chain', async () => {
     await expect(
       assertNativeSwapReadyForBroadcast({
@@ -100,35 +154,6 @@ describe('assertNativeSwapReadyForBroadcast', () => {
     ).resolves.toBeUndefined()
   })
 
-  it('rejects stale MayaChain inbound vault addresses', async () => {
-    await expect(
-      assertNativeSwapReadyForBroadcast({
-        chain: Chain.Dash,
-        keysignPayload: makeMayachainSwapPayload(),
-        getInboundAddresses: async nativeChain => {
-          expect(nativeChain).toBe(Chain.MayaChain)
-          return [makeInbound('DASH', 'dash1rotated')]
-        },
-        now: () => 1_700_000_000_000,
-      })
-    ).rejects.toThrow(/MayaChain inbound vault address changed/)
-  })
-
-  it('rejects expired Maya native swap payloads before fetching inbound addresses', async () => {
-    const getInboundAddresses = vi.fn()
-
-    await expect(
-      assertNativeSwapReadyForBroadcast({
-        chain: Chain.MayaChain,
-        keysignPayload: makeMayachainSwapPayload(1_700_000_000n),
-        getInboundAddresses,
-        now: () => 1_700_000_001_000,
-      })
-    ).rejects.toThrow(/expired/)
-
-    expect(getInboundAddresses).not.toHaveBeenCalled()
-  })
-
   it('rejects stale THORChain inbound vault addresses', async () => {
     await expect(
       assertNativeSwapReadyForBroadcast({
@@ -136,7 +161,10 @@ describe('assertNativeSwapReadyForBroadcast', () => {
         keysignPayload: makeThorchainSwapPayload({
           vaultAddress: 'bc1qold',
         }),
-        getInboundAddresses: async () => [makeInbound('BTC', 'bc1qactive')],
+        getInboundAddresses: async nativeChain => {
+          expect(nativeChain).toBe(Chain.THORChain)
+          return [makeInbound('BTC', 'bc1qactive')]
+        },
         now: () => 1_700_000_000_000,
       })
     ).rejects.toThrow(/inbound vault address changed/)
@@ -147,7 +175,10 @@ describe('assertNativeSwapReadyForBroadcast', () => {
       assertNativeSwapReadyForBroadcast({
         chain: Chain.Bitcoin,
         keysignPayload: makeThorchainSwapPayload(),
-        getInboundAddresses: async () => [makeInbound('BTC', 'bc1qactive')],
+        getInboundAddresses: async nativeChain => {
+          expect(nativeChain).toBe(Chain.THORChain)
+          return [makeInbound('BTC', 'bc1qactive')]
+        },
         now: () => 1_700_000_000_000,
       })
     ).resolves.toBeUndefined()


### PR DESCRIPTION
Closes #934

Rejects native swap payloads with a missing or non-positive expiration before fetching inbound addresses or broadcasting, while preserving the existing expired-quote failure for positive stale expirations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fail-closed native swap broadcasts are rejected when quote expiration is missing, zero, or invalid.
  * Secured-asset withdrawals are allowed to proceed without standard inbound expiration/inbound-vault validation.
  * THORChain deposit signing now derives asset details from the native swap payload (memo/decimals/secured status), including secured-withdrawals using 0 decimals.
* **Tests**
  * Added THORChain regression coverage for secured vs standard withdrawals and strengthened missing/invalid expiration rejection order/behavior.
  * Updated unit tests to assert the new nested swap payload shape.
* **Chores**
  * Updated published release metadata for core-mpc and sdk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->