### PR TITLE
feat(swap): consolidate cosmos fee-denom allowlist into the SDK

### DIFF
--- a/.changeset/cosmos-fee-denom-allowlist.md
+++ b/.changeset/cosmos-fee-denom-allowlist.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/sdk": patch
+---
+
+Add cosmos per-chain fee-denom allowlist helpers (`getCosmosAllowedFeeDenoms`, `isCosmosFeeDenomAllowed`) as the single source of truth for which denoms a cosmos chain's ante handler accepts as a gas fee, consolidating copies previously maintained independently in agent-backend-ts (execute_send.ts, astroport-classic-swap.ts, cosmos-staking.ts).

--- a/packages/core/chain/chains/cosmos/cosmosFeeDenomAllowlist.test.ts
+++ b/packages/core/chain/chains/cosmos/cosmosFeeDenomAllowlist.test.ts
@@ -1,0 +1,59 @@
+import { CosmosChain } from '@vultisig/core-chain/Chain'
+import { describe, expect, it } from 'vitest'
+
+import { getCosmosAllowedFeeDenoms, isCosmosFeeDenomAllowed } from './cosmosFeeDenomAllowlist'
+
+describe('getCosmosAllowedFeeDenoms', () => {
+  it('is single-entry (native only) for chains with no live-verified alternate', () => {
+    expect(getCosmosAllowedFeeDenoms(CosmosChain.Cosmos)).toEqual(['uatom'])
+    expect(getCosmosAllowedFeeDenoms(CosmosChain.Kujira)).toEqual(['ukuji'])
+    expect(getCosmosAllowedFeeDenoms(CosmosChain.Terra)).toEqual(['uluna'])
+    expect(getCosmosAllowedFeeDenoms(CosmosChain.Akash)).toEqual(['uakt'])
+    expect(getCosmosAllowedFeeDenoms(CosmosChain.Dydx)).toEqual(['adydx'])
+    expect(getCosmosAllowedFeeDenoms(CosmosChain.Noble)).toEqual(['uusdc'])
+    expect(getCosmosAllowedFeeDenoms(CosmosChain.THORChain)).toEqual(['rune'])
+    expect(getCosmosAllowedFeeDenoms(CosmosChain.MayaChain)).toEqual(['cacao'])
+  })
+
+  it('includes the uusd (USTC) alternate for TerraClassic alongside the native uluna', () => {
+    expect(getCosmosAllowedFeeDenoms(CosmosChain.TerraClassic)).toEqual(['uluna', 'uusd'])
+  })
+
+  it('includes the whitelisted IBC fee tokens for Osmosis alongside native uosmo', () => {
+    const allowed = getCosmosAllowedFeeDenoms(CosmosChain.Osmosis)
+    expect(allowed[0]).toBe('uosmo')
+    expect(allowed).toHaveLength(4)
+    expect(allowed).toContain(
+      'ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2' // ATOM
+    )
+    expect(allowed).toContain(
+      'ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4' // Noble USDC
+    )
+    expect(allowed).toContain(
+      'ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858' // axlUSDC
+    )
+  })
+})
+
+describe('isCosmosFeeDenomAllowed', () => {
+  it('accepts the native denom on every chain', () => {
+    expect(isCosmosFeeDenomAllowed(CosmosChain.Cosmos, 'uatom')).toBe(true)
+    expect(isCosmosFeeDenomAllowed(CosmosChain.Osmosis, 'uosmo')).toBe(true)
+  })
+
+  it('accepts uusd on TerraClassic but rejects it on Terra v2 (shared uluna denom, different fee rules)', () => {
+    expect(isCosmosFeeDenomAllowed(CosmosChain.TerraClassic, 'uusd')).toBe(true)
+    expect(isCosmosFeeDenomAllowed(CosmosChain.Terra, 'uusd')).toBe(false)
+  })
+
+  it('accepts a whitelisted IBC fee token on Osmosis but rejects it on Cosmos Hub (same token, different chain)', () => {
+    const atomIbcHash = 'ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2'
+    expect(isCosmosFeeDenomAllowed(CosmosChain.Osmosis, atomIbcHash)).toBe(true)
+    expect(isCosmosFeeDenomAllowed(CosmosChain.Cosmos, atomIbcHash)).toBe(false)
+  })
+
+  it('rejects an arbitrary unrecognized denom on every chain', () => {
+    expect(isCosmosFeeDenomAllowed(CosmosChain.Cosmos, 'not-a-real-denom')).toBe(false)
+    expect(isCosmosFeeDenomAllowed(CosmosChain.Osmosis, 'not-a-real-denom')).toBe(false)
+  })
+})

--- a/packages/core/chain/chains/cosmos/cosmosFeeDenomAllowlist.test.ts
+++ b/packages/core/chain/chains/cosmos/cosmosFeeDenomAllowlist.test.ts
@@ -19,7 +19,7 @@ describe('getCosmosAllowedFeeDenoms', () => {
     expect(getCosmosAllowedFeeDenoms(CosmosChain.TerraClassic)).toEqual(['uluna', 'uusd'])
   })
 
-  it('includes the whitelisted IBC fee tokens for Osmosis alongside native uosmo', () => {
+  it('includes the curated IBC fee tokens for Osmosis alongside native uosmo (not the full 173+ on-chain txfees whitelist)', () => {
     const allowed = getCosmosAllowedFeeDenoms(CosmosChain.Osmosis)
     expect(allowed[0]).toBe('uosmo')
     expect(allowed).toHaveLength(4)

--- a/packages/core/chain/chains/cosmos/cosmosFeeDenomAllowlist.ts
+++ b/packages/core/chain/chains/cosmos/cosmosFeeDenomAllowlist.ts
@@ -1,0 +1,47 @@
+import { CosmosChain } from '@vultisig/core-chain/Chain'
+
+import { cosmosFeeCoinDenom } from './cosmosFeeCoinDenom'
+
+/**
+ * Non-native denoms a chain's ante handler additionally accepts as a gas fee,
+ * beyond its own native `cosmosFeeCoinDenom`. A chain absent here (or with no
+ * entry) accepts ONLY its native denom.
+ *
+ * TerraClassic (columbus-5): live-verified 2026-05-28 deep spike — 3.6% of
+ * recent columbus-5 txs paid fee in `uusd` (USTC), all succeeded
+ * (tx_response.code: 0), confirmed for MsgWithdrawDelegatorReward /
+ * MsgDelegate / MsgBeginRedelegate at heights 28810338 / 28810677 / 28810409.
+ * Minimum gas price for uusd = 0.75 uusd/gas (network floor, pinned across
+ * all 9 observed minimum-fee txs).
+ *
+ * Osmosis: the x/txfees module whitelists IBC tokens for fee payment
+ * (/osmosis/txfees/v1beta1/fee_tokens has 173+ entries) — hardcoding the
+ * top-3 stable/common ones (ATOM, Noble USDC, Axelar USDC) rather than a live
+ * LCD query on every fee-denom validation. IBC hashes verified against
+ * osmosis-rest.publicnode.com chain-registry 2026-05-31.
+ */
+const COSMOS_ALTERNATE_FEE_DENOMS: Partial<Record<CosmosChain, readonly string[]>> = {
+  [CosmosChain.TerraClassic]: ['uusd'],
+  [CosmosChain.Osmosis]: [
+    // ATOM from Cosmos Hub (pool 1 - highest liquidity osmosis IBC pair)
+    'ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2',
+    // USDC from Noble (pool 1464 - primary USDC venue on Osmosis)
+    'ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4',
+    // axlUSDC from Axelar (pool 678 - legacy USDC before Noble)
+    'ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858',
+  ],
+}
+
+/**
+ * Full allowlist of denoms a chain's ante handler accepts as a gas fee: the
+ * chain's own native denom plus any live-verified alternates. A `fee_denom`
+ * outside this list is rejected at broadcast by the chain itself.
+ */
+export const getCosmosAllowedFeeDenoms = (chain: CosmosChain): readonly string[] => [
+  cosmosFeeCoinDenom[chain],
+  ...(COSMOS_ALTERNATE_FEE_DENOMS[chain] ?? []),
+]
+
+/** True when `feeDenom` is an accepted gas-fee denom for `chain`. */
+export const isCosmosFeeDenomAllowed = (chain: CosmosChain, feeDenom: string): boolean =>
+  getCosmosAllowedFeeDenoms(chain).includes(feeDenom)

--- a/packages/core/chain/chains/cosmos/cosmosFeeDenomAllowlist.ts
+++ b/packages/core/chain/chains/cosmos/cosmosFeeDenomAllowlist.ts
@@ -33,15 +33,20 @@ const COSMOS_ALTERNATE_FEE_DENOMS: Partial<Record<CosmosChain, readonly string[]
 }
 
 /**
- * Full allowlist of denoms a chain's ante handler accepts as a gas fee: the
- * chain's own native denom plus any live-verified alternates. A `fee_denom`
- * outside this list is rejected at broadcast by the chain itself.
+ * Denoms this SDK will build a tx fee in for `chain`: the chain's own native
+ * denom plus the curated alternates above. This is NOT the exhaustive list of
+ * every denom the chain's ante handler would accept (Osmosis's real
+ * `/osmosis/txfees/v1beta1/fee_tokens` whitelist has 173+ entries) — it's the
+ * deliberately-curated subset we support without a live LCD query. Rejecting
+ * a `fee_denom` outside this list is a fail-closed product choice (ask the
+ * user to pick a supported denom), not a claim that the chain itself would
+ * reject it.
  */
 export const getCosmosAllowedFeeDenoms = (chain: CosmosChain): readonly string[] => [
   cosmosFeeCoinDenom[chain],
   ...(COSMOS_ALTERNATE_FEE_DENOMS[chain] ?? []),
 ]
 
-/** True when `feeDenom` is an accepted gas-fee denom for `chain`. */
+/** True when `feeDenom` is one of this SDK's supported gas-fee denoms for `chain` (see {@link getCosmosAllowedFeeDenoms}). */
 export const isCosmosFeeDenomAllowed = (chain: CosmosChain, feeDenom: string): boolean =>
   getCosmosAllowedFeeDenoms(chain).includes(feeDenom)

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -215,6 +215,11 @@
       "import": "./dist/chains/cosmos/cosmosFeeCoinDenom.js",
       "default": "./dist/chains/cosmos/cosmosFeeCoinDenom.js"
     },
+    "./chains/cosmos/cosmosFeeDenomAllowlist": {
+      "types": "./dist/chains/cosmos/cosmosFeeDenomAllowlist.d.ts",
+      "import": "./dist/chains/cosmos/cosmosFeeDenomAllowlist.js",
+      "default": "./dist/chains/cosmos/cosmosFeeDenomAllowlist.js"
+    },
     "./chains/cosmos/cosmosGasLimitRecord": {
       "types": "./dist/chains/cosmos/cosmosGasLimitRecord.d.ts",
       "import": "./dist/chains/cosmos/cosmosGasLimitRecord.js",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -186,6 +186,10 @@ export { getChainKind, isChainOfKind } from '@vultisig/core-chain/ChainKind'
 // Cosmos chain metadata — surfaced so consumers stop re-declaring LCD urls /
 // fee denoms / gas limits (e.g. mcp-ts lib/cosmos-chains.ts).
 export { cosmosFeeCoinDenom } from '@vultisig/core-chain/chains/cosmos/cosmosFeeCoinDenom'
+export {
+  getCosmosAllowedFeeDenoms,
+  isCosmosFeeDenomAllowed,
+} from '@vultisig/core-chain/chains/cosmos/cosmosFeeDenomAllowlist'
 export { getCosmosGasLimit, getCosmosStakingGasLimit } from '@vultisig/core-chain/chains/cosmos/cosmosGasLimitRecord'
 export { cosmosRpcUrl } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
 


### PR DESCRIPTION
## what

`execute_send.ts` only honors a `fee_denom` override on TerraClassic (`uluna`/`uusd`) - every other cosmos chain rejects any non-native `fee_denom`, including Osmosis, even though Osmosis's `x/txfees` module genuinely whitelists several IBC tokens (ATOM, Noble USDC, Axelar USDC) for fee payment. `cosmos-staking.ts` already has this richer per-chain allowlist for delegate/claim/redelegate/undelegate - so paying an Osmosis staking fee in USDC works, but the exact same `fee_denom` on a plain send gets wrongly rejected. `astroport-classic-swap.ts` carries a third independent copy of the TerraClassic-only allowlist.

## how

Adds `getCosmosAllowedFeeDenoms` / `isCosmosFeeDenomAllowed` as tested core functions under `@vultisig/core-chain/chains/cosmos/cosmosFeeDenomAllowlist`, re-exported from `@vultisig/sdk`. Deliberately curated (native denom + live-verified alternates), not a claim of exhaustiveness against Osmosis's real 173+-entry on-chain whitelist - matches the existing design already accepted in `cosmos-staking.ts`.

Follow-up abts PR will wire `execute_send.ts` / `astroport-classic-swap.ts` / `cosmos-staking.ts` to this shared source instead of their 3 independently-maintained copies.

## testing

- `yarn test:core` - 163 test files / 1400 tests, all green
- `yarn typecheck` - clean
- `yarn lint` - clean
- Codex adversarial review: 1 real finding (Osmosis doc comment could be read as claiming exhaustive coverage) - tackled in a follow-up commit clarifying it's a deliberately-curated subset

## risk

Low - purely additive SDK export, no existing behavior changed. abts wiring (the actual bug fix) comes in a follow-up PR, same pattern as #1020/#1022.