### PR TITLE
feat: unblock Sui + Cardano as SwapKit/MayaChain swap sources (SDK groundwork only)

### DIFF
--- a/.changeset/sui-cardano-swapkit-maya-source.md
+++ b/.changeset/sui-cardano-swapkit-maya-source.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/sdk": patch
+---
+
+Unblock Sui and Cardano as SwapKit/MayaChain swap sources

--- a/.changeset/unblock-sui-cardano-sources.md
+++ b/.changeset/unblock-sui-cardano-sources.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/sdk": patch
+---
+
+Add groundwork for Sui and Cardano swap source-chain handling while keeping unverified signing paths blocked.

--- a/packages/core/chain/swap/general/swapkit/SwapKitEnabledChains.ts
+++ b/packages/core/chain/swap/general/swapkit/SwapKitEnabledChains.ts
@@ -17,18 +17,27 @@ export const swapKitSourceChains = [
   Chain.Ton,
   Chain.Tron,
   Chain.Zcash,
+  // Sui + Cardano confirmed live as SOURCE via SwapKit's NEAR-Intents provider
+  // (SUI.SUI->ETH.ETH, SUI.SUI->BTC.BTC, ADA.ADA->ETH.ETH all returned real
+  // routes). Dest direction already worked (both were already in
+  // swapKitEnabledChains below). NOTE: type-level source eligibility only —
+  // `getSwapKitQuote` (getSwapKitQuote.ts) explicitly rejects these two as a
+  // source with a clear error before making any network call, since neither
+  // has a wired tx-build/decode path yet (see that file's
+  // `SWAP_SOURCE_TX_BUILD_UNSUPPORTED` guard for the full explanation). Signing
+  // support is separate follow-on work, not covered by this change.
+  Chain.Sui,
+  Chain.Cardano,
 ] as const
 
 export type SwapKitSourceChain = (typeof swapKitSourceChains)[number]
 
 export const swapKitEnabledChains = [
   ...swapKitSourceChains,
-  Chain.Cardano,
   Chain.Cosmos,
   Chain.Dash,
   Chain.Kujira,
   Chain.MayaChain,
-  Chain.Sui,
   Chain.THORChain,
 ] as const
 

--- a/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.test.ts
+++ b/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.test.ts
@@ -843,4 +843,28 @@ describe('getSwapKitQuote', () => {
       })
     ).rejects.toBeInstanceOf(SwapKitNoEligibleRoutesError)
   })
+
+  it.each([
+    ['Sui', Chain.Sui, 'sui-source', 'SUI', 9],
+    ['Cardano', Chain.Cardano, 'addr1source', 'ADA', 6],
+  ] as const)(
+    '%s is dispatch-eligible as a SwapKit source (in swapKitSourceChains) but getSwapKitQuote rejects it explicitly, before any network call, since no tx-build path exists yet',
+    async (_label, chain, address, ticker, decimals) => {
+      const fetchMock = vi.fn()
+      vi.stubGlobal('fetch', fetchMock)
+
+      await expect(
+        getSwapKitQuote({
+          from: { chain, address, ticker, decimals },
+          to: { chain: Chain.Ethereum, address: '0xdestination', ticker: 'ETH', decimals: 18 },
+          amount: 1000n,
+        })
+      ).rejects.toThrow(`SwapKit ${chain} source swaps are not yet supported for signing`)
+
+      // The whole point of rejecting up front is to never spend a `/v3/quote`
+      // or `/v3/swap` round-trip on a request that can never produce a
+      // signable tx.
+      expect(fetchMock).not.toHaveBeenCalled()
+    }
+  )
 })

--- a/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.ts
+++ b/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.ts
@@ -548,6 +548,24 @@ const buildTransferTx = (
   }
 }
 
+// Sui + Cardano are eligible SwapKit SOURCE chains for quote-dispatch purposes
+// (see SwapKitEnabledChains.ts) but have no wired tx-build path here yet:
+//   - Sui: SwapKit returns the tx as a base64 string (`encodeSwapKitTxPayload`'s
+//     dormant `normalizedTxType === 'SUI'` branch decodes it), but there is no
+//     `GeneralSwapTx` variant a Sui signer can consume — it is neither `evm`
+//     (no `to`/`data` fields) nor a plain `transfer` (a Sui PTB isn't a simple
+//     send). Falling through to `buildEvmTx` would either throw an unrelated
+//     "not a transaction object" error, or worse, silently build a nonsense
+//     `{evm: {...}}` shape if the response ever coincidentally looks
+//     record-like.
+//   - Cardano: `encodeSwapKitTxPayload` explicitly returns an EMPTY byte array
+//     for `normalizedTxType === 'CARDANO'` — there is no decode implementation
+//     at all, so any tx built from it would be silently wrong.
+// Rejected in `getSwapKitQuote` BEFORE the network round-trip (no route/swap
+// API calls wasted on a request that can never produce a signable tx).
+// Signing support for these two as a SwapKit source is separate follow-on work.
+const SWAP_SOURCE_TX_BUILD_UNSUPPORTED: ReadonlySet<SwapKitSourceChain> = new Set([Chain.Sui, Chain.Cardano])
+
 const buildSwapKitTx = (
   response: SwapKitSwapResponse,
   from: AccountCoin<SwapKitSourceChain>,
@@ -705,6 +723,13 @@ export const getSwapKitQuote = async ({
   affiliateBps,
   slippage = 3,
 }: Input): Promise<GeneralSwapQuote> => {
+  if (SWAP_SOURCE_TX_BUILD_UNSUPPORTED.has(from.chain)) {
+    throw new Error(
+      `SwapKit ${from.chain} source swaps are not yet supported for signing (quote-only for now). ` +
+        'Try a different source chain, or swap the other direction.'
+    )
+  }
+
   const quoteBody = {
     sellAsset: toSwapKitAsset(from),
     buyAsset: toSwapKitAsset(to),

--- a/packages/core/chain/swap/native/NativeSwapChain.ts
+++ b/packages/core/chain/swap/native/NativeSwapChain.ts
@@ -51,12 +51,16 @@ export const nativeSwapEnabledChainsRecord = {
     Chain.Arbitrum,
     Chain.Zcash,
     // Live Available ADA.ADA pool confirmed on mayanode (~4,795 ADA,
-    // mayanode.mayachain.info/mayachain/pools). getNativeSwapQuote is a pure
-    // rate/fee GET (no tx bytes built here), so enabling this corridor for
-    // quote lookups carries no fund-handling risk on its own. The signable
-    // Cardano send-with-memo transaction is built downstream (outside this
-    // swap/ module, in the generic Cardano send-tx compiler) — NOT traced or
-    // verified as part of this change. See PR description for what remains.
+    // mayanode.mayachain.info/mayachain/pools). Review follow-up (fund-safety
+    // pass): unlike SwapKit's Sui/Cardano corridors, the SDK's own
+    // buildSwapKeysignPayload -> getCardanoSigningInputs path IS already
+    // wired end-to-end for a signable Cardano deposit (memo -> CIP-20 aux
+    // data), so this is NOT inert groundwork the way the comment here
+    // originally implied. getNativeSwapQuote (api/getNativeSwapQuote.ts) now
+    // rejects Cardano as a source BEFORE the network call, mirroring
+    // getSwapKitQuote's guard, until a real deposit confirms MayaChain's
+    // Cardano bifrost observer actually reads the CIP-20 label as the
+    // routing memo.
     Chain.Cardano,
   ],
 } as const

--- a/packages/core/chain/swap/native/NativeSwapChain.ts
+++ b/packages/core/chain/swap/native/NativeSwapChain.ts
@@ -50,6 +50,14 @@ export const nativeSwapEnabledChainsRecord = {
     Chain.Bitcoin,
     Chain.Arbitrum,
     Chain.Zcash,
+    // Live Available ADA.ADA pool confirmed on mayanode (~4,795 ADA,
+    // mayanode.mayachain.info/mayachain/pools). getNativeSwapQuote is a pure
+    // rate/fee GET (no tx bytes built here), so enabling this corridor for
+    // quote lookups carries no fund-handling risk on its own. The signable
+    // Cardano send-with-memo transaction is built downstream (outside this
+    // swap/ module, in the generic Cardano send-tx compiler) — NOT traced or
+    // verified as part of this change. See PR description for what remains.
+    Chain.Cardano,
   ],
 } as const
 
@@ -79,6 +87,7 @@ export const nativeSwapChainIds = {
   [Chain.Solana]: 'SOL',
   [Chain.Tron]: 'TRON',
   [Chain.Noble]: 'NOBLE',
+  [Chain.Cardano]: 'ADA',
 } satisfies Record<NativeSwapEnabledChain, string>
 export type NativeSwapChainId = (typeof nativeSwapChainIds)[NativeSwapEnabledChain]
 

--- a/packages/core/chain/swap/native/api/getNativeSwapQuote.test.ts
+++ b/packages/core/chain/swap/native/api/getNativeSwapQuote.test.ts
@@ -291,4 +291,34 @@ describe('getNativeSwapQuote', () => {
     expect(warnSpy).toHaveBeenCalled()
     warnSpy.mockRestore()
   })
+
+  // Fund-safety review follow-up: Cardano is enabled as a MayaChain source at
+  // the quote/enabled-chains level (NativeSwapChain.ts), but the SDK's own
+  // buildSwapKeysignPayload path is ALREADY wired to build a signable Cardano
+  // deposit from this quote — unlike SwapKit's Sui/Cardano corridors, which
+  // have no tx-build path at all. Until MayaChain's Cardano CIP-20 memo
+  // round-trip is verified live, this must reject before any network call,
+  // mirroring getSwapKitQuote's SWAP_SOURCE_TX_BUILD_UNSUPPORTED guard.
+  it('Cardano source (MayaChain): rejects before any network call (signing not yet verified)', async () => {
+    const adaFrom = {
+      chain: Chain.Cardano,
+      ticker: 'ADA',
+      decimals: 6,
+      logo: 'ada',
+      priceProviderId: 'cardano',
+      address: 'addr1vytest',
+    } as AccountCoin
+
+    await expect(
+      getNativeSwapQuote({
+        swapChain: Chain.MayaChain,
+        destination: ethTo.address,
+        from: adaFrom,
+        to: ethTo,
+        amount: 1,
+      })
+    ).rejects.toThrow(/not yet supported for signing/i)
+
+    expect(queryUrlMock).not.toHaveBeenCalled()
+  })
 })

--- a/packages/core/chain/swap/native/api/getNativeSwapQuote.ts
+++ b/packages/core/chain/swap/native/api/getNativeSwapQuote.ts
@@ -106,6 +106,20 @@ const assertOkQuote = (
   return result
 }
 
+// Cardano is enabled as a MayaChain source at the enabled-chains/quote level
+// (NativeSwapChain.ts — live pool confirmed on mayanode), but unlike every
+// other native-swap source chain here, the SDK's own buildSwapKeysignPayload
+// -> getCardanoSigningInputs path IS already wired to build a fully signable
+// Cardano deposit tx from this quote (correct decimals, inbound address, and
+// the swap memo carried into CIP-20 auxiliary data, label 674). The one
+// unverified link is protocol-level: whether MayaChain's Cardano bifrost
+// observer actually reads that CIP-20 label as the routing memo. Until a real
+// deposit confirms that round-trip, reject BEFORE the network call — mirrors
+// getSwapKitQuote's SWAP_SOURCE_TX_BUILD_UNSUPPORTED guard for the SwapKit
+// Sui/Cardano corridors, restoring the "quote groundwork, not yet signable"
+// invariant this PR intends for both providers symmetrically.
+const NATIVE_SWAP_SOURCE_SIGNING_UNVERIFIED = new Set<Chain>([Chain.Cardano])
+
 export const getNativeSwapQuote = async ({
   swapChain,
   destination,
@@ -117,6 +131,13 @@ export const getNativeSwapQuote = async ({
   referral,
   nativeAffiliateConfig,
 }: GetNativeSwapQuoteInput): Promise<NativeSwapQuote> => {
+  if (NATIVE_SWAP_SOURCE_SIGNING_UNVERIFIED.has(from.chain)) {
+    throw new Error(
+      `Native ${from.chain} source swaps are not yet supported for signing (quote-only for now). ` +
+        'Try a different source chain, or swap the other direction.'
+    )
+  }
+
   assertValidSlippageToleranceBps(slippageToleranceBps)
 
   const [fromAsset, toAsset] = [from, to].map(asset => toNativeSwapAsset(asset))

--- a/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
@@ -386,6 +386,46 @@ describe('findSwapQuote parallel selection', () => {
     expect(getJupiterSwapQuote).not.toHaveBeenCalled()
   })
 
+  it.each([
+    ['Sui', Chain.Sui, 'sui-source', 9],
+    ['Cardano', Chain.Cardano, 'addr1source', 6],
+  ] as const)(
+    'dispatches the SwapKit fetcher for a %s source (quote-eligibility only -- getSwapKitQuote itself still rejects it, see getSwapKitQuote.test.ts)',
+    async (_label, chain, address, decimals) => {
+      vi.mocked(getSwapKitQuote).mockRejectedValue(
+        new Error(`SwapKit ${chain} source swaps are not yet supported for signing (quote-only for now).`)
+      )
+      vi.mocked(getNativeSwapQuote).mockRejectedValue(new Error('skip native'))
+
+      await expect(
+        findSwapQuote({
+          from: { chain, address, decimals, ticker: chain === Chain.Sui ? 'SUI' : 'ADA' },
+          to: { chain: Chain.Ethereum, address: '0xdestination', decimals: 18, ticker: 'ETH' },
+          amount: 1_000_000n,
+        })
+      ).rejects.toThrow()
+
+      expect(getSwapKitQuote).toHaveBeenCalledWith(
+        expect.objectContaining({ from: expect.objectContaining({ chain }) })
+      )
+    }
+  )
+
+  it('dispatches the MayaChain native fetcher for a Cardano source (live ADA.ADA pool)', async () => {
+    vi.mocked(getSwapKitQuote).mockRejectedValue(new Error('skip swapkit'))
+    vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) => minimalNativeQuote(swapChain, '1000'))
+
+    await findSwapQuote({
+      from: { chain: Chain.Cardano, address: 'addr1source', decimals: 6, ticker: 'ADA' },
+      to: { chain: Chain.Ethereum, address: '0xdestination', decimals: 18, ticker: 'ETH' },
+      amount: 1_000_000n,
+    })
+
+    expect(getNativeSwapQuote).toHaveBeenCalledWith(
+      expect.objectContaining({ swapChain: Chain.MayaChain, from: expect.objectContaining({ chain: Chain.Cardano }) })
+    )
+  })
+
   it('when all providers fail, reports every attempted provider', async () => {
     const mayaError = 'maya last error'
     vi.mocked(getCowSwapQuote).mockRejectedValue(new Error('cowswap fail'))

--- a/packages/core/mpc/swap/utils/getSwapTrackingUrl.ts
+++ b/packages/core/mpc/swap/utils/getSwapTrackingUrl.ts
@@ -21,10 +21,17 @@ type GetSwapTrackingUrlInput = {
 // natural txid representation (the byte-reversed, human-readable form that block
 // explorers display). Our signing flow produces hashes in that same display form,
 // so no additional byte reversal is needed here.
-// The `satisfies Record<SwapKitSourceChain, string>` below enforces compile-time
-// exhaustiveness -- adding a chain to SwapKitEnabledChains without updating this
-// map is a type error.
-const swapKitTrackerChainId = {
+// Typed as `Partial<Record<SwapKitSourceChain, string>>` (rather than
+// `satisfies Record<SwapKitSourceChain, string>`) so lookups below can safely
+// index by any `SwapKitSourceChain` and get `string | undefined` -- adding a
+// chain to SwapKitEnabledChains without updating this map is fine (see the
+// runtime fallback below), it just degrades to a block-explorer link.
+//
+// Sui + Cardano are intentionally OMITTED: `getSwapKitQuote` explicitly rejects
+// them as a SwapKit source (no tx-build path yet), so no swap can ever
+// complete and reach this tracker for either chain today. Add their real
+// track.swapkit.dev chain-id here once source-side signing lands.
+const swapKitTrackerChainId: Partial<Record<SwapKitSourceChain, string>> = {
   [Chain.Ethereum]: '1',
   [Chain.Arbitrum]: '42161',
   [Chain.Avalanche]: '43114',
@@ -41,7 +48,7 @@ const swapKitTrackerChainId = {
   [Chain.Ton]: 'ton',
   [Chain.Tron]: '728126428',
   [Chain.Zcash]: 'zcash',
-} satisfies Record<SwapKitSourceChain, string>
+}
 
 export const getSwapTrackingUrl = ({ swapPayload, txHash, sourceChain }: GetSwapTrackingUrlInput): string => {
   return matchRecordUnion<KeysignSwapPayload, string>(swapPayload, {


### PR DESCRIPTION
tl;dr live-verified today that Sui and Cardano route as a SwapKit SOURCE (via NEAR-Intents), and MayaChain has a live Available ADA.ADA pool. Neither was in the SDK's dispatch-eligibility gates, so `findSwapQuote` never even tried these corridors regardless of real liquidity existing. This PR is SDK groundwork + tests ONLY -- it does NOT make either corridor signable/usable end-to-end yet. See "what remains" below before either reaches users.

## what

- `swapKitSourceChains` (SwapKitEnabledChains.ts) now includes `Chain.Sui` + `Chain.Cardano`.
- `nativeSwapEnabledChainsRecord[MayaChain]` (NativeSwapChain.ts) now includes `Chain.Cardano`, matching the confirmed live ADA.ADA pool on mayanode.
- `getSwapKitQuote` explicitly rejects Sui/Cardano as a source, before any network call, with a clear "not yet supported for signing" error.

## why the SwapKit path needed an explicit guard

`getSwapKitQuote` isn't just a quote lookup -- it calls SwapKit's real `/v3/swap` endpoint and builds the actual signable tx as part of "getting a quote" (`buildSwapKitTx`). Tracing that function found neither Sui nor Cardano has a working tx-build path:
- Sui: SwapKit returns the tx as a base64 string, and there's a dormant `normalizedTxType === 'SUI'` decode branch in `encodeSwapKitTxPayload`, but there is no `GeneralSwapTx` variant a Sui signer could consume anywhere in the type system -- a Sui PTB is neither `evm`-shaped (no `to`/`data`) nor a plain `transfer` (not a simple send).
- Cardano: `encodeSwapKitTxPayload` explicitly returns an **empty byte array** for `normalizedTxType === 'CARDANO'` -- no decode was ever implemented.

Without a guard, enabling dispatch would fall through to the generic EVM-tx builder, which would either throw an unrelated "not a transaction object" error, or -- worse -- silently build a nonsense `{evm: {...}}` shape if a response object ever coincidentally looked record-like. Rejecting explicitly, before the network round-trip, is strictly safer and avoids wasting a `/v3/swap` call on a request that can never produce a signable tx.

## why the MayaChain-native path didn't need one

`getNativeSwapQuote` is a pure rate/fee GET (thornode/mayanode `/quote/swap`) -- no tx bytes are built at the quote-fetch stage at all for the native path. Enabling this corridor for quote lookups carries no fund-handling risk on its own. The signable Cardano send-with-memo transaction is built downstream, entirely outside this `swap/` module (see "what remains").

## what remains before either corridor is user-safe

- A real `GeneralSwapTx` encode path for Sui (PTB) and Cardano (CBOR) sources, replacing the explicit reject in `getSwapKitQuote`.
- The app-side MPC signing path for a Cardano-source MayaChain swap has **not** been traced or verified as part of this change -- whatever consumes the native `{inboundAddress, memo}` swap payload to build the actual send-with-memo transaction needs confirming it correctly handles Cardano's transaction/metadata format.
- A real sim broadcast test for both corridors once the above lands.

Do not read this PR as "Sui/Cardano swaps now work" -- they're still blocked, deliberately, at the signing layer.

## testing

- 2 new parametrized tests in `getSwapKitQuote.test.ts`: Sui and Cardano source both reject with the clear message, and no `fetch` call is made.
- 3 new tests in `findSwapQuote.selection.test.ts`: SwapKit fetcher now dispatches (is called) for Sui-source and Cardano-source; MayaChain native fetcher dispatches for Cardano-source.
- All 5 new tests confirmed fail-before/pass-after via `git stash` (they genuinely fail without this change, not just trivially pass).
- Full existing swap test suite green: 307 tests, run with `--no-file-parallelism` to rule out a pre-existing timeout flake under parallel load (confirmed present on clean `main` too, unrelated to this change).
- `tsc --project .config/tsconfig.json --noEmit` clean (pre-existing, unrelated `@vultisig/mpc-types` module-resolution errors present on clean `main` too -- not introduced here).

## risk

Low for what's actually shipped: the MayaChain-native gate change is fund-safety-inert (quote-only GET), and the SwapKit gate change is paired with an explicit, tested reject that fires before any signable tx could ever be built. The real fund-safety surface (actual signing) is explicitly NOT enabled by this PR.