### PR TITLE
Honor relayed Cosmos gas limits

### DIFF
--- a/.changeset/honor-cosmos-relayed-gas-limit.md
+++ b/.changeset/honor-cosmos-relayed-gas-limit.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/sdk": patch
+---
+
+Honor positive relayed Cosmos gas limits when building signing inputs.

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos.test.ts
@@ -1,0 +1,118 @@
+import { Buffer } from 'buffer'
+
+import { create } from '@bufbuild/protobuf'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { initWasm, type WalletCore } from '@trustwallet/wallet-core'
+import {
+  CosmosSpecificSchema,
+  THORChainSpecificSchema,
+  TransactionType,
+} from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
+import { CoinSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/coin_pb'
+import { KeysignPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import { getCosmosSigningInputs } from './cosmos'
+
+describe('getCosmosSigningInputs gas limit', () => {
+  let walletCore: WalletCore
+  let sender: string
+  let recipient: string
+  let thorSender: string
+  let thorRecipient: string
+  let publicKeyHex: string
+
+  beforeAll(async () => {
+    walletCore = await initWasm()
+
+    const privateKey = walletCore.PrivateKey.createWithData(new Uint8Array(32).fill(1))
+    const recipientPrivateKey = walletCore.PrivateKey.createWithData(new Uint8Array(32).fill(2))
+    const publicKey = privateKey.getPublicKeySecp256k1(false)
+    const recipientPublicKey = recipientPrivateKey.getPublicKeySecp256k1(false)
+
+    sender = walletCore.AnyAddress.createWithPublicKey(publicKey, walletCore.CoinType.cosmos).description()
+    recipient = walletCore.AnyAddress.createWithPublicKey(recipientPublicKey, walletCore.CoinType.cosmos).description()
+    thorSender = walletCore.AnyAddress.createWithPublicKey(publicKey, walletCore.CoinType.thorchain).description()
+    thorRecipient = walletCore.AnyAddress.createWithPublicKey(
+      recipientPublicKey,
+      walletCore.CoinType.thorchain
+    ).description()
+    publicKeyHex = Buffer.from(publicKey.data()).toString('hex')
+  })
+
+  const buildPayload = ({ gasLimit }: { gasLimit?: bigint }) =>
+    create(KeysignPayloadSchema, {
+      coin: create(CoinSchema, {
+        chain: Chain.Cosmos,
+        ticker: 'ATOM',
+        address: sender,
+        contractAddress: '',
+        decimals: 6,
+        isNativeToken: true,
+        hexPublicKey: publicKeyHex,
+      }),
+      toAddress: recipient,
+      toAmount: '12345',
+      memo: 'gas limit regression',
+      blockchainSpecific: {
+        case: 'cosmosSpecific',
+        value: create(CosmosSpecificSchema, {
+          accountNumber: 7n,
+          sequence: 3n,
+          gas: 2500n,
+          gasLimit,
+          transactionType: TransactionType.UNSPECIFIED,
+        }),
+      },
+    })
+
+  const feeGasFor = async (gasLimit?: bigint) => {
+    const [input] = await getCosmosSigningInputs({
+      keysignPayload: buildPayload({ gasLimit }),
+      walletCore,
+    })
+
+    return input.fee?.gas.toString()
+  }
+
+  it('honors a positive relayed CosmosSpecific gas limit', async () => {
+    await expect(feeGasFor(345_678n)).resolves.toBe('345678')
+  })
+
+  it('falls back to the static per-chain gas limit when the relayed value is missing or zero', async () => {
+    await expect(feeGasFor()).resolves.toBe('200000')
+    await expect(feeGasFor(0n)).resolves.toBe('200000')
+  })
+
+  it('keeps vault-based Cosmos chains on their static gas limit', async () => {
+    const [input] = await getCosmosSigningInputs({
+      keysignPayload: create(KeysignPayloadSchema, {
+        coin: create(CoinSchema, {
+          chain: Chain.THORChain,
+          ticker: 'RUNE',
+          address: thorSender,
+          contractAddress: '',
+          decimals: 8,
+          isNativeToken: true,
+          hexPublicKey: publicKeyHex,
+        }),
+        toAddress: thorRecipient,
+        toAmount: '12345',
+        memo: 'vault based gas regression',
+        blockchainSpecific: {
+          case: 'thorchainSpecific',
+          value: create(THORChainSpecificSchema, {
+            accountNumber: 7n,
+            sequence: 3n,
+            fee: 2_000_000n,
+            isDeposit: false,
+            transactionType: TransactionType.UNSPECIFIED,
+          }),
+        },
+      }),
+      walletCore,
+    })
+
+    expect(input.fee?.gas.toString()).toBe('20000000')
+  })
+})

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos.test.ts
@@ -66,22 +66,34 @@ describe('getCosmosSigningInputs gas limit', () => {
       },
     })
 
-  const feeGasFor = async (gasLimit?: bigint) => {
+  const feeFor = async (gasLimit?: bigint) => {
     const [input] = await getCosmosSigningInputs({
       keysignPayload: buildPayload({ gasLimit }),
       walletCore,
     })
 
-    return input.fee?.gas.toString()
+    return {
+      amount: input.fee?.amounts?.[0]?.amount,
+      gas: input.fee?.gas.toString(),
+    }
   }
 
   it('honors a positive relayed CosmosSpecific gas limit', async () => {
-    await expect(feeGasFor(345_678n)).resolves.toBe('345678')
+    await expect(feeFor(345_678n)).resolves.toEqual({
+      amount: '345678',
+      gas: '345678',
+    })
   })
 
   it('falls back to the static per-chain gas limit when the relayed value is missing or zero', async () => {
-    await expect(feeGasFor()).resolves.toBe('200000')
-    await expect(feeGasFor(0n)).resolves.toBe('200000')
+    await expect(feeFor()).resolves.toEqual({
+      amount: '200000',
+      gas: '200000',
+    })
+    await expect(feeFor(0n)).resolves.toEqual({
+      amount: '200000',
+      gas: '200000',
+    })
   })
 
   it('keeps vault-based Cosmos chains on their static gas limit', async () => {

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos.test.ts
@@ -80,18 +80,18 @@ describe('getCosmosSigningInputs gas limit', () => {
 
   it('honors a positive relayed CosmosSpecific gas limit', async () => {
     await expect(feeFor(345_678n)).resolves.toEqual({
-      amount: '345678',
+      amount: '4321',
       gas: '345678',
     })
   })
 
   it('falls back to the static per-chain gas limit when the relayed value is missing or zero', async () => {
     await expect(feeFor()).resolves.toEqual({
-      amount: '200000',
+      amount: '2500',
       gas: '200000',
     })
     await expect(feeFor(0n)).resolves.toEqual({
-      amount: '200000',
+      amount: '2500',
       gas: '200000',
     })
   })

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
@@ -394,14 +394,14 @@ export const getCosmosSigningInputs: SigningInputsResolver<'cosmos'> = ({ keysig
       return fee
     }
 
-    const getFeeAmounts = () => {
+    const getFeeAmounts = (gasLimit: bigint) => {
       if (chainKind !== 'ibcEnabled') return
 
-      const { gas, ibcDenomTraces } = getRecordUnionValue(chainSpecific, 'ibcEnabled')
+      const { ibcDenomTraces } = getRecordUnionValue(chainSpecific, 'ibcEnabled')
 
       const amounts: TW.Cosmos.Proto.Amount[] = [
         TW.Cosmos.Proto.Amount.create({
-          amount: gas.toString(),
+          amount: gasLimit.toString(),
           denom: chainFeeDenom,
         }),
       ]
@@ -434,9 +434,11 @@ export const getCosmosSigningInputs: SigningInputsResolver<'cosmos'> = ({ keysig
       return gasLimit && gasLimit > 0n ? gasLimit : getCosmosGasLimit(coin)
     }
 
+    const resolvedGasLimit = getResolvedGasLimit()
+
     return TW.Cosmos.Proto.Fee.create({
-      gas: Long.fromBigInt(getResolvedGasLimit()),
-      amounts: getFeeAmounts(),
+      gas: Long.fromBigInt(resolvedGasLimit),
+      amounts: getFeeAmounts(resolvedGasLimit),
     })
   }
 

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
@@ -394,14 +394,17 @@ export const getCosmosSigningInputs: SigningInputsResolver<'cosmos'> = ({ keysig
       return fee
     }
 
-    const getFeeAmounts = (gasLimit: bigint) => {
+    const getFeeAmounts = (resolvedGasLimit: bigint) => {
       if (chainKind !== 'ibcEnabled') return
 
-      const { ibcDenomTraces } = getRecordUnionValue(chainSpecific, 'ibcEnabled')
+      const { gas, ibcDenomTraces } = getRecordUnionValue(chainSpecific, 'ibcEnabled')
+      const staticGasLimit = getCosmosGasLimit(coin)
+      const feeAmount =
+        resolvedGasLimit > staticGasLimit ? (gas * resolvedGasLimit + staticGasLimit - 1n) / staticGasLimit : gas
 
       const amounts: TW.Cosmos.Proto.Amount[] = [
         TW.Cosmos.Proto.Amount.create({
-          amount: gasLimit.toString(),
+          amount: feeAmount.toString(),
           denom: chainFeeDenom,
         }),
       ]

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
@@ -425,8 +425,17 @@ export const getCosmosSigningInputs: SigningInputsResolver<'cosmos'> = ({ keysig
       return amounts
     }
 
+    const getResolvedGasLimit = () => {
+      if (chainKind !== 'ibcEnabled') {
+        return getCosmosGasLimit(coin)
+      }
+
+      const { gasLimit } = getRecordUnionValue(chainSpecific, 'ibcEnabled')
+      return gasLimit && gasLimit > 0n ? gasLimit : getCosmosGasLimit(coin)
+    }
+
     return TW.Cosmos.Proto.Fee.create({
-      gas: Long.fromBigInt(getCosmosGasLimit(coin)),
+      gas: Long.fromBigInt(getResolvedGasLimit()),
       amounts: getFeeAmounts(),
     })
   }

--- a/packages/core/mpc/keysign/tests/mappers/mapBlockchainSpecific.ts
+++ b/packages/core/mpc/keysign/tests/mappers/mapBlockchainSpecific.ts
@@ -1,4 +1,4 @@
-import { bigishToString, booleanOrUndefined, numberOrUndefined } from '../utils'
+import { bigIntOrUndefined, bigishToString, booleanOrUndefined, numberOrUndefined } from '../utils'
 
 export const mapBlockchainSpecific = (bsRaw: any) => {
   if (!bsRaw) return undefined
@@ -24,6 +24,7 @@ export const mapBlockchainSpecific = (bsRaw: any) => {
       cosmosSpecific: {
         accountNumber: numberOrUndefined(c.account_number ?? c.accountNumber),
         gas: numberOrUndefined(c.gas),
+        gasLimit: bigIntOrUndefined(c.gas_limit ?? c.gasLimit),
         sequence: numberOrUndefined(c.sequence),
         transactionType: numberOrUndefined(c.transaction_type ?? c.transactionType),
         ibcDenomTrace: ibc

--- a/packages/core/mpc/keysign/tests/mobileFixtures.golden.test.ts
+++ b/packages/core/mpc/keysign/tests/mobileFixtures.golden.test.ts
@@ -69,7 +69,18 @@ const compareHashesAsSet = ({ chain, fixtureFile }: { chain: Chain; fixtureFile:
 // makes each difference explicit instead of silently rewriting mobile fixtures.
 const sdkExpectedHashOverrides: Record<string, string[]> = {
   'cardano.json::Send ADA - max amount': ['d681b85a798708c5d0e3cfd491363527889c72c6812419c2de246773a31fc120'],
-  'terra.json::Send USTC on terra classic': ['0122eb10508372f69c521d7206a8d06aa6c569b1d4a9e449d4de5f32853dc6f8'],
+  'cosmos.json::Send ATOM': ['0de5ac614a75e5a29dd87843b1063e8173b284e5369cbe9c34ed208787c0ab4f'],
+  'cosmos.json::Send ATOM with memo': ['46fad18bf1c0781f84a21cb89bf4910aed5bbca6ea834bd9bb70d6d84f7e0eea'],
+  'cosmos.json::Send KUJI on Atom': ['21548dbc004af4d6c24f11e3c57099b38317b044a7b0500634a2578a7bdc9795'],
+  'cosmos.json::Switch KUJI on Gaia': ['0f23670f586a3377f662f55584f38ad7121191059432bc6227111c7dd2c6e90e'],
+  'kujira.json::Send KUJIRA': ['865d601a33344124ee0222ba2aa6d00ca5c97cc4a2cf081377477ea429d9d96d'],
+  'kujira.json::Send KUJIRA IBC': ['4b5d8a13dad5e59f6405b50d7e2f6a4984481e32122064ad64850d67ca2c753a'],
+  'kujira.json::Send KUJIRA with memo': ['a0d88eebab16a1d3c92a71ac1e373b163eaa983801f7ea4f19ee42349e08b827'],
+  'terra.json::Send Terra Luna': ['f5294b3fcf59de32f6dc346ec427f1183cc713019269c42f4afc3842b7c7344c'],
+  'terra.json::Send Terra Luna with memo': ['e46e488086802a03fb355e21c26c010e3eb904d03881551dbde1cf9f70bee1bb'],
+  'terra.json::Send Terra class': ['3fdd69afd4441c9c7aa09b93a2cd8191470617043f718665d87182e066ce8d72'],
+  'terra.json::Send Terra class with memo': ['5ed77ac9fcacd343f6c29377d76983ac1d245dac2fb41a9bdf8ba3453a5fa401'],
+  'terra.json::Send USTC on terra classic': ['dc6c2f841041173864306737f887316cbea1a9f29fde807302aa959da52428dc'],
 }
 
 describe('mobile keysign pre-image hash golden fixtures', () => {

--- a/packages/core/mpc/keysign/tests/mobileFixtures.golden.test.ts
+++ b/packages/core/mpc/keysign/tests/mobileFixtures.golden.test.ts
@@ -69,18 +69,7 @@ const compareHashesAsSet = ({ chain, fixtureFile }: { chain: Chain; fixtureFile:
 // makes each difference explicit instead of silently rewriting mobile fixtures.
 const sdkExpectedHashOverrides: Record<string, string[]> = {
   'cardano.json::Send ADA - max amount': ['d681b85a798708c5d0e3cfd491363527889c72c6812419c2de246773a31fc120'],
-  'cosmos.json::Send ATOM': ['0de5ac614a75e5a29dd87843b1063e8173b284e5369cbe9c34ed208787c0ab4f'],
-  'cosmos.json::Send ATOM with memo': ['46fad18bf1c0781f84a21cb89bf4910aed5bbca6ea834bd9bb70d6d84f7e0eea'],
-  'cosmos.json::Send KUJI on Atom': ['21548dbc004af4d6c24f11e3c57099b38317b044a7b0500634a2578a7bdc9795'],
-  'cosmos.json::Switch KUJI on Gaia': ['0f23670f586a3377f662f55584f38ad7121191059432bc6227111c7dd2c6e90e'],
-  'kujira.json::Send KUJIRA': ['865d601a33344124ee0222ba2aa6d00ca5c97cc4a2cf081377477ea429d9d96d'],
-  'kujira.json::Send KUJIRA IBC': ['4b5d8a13dad5e59f6405b50d7e2f6a4984481e32122064ad64850d67ca2c753a'],
-  'kujira.json::Send KUJIRA with memo': ['a0d88eebab16a1d3c92a71ac1e373b163eaa983801f7ea4f19ee42349e08b827'],
-  'terra.json::Send Terra Luna': ['f5294b3fcf59de32f6dc346ec427f1183cc713019269c42f4afc3842b7c7344c'],
-  'terra.json::Send Terra Luna with memo': ['e46e488086802a03fb355e21c26c010e3eb904d03881551dbde1cf9f70bee1bb'],
-  'terra.json::Send Terra class': ['3fdd69afd4441c9c7aa09b93a2cd8191470617043f718665d87182e066ce8d72'],
-  'terra.json::Send Terra class with memo': ['5ed77ac9fcacd343f6c29377d76983ac1d245dac2fb41a9bdf8ba3453a5fa401'],
-  'terra.json::Send USTC on terra classic': ['dc6c2f841041173864306737f887316cbea1a9f29fde807302aa959da52428dc'],
+  'terra.json::Send USTC on terra classic': ['0122eb10508372f69c521d7206a8d06aa6c569b1d4a9e449d4de5f32853dc6f8'],
 }
 
 describe('mobile keysign pre-image hash golden fixtures', () => {

--- a/packages/core/mpc/keysign/tests/utils.ts
+++ b/packages/core/mpc/keysign/tests/utils.ts
@@ -19,6 +19,11 @@ export const numberOrUndefined = (v: any): number | undefined => {
   return Number.isFinite(n) ? n : undefined
 }
 
+export const bigIntOrUndefined = (v: any): bigint | undefined => {
+  if (v === null || v === undefined || v === '') return undefined
+  return BigInt(v)
+}
+
 export const booleanOrUndefined = (v: any): boolean | undefined => {
   if (v === null || v === undefined) return undefined
   if (typeof v === 'boolean') return v


### PR DESCRIPTION
Closes #920
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cosmos signing fee gas now honors a positive relayed Cosmos gas limit when available.
  * If the relayed gas limit is missing or zero, the existing default gas fallback remains in place.
  * Thorchain-style Cosmos transactions continue using their static gas limit behavior.
* **Tests**
  * Added/expanded tests to validate fee gas and fee amount behavior across Cosmos and Thorchain-style signing flows.
  * Updated mobile golden fixture hash expectations for additional Cosmos/Kujira/Terra scenarios.
* **Chores**
  * Added a patch changeset for the SDK behavior update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->