### PR TITLE
Route CLI chain imports through SDK

### DIFF
--- a/.changeset/cli-sdk-boundary-imports.md
+++ b/.changeset/cli-sdk-boundary-imports.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/sdk": patch
+---
+
+Document the public SDK chain metadata boundary used by CLI consumers.

--- a/clients/cli/src/agent/executor.ts
+++ b/clients/cli/src/agent/executor.ts
@@ -6,10 +6,8 @@
  * Each handler takes `(toolCallId, input)` and returns a `RecentAction` ready
  * to be flushed into the next outbound `context.recent_actions`.
  */
-import { getChainKind } from '@vultisig/core-chain/ChainKind'
-import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import type { VaultBase, Vultisig } from '@vultisig/sdk'
-import { Chain, VaultError, VaultErrorCode, Vultisig as VultisigSdk } from '@vultisig/sdk'
+import { Chain, chainFeeCoin, getChainKind, VaultError, VaultErrorCode, Vultisig as VultisigSdk } from '@vultisig/sdk'
 import { formatUnits, hashTypedData, recoverAddress } from 'viem'
 
 import { VaultStateStore } from '../core/VaultStateStore'

--- a/clients/cli/src/agent/toolOutputSigning.ts
+++ b/clients/cli/src/agent/toolOutputSigning.ts
@@ -33,8 +33,7 @@
  *
  * ZERO agent-backend / mcp-ts change; entirely within `clients/cli`.
  */
-import { getChainKind } from '@vultisig/core-chain/ChainKind'
-import { Chain } from '@vultisig/sdk'
+import { Chain, getChainKind } from '@vultisig/sdk'
 
 import { resolveChain, resolveChainId } from './executor'
 import type { TxReadyPayload } from './types'

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -89,6 +89,7 @@ describe('@vultisig/sdk public exports', () => {
 
   it('exports chain kind and native fee coin metadata for client boundary consumers', () => {
     expect(typeof sdk.getChainKind).toBe('function')
+    expect(sdk.getChainKind(sdk.Chain.Ethereum)).toBe('evm')
     expect(sdk.chainFeeCoin[sdk.Chain.Ethereum]?.ticker).toBe('ETH')
   })
 

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -87,6 +87,11 @@ describe('@vultisig/sdk public exports', () => {
     expect(typeof sdk.VaultBase).toBe('function')
   })
 
+  it('exports chain kind and native fee coin metadata for client boundary consumers', () => {
+    expect(typeof sdk.getChainKind).toBe('function')
+    expect(sdk.chainFeeCoin[sdk.Chain.Ethereum]?.ticker).toBe('ETH')
+  })
+
   it('exports seedphrase import chain support policy for consumers', () => {
     expect(Array.isArray(sdk.SEEDPHRASE_IMPORT_SUPPORTED_CHAINS)).toBe(true)
     expect(Array.isArray(sdk.SEEDPHRASE_IMPORT_UNSUPPORTED_CHAINS)).toBe(true)


### PR DESCRIPTION
Refs #949
Runtime proof: built SDK and CLI bundle loaded successfully; node clients/cli/dist/index.js --help printed CLI help, and a built-SDK runtime import printed getChainKind Ethereum: evm, chainFeeCoin Ethereum: ETH, and SDK boundary imports ok. The CLI agent boundary no longer imports getChainKind or chainFeeCoin from @vultisig/core-chain directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public SDK access to chain classification and native fee coin metadata.
  * CLI tools now use the SDK’s unified chain metadata interface.

* **Tests**
  * Added coverage confirming chain metadata exports and Ethereum fee coin details.

* **Documentation**
  * Added release documentation for the public SDK chain metadata boundary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->