### PR TITLE
fix(e2e): relay url env override in secure-vault mpc helpers

### DIFF
--- a/packages/sdk/tests/e2e/helpers/multi-party-keygen-helpers.ts
+++ b/packages/sdk/tests/e2e/helpers/multi-party-keygen-helpers.ts
@@ -35,7 +35,7 @@ const getSchnorr = async () => {
 /**
  * Relay server URL for MPC coordination
  */
-export const RELAY_URL = 'https://api.vultisig.com/router'
+export const RELAY_URL = process.env.VULTISIG_ROUTER_URL || 'https://api.vultisig.com/router'
 
 /**
  * Result from a single key import operation

--- a/packages/sdk/tests/e2e/helpers/secure-vault-helpers.ts
+++ b/packages/sdk/tests/e2e/helpers/secure-vault-helpers.ts
@@ -67,7 +67,7 @@ export type MultiPartySigningParams = {
 /**
  * Relay server URL for MPC coordination
  */
-export const RELAY_URL = 'https://api.vultisig.com/router'
+export const RELAY_URL = process.env.VULTISIG_ROUTER_URL || 'https://api.vultisig.com/router'
 
 /**
  * Load and decrypt a vault share from a .vult file


### PR DESCRIPTION
## what

`secure-vault-helpers.ts` and `multi-party-keygen-helpers.ts` hardcoded `RELAY_URL` to `https://api.vultisig.com/router` as a literal, with no env override. This blocked `secure-vault-multiparty-signing.test.ts` (and `secure-vault-from-seedphrase.test.ts`, which shares the same helper) from ever running against a local relay stack.

## why

`test-vault.ts:78-79` already reads `VULTISIG_API_URL` / `VULTISIG_ROUTER_URL` env vars with a prod fallback, which is why `fast-signing.test.ts` can already run fully local (proved during last night's Layer 4 headless-MPC-signing sweep). This PR extends the same capability to the secure-vault multiparty test.

## how

Mirrored the exact `test-vault.ts` fallback pattern in both files:

```ts
export const RELAY_URL = process.env.VULTISIG_ROUTER_URL || 'https://api.vultisig.com/router'
```

Kept the variable name (`RELAY_URL`) and value unchanged when the env var is unset, so it's a pure drop-in - no callers changed. Grepped all e2e helper files (`helpers/*.ts` + `funded/helpers.ts`) for other hardcoded `api.vultisig.com` URLs; the only other helper file (`funded/helpers.ts`) already uses the env-var pattern. Test files themselves (`*.test.ts`) also hardcode fastVault/messageRelay inline but are out of scope here (helpers only, per brief).

## test plan

- [x] `yarn typecheck` in `packages/sdk` - confirmed zero NEW errors from this diff (diffed against the same command run with the change stashed; pre-existing `@vultisig/mpc-types`/`@vultisig/mpc-wasm` module-resolution errors are identical with or without this change - they're missing generated wasm bindings, unrelated to this fix)
- [x] Grepped all callers of `RELAY_URL` in both files - variable name/shape unchanged, no other file needs updates
- Not run: the actual e2e test (`secure-vault-multiparty-signing.test.ts`) - needs a live VultiServer + relay + funded/provisioned vault, out of scope for this helper-only fix

Closes the last piece of tonight's Layer 4 (headless local MPC signing) sweep.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Made the router endpoint configurable via an environment variable, with a default fallback to the existing URL. This makes it easier to run the SDK tests against different environments without changing code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->