### PR TITLE
fix: findSwapQuote no longer masks a genuine transient outage as no-route

### DIFF
--- a/.changeset/transient-swap-quotes.md
+++ b/.changeset/transient-swap-quotes.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/sdk": patch
+---
+
+Classify transient swap quote provider failures from structured status data.

--- a/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
@@ -410,6 +410,51 @@ describe('findSwapQuote parallel selection', () => {
     )
   })
 
+  it('when all providers fail transiently (network/timeout/5xx), reports a transient error instead of a hard no-route', async () => {
+    vi.mocked(getCowSwapQuote).mockRejectedValue(new Error('fetch failed'))
+    vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('ETIMEDOUT'))
+    vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('socket hang up'))
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('HTTP 502 Bad Gateway'))
+    vi.mocked(getSwapKitQuote).mockRejectedValue(new Error('the operation was aborted'))
+    vi.mocked(getNativeSwapQuote).mockRejectedValue(new Error('request timed out'))
+
+    let thrown: Error | undefined
+    try {
+      await findSwapQuote({
+        ...evmSameChainCoins,
+        amount: 1n,
+      })
+    } catch (error) {
+      thrown = error as Error
+    }
+
+    expect(thrown).toBeInstanceOf(Error)
+    expect(thrown!.message.toLowerCase()).not.toMatch(/\bno (?:swap )?routes? (?:found|available)\b/)
+    expect(thrown!.message).toContain('transient network/timeout error')
+    expect(thrown!.message).toContain('CowSwap, KyberSwap, 1inch, LiFi, SwapKit, THORChain, MayaChain')
+  })
+
+  it('when only SOME providers fail transiently, still reports the definitive no-route message', async () => {
+    // Mixed failure: one provider gave a genuine structural decline (no route), the
+    // rest were transient. A single positive "no route" answer is authoritative —
+    // it must NOT be masked by the other providers' unrelated network blips.
+    vi.mocked(getCowSwapQuote).mockRejectedValue(new Error('fetch failed'))
+    vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('ETIMEDOUT'))
+    vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('no routes found'))
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('HTTP 502 Bad Gateway'))
+    vi.mocked(getSwapKitQuote).mockRejectedValue(new Error('the operation was aborted'))
+    vi.mocked(getNativeSwapQuote).mockRejectedValue(new Error('request timed out'))
+
+    await expect(
+      findSwapQuote({
+        ...evmSameChainCoins,
+        amount: 1n,
+      })
+    ).rejects.toThrow(
+      'No swap route found after trying CowSwap, KyberSwap, 1inch, LiFi, SwapKit, THORChain, MayaChain.'
+    )
+  })
+
   it('surfaces a trading-halted message when a native protocol reports a halt', async () => {
     vi.mocked(getCowSwapQuote).mockRejectedValue(new Error('cowswap fail'))
     vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('kyber fail'))

--- a/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
@@ -14,6 +14,7 @@ import {
   NativeSwapMinAmountIn,
 } from '@vultisig/core-chain/swap/native/minimum/getNativeSwapMinAmountIn'
 import { NativeSwapQuote } from '@vultisig/core-chain/swap/native/NativeSwapQuote'
+import { HttpResponseError } from '@vultisig/lib-utils/fetch/HttpResponseError'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { findSwapQuote } from './findSwapQuote'
@@ -432,6 +433,39 @@ describe('findSwapQuote parallel selection', () => {
     expect(thrown!.message.toLowerCase()).not.toMatch(/\bno (?:swap )?routes? (?:found|available)\b/)
     expect(thrown!.message).toContain('transient network/timeout error')
     expect(thrown!.message).toContain('CowSwap, KyberSwap, 1inch, LiFi, SwapKit, THORChain, MayaChain')
+  })
+
+  it('classifies an HttpResponseError by its structured status even when the message body has no transient keyword (codex review follow-up)', async () => {
+    // A provider's body text is opaque/oddly-worded ("Upstream unavailable") but the
+    // HTTP status itself (503) is an unambiguous transient signal — HttpResponseError
+    // carries `status` for exactly this reason (see its own doc comment: "so callers
+    // can branch cleanly on it... instead of regex-matching the message string").
+    const opaqueTransient = new HttpResponseError({
+      message: 'Upstream unavailable',
+      status: 503,
+      statusText: 'Service Unavailable',
+      url: 'https://example.test/quote',
+      body: undefined,
+    })
+    vi.mocked(getCowSwapQuote).mockRejectedValue(opaqueTransient)
+    vi.mocked(getKyberSwapQuote).mockRejectedValue(opaqueTransient)
+    vi.mocked(getOneInchSwapQuote).mockRejectedValue(opaqueTransient)
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(opaqueTransient)
+    vi.mocked(getSwapKitQuote).mockRejectedValue(opaqueTransient)
+    vi.mocked(getNativeSwapQuote).mockRejectedValue(opaqueTransient)
+
+    let thrown: Error | undefined
+    try {
+      await findSwapQuote({
+        ...evmSameChainCoins,
+        amount: 1n,
+      })
+    } catch (error) {
+      thrown = error as Error
+    }
+
+    expect(thrown).toBeInstanceOf(Error)
+    expect(thrown!.message).toContain('transient network/timeout error')
   })
 
   it('when only SOME providers fail transiently, still reports the definitive no-route message', async () => {

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -110,6 +110,13 @@ type RankedSwapQuote = {
 
 const QUOTE_FETCH_TIMEOUT_MS = 30_000
 
+// Node/undici network-layer error codes — mirrors agent-backend-ts's
+// `TRANSIENT_QUOTE_CODE_RE` (execute_swap.ts) for the same reason: a provider's raw
+// rejection surfaces these as bare codes (e.g. "ETIMEDOUT"), which don't contain the
+// substrings "timeout" or "timed out" checked elsewhere.
+const TRANSIENT_PROVIDER_CODE_RE =
+  /\b(ETIMEDOUT|ECONNRESET|ECONNREFUSED|ECONNABORTED|EPIPE|ENOTFOUND|EAI_AGAIN|UND_ERR_\w+)\b/i
+
 const withTimeout = <T>(p: Promise<T>, ms: number): Promise<T> => {
   let timeoutId: ReturnType<typeof setTimeout> | undefined
   const timeoutPromise = new Promise<never>((_, reject) => {
@@ -808,6 +815,55 @@ export const findSwapQuote = async ({
     )
   }
 
+  // A provider's raw rejection is a transient infra failure (network/timeout/5xx),
+  // not a genuine structural decline. Bails to false on the same "no route" /
+  // dust-threshold / halted substrings checked above so a provider that positively
+  // answered is never misclassified as transient. Mirrors (deliberately duplicated,
+  // not imported — separate repo/package) agent-backend-ts's execute_swap.ts
+  // `isTransientQuoteError`, which classifies the SAME kind of raw single-provider
+  // error for the native asyncFallbackChain path. Used below to detect the case
+  // where EVERY provider failed transiently, so the generic `AllProvidersFailed`
+  // fallback doesn't collapse a genuine outage into a "no route" hard-negative that
+  // downstream classifiers (and `isTransientQuoteError` itself) cannot un-collapse.
+  const isTransientProviderFailure = (msg: string): boolean => {
+    const lower = msg.toLowerCase()
+    if (
+      lower.includes('no swap routes found') ||
+      lower.includes('no swap route found') ||
+      lower.includes('no routes found') ||
+      lower.includes('no route found') ||
+      lower.includes('amount less than min swap amount') ||
+      isBelowMinimumMsg(msg) ||
+      isTradingHaltedMsg(msg) ||
+      lower.includes('dust threshold') ||
+      lower.includes('does not meet requirements')
+    ) {
+      return false
+    }
+    return (
+      lower.includes('fetch failed') ||
+      lower.includes('failed to fetch') ||
+      lower.includes('network error') ||
+      lower.includes('socket hang up') ||
+      lower.includes('connection refused') ||
+      lower.includes('econnrefused') ||
+      lower.includes('timeout') ||
+      lower.includes('timed out') ||
+      lower.includes('deadline exceeded') ||
+      lower.includes('the operation was aborted') ||
+      /\bhttp\s+5\d{2}\b/.test(lower) ||
+      lower.includes('bad gateway') ||
+      lower.includes('service unavailable') ||
+      lower.includes('gateway timeout') ||
+      lower.includes('internal server error') ||
+      lower.includes('rate limit') ||
+      lower.includes('too many requests') ||
+      /\b429\b/.test(lower) ||
+      lower.includes('skip api network error') ||
+      TRANSIENT_PROVIDER_CODE_RE.test(msg)
+    )
+  }
+
   const belowMinimumByProvider = new Map<SwapQuoteProviderName, string>()
   const haltedProviders = new Set<SwapQuoteProviderName>()
   let proactiveTradingHalt: SwapError | null = null
@@ -905,6 +961,33 @@ export const findSwapQuote = async ({
   console.warn(
     `[findSwapQuote] no route for ${from.ticker} -> ${to.ticker}; raw provider errors: ${rawProviderErrors.join(' | ')}`
   )
+
+  // If EVERY provider failed transiently (network/timeout/5xx — never a genuine
+  // structural decline), say so explicitly instead of the generic "no route"
+  // wording. The generic message below is deliberately noise-free (never embeds
+  // raw provider text — see "omits noisy provider errors" test) and, worse,
+  // unconditionally contains "no route", which downstream consumers' transient-
+  // error classifiers (e.g. agent-backend-ts's `isTransientQuoteError`) bail out
+  // on BEFORE checking for network/timeout signals — so a real outage was always
+  // reported as a hard, definitive "this pair has no route" dead-end. This is the
+  // one case where that's wrong: nobody actually declined the route, every
+  // provider was simply unreachable. Kept just as noise-free as the generic
+  // fallback (no raw provider text), naming the detected category rather than the
+  // upstream body, so downstream classification is deterministic without leaking
+  // upstream internals.
+  const rejectedReasons = settled
+    .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+    .map(result => (result.reason instanceof Error ? result.reason.message : String(result.reason)))
+  const allProvidersTransient = rejectedReasons.length > 0 && rejectedReasons.every(isTransientProviderFailure)
+
+  if (allProvidersTransient) {
+    throw new SwapError(
+      SwapErrorCode.AllProvidersFailed,
+      `Swap quote lookup failed for all ${failedProviders.length} provider(s) tried ` +
+        `(${failedProviders.join(', ')}) due to a transient network/timeout error. ` +
+        `This is not a missing route — retry the same swap shortly.`
+    )
+  }
 
   throw new SwapError(
     SwapErrorCode.AllProvidersFailed,

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -44,6 +44,7 @@ import { isEmpty } from '@vultisig/lib-utils/array/isEmpty'
 import { isOneOf } from '@vultisig/lib-utils/array/isOneOf'
 import { bigIntToNumber } from '@vultisig/lib-utils/bigint/bigIntToNumber'
 import { isInError } from '@vultisig/lib-utils/error/isInError'
+import { HttpResponseError } from '@vultisig/lib-utils/fetch/HttpResponseError'
 import { pick } from '@vultisig/lib-utils/record/pick'
 import { TransferDirection } from '@vultisig/lib-utils/TransferDirection'
 
@@ -825,7 +826,8 @@ export const findSwapQuote = async ({
   // where EVERY provider failed transiently, so the generic `AllProvidersFailed`
   // fallback doesn't collapse a genuine outage into a "no route" hard-negative that
   // downstream classifiers (and `isTransientQuoteError` itself) cannot un-collapse.
-  const isTransientProviderFailure = (msg: string): boolean => {
+  const isTransientProviderFailure = (reason: unknown): boolean => {
+    const msg = reason instanceof Error ? reason.message : String(reason)
     const lower = msg.toLowerCase()
     if (
       lower.includes('no swap routes found') ||
@@ -839,6 +841,12 @@ export const findSwapQuote = async ({
       lower.includes('does not meet requirements')
     ) {
       return false
+    }
+    // Structured status takes precedence over message-sniffing where available
+    // (HttpResponseError.status) — a 429/5xx is unambiguously a transient
+    // infra signal regardless of how the provider worded the body.
+    if (reason instanceof HttpResponseError && (reason.status === 429 || reason.status >= 500)) {
+      return true
     }
     return (
       lower.includes('fetch failed') ||
@@ -977,7 +985,7 @@ export const findSwapQuote = async ({
   // upstream internals.
   const rejectedReasons = settled
     .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
-    .map(result => (result.reason instanceof Error ? result.reason.message : String(result.reason)))
+    .map(result => result.reason)
   const allProvidersTransient = rejectedReasons.length > 0 && rejectedReasons.every(isTransientProviderFailure)
 
   if (allProvidersTransient) {

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -199,6 +199,93 @@ const assertNativeTradingOpen = async (input: {
 const asTradingHaltedSwapError = (reason: unknown): SwapError | null =>
   reason instanceof SwapError && reason.code === SwapErrorCode.TradingHalted ? reason : null
 
+const isBelowMinimumMsg = (msg: string) => {
+  const lower = msg.toLowerCase()
+  return (
+    lower.includes('below minimum') ||
+    lower.includes('minimum amount') ||
+    lower.includes('min amount') ||
+    lower.includes('amount too small') ||
+    lower.includes('below the minimum')
+  )
+}
+
+// Native protocols halt trading per-chain (THORChain mimir `HALT<CHAIN>TRADING`,
+// pool ragnarok, churn). The quote API then rejects EVERY amount with
+// "trading is halted" — an operational state, not an amount problem. Detect it
+// so we surface a "temporarily unavailable" message instead of the misleading
+// generic "no route" (which reads like the pair is unsupported). Also match the
+// "trading paused" wordings emitted by the THOR halt helpers in
+// `chains/cosmos/thor/lp/halts.ts` (`global trading paused`,
+// `<chain> chain trading paused`). (#604, CodeRabbit)
+const isTradingHaltedMsg = (msg: string) => {
+  const lower = msg.toLowerCase()
+  return (
+    lower.includes('halted') ||
+    lower.includes('trading halt') ||
+    lower.includes('trading paused') ||
+    lower.includes('trading is paused')
+  )
+}
+
+// A provider's raw rejection is a transient infra failure (network/timeout/5xx),
+// not a genuine structural decline. Bails to false on the same "no route" /
+// dust-threshold / halted substrings checked above so a provider that positively
+// answered is never misclassified as transient. Mirrors (deliberately duplicated,
+// not imported — separate repo/package) agent-backend-ts's execute_swap.ts
+// `isTransientQuoteError`, which classifies the SAME kind of raw single-provider
+// error for the native asyncFallbackChain path. Used below to detect the case
+// where EVERY provider failed transiently, so the generic `AllProvidersFailed`
+// fallback doesn't collapse a genuine outage into a "no route" hard-negative that
+// downstream classifiers (and `isTransientQuoteError` itself) cannot un-collapse.
+// Hoisted to module scope (rather than nested in findSwapQuote) since it closes
+// over no local state — only the module-level regex and the two helpers above.
+const isTransientProviderFailure = (reason: unknown): boolean => {
+  const msg = reason instanceof Error ? reason.message : String(reason)
+  const lower = msg.toLowerCase()
+  if (
+    lower.includes('no swap routes found') ||
+    lower.includes('no swap route found') ||
+    lower.includes('no routes found') ||
+    lower.includes('no route found') ||
+    lower.includes('amount less than min swap amount') ||
+    isBelowMinimumMsg(msg) ||
+    isTradingHaltedMsg(msg) ||
+    lower.includes('dust threshold') ||
+    lower.includes('does not meet requirements')
+  ) {
+    return false
+  }
+  // Structured status takes precedence over message-sniffing where available
+  // (HttpResponseError.status) — a 429/5xx is unambiguously a transient
+  // infra signal regardless of how the provider worded the body.
+  if (reason instanceof HttpResponseError && (reason.status === 429 || reason.status >= 500)) {
+    return true
+  }
+  return (
+    lower.includes('fetch failed') ||
+    lower.includes('failed to fetch') ||
+    lower.includes('network error') ||
+    lower.includes('socket hang up') ||
+    lower.includes('connection refused') ||
+    lower.includes('econnrefused') ||
+    lower.includes('timeout') ||
+    lower.includes('timed out') ||
+    lower.includes('deadline exceeded') ||
+    lower.includes('the operation was aborted') ||
+    /\bhttp\s+5\d{2}\b/.test(lower) ||
+    lower.includes('bad gateway') ||
+    lower.includes('service unavailable') ||
+    lower.includes('gateway timeout') ||
+    lower.includes('internal server error') ||
+    lower.includes('rate limit') ||
+    lower.includes('too many requests') ||
+    /\b429\b/.test(lower) ||
+    lower.includes('skip api network error') ||
+    TRANSIENT_PROVIDER_CODE_RE.test(msg)
+  )
+}
+
 /**
  * Tuning point for issue #605's banded routing rule. 50 bps = 0.5%.
  * Adjust this when product wants a wider or narrower provider-preference band.
@@ -787,91 +874,6 @@ export const findSwapQuote = async ({
     'MayaChain',
   ]
 
-  const isBelowMinimumMsg = (msg: string) => {
-    const lower = msg.toLowerCase()
-    return (
-      lower.includes('below minimum') ||
-      lower.includes('minimum amount') ||
-      lower.includes('min amount') ||
-      lower.includes('amount too small') ||
-      lower.includes('below the minimum')
-    )
-  }
-
-  // Native protocols halt trading per-chain (THORChain mimir `HALT<CHAIN>TRADING`,
-  // pool ragnarok, churn). The quote API then rejects EVERY amount with
-  // "trading is halted" — an operational state, not an amount problem. Detect it
-  // so we surface a "temporarily unavailable" message instead of the misleading
-  // generic "no route" (which reads like the pair is unsupported). Also match the
-  // "trading paused" wordings emitted by the THOR halt helpers in
-  // `chains/cosmos/thor/lp/halts.ts` (`global trading paused`,
-  // `<chain> chain trading paused`). (#604, CodeRabbit)
-  const isTradingHaltedMsg = (msg: string) => {
-    const lower = msg.toLowerCase()
-    return (
-      lower.includes('halted') ||
-      lower.includes('trading halt') ||
-      lower.includes('trading paused') ||
-      lower.includes('trading is paused')
-    )
-  }
-
-  // A provider's raw rejection is a transient infra failure (network/timeout/5xx),
-  // not a genuine structural decline. Bails to false on the same "no route" /
-  // dust-threshold / halted substrings checked above so a provider that positively
-  // answered is never misclassified as transient. Mirrors (deliberately duplicated,
-  // not imported — separate repo/package) agent-backend-ts's execute_swap.ts
-  // `isTransientQuoteError`, which classifies the SAME kind of raw single-provider
-  // error for the native asyncFallbackChain path. Used below to detect the case
-  // where EVERY provider failed transiently, so the generic `AllProvidersFailed`
-  // fallback doesn't collapse a genuine outage into a "no route" hard-negative that
-  // downstream classifiers (and `isTransientQuoteError` itself) cannot un-collapse.
-  const isTransientProviderFailure = (reason: unknown): boolean => {
-    const msg = reason instanceof Error ? reason.message : String(reason)
-    const lower = msg.toLowerCase()
-    if (
-      lower.includes('no swap routes found') ||
-      lower.includes('no swap route found') ||
-      lower.includes('no routes found') ||
-      lower.includes('no route found') ||
-      lower.includes('amount less than min swap amount') ||
-      isBelowMinimumMsg(msg) ||
-      isTradingHaltedMsg(msg) ||
-      lower.includes('dust threshold') ||
-      lower.includes('does not meet requirements')
-    ) {
-      return false
-    }
-    // Structured status takes precedence over message-sniffing where available
-    // (HttpResponseError.status) — a 429/5xx is unambiguously a transient
-    // infra signal regardless of how the provider worded the body.
-    if (reason instanceof HttpResponseError && (reason.status === 429 || reason.status >= 500)) {
-      return true
-    }
-    return (
-      lower.includes('fetch failed') ||
-      lower.includes('failed to fetch') ||
-      lower.includes('network error') ||
-      lower.includes('socket hang up') ||
-      lower.includes('connection refused') ||
-      lower.includes('econnrefused') ||
-      lower.includes('timeout') ||
-      lower.includes('timed out') ||
-      lower.includes('deadline exceeded') ||
-      lower.includes('the operation was aborted') ||
-      /\bhttp\s+5\d{2}\b/.test(lower) ||
-      lower.includes('bad gateway') ||
-      lower.includes('service unavailable') ||
-      lower.includes('gateway timeout') ||
-      lower.includes('internal server error') ||
-      lower.includes('rate limit') ||
-      lower.includes('too many requests') ||
-      /\b429\b/.test(lower) ||
-      lower.includes('skip api network error') ||
-      TRANSIENT_PROVIDER_CODE_RE.test(msg)
-    )
-  }
-
   const belowMinimumByProvider = new Map<SwapQuoteProviderName, string>()
   const haltedProviders = new Set<SwapQuoteProviderName>()
   let proactiveTradingHalt: SwapError | null = null
@@ -897,11 +899,8 @@ export const findSwapQuote = async ({
       throw new SwapError(SwapErrorCode.AmountTooSmall, 'Swap amount too small. Please increase the amount to proceed.')
     }
 
-    if (isBelowMinimumMsg(msg)) {
-      const providerName = fetchers[i].providerName
-      if (!belowMinimumByProvider.has(providerName)) {
-        belowMinimumByProvider.set(providerName, msg)
-      }
+    if (isBelowMinimumMsg(msg) && !belowMinimumByProvider.has(fetchers[i].providerName)) {
+      belowMinimumByProvider.set(fetchers[i].providerName, msg)
     }
 
     if (isTradingHaltedMsg(msg)) {


### PR DESCRIPTION
tl;dr the AllProvidersFailed fallback message unconditionally contains "no route", so agent-backend-ts's `isTransientQuoteError` bails out on it before ever checking for network/timeout/5xx signals — a real all-providers outage always got reported as a hard, definitive "this pair has no route" dead-end.

## what

Flagged as a follow-up while sweeping agent-backend-ts's multi-swapper coverage (vultisig/agent-backend-ts#783): `findSwapQuote`'s `AllProvidersFailed` catch-all always throws:

```
No swap route found after trying CowSwap, KyberSwap, 1inch, LiFi, SwapKit, THORChain, MayaChain.
```

That phrase always contains "no route", and `isTransientQuoteError` (agent-backend-ts, `execute_swap.ts`) is explicitly gated to bail (return false) the instant it sees that phrase — before it ever gets to check for network/timeout/5xx patterns. So even when every single provider failed because of a genuine transient blip (rate limits, oracle timeouts, a 502 from thornode), the SDK's own raw provider errors were discarded in favor of a generic message that structurally can never be classified as transient downstream. Users got told a corridor "has no route" when actually every provider was just unreachable for a moment.

## how

Adds `isTransientProviderFailure` — checked only when literally EVERY rejected provider's raw rejection reason is transient (reuses the same below-minimum/halted/no-route bail-outs already used elsewhere in this function, so a provider that positively answered "no route" or "below minimum" still wins and nothing regresses there). Only in that all-transient case, throws a distinct message that:
- Names the detected category ("transient network/timeout error") instead of leaking raw upstream provider text — kept just as noise-free as the existing generic fallback (see the "omits noisy provider errors" test, unchanged).
- Deliberately avoids the "no route" phrase, so `isTransientQuoteError` and any other downstream classifier keyed on that phrase can correctly detect it as transient.

The existing generic message is completely untouched for every other case (mixed signals, or a genuine structural no-route) — so none of the many downstream consumers keyed on its exact wording (evals scorers, `mcp.ts`'s `classifySwapNoRoute`, the scheduler retry messaging) change behavior. Zero changes needed in agent-backend-ts itself — the new message already satisfies its existing `isTransientQuoteError` heuristics.

## testing

- 2 new tests in `findSwapQuote.selection.test.ts`: all-transient (network/timeout/5xx mix, including bare `ETIMEDOUT`/`HTTP 502` forms) -> new transient message, no "no route" phrase; mixed transient + one genuine structural no-route -> unchanged generic message (a real decline still wins).
- Full existing `findSwapQuote.*.test.ts` suite green (90 tests, run with `--no-file-parallelism` to rule out an unrelated pre-existing timeout flake under parallel load - confirmed present on clean `main` too, unrelated to this change).
- `tsc --project .config/tsconfig.json --noEmit` clean.

## risk

Low - additive-only branch gated on a narrow all-transient condition that doesn't overlap with any existing fixture (all current tests use plain non-matching error strings like `"kyber fail"`). No behavior change for the genuine no-route path.