### PR TITLE
feat(cosmos): parameterize thorchain-family msgdeposit asset (thor.rune / maya.cacao)

### DIFF
--- a/.changeset/maya-deposit-asset.md
+++ b/.changeset/maya-deposit-asset.md
@@ -1,5 +1,5 @@
 ---
-"@vultisig/sdk": minor
+'@vultisig/sdk': minor
 ---
 
 feat(cosmos): parameterize the THORChain-family MsgDeposit asset (THOR.RUNE / MAYA.CACAO)

--- a/.changeset/maya-deposit-asset.md
+++ b/.changeset/maya-deposit-asset.md
@@ -1,0 +1,11 @@
+---
+"@vultisig/sdk": minor
+---
+
+feat(cosmos): parameterize the THORChain-family MsgDeposit asset (THOR.RUNE / MAYA.CACAO)
+
+`buildThorchainDepositTx` gains an optional `asset` ({ chain, symbol, ticker }) that
+defaults to THOR.RUNE, so every existing caller is byte-identical. MayaChain-source
+swaps pass MAYA.CACAO, enabling native CACAO->RUNE (and RUNE-source) deposit swaps in
+the app's react-native signing path (previously hardcoded THOR.RUNE, which would sign
+the wrong asset for a Maya deposit).

--- a/packages/sdk/src/platforms/react-native/chains/cosmos/index.ts
+++ b/packages/sdk/src/platforms/react-native/chains/cosmos/index.ts
@@ -6,6 +6,7 @@ export type {
   BuildThorchainDepositOptions,
   CosmosStakingMsg,
   CosmosTxBuilderResult,
+  ThorchainDepositAsset,
 } from './tx'
 export {
   buildCosmosSendTx,

--- a/packages/sdk/src/platforms/react-native/chains/cosmos/tx.ts
+++ b/packages/sdk/src/platforms/react-native/chains/cosmos/tx.ts
@@ -151,9 +151,33 @@ function buildThorMsgSend(fromAddress: string, toAddress: string, amount: string
 }
 
 /** THORChain-family MsgDeposit Asset { chain, symbol, ticker } — THOR.RUNE / MAYA.CACAO. */
-export type ThorchainDepositAsset = { chain: string; symbol: string; ticker: string }
+export type ThorchainDepositAsset = {
+  chain: string
+  symbol: string
+  ticker: string
+}
 
-const THOR_RUNE_ASSET: ThorchainDepositAsset = { chain: 'THOR', symbol: 'RUNE', ticker: 'RUNE' }
+const THOR_RUNE_ASSET: ThorchainDepositAsset = {
+  chain: 'THOR',
+  symbol: 'RUNE',
+  ticker: 'RUNE',
+}
+
+/**
+ * Fail closed on a malformed MsgDeposit asset. An empty/blank chain, symbol, or
+ * ticker serializes an empty protobuf field and would sign a garbage Coin.asset;
+ * refuse before producing a signature. Asset-family *correctness* (THOR.RUNE for
+ * THORChain vs MAYA.CACAO for MayaChain) remains the caller's responsibility —
+ * this builder only encodes the triplet it is given and cannot map a raw chainId
+ * string to a family without brittle heuristics.
+ */
+function assertValidDepositAsset(asset: ThorchainDepositAsset): void {
+  if (!asset.chain?.trim() || !asset.symbol?.trim() || !asset.ticker?.trim()) {
+    throw new Error(
+      `Invalid THORChain-family MsgDeposit asset: chain/symbol/ticker must all be non-empty (got ${JSON.stringify(asset)}).`
+    )
+  }
+}
 
 function buildThorMsgDeposit(
   signerAddress: string,
@@ -161,6 +185,7 @@ function buildThorMsgDeposit(
   memo: string,
   asset: ThorchainDepositAsset
 ): Uint8Array {
+  assertValidDepositAsset(asset)
   const signerBytes = new Uint8Array(bech32.fromWords(bech32.decode(signerAddress as `${string}1${string}`).words))
   const assetProto = concat(
     field(1, 2, encodeString(asset.chain)),

--- a/packages/sdk/src/platforms/react-native/chains/cosmos/tx.ts
+++ b/packages/sdk/src/platforms/react-native/chains/cosmos/tx.ts
@@ -150,15 +150,25 @@ function buildThorMsgSend(fromAddress: string, toAddress: string, amount: string
   return concat(field(1, 2, fromBytes), field(2, 2, toBytes), field(3, 2, encodeCoin(denom, amount)))
 }
 
-function buildThorMsgDeposit(signerAddress: string, runeAmountBaseUnits: string, memo: string): Uint8Array {
+/** THORChain-family MsgDeposit Asset { chain, symbol, ticker } — THOR.RUNE / MAYA.CACAO. */
+export type ThorchainDepositAsset = { chain: string; symbol: string; ticker: string }
+
+const THOR_RUNE_ASSET: ThorchainDepositAsset = { chain: 'THOR', symbol: 'RUNE', ticker: 'RUNE' }
+
+function buildThorMsgDeposit(
+  signerAddress: string,
+  amountBaseUnits: string,
+  memo: string,
+  asset: ThorchainDepositAsset
+): Uint8Array {
   const signerBytes = new Uint8Array(bech32.fromWords(bech32.decode(signerAddress as `${string}1${string}`).words))
-  const runeAsset = concat(
-    field(1, 2, encodeString('THOR')),
-    field(2, 2, encodeString('RUNE')),
-    field(3, 2, encodeString('RUNE'))
+  const assetProto = concat(
+    field(1, 2, encodeString(asset.chain)),
+    field(2, 2, encodeString(asset.symbol)),
+    field(3, 2, encodeString(asset.ticker))
   )
-  const runeCoin = concat(field(1, 2, runeAsset), field(2, 2, encodeString(runeAmountBaseUnits)))
-  return concat(field(1, 2, runeCoin), field(2, 2, encodeString(memo)), field(3, 2, signerBytes))
+  const coin = concat(field(1, 2, assetProto), field(2, 2, encodeString(amountBaseUnits)))
+  return concat(field(1, 2, coin), field(2, 2, encodeString(memo)), field(3, 2, signerBytes))
 }
 
 function buildMsgExecuteContract(
@@ -410,10 +420,12 @@ export type BuildThorchainDepositOptions = {
   gasLimit: number
   feeDenom: string
   feeAmount: string
+  /** Native asset for the MsgDeposit Coin. Defaults to THOR.RUNE. MayaChain callers pass { chain: 'MAYA', symbol: 'CACAO', ticker: 'CACAO' }. */
+  asset?: ThorchainDepositAsset
 }
 
 export function buildThorchainDepositTx(opts: BuildThorchainDepositOptions): CosmosTxBuilderResult {
-  const msgDeposit = buildThorMsgDeposit(opts.fromAddress, opts.amountBaseUnits, opts.memo)
+  const msgDeposit = buildThorMsgDeposit(opts.fromAddress, opts.amountBaseUnits, opts.memo, opts.asset ?? THOR_RUNE_ASSET)
   const msgAny = wrapAny('/types.MsgDeposit', msgDeposit)
   const txBodyBytes = buildTxBody(msgAny, '')
   const authInfoBytes = buildAuthInfo(opts.pubKeyBytes, opts.sequence, opts.gasLimit, opts.feeDenom, opts.feeAmount)

--- a/packages/sdk/src/platforms/react-native/chains/cosmos/tx.ts
+++ b/packages/sdk/src/platforms/react-native/chains/cosmos/tx.ts
@@ -425,7 +425,12 @@ export type BuildThorchainDepositOptions = {
 }
 
 export function buildThorchainDepositTx(opts: BuildThorchainDepositOptions): CosmosTxBuilderResult {
-  const msgDeposit = buildThorMsgDeposit(opts.fromAddress, opts.amountBaseUnits, opts.memo, opts.asset ?? THOR_RUNE_ASSET)
+  const msgDeposit = buildThorMsgDeposit(
+    opts.fromAddress,
+    opts.amountBaseUnits,
+    opts.memo,
+    opts.asset ?? THOR_RUNE_ASSET
+  )
   const msgAny = wrapAny('/types.MsgDeposit', msgDeposit)
   const txBodyBytes = buildTxBody(msgAny, '')
   const authInfoBytes = buildAuthInfo(opts.pubKeyBytes, opts.sequence, opts.gasLimit, opts.feeDenom, opts.feeAmount)

--- a/packages/sdk/tests/unit/platforms/react-native/thorchain-deposit-asset.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/thorchain-deposit-asset.test.ts
@@ -100,4 +100,34 @@ describe('buildThorchainDepositTx / asset parametrization', () => {
     // deposit Coin's own asset is still MAYA.CACAO, not THOR.RUNE
     expect(hex).toContain('4d415941')
   })
+
+  // Byte-identity regression: pins the FULL default (omit-asset) txBody encoding.
+  // This value is exactly what the pre-PR hardcoded-THOR.RUNE builder produced
+  // (THOR_RUNE_ASSET = { chain:'THOR', symbol:'RUNE', ticker:'RUNE' } encoded in
+  // the same field order), so it guards every existing THORChain LP/swap caller
+  // against silent drift — a substring assertion alone can't catch a field-order
+  // or length-prefix regression. Decodes as:
+  //   Coin{ asset{ THOR, RUNE, RUNE }, amount "100000000" } · memo "+:pool1:1000000" · signer(20B)
+  it('default (omit asset) is byte-identical to the pre-PR THOR.RUNE encoding', () => {
+    const GOLDEN_THOR_RUNE_TXBODY =
+      '0a5d0a112f74797065732e4d73674465706f73697412480a1f0a120a0454484f52120452554e451a0452554e451209313030303030303030120f2b3a706f6f6c313a313030303030301a14414f824665dee430cdf036e7a8fc4bcff23ec7d3'
+    const built = buildThorchainDepositTx(baseOpts())
+    expect(toHex(built.txBodyBytes)).toBe(GOLDEN_THOR_RUNE_TXBODY)
+  })
+
+  // Fail closed: a malformed asset (empty/blank chain, symbol, or ticker) must
+  // throw before signing rather than encode a garbage Coin.asset. Asset-family
+  // *correctness* (right asset per chain) is the caller's job, but an empty
+  // triplet is never valid on any THORChain-family chain.
+  it('rejects a malformed asset (empty triplet) before signing', () => {
+    expect(() => buildThorchainDepositTx(baseOpts({ asset: { chain: '', symbol: '', ticker: '' } }))).toThrow(
+      /non-empty/
+    )
+  })
+
+  it('rejects a partially-empty asset (blank symbol) before signing', () => {
+    expect(() =>
+      buildThorchainDepositTx(baseOpts({ asset: { chain: 'MAYA', symbol: '   ', ticker: 'CACAO' } }))
+    ).toThrow(/non-empty/)
+  })
 })

--- a/packages/sdk/tests/unit/platforms/react-native/thorchain-deposit-asset.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/thorchain-deposit-asset.test.ts
@@ -1,0 +1,103 @@
+/**
+ * THORChain-family MsgDeposit asset parametrization.
+ *
+ * buildThorchainDepositTx hardcoded THOR.RUNE as the deposit Coin's Asset
+ * until this PR. MayaChain is a THORChain fork whose MsgDeposit is
+ * byte-identical except for the Asset { chain, symbol, ticker } — MAYA.CACAO
+ * instead of THOR.RUNE. These tests pin:
+ *   - default (no `asset` opt) still encodes THOR.RUNE, so every existing
+ *     THORChain LP/swap caller is unaffected (back-compat).
+ *   - passing `asset: { chain: 'MAYA', symbol: 'CACAO', ticker: 'CACAO' }`
+ *     encodes the Maya asset instead.
+ *
+ * There's no cosmjs-types reference encoder for THORChain's custom
+ * /types.MsgDeposit (it's not a standard cosmos-sdk message), so this mirrors
+ * the hex-substring assertion style already used by vultiagent-poc's
+ * cosmosTx.test.ts for the same hand-rolled builder.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { buildThorchainDepositTx } from '../../../../src/platforms/react-native/chains/cosmos/tx'
+
+const toHex = (bytes: Uint8Array) =>
+  Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+
+const FX = {
+  chainId: 'thorchain-1',
+  signer: 'thor1g98cy3n9mmjrpn0sxmn63lztelera37n8n67c0',
+  amount: '100000000',
+  // Neutral memo (no chain-name substrings) so the asset-encoding assertions
+  // below aren't confounded by chain names appearing in the memo bytes too.
+  memo: '+:pool1:1000000',
+  // Realistic CACAO->RUNE swap memo — deliberately contains "THOR.RUNE" as
+  // the swap destination asset, used only by the memo-passthrough test.
+  swapMemo: '=:THOR.RUNE:thor1dest::0:0',
+  sequence: 5,
+  accountNumber: 42,
+  pubKey: new Uint8Array(33).fill(0x02),
+  gasLimit: 2_000_000,
+  feeAmount: '0',
+}
+
+function baseOpts(overrides: Partial<Parameters<typeof buildThorchainDepositTx>[0]> = {}) {
+  return {
+    chainId: FX.chainId,
+    fromAddress: FX.signer,
+    amountBaseUnits: FX.amount,
+    memo: FX.memo,
+    sequence: FX.sequence,
+    accountNumber: FX.accountNumber,
+    pubKeyBytes: FX.pubKey,
+    gasLimit: FX.gasLimit,
+    feeDenom: 'rune',
+    feeAmount: FX.feeAmount,
+    ...overrides,
+  }
+}
+
+describe('buildThorchainDepositTx / asset parametrization', () => {
+  it('defaults to THOR.RUNE when no asset override is passed (THORChain back-compat)', () => {
+    const built = buildThorchainDepositTx(baseOpts())
+    const hex = toHex(built.txBodyBytes)
+    // "THOR" = 0x54484f52, "RUNE" = 0x52554e45 (appears twice: symbol + ticker)
+    expect(hex).toContain('54484f52')
+    const runeMatches = hex.match(/52554e45/g) ?? []
+    expect(runeMatches.length).toBeGreaterThanOrEqual(2)
+    expect(hex).not.toContain('4d415941') // "MAYA"
+  })
+
+  it('encodes MAYA.CACAO when asset override targets MayaChain', () => {
+    const built = buildThorchainDepositTx(
+      baseOpts({
+        chainId: 'mayachain-mainnet-v1',
+        feeDenom: 'cacao',
+        asset: { chain: 'MAYA', symbol: 'CACAO', ticker: 'CACAO' },
+      })
+    )
+    const hex = toHex(built.txBodyBytes)
+    // "MAYA" = 0x4d415941, "CACAO" = 0x434143414f (appears twice: symbol + ticker)
+    expect(hex).toContain('4d415941')
+    const cacaoMatches = hex.match(/434143414f/g) ?? []
+    expect(cacaoMatches.length).toBeGreaterThanOrEqual(2)
+    expect(hex).not.toContain('54484f52') // "THOR"
+  })
+
+  it('carries a realistic CACAO->RUNE swap memo and amount through untouched', () => {
+    const built = buildThorchainDepositTx(
+      baseOpts({
+        memo: FX.swapMemo,
+        asset: { chain: 'MAYA', symbol: 'CACAO', ticker: 'CACAO' },
+      })
+    )
+    const hex = toHex(built.txBodyBytes)
+    // amount "100000000" as ASCII
+    expect(hex).toContain(Buffer.from(FX.amount, 'ascii').toString('hex'))
+    // swap memo ASCII (destination asset THOR.RUNE legitimately appears here —
+    // it's the swap's destination, not the deposit Coin's asset)
+    expect(hex).toContain(Buffer.from(FX.swapMemo, 'ascii').toString('hex'))
+    // deposit Coin's own asset is still MAYA.CACAO, not THOR.RUNE
+    expect(hex).toContain('4d415941')
+  })
+})


### PR DESCRIPTION
Companion to the app's Maya-source swap support. The react-native `buildThorMsgDeposit` hardcoded `THOR.RUNE` in the MsgDeposit Coin, so a MayaChain deposit built via that path would sign RUNE instead of CACAO (wrong asset).

## what
`buildThorchainDepositTx` gains an optional `asset` (`{ chain, symbol, ticker }`) that defaults to `THOR.RUNE`. Existing callers that omit it are byte-identical; MayaChain-source swaps pass `MAYA.CACAO`.

## risk
Minimal - a single default-param addition. Verified: default omitted -> byte-identical THOR.RUNE output (pinned in the golden test), so no existing THORChain LP/swap deposit changes.

## test
3/3 new (`thorchain-deposit-asset.test.ts`): back-compat THOR.RUNE default, MAYA.CACAO encoding, and a realistic CACAO->RUNE swap memo/amount carried through untouched.

## unblocks
vultiagent-app Maya-source swap PR (which passes `asset: MAYA.CACAO` and bumps to this version) + the agent-backend-ts execute_swap Maya branch. That app PR must land AFTER this publishes (else CACAO deposits sign RUNE), so it's gated on this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cosmos THORChain-family deposit transactions now allow selecting the deposit asset (instead of always using the default).
  * MayaChain deposit flows can encode the intended asset values for correct signing behavior.

* **Bug Fixes**
  * Preserves prior behavior when no asset is specified, ensuring existing deposit transactions remain unchanged.
  * Ensures the encoded deposit coin asset matches the selected asset while keeping the memo content intact.

* **Tests**
  * Added unit test coverage for asset parametrization, memo preservation, and invalid-asset validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->