### PR TITLE
feat(swap): consolidate Skip Go routing-eligibility into the SDK

### DIFF
--- a/.changeset/skip-routing-consolidation.md
+++ b/.changeset/skip-routing-consolidation.md
@@ -1,0 +1,13 @@
+---
+"@vultisig/sdk": patch
+---
+
+feat(swap): consolidate Skip Go routing-eligibility predicates into the SDK
+
+Adds `isSkipRoutableChain`, `isTerraChain`, and `willRouteViaSkip` as tested
+core functions under `@vultisig/core-chain/swap/skip/skipRouting`, re-exported
+from the main `@vultisig/sdk` entry. Pure chain-topology predicates (no network
+calls, no AI-specific logic) that give consumers one shared source of truth for
+"does this from/to chain pair route through Skip Go?" instead of the
+independently-maintained copies that can drift (the mcp-ts #384 bug class).
+Purely additive — no existing export or behavior changed.

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -1717,6 +1717,11 @@
       "import": "./dist/swap/quote/SwapQuote.js",
       "default": "./dist/swap/quote/SwapQuote.js"
     },
+    "./swap/skip/skipRouting": {
+      "types": "./dist/swap/skip/skipRouting.d.ts",
+      "import": "./dist/swap/skip/skipRouting.js",
+      "default": "./dist/swap/skip/skipRouting.js"
+    },
     "./swap/swapEnabledChains": {
       "types": "./dist/swap/swapEnabledChains.d.ts",
       "import": "./dist/swap/swapEnabledChains.js",

--- a/packages/core/chain/swap/skip/skipRouting.test.ts
+++ b/packages/core/chain/swap/skip/skipRouting.test.ts
@@ -1,0 +1,83 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { describe, expect, it } from 'vitest'
+
+import { isSkipRoutableChain, isTerraChain, willRouteViaSkip } from './skipRouting'
+
+describe('isTerraChain', () => {
+  it('is true for Terra v2 and TerraClassic only', () => {
+    expect(isTerraChain(Chain.Terra)).toBe(true)
+    expect(isTerraChain(Chain.TerraClassic)).toBe(true)
+  })
+
+  it('is false for every other chain, including other Skip-routable cosmos chains', () => {
+    expect(isTerraChain(Chain.Cosmos)).toBe(false)
+    expect(isTerraChain(Chain.Osmosis)).toBe(false)
+    expect(isTerraChain(Chain.THORChain)).toBe(false)
+    expect(isTerraChain(Chain.Ethereum)).toBe(false)
+    expect(isTerraChain('NotAChain')).toBe(false)
+  })
+})
+
+describe('isSkipRoutableChain', () => {
+  it('is true for every Skip-indexed cosmos chain', () => {
+    for (const chain of [
+      Chain.Cosmos,
+      Chain.Osmosis,
+      Chain.Kujira,
+      Chain.Terra,
+      Chain.TerraClassic,
+      Chain.Akash,
+      Chain.Dydx,
+      Chain.Noble,
+    ]) {
+      expect(isSkipRoutableChain(chain)).toBe(true)
+    }
+  })
+
+  it('is false for THORChain/MayaChain (native providers, not Skip-indexed) and non-cosmos chains', () => {
+    expect(isSkipRoutableChain(Chain.THORChain)).toBe(false)
+    expect(isSkipRoutableChain(Chain.MayaChain)).toBe(false)
+    expect(isSkipRoutableChain(Chain.Ethereum)).toBe(false)
+    expect(isSkipRoutableChain(Chain.Bitcoin)).toBe(false)
+    expect(isSkipRoutableChain('NotAChain')).toBe(false)
+  })
+})
+
+describe('willRouteViaSkip', () => {
+  it('routes both-sides-Skip-routable-cosmos pairs (ATOM<->OSMO)', () => {
+    expect(willRouteViaSkip(Chain.Cosmos, Chain.Osmosis)).toBe(true)
+    expect(willRouteViaSkip(Chain.Osmosis, Chain.Kujira)).toBe(true)
+  })
+
+  it('routes any pair touching Terra v2 or TerraClassic', () => {
+    expect(willRouteViaSkip(Chain.Terra, Chain.Bitcoin)).toBe(true)
+    expect(willRouteViaSkip(Chain.Ethereum, Chain.TerraClassic)).toBe(true)
+    expect(willRouteViaSkip(Chain.Terra, Chain.THORChain)).toBe(true)
+  })
+
+  it('routes a Skip-routable-cosmos <-> Skip-supported-EVM cross pair (the #384-class bug: this branch was MISSING from abts list_swap_routes while execute_swap already had it)', () => {
+    expect(willRouteViaSkip(Chain.Cosmos, Chain.Ethereum)).toBe(true)
+    expect(willRouteViaSkip(Chain.Arbitrum, Chain.Osmosis)).toBe(true)
+    expect(willRouteViaSkip(Chain.Kujira, Chain.Base)).toBe(true)
+  })
+
+  it('does NOT route a cosmos <-> EVM pair when the EVM chain is not Skip-supported', () => {
+    expect(willRouteViaSkip(Chain.Cosmos, Chain.CronosChain)).toBe(false)
+    expect(willRouteViaSkip(Chain.Zksync, Chain.Osmosis)).toBe(false)
+  })
+
+  it('does NOT route THORChain/MayaChain-native pairs (they have their own dedicated quote APIs, not Skip-indexed)', () => {
+    expect(willRouteViaSkip(Chain.THORChain, Chain.Bitcoin)).toBe(false)
+    expect(willRouteViaSkip(Chain.MayaChain, Chain.Ethereum)).toBe(false)
+  })
+
+  it('does NOT route a cross-family pair with no Skip/Terra involvement at all (stays on the general aggregator lane)', () => {
+    expect(willRouteViaSkip(Chain.Bitcoin, Chain.Ethereum)).toBe(false)
+    expect(willRouteViaSkip(Chain.Solana, Chain.Sui)).toBe(false)
+  })
+
+  it('fails closed to false for a genuinely-unknown/uncanonicalized chain string on either side', () => {
+    expect(willRouteViaSkip('terra classic', Chain.Ethereum)).toBe(false)
+    expect(willRouteViaSkip(Chain.Cosmos, 'notachain')).toBe(false)
+  })
+})

--- a/packages/core/chain/swap/skip/skipRouting.test.ts
+++ b/packages/core/chain/swap/skip/skipRouting.test.ts
@@ -55,10 +55,19 @@ describe('willRouteViaSkip', () => {
     expect(willRouteViaSkip(Chain.Terra, Chain.THORChain)).toBe(true)
   })
 
-  it('routes a Skip-routable-cosmos <-> Skip-supported-EVM cross pair (the #384-class bug: this branch was MISSING from abts list_swap_routes while execute_swap already had it)', () => {
-    expect(willRouteViaSkip(Chain.Cosmos, Chain.Ethereum)).toBe(true)
-    expect(willRouteViaSkip(Chain.Arbitrum, Chain.Osmosis)).toBe(true)
-    expect(willRouteViaSkip(Chain.Kujira, Chain.Base)).toBe(true)
+  it('routes a Skip-routable-cosmos <-> Skip-supported-EVM cross pair for every allowlisted EVM chain (the #384-class bug: this branch was MISSING from abts list_swap_routes while execute_swap already had it)', () => {
+    for (const evmChain of [
+      Chain.Ethereum,
+      Chain.Arbitrum,
+      Chain.Optimism,
+      Chain.Base,
+      Chain.Polygon,
+      Chain.Avalanche,
+      Chain.BSC,
+    ]) {
+      expect(willRouteViaSkip(Chain.Cosmos, evmChain)).toBe(true)
+      expect(willRouteViaSkip(evmChain, Chain.Kujira)).toBe(true)
+    }
   })
 
   it('does NOT route a cosmos <-> EVM pair when the EVM chain is not Skip-supported', () => {

--- a/packages/core/chain/swap/skip/skipRouting.ts
+++ b/packages/core/chain/swap/skip/skipRouting.ts
@@ -1,0 +1,87 @@
+import { Chain, CosmosChain, EvmChain } from '@vultisig/core-chain/Chain'
+import { isChainOfKind } from '@vultisig/core-chain/ChainKind'
+
+/**
+ * Terra-family chains (Terra v2/phoenix-1, TerraClassic/columbus-5) that
+ * route swaps through Skip Go's bridge rather than a native/general
+ * aggregator quote. Keep this narrower than `isSkipRoutableChain` for the
+ * few call sites that genuinely need to special-case Terra specifically
+ * (e.g. a THORChain/MayaChain discoverer returning a no-pools-anymore hint).
+ */
+const TERRA_CHAINS: ReadonlySet<Chain> = new Set([CosmosChain.Terra, CosmosChain.TerraClassic])
+
+export const isTerraChain = (chain: string): boolean => TERRA_CHAINS.has(chain as Chain)
+
+/**
+ * Cosmos-family chains Skip Go indexes as source/destination chains for its
+ * IBC + Osmosis-poolmanager swap routes. Deliberately NOT "any Cosmos
+ * chain" — THORChain and MayaChain are native-RUNE/CACAO providers with
+ * their own dedicated quote APIs; Skip does not route through them.
+ *
+ * Each entry below was verified live against Skip's `/v2/fungible/route`
+ * endpoint before being added (see the consuming apps' git history for the
+ * probe dates) — do not add a chain here on assumption alone.
+ */
+const SKIP_ROUTABLE_COSMOS_CHAINS: ReadonlySet<Chain> = new Set([
+  CosmosChain.Cosmos,
+  CosmosChain.Osmosis,
+  CosmosChain.Kujira,
+  CosmosChain.Terra,
+  CosmosChain.TerraClassic,
+  CosmosChain.Akash,
+  CosmosChain.Dydx,
+  CosmosChain.Noble,
+])
+
+/**
+ * True when the chain participates in a Skip-routed swap pair (as either
+ * the source or destination side of `willRouteViaSkip`). Use this in
+ * routing predicates ("should we try Skip for this pair?"); use
+ * `isTerraChain` only for the narrower Terra-specific special cases.
+ */
+export const isSkipRoutableChain = (chain: string): boolean => SKIP_ROUTABLE_COSMOS_CHAINS.has(chain as Chain)
+
+/**
+ * EVM chains Skip Go bridges cosmos-side liquidity to/from (e.g. ATOM ->
+ * USDC.eth via CCTP/Axelar). Skip does not bridge to every EVM chain — only
+ * probe-verified entries are listed.
+ */
+const SKIP_SUPPORTED_EVM_CHAINS: ReadonlySet<Chain> = new Set([
+  EvmChain.Ethereum,
+  EvmChain.Arbitrum,
+  EvmChain.Optimism,
+  EvmChain.Base,
+  EvmChain.Polygon,
+  EvmChain.Avalanche,
+  EvmChain.BSC,
+])
+
+const isSkipSupportedEvmChain = (chain: string): boolean =>
+  isChainOfKind(chain as Chain, 'evm') && SKIP_SUPPORTED_EVM_CHAINS.has(chain as Chain)
+
+/**
+ * Single source of truth for "does this from/to chain pair route through
+ * Skip Go?" — the gate every consumer (execute/build tools, route
+ * discovery/listing, destination-format validation) must share so they can
+ * never drift from each other. A pair routes via Skip when ANY of:
+ *
+ *   - skipBoth:       both sides are Skip-routable cosmos chains (ATOM<->OSMO).
+ *   - terraTouching:  either side is Terra v2 / TerraClassic (Skip bridge).
+ *   - cosmosEvmCross: one side is Skip-routable cosmos AND the other is a
+ *                      Skip-supported EVM chain (ATOM->USDC.eth via CCTP/Axelar).
+ *
+ * A consumer whose Skip-routing decision drifts from its own destination-
+ * validation or route-discovery logic (two independently-maintained copies
+ * of this same chain-topology knowledge, one per consumer) is exactly the
+ * bug class this function exists to close — accept a raw, uncanonicalized
+ * chain string here and it fails closed to `false` (falls through to the
+ * caller's native/general-aggregator lane) rather than silently guessing.
+ */
+export const willRouteViaSkip = (fromChain: string, toChain: string): boolean => {
+  const cosmosEvmCross =
+    (isSkipRoutableChain(fromChain) && isSkipSupportedEvmChain(toChain)) ||
+    (isSkipRoutableChain(toChain) && isSkipSupportedEvmChain(fromChain))
+  const skipBoth = isSkipRoutableChain(fromChain) && isSkipRoutableChain(toChain)
+  const terraTouching = isTerraChain(fromChain) || isTerraChain(toChain)
+  return skipBoth || terraTouching || cosmosEvmCross
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -275,6 +275,13 @@ export { isAccountCoin, isSimpleCoinInput, KeysignPayloadSchema } from './types'
 export type { GetSwapExplorerUrlInput, SwapExplorerProvider } from '@vultisig/core-chain/swap/utils/getSwapExplorerUrl'
 export { getSwapExplorerUrl, swapExplorerProviders } from '@vultisig/core-chain/swap/utils/getSwapExplorerUrl'
 
+// Skip Go routing-eligibility predicates. Single source of truth for "does this
+// from/to chain pair route through Skip Go?" — consolidated here so consumers
+// (execute/build tools, route discovery/listing, destination-format validation)
+// share one tested implementation instead of independently-maintained copies
+// that can drift from each other (the mcp-ts #384 bug class).
+export { isSkipRoutableChain, isTerraChain, willRouteViaSkip } from '@vultisig/core-chain/swap/skip/skipRouting'
+
 // Noon USDC yield vault SDK boundary. Consumers should use these helpers
 // instead of calling Noon/Accountable APIs or hand-encoding ERC-7540 calldata.
 export type {


### PR DESCRIPTION
Chain/swap consolidation directive (recurring, user-emphasized): move non-AI chain/swap routing logic out of agent-backend-ts's ad-hoc special-casing and into the SDK as tested core functions.

## what

"Does this from/to chain pair route through Skip Go?" was independently reimplemented by:
- agent-backend-ts's `execute_swap.ts` (`willRouteViaSkip`, includes the cosmos<->EVM cross-chain branch)
- agent-backend-ts's `list-swap-routes.ts` (its OWN inline `skipBoth`/`terraTouching` computation - **missing the cosmos<->EVM cross branch `execute_swap.ts` has**)
- mcp-ts's `lib/skip-chain-mapping.ts` (a third, separately-maintained copy, whose own doc comment records a *past* incident, #384, caused by exactly this kind of drift between execution and route-discovery)

Neither of abts's two copies shares a single tested source, so the exact bug class mcp-ts already got burned by (#384) is currently live in abts today: a cosmos<->EVM cross pair (e.g. ATOM -> USDC.eth) routes via Skip in `execute_swap` but `list_swap_routes` would report it as routing via the general aggregator instead.

## how

Adds `isSkipRoutableChain`/`isTerraChain`/`willRouteViaSkip` as tested core functions in `packages/core/chain/swap/skip/skipRouting.ts`, exported from the main `@vultisig/sdk` entry. Pure chain-topology predicates - no network calls, no AI-specific logic - mirrors the existing `swapEnabledChains`/`NativeSwapChain` pattern already in the SDK.

Purely additive: no existing export changed, no behavior change to any current consumer.

## why the SDK (not just a shared abts file)

mcp-ts already depends on `@vultisig/sdk` (`^2.13.1`) and already calls the SDK's `findSwapQuote` from its own `execute_swap.ts`/`list-swap-routes.ts`. Once abts adopts this export (companion PR incoming) and mcp-ts eventually bumps its own SDK pin, both backends converge on one tested source instead of drifting independently - the structural fix, not another one-off port.

## testing

- 12 new tests: full positive coverage for `isTerraChain`/`isSkipRoutableChain`, `willRouteViaSkip`'s 3 true-branches (skipBoth/terraTouching/cosmosEvmCross - looped over all 7 allowlisted EVM chains per codex review follow-up), 4 false-branch cases, and a fail-closed-on-unknown-chain-string case.
- Full core suite green (1388 tests), lint clean, typecheck clean, build clean.
- Codex adversarial review: faithful port, no logic drift, one test-coverage gap found and closed (full EVM allowlist coverage, not just 3 of 7 chains).

🤖 Agent-generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public swap-routing helpers to identify eligible chains and decide when routes can use Skip.
  * Expanded SDK exports so these routing checks are available through the main package.
* **Bug Fixes**
  * Improved routing decisions for Cosmos/EVM combinations and Terra-related paths.
  * Added coverage for unknown chain inputs to fail safely and avoid incorrect routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->