### PR TITLE
Reject oversized relay peer committees

### DIFF
--- a/.changeset/nervous-committees-wait.md
+++ b/.changeset/nervous-committees-wait.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/sdk": patch
+---
+
+Reject secure vault creation and import sessions when more relay peers join than the requested device count.

--- a/packages/sdk/src/services/JoinSecureVaultService.ts
+++ b/packages/sdk/src/services/JoinSecureVaultService.ts
@@ -16,10 +16,8 @@ import { Schnorr } from '@vultisig/core-mpc/schnorr/schnorrKeygen'
 import { joinMpcSession } from '@vultisig/core-mpc/session/joinMpcSession'
 import { startMpcSessionWithRetry } from '@vultisig/core-mpc/session/startMpcSession'
 import { Vault as CoreVault } from '@vultisig/core-mpc/vault/Vault'
-import { withoutDuplicates } from '@vultisig/lib-utils/array/withoutDuplicates'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { attempt } from '@vultisig/lib-utils/attempt'
-import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
 import type { SdkContext } from '../context/SdkContext'
 import { MasterKeyDeriver } from '../seedphrase/MasterKeyDeriver'
@@ -29,6 +27,7 @@ import type { VaultCreationStep } from '../types'
 import type { ParsedKeygenQR } from '../utils/parseKeygenQR'
 import { getChainBatchMessageIds, TSS_BATCH_MESSAGE_IDS } from '../utils/tssBatching'
 import { VaultError, VaultErrorCode } from '../vault/VaultError'
+import { waitForRelayPeerCommittee } from './waitForRelayPeerCommittee'
 
 /**
  * JoinSecureVaultService
@@ -54,53 +53,22 @@ export class JoinSecureVaultService {
    */
   private async waitForPeers(
     sessionId: string,
-    localPartyId: string,
     requiredDevices: number,
     signal?: AbortSignal,
     onDeviceJoined?: (deviceId: string, totalJoined: number, required: number) => void
   ): Promise<string[]> {
-    const maxWaitTime = 300000 // 5 minutes
-    const checkInterval = 2000
-    const startTime = Date.now()
-    let lastJoinedCount = 0
-
-    while (Date.now() - startTime < maxWaitTime) {
-      if (signal?.aborted) {
-        throw new Error('Operation aborted')
-      }
-
-      const url = `${this.relayUrl}/${sessionId}`
-      const { data: allPeers, error } = await attempt(queryUrl<string[]>(url))
-
-      if (error || !allPeers) {
-        await new Promise(resolve => setTimeout(resolve, checkInterval))
-        continue
-      }
-
-      const uniquePeers = withoutDuplicates(allPeers)
-
-      // Notify about new devices
-      if (uniquePeers.length > lastJoinedCount && onDeviceJoined) {
-        const newDevices = uniquePeers.slice(lastJoinedCount)
-        for (const device of newDevices) {
-          onDeviceJoined(device, uniquePeers.length, requiredDevices)
-        }
-        lastJoinedCount = uniquePeers.length
-      }
-
-      // Check if we have enough devices
-      if (uniquePeers.length >= requiredDevices) {
-        // Must match initiator (SecureVaultCreationService / SecureVaultFromSeedphraseService)
-        return [...uniquePeers].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
-      }
-
-      await new Promise(resolve => setTimeout(resolve, checkInterval))
-    }
-
-    throw new VaultError(
-      VaultErrorCode.NetworkError,
-      `Timeout waiting for devices. Got ${lastJoinedCount}/${requiredDevices} devices.`
-    )
+    return waitForRelayPeerCommittee({
+      relayUrl: this.relayUrl,
+      sessionId,
+      requiredDevices,
+      signal,
+      onDeviceJoined,
+      createTimeoutError: (lastJoinedCount, requiredDevices) =>
+        new VaultError(
+          VaultErrorCode.NetworkError,
+          `Timeout waiting for devices. Got ${lastJoinedCount}/${requiredDevices} devices.`
+        ),
+    })
   }
 
   /**
@@ -186,7 +154,6 @@ export class JoinSecureVaultService {
 
     const allDevices = await this.waitForPeers(
       qrParams.sessionId,
-      localPartyId,
       requiredDevices,
       signal,
       (deviceId, total, required) => {
@@ -418,7 +385,6 @@ export class JoinSecureVaultService {
 
     const allDevices = await this.waitForPeers(
       qrParams.sessionId,
-      localPartyId,
       requiredDevices,
       signal,
       (deviceId, total, required) => {

--- a/packages/sdk/src/services/waitForRelayPeerCommittee.ts
+++ b/packages/sdk/src/services/waitForRelayPeerCommittee.ts
@@ -37,6 +37,13 @@ export async function waitForRelayPeerCommittee(params: {
 
     const uniquePeers = withoutDuplicates(allPeers)
 
+    if (uniquePeers.length > requiredDevices) {
+      throw new VaultError(
+        VaultErrorCode.NetworkError,
+        `Too many devices joined. Got ${uniquePeers.length}/${requiredDevices} devices.`
+      )
+    }
+
     if (uniquePeers.length > lastJoinedCount) {
       if (onDeviceJoined) {
         const newDevices = uniquePeers.slice(lastJoinedCount)
@@ -45,13 +52,6 @@ export async function waitForRelayPeerCommittee(params: {
         }
       }
       lastJoinedCount = uniquePeers.length
-    }
-
-    if (uniquePeers.length > requiredDevices) {
-      throw new VaultError(
-        VaultErrorCode.NetworkError,
-        `Too many devices joined. Got ${uniquePeers.length}/${requiredDevices} devices.`
-      )
     }
 
     if (uniquePeers.length === requiredDevices) {

--- a/packages/sdk/src/services/waitForRelayPeerCommittee.ts
+++ b/packages/sdk/src/services/waitForRelayPeerCommittee.ts
@@ -1,4 +1,5 @@
 import { withoutDuplicates } from '@vultisig/lib-utils/array/withoutDuplicates'
+import { attempt } from '@vultisig/lib-utils/attempt'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
 import { VaultError, VaultErrorCode } from '../vault/VaultError'
@@ -26,30 +27,39 @@ export async function waitForRelayPeerCommittee(params: {
       throw new VaultError(VaultErrorCode.OperationAborted, 'Operation aborted')
     }
 
-    try {
-      const url = `${relayUrl}/${sessionId}`
-      const allPeers = await queryUrl<string[]>(url)
-      const uniquePeers = withoutDuplicates(allPeers)
+    const url = `${relayUrl}/${sessionId}`
+    const { data: allPeers, error } = await attempt(queryUrl<string[]>(url))
 
-      if (uniquePeers.length > lastJoinedCount) {
-        if (onDeviceJoined) {
-          const newDevices = uniquePeers.slice(lastJoinedCount)
-          for (const device of newDevices) {
-            onDeviceJoined(device, uniquePeers.length, requiredDevices)
-          }
-        }
-        lastJoinedCount = uniquePeers.length
-      }
-
-      if (uniquePeers.length >= requiredDevices) {
-        // Must match JoinSecureVaultService: sorted committee so all parties use identical order
-        return [...uniquePeers].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
-      }
-
+    if (error || !allPeers) {
       await new Promise(resolve => setTimeout(resolve, checkInterval))
-    } catch {
-      await new Promise(resolve => setTimeout(resolve, checkInterval))
+      continue
     }
+
+    const uniquePeers = withoutDuplicates(allPeers)
+
+    if (uniquePeers.length > lastJoinedCount) {
+      if (onDeviceJoined) {
+        const newDevices = uniquePeers.slice(lastJoinedCount)
+        for (const device of newDevices) {
+          onDeviceJoined(device, uniquePeers.length, requiredDevices)
+        }
+      }
+      lastJoinedCount = uniquePeers.length
+    }
+
+    if (uniquePeers.length > requiredDevices) {
+      throw new VaultError(
+        VaultErrorCode.NetworkError,
+        `Too many devices joined. Got ${uniquePeers.length}/${requiredDevices} devices.`
+      )
+    }
+
+    if (uniquePeers.length === requiredDevices) {
+      // Must match all parties: sorted committee so every device uses identical order.
+      return [...uniquePeers].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+    }
+
+    await new Promise(resolve => setTimeout(resolve, checkInterval))
   }
 
   throw createTimeoutError(lastJoinedCount, requiredDevices)

--- a/packages/sdk/src/services/waitForRelayPeerCommittee.ts
+++ b/packages/sdk/src/services/waitForRelayPeerCommittee.ts
@@ -35,6 +35,11 @@ export async function waitForRelayPeerCommittee(params: {
       continue
     }
 
+    if (!Array.isArray(allPeers)) {
+      await new Promise(resolve => setTimeout(resolve, checkInterval))
+      continue
+    }
+
     const uniquePeers = withoutDuplicates(allPeers)
 
     if (uniquePeers.length > requiredDevices) {

--- a/packages/sdk/tests/unit/services/waitForRelayPeerCommittee.test.ts
+++ b/packages/sdk/tests/unit/services/waitForRelayPeerCommittee.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { waitForRelayPeerCommittee } from '../../../src/services/waitForRelayPeerCommittee'
+import { VaultErrorCode } from '../../../src/vault/VaultError'
+
+const queryUrlMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
+  queryUrl: (...args: unknown[]) => queryUrlMock(...args),
+}))
+
+describe('waitForRelayPeerCommittee', () => {
+  beforeEach(() => {
+    queryUrlMock.mockReset()
+  })
+
+  it('returns the sorted committee when exactly the required devices joined', async () => {
+    queryUrlMock.mockResolvedValue(['device-b', 'device-a', 'device-a'])
+
+    await expect(
+      waitForRelayPeerCommittee({
+        relayUrl: 'https://relay.example',
+        sessionId: 'session-1',
+        requiredDevices: 2,
+        createTimeoutError: () => new Error('timed out'),
+      })
+    ).resolves.toEqual(['device-a', 'device-b'])
+
+    expect(queryUrlMock).toHaveBeenCalledWith('https://relay.example/session-1')
+  })
+
+  it('rejects oversized committees instead of returning ghost peers', async () => {
+    queryUrlMock.mockResolvedValue(['device-a', 'device-b', 'device-c'])
+
+    await expect(
+      waitForRelayPeerCommittee({
+        relayUrl: 'https://relay.example',
+        sessionId: 'session-1',
+        requiredDevices: 2,
+        createTimeoutError: () => new Error('timed out'),
+      })
+    ).rejects.toMatchObject({
+      code: VaultErrorCode.NetworkError,
+      message: 'Too many devices joined. Got 3/2 devices.',
+    })
+  })
+})

--- a/packages/sdk/tests/unit/services/waitForRelayPeerCommittee.test.ts
+++ b/packages/sdk/tests/unit/services/waitForRelayPeerCommittee.test.ts
@@ -47,4 +47,22 @@ describe('waitForRelayPeerCommittee', () => {
     })
     expect(onDeviceJoined).not.toHaveBeenCalled()
   })
+
+  it('treats malformed successful relay payloads as retriable poll failures', async () => {
+    const controller = new AbortController()
+    queryUrlMock.mockImplementation(async () => {
+      controller.abort()
+      return {}
+    })
+
+    await expect(
+      waitForRelayPeerCommittee({
+        relayUrl: 'https://relay.example',
+        sessionId: 'session-1',
+        requiredDevices: 2,
+        signal: controller.signal,
+        createTimeoutError: () => new Error('timed out'),
+      })
+    ).rejects.toMatchObject({ code: VaultErrorCode.OperationAborted })
+  })
 })

--- a/packages/sdk/tests/unit/services/waitForRelayPeerCommittee.test.ts
+++ b/packages/sdk/tests/unit/services/waitForRelayPeerCommittee.test.ts
@@ -31,17 +31,20 @@ describe('waitForRelayPeerCommittee', () => {
 
   it('rejects oversized committees instead of returning ghost peers', async () => {
     queryUrlMock.mockResolvedValue(['device-a', 'device-b', 'device-c'])
+    const onDeviceJoined = vi.fn()
 
     await expect(
       waitForRelayPeerCommittee({
         relayUrl: 'https://relay.example',
         sessionId: 'session-1',
         requiredDevices: 2,
+        onDeviceJoined,
         createTimeoutError: () => new Error('timed out'),
       })
     ).rejects.toMatchObject({
       code: VaultErrorCode.NetworkError,
       message: 'Too many devices joined. Got 3/2 devices.',
     })
+    expect(onDeviceJoined).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Closes #951
Runtime proof: a local HTTP relay returned device-a, device-b, and device-c for a two-device session; waitForRelayPeerCommittee rejected it with NETWORK_ERROR: Too many devices joined. Got 3/2 devices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Secure vault creation and import now fail when too many devices join a session.
  * Peer joining now waits for the exact expected number of devices, reducing unexpected session completion.
  * Improved reliability of device join handling and timeout behavior during vault setup.

* **Tests**
  * Added coverage for exact committee sizing and over-capacity rejection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->