### PR TITLE
feat(sdk): fold LLM chain-alias tolerance into normalizeChain

### DIFF
--- a/packages/sdk/src/utils/normalizeChain.ts
+++ b/packages/sdk/src/utils/normalizeChain.ts
@@ -61,6 +61,55 @@ for (const value of Object.values(Chain)) {
   aliasToChain[value.toLowerCase()] = value
 }
 
+/** Lowercase + strip spaces/underscores/hyphens, e.g. "Terra Classic" -> "terraclassic". */
+function stripSeparators(key: string): string {
+  return key.replace(/[\s_-]+/g, '')
+}
+
+/**
+ * Separator-stripped fallback table (LLM-tolerance layer, consolidated from
+ * agent-backend-ts's `zodHelpers.ts` `chainString()` — the fix for the
+ * LUNA<->LUNC "no route" bug: deepseek emits `to_chain: "Terra Classic"`
+ * (with a space) routinely, and the exact-match table above rejects it
+ * outright since neither `"terra classic"` nor any hand-curated alias
+ * carries a literal space).
+ *
+ * Derived automatically from every entry already in `aliasToChain` (so
+ * "Bitcoin Cash" / "Cronos Chain" / "THOR Chain" / "ZK Sync" all resolve via
+ * their EXISTING un-spaced aliases/canonical forms — no per-chain
+ * maintenance needed), PLUS a small hand-curated set of chain-id / marketing
+ * names that don't reduce from any existing key at all (`columbus-5`,
+ * `phoenix-1`, `"Terra V2"`).
+ *
+ * Same ownership-claim safety as the ticker table above: a stripped key that
+ * would resolve to more than one DISTINCT chain is dropped rather than
+ * guessing — fund-safety (a wrong collision could misroute a swap/send to
+ * the wrong chain), never silently pick a side.
+ */
+const strippedAliasToChain: Record<string, Chain> = {}
+const strippedOwnersByAlias = new Map<string, Set<Chain>>()
+const claimStripped = (alias: string, chain: Chain) => {
+  const key = stripSeparators(alias.toLowerCase())
+  const owners = strippedOwnersByAlias.get(key) ?? new Set<Chain>()
+  owners.add(chain)
+  strippedOwnersByAlias.set(key, owners)
+}
+for (const [alias, chain] of Object.entries(aliasToChain)) {
+  claimStripped(alias, chain)
+}
+// Chain-id / marketing-name aliases that carry no separator-free form anywhere above.
+// Kept in sync with agent-backend-ts's zodHelpers.ts CHAIN_ALIAS_TABLE.
+claimStripped('columbus-5', Chain.TerraClassic) // Terra Classic's chain-id
+claimStripped('phoenix-1', Chain.Terra) // Terra v2's chain-id
+claimStripped('terra v2', Chain.Terra) // common marketing name for post-fork Terra
+for (const [key, owners] of strippedOwnersByAlias) {
+  if (owners.size !== 1) continue
+  for (const only of owners) {
+    strippedAliasToChain[key] = only
+    break
+  }
+}
+
 /**
  * Resolve a case-insensitive chain string (canonical name, ticker, or common
  * alias) to the SDK's canonical Chain value.
@@ -69,10 +118,18 @@ for (const value of Object.values(Chain)) {
  * - Canonical Chain enum values (`"Ethereum"`, `"Bitcoin"`, `"Bitcoin-Cash"`, ...)
  * - Tickers (`"btc"`, `"eth"`, `"sol"`, ...)
  * - Common aliases (`"bitcoin"`, `"binance"`, `"thorchain"`, ...)
+ * - Space/underscore/hyphen-insensitive natural-language phrasings LLMs
+ *   routinely emit (`"Terra Classic"`, `"Bitcoin Cash"`, `"Cronos Chain"`,
+ *   `"THOR Chain"`, `"ZK Sync"`) and chain-id / marketing-name forms
+ *   (`"columbus-5"`, `"phoenix-1"`, `"Terra V2"`)
  *
  * Accepts nullish input because this utility is commonly called with
  * LLM-sourced strings that may be missing — such inputs throw
  * `UnknownChainError` with a blank input rather than a `TypeError`.
+ *
+ * This is the SINGLE canonical LLM-tolerant chain normalizer — callers
+ * needing chain-string tolerance should use this directly rather than
+ * layering their own separator-stripping / alias fallback on top of it.
  *
  * @throws {UnknownChainError} When the input cannot be resolved.
  */
@@ -80,6 +137,10 @@ export const normalizeChain = (input: string | null | undefined): Chain => {
   const key = input?.trim().toLowerCase() ?? ''
   const resolved = aliasToChain[key]
   if (resolved) return resolved
+
+  const stripped = stripSeparators(key)
+  const strippedResolved = strippedAliasToChain[stripped]
+  if (strippedResolved) return strippedResolved
 
   const known = Object.values(Chain).map(c => c.toLowerCase())
   throw new UnknownChainError(key, known)

--- a/packages/sdk/tests/unit/utils/normalizeChain.test.ts
+++ b/packages/sdk/tests/unit/utils/normalizeChain.test.ts
@@ -211,4 +211,110 @@ describe('normalizeChain', () => {
       expect(normalizeChain('usdc')).toBe(Chain.Noble)
     })
   })
+
+  // Consolidated from agent-backend-ts's zodHelpers.ts chainString() — the fix for the
+  // LUNA<->LUNC "no route" bug (deepseek emits `to_chain: "Terra Classic"` with a space
+  // ~2/3 of the time, which the pre-consolidation SDK rejected outright). These natural-
+  // language, space/underscore/hyphen-insensitive forms must resolve WITHOUT any caller-side
+  // fallback layer — the SDK is now the single source of this tolerance.
+  describe('separator-insensitive natural-language phrasings (LLM tolerance)', () => {
+    it.each([
+      ['Terra Classic', Chain.TerraClassic],
+      ['terra classic', Chain.TerraClassic],
+      ['TERRA CLASSIC', Chain.TerraClassic],
+      ['terra_classic', Chain.TerraClassic],
+      ['terra-classic', Chain.TerraClassic],
+      ['Bitcoin Cash', Chain.BitcoinCash],
+      ['bitcoin cash', Chain.BitcoinCash],
+      ['BITCOIN CASH', Chain.BitcoinCash],
+      ['bitcoin_cash', Chain.BitcoinCash],
+      ['Cronos Chain', Chain.CronosChain],
+      ['cronos chain', Chain.CronosChain],
+      ['THOR Chain', Chain.THORChain],
+      ['thor chain', Chain.THORChain],
+      ['Thor Chain', Chain.THORChain],
+      ['ZK Sync', Chain.Zksync],
+      ['zk sync', Chain.Zksync],
+      ['Maya Chain', Chain.MayaChain],
+      ['maya chain', Chain.MayaChain],
+      ['Binance Smart Chain', Chain.BSC],
+      ['binance smart chain', Chain.BSC],
+    ])('resolves separator-insensitive "%s" to %s', (input, expected) => {
+      expect(normalizeChain(input)).toBe(expected)
+    })
+
+    it('still resolves the exact hyphenated canonical form directly (no regression)', () => {
+      expect(normalizeChain('Bitcoin-Cash')).toBe(Chain.BitcoinCash)
+    })
+
+    it('still resolves the un-spaced hand-curated alias directly (no regression)', () => {
+      expect(normalizeChain('bitcoincash')).toBe(Chain.BitcoinCash)
+      expect(normalizeChain('binancesmartchain')).toBe(Chain.BSC)
+    })
+
+    it('tolerates surrounding whitespace combined with internal separators', () => {
+      expect(normalizeChain('  Terra Classic  ')).toBe(Chain.TerraClassic)
+      expect(normalizeChain('\tBitcoin Cash\n')).toBe(Chain.BitcoinCash)
+    })
+  })
+
+  // Chain-id / marketing-name aliases (agent-backend-ts CHAIN_ALIAS_TABLE): these carry no
+  // separator-free form anywhere in the existing alias/ticker/canonical tables, so they are
+  // hand-curated additions, not a side effect of separator-stripping alone.
+  describe('chain-id / marketing-name aliases', () => {
+    it.each([
+      ['columbus-5', Chain.TerraClassic],
+      ['columbus5', Chain.TerraClassic],
+      ['Columbus-5', Chain.TerraClassic],
+      ['COLUMBUS-5', Chain.TerraClassic],
+      ['phoenix-1', Chain.Terra],
+      ['phoenix1', Chain.Terra],
+      ['Phoenix-1', Chain.Terra],
+      ['terra v2', Chain.Terra],
+      ['Terra V2', Chain.Terra],
+      ['TERRA V2', Chain.Terra],
+      ['terra-v2', Chain.Terra],
+      ['terra_v2', Chain.Terra],
+      ['terrav2', Chain.Terra],
+    ])('resolves chain-id/marketing alias "%s" to %s', (input, expected) => {
+      expect(normalizeChain(input)).toBe(expected)
+    })
+
+    it('does not conflate Terra v2 aliases with Terra Classic (fund-safety: distinct chains, shared address)', () => {
+      expect(normalizeChain('phoenix-1')).not.toBe(Chain.TerraClassic)
+      expect(normalizeChain('terra v2')).not.toBe(Chain.TerraClassic)
+      expect(normalizeChain('columbus-5')).not.toBe(Chain.Terra)
+    })
+  })
+
+  // Fund-safety guard: a wrong collision here could misroute a swap/send to the wrong chain.
+  // Every canonical Chain value's own separator-stripped form must resolve to ITSELF, never to
+  // a different chain — proves the auto-derived stripped-alias table never cross-wires two
+  // distinct chains that happen to share a stripped form.
+  describe('collision guard — every known chain resolves to itself, never another chain', () => {
+    it.each(Object.values(Chain))('canonical value %s round-trips to itself', chain => {
+      expect(normalizeChain(chain)).toBe(chain)
+      expect(normalizeChain(chain.toLowerCase())).toBe(chain)
+      expect(normalizeChain(chain.toUpperCase())).toBe(chain)
+    })
+
+    it('Terra and TerraClassic never resolve to each other despite sharing an address/name prefix', () => {
+      expect(normalizeChain('Terra')).toBe(Chain.Terra)
+      expect(normalizeChain('Terra')).not.toBe(Chain.TerraClassic)
+      expect(normalizeChain('TerraClassic')).toBe(Chain.TerraClassic)
+      expect(normalizeChain('TerraClassic')).not.toBe(Chain.Terra)
+      expect(normalizeChain('Terra Classic')).toBe(Chain.TerraClassic)
+      expect(normalizeChain('Terra Classic')).not.toBe(Chain.Terra)
+    })
+  })
+
+  describe('error cases (separator-stripped fallback)', () => {
+    it('still throws for a genuinely unknown space-separated phrase', () => {
+      expect(() => normalizeChain('not a real chain')).toThrow(UnknownChainError)
+    })
+
+    it('still throws for a partial/ambiguous fragment', () => {
+      expect(() => normalizeChain('terra classic 2')).toThrow(UnknownChainError)
+    })
+  })
 })


### PR DESCRIPTION
Structural follow-on to the LUNC<->USTC bug (candidate #1 from the SDK-consolidation spike, highest bug-prevention/effort). SDK-only, additive.

## what

The LUNC<->USTC incident traced back to THREE independent, divergent reimplementations of "make an LLM-emitted chain string canonical":

1. agent-backend-ts's `zodHelpers.ts` `chainString()` (SDK `normalizeChain` + a rich alias table + space-stripping) - the richest, but bypassable (movement tools skip `inputSchema.parse`, the LUNC<->USTC bug being fixed separately in abts right now).
2. agent-backend-ts's `resolveToken.ts` `normalizeChainInput` - a thin `sdkNormalizeChain` wrapper with NO separator tolerance. Different tolerance than #1.
3. the SDK's own `normalizeChain` - the weakest of the three (exact-match only, no space-stripping fallback).

The divergence between #1 and #2 (one tolerates a form the other doesn't) is exactly what let the split-brain bug through.

This PR enriches the SDK's `normalizeChain` (`packages/sdk/src/utils/normalizeChain.ts`) to be the single canonical LLM-tolerant normalizer, folding in the separator-stripping fallback + explicit chain-id/marketing-name alias table currently living in abts's `zodHelpers.ts:135-195`.

## how

The existing ticker/hand-curated/canonical alias table is untouched - exact-match stays the fast, backward-compatible first attempt. A second table is auto-derived from every entry in that table by stripping spaces/underscores/hyphens, using the SAME single-owner claim mechanism already used for ticker aliases: a stripped key that would resolve to more than one distinct chain is dropped rather than guessed (fund-safety - a wrong collision could misroute a swap/send).

This means `"Bitcoin Cash"` / `"Cronos Chain"` / `"THOR Chain"` / `"ZK Sync"` / `"Terra Classic"` / `"Binance Smart Chain"` all resolve automatically from their EXISTING un-spaced aliases or canonical forms - zero per-chain maintenance needed. The only hand-curated additions are the three chain-id/marketing names that have no separator-free form anywhere else in the table: `columbus-5` -> TerraClassic, `phoenix-1` -> Terra, `"Terra V2"` -> Terra (kept in sync with abts's `CHAIN_ALIAS_TABLE`).

## what I deliberately did / didn't include

- Included: every alias/separator case from abts's `zodHelpers.ts` `chainString()` fallback path (`stripChainSeparators` + `CHAIN_ALIAS_TABLE`).
- Deliberately NOT included: mcp-ts's own copy of this same alias table (zodHelpers.ts's comments reference it as a second, currently-unconsolidated vendored copy, PR #753) - out of scope here, a further follow-on.
- Deliberately NOT touching abts's `zodHelpers.ts` or `resolveToken.ts` in this PR (see scope discipline below).

## scope discipline

Per the task brief: this PR is SDK-only and purely additive. It does NOT touch agent-backend-ts's `zodHelpers.ts` or `resolveToken.ts` - de-duplicating those call sites (deleting the now-redundant `CHAIN_ALIAS_TABLE`/`stripChainSeparators` fallback and delegating straight to this enriched SDK function) is an intentional SEPARATE follow-on PR, to land AFTER both (a) the in-flight abts LUNC<->USTC canonicalization fix and (b) this PR - avoiding merge conflicts and keeping each PR independently reviewable.

## test matrix

`packages/sdk/tests/unit/utils/normalizeChain.test.ts`:
- every existing canonical/alias/whitespace/error case unchanged and still passing (no regression)
- separator-insensitive natural-language phrasings: Terra Classic, Bitcoin Cash, Cronos Chain, THOR Chain, ZK Sync, Maya Chain, Binance Smart Chain, each across space/underscore/hyphen/casing variants
- chain-id/marketing-name aliases: columbus-5, phoenix-1, "Terra V2" across casing/separator variants
- fund-safety collision guard: every `Chain` enum value round-trips to itself (canonical/lower/upper case), and Terra/TerraClassic are asserted to never resolve to each other despite sharing an address and name prefix
- still fails closed for genuinely unknown/ambiguous phrases

167 SDK unit test files / 2373 tests passing (`yarn test:unit`), `yarn typecheck` clean, lint clean.

🤖 Agent-generated