### PR TITLE
fix(swap): check every cosmos leg for the memo cap in runSkipSwap (VA-86)

### DIFF
--- a/.changeset/skipswap-multitx-memo-cap.md
+++ b/.changeset/skipswap-multitx-memo-cap.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/sdk": patch
+---
+
+Fix `runSkipSwap`'s cosmos memo-length preflight to check every leg of a Skip route, not just the first leg of single-tx routes. Previously the check only ran when the route required a single signature and only inspected the first cosmos leg's memo — a multi-tx route (`allowMultiTx: true`) with an over-cap memo on a later leg sailed through undetected and would fail at broadcast (sdk error code 12, "memo too long") after signing, burning the MPC ceremony. This mirrors a check already present and more thorough in agent-backend-ts's own Skip integration.

--- a/packages/sdk/src/tools/swap/skip/skipSwap.ts
+++ b/packages/sdk/src/tools/swap/skip/skipSwap.ts
@@ -224,22 +224,47 @@ function firstUnsupportedCustodyChain(
 }
 
 /**
- * Extract the cosmos source-leg SDK transaction-level memo byte length from a
- * Skip /msgs_direct response, or `null` when no cosmos leg exists. cosmoshub-4 /
- * columbus-5 enforce the cap against the SDK transaction-level memo
- * (`cosmos_tx.memo`), NOT the inner ICS-20 packet memo (which is unbounded).
+ * Extract the SDK transaction-level memo byte length for EVERY cosmos leg in a
+ * Skip /msgs_direct response. Returns one entry per cosmos tx (empty array when
+ * the route is EVM-only and the cap check doesn't apply).
+ *
+ * cosmoshub-4 / columbus-5 / etc. enforce `x/auth.MaxMemoCharacters` against
+ * the SDK **transaction**-level memo (`cosmos_tx.memo`), NOT against the inner
+ * ICS-20 packet `memo` (which is unbounded).
  */
-function getSourceLegMemoByteLength(
+function getCosmosLegMemoInfos(
   txs: ReadonlyArray<SkipMsgsDirectTx>
-): { sourceChainId: string; memoBytes: number } | null {
+): Array<{ sourceChainId: string; memoBytes: number }> {
+  const out: Array<{ sourceChainId: string; memoBytes: number }> = []
   for (const tx of txs) {
     if (!tx || !('cosmos_tx' in tx)) continue
     const cosmosTx = tx.cosmos_tx
     const memo = typeof cosmosTx.memo === 'string' ? cosmosTx.memo : ''
-    return {
+    out.push({
       sourceChainId: cosmosTx.chain_id,
-      memoBytes: Buffer.byteLength(memo, 'utf-8'),
-    }
+      memoBytes: new TextEncoder().encode(memo).length,
+    })
+  }
+  return out
+}
+
+/**
+ * Return the first cosmos leg whose top-level memo exceeds its chain's
+ * `MaxMemoCharacters` cap, or `null` when every cosmos leg fits.
+ *
+ * Checks EVERY leg, including multi-tx routes — a leg whose own memo exceeds
+ * its own chain's cap fails on-chain no matter how the route is split. This
+ * previously only ran for single-tx routes and only inspected the first
+ * cosmos leg, which meant a multi-tx route (`allowMultiTx:true`) with an
+ * over-cap non-first leg would sail through undetected and fail at broadcast
+ * (sdk code 12, "memo too long") AFTER signing.
+ */
+function firstCosmosLegOverMemoCap(
+  txs: ReadonlyArray<SkipMsgsDirectTx>
+): { sourceChainId: string; memoBytes: number; cap: number } | null {
+  for (const memoInfo of getCosmosLegMemoInfos(txs)) {
+    const cap = getCosmosMemoMaxBytesByChainId(memoInfo.sourceChainId)
+    if (memoInfo.memoBytes > cap) return { ...memoInfo, cap }
   }
   return null
 }
@@ -928,23 +953,22 @@ function validateMsgsResponse(
     }
   }
 
-  if (!isMultiTx) {
-    const memoInfo = getSourceLegMemoByteLength(msgs.txs)
-    const cap = memoInfo ? getCosmosMemoMaxBytesByChainId(memoInfo.sourceChainId) : undefined
-    if (memoInfo && cap !== undefined && memoInfo.memoBytes > cap) {
-      return {
-        error: {
-          error: 'skip_source_memo_too_long',
-          message:
-            `Skip route's source-leg memo is ${memoInfo.memoBytes} bytes, but ` +
-            `${memoInfo.sourceChainId} enforces a ${cap}-byte limit. Broadcast would fail with ` +
-            `sdk code 12 "memo too long" after signing. This corridor requires a multi-step ` +
-            `route (pass allowMultiTx:true) or a different routing strategy.`,
-          source_chain_id: memoInfo.sourceChainId,
-          memo_bytes: memoInfo.memoBytes,
-          memo_max_bytes: cap,
-        },
-      }
+  const overCap = firstCosmosLegOverMemoCap(msgs.txs)
+  if (overCap) {
+    const reroute = isMultiTx
+      ? `This corridor's memo exceeds the cap even when split; try a different routing strategy.`
+      : `This corridor requires a multi-step route (pass allowMultiTx:true) or a different routing strategy.`
+    return {
+      error: {
+        error: 'skip_source_memo_too_long',
+        message:
+          `Skip route's cosmos leg memo is ${overCap.memoBytes} bytes, but ` +
+          `${overCap.sourceChainId} enforces a ${overCap.cap}-byte limit. Broadcast would fail with ` +
+          `sdk code 12 "memo too long" after signing. ${reroute}`,
+        source_chain_id: overCap.sourceChainId,
+        memo_bytes: overCap.memoBytes,
+        memo_max_bytes: overCap.cap,
+      },
     }
   }
 

--- a/packages/sdk/src/tools/swap/skip/skipSwap.ts
+++ b/packages/sdk/src/tools/swap/skip/skipSwap.ts
@@ -239,6 +239,11 @@ function getCosmosLegMemoInfos(
   for (const tx of txs) {
     if (!tx || !('cosmos_tx' in tx)) continue
     const cosmosTx = tx.cosmos_tx
+    // A malformed multi-tx response can carry the `cosmos_tx` key with a
+    // null/undefined value - skip rather than crash. validateTxEnvelopes
+    // (later in the pipeline) is what surfaces a structured error for a
+    // malformed tx envelope; this preflight only cares about well-formed legs.
+    if (!cosmosTx || typeof cosmosTx.chain_id !== 'string') continue
     const memo = typeof cosmosTx.memo === 'string' ? cosmosTx.memo : ''
     out.push({
       sourceChainId: cosmosTx.chain_id,

--- a/packages/sdk/tests/unit/tools/swap/skipSwap.test.ts
+++ b/packages/sdk/tests/unit/tools/swap/skipSwap.test.ts
@@ -306,6 +306,34 @@ describe('multi-tx memo-cap regression (SDK-vs-abts reconciliation, VA-86)', () 
     expect(out.ok).toBe(true)
     if (out.ok) expect(out.multi_tx).toBe(true)
   })
+
+  // Codex review (this fix): removing the isMultiTx gate means the memo-cap
+  // preflight now runs on every multi-tx leg, including a malformed one. A
+  // leg with `cosmos_tx: null` (key present, value null) must be skipped by
+  // the preflight rather than crash on `cosmosTx.memo` - and correctly caught
+  // downstream by validateTxEnvelopes as a malformed envelope instead.
+  it('does not crash on a malformed leg (cosmos_tx: null) and surfaces the existing malformed-envelope error', async () => {
+    const chainIds = ['osmosis-1', 'columbus-5']
+    mockFetchSequence([
+      { body: { ...okRoute, txs_required: 2, chain_ids: chainIds, required_chain_addresses: chainIds } },
+      {
+        body: {
+          txs: [
+            { cosmos_tx: { chain_id: 'osmosis-1', signer_address: multiTxArgs.fromAddress, msgs: [], memo: '' } },
+            { cosmos_tx: null },
+          ],
+          msgs: [],
+          min_amount_out: '118800',
+          route: { ...okRoute, txs_required: 2, chain_ids: chainIds, required_chain_addresses: chainIds },
+        },
+      },
+    ])
+
+    const out = await runSkipSwap(multiTxArgs)
+
+    expect(out.ok).toBe(false)
+    if (!out.ok) expect(out.envelope.error).toBe('skip_msgs_tx_malformed')
+  })
 })
 
 describe('quoteSkipRoute (quote-only path)', () => {

--- a/packages/sdk/tests/unit/tools/swap/skipSwap.test.ts
+++ b/packages/sdk/tests/unit/tools/swap/skipSwap.test.ts
@@ -224,6 +224,90 @@ describe('runSkipSwap fund-safety guards (mocked Skip)', () => {
   })
 })
 
+describe('multi-tx memo-cap regression (SDK-vs-abts reconciliation, VA-86)', () => {
+  // BEFORE this fix: the memo-cap check only ran `if (!isMultiTx)` and only
+  // inspected the FIRST cosmos leg. A multi-tx route (allowMultiTx:true)
+  // with an over-cap memo on a NON-FIRST leg sailed through undetected and
+  // would fail at broadcast (sdk code 12, "memo too long") AFTER signing,
+  // burning the MPC ceremony. This test proves every leg is now checked
+  // regardless of multi-tx status.
+  // Osmosis (source) -> TerraClassic (dest) so both legs are source/dest
+  // (no intermediate-chain address requirement to satisfy in the mock).
+  const multiTxArgs: SkipSwapArgs = {
+    ...baseArgs,
+    toAddress: 'terra1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+    destChainId: 'columbus-5',
+    destAssetDenom: 'uluna',
+    allowMultiTx: true,
+  }
+
+  it('catches an over-cap memo on a non-first leg of a multi-tx route', async () => {
+    const overCapMemo = 'a'.repeat(300) // over columbus-5's 256-byte MaxMemoCharacters cap
+    const chainIds = ['osmosis-1', 'columbus-5']
+    mockFetchSequence([
+      { body: { ...okRoute, txs_required: 2, chain_ids: chainIds, required_chain_addresses: chainIds } },
+      {
+        body: {
+          txs: [
+            { cosmos_tx: { chain_id: 'osmosis-1', signer_address: multiTxArgs.fromAddress, msgs: [], memo: '' } },
+            {
+              cosmos_tx: {
+                chain_id: 'columbus-5',
+                signer_address: multiTxArgs.fromAddress,
+                msgs: [],
+                memo: overCapMemo,
+              },
+            },
+          ],
+          msgs: [],
+          min_amount_out: '118800',
+          route: { ...okRoute, txs_required: 2, chain_ids: chainIds, required_chain_addresses: chainIds },
+        },
+      },
+    ])
+
+    const out = await runSkipSwap(multiTxArgs)
+
+    expect(out.ok).toBe(false)
+    if (!out.ok) {
+      expect(out.envelope.error).toBe('skip_source_memo_too_long')
+      expect(out.envelope.source_chain_id).toBe('columbus-5')
+      expect(out.envelope.memo_bytes).toBe(300)
+      expect(out.envelope.memo_max_bytes).toBe(256)
+    }
+  })
+
+  it('accepts a multi-tx route when every leg fits its own chain cap', async () => {
+    const chainIds = ['osmosis-1', 'columbus-5']
+    mockFetchSequence([
+      { body: { ...okRoute, txs_required: 2, chain_ids: chainIds, required_chain_addresses: chainIds } },
+      {
+        body: {
+          txs: [
+            { cosmos_tx: { chain_id: 'osmosis-1', signer_address: multiTxArgs.fromAddress, msgs: [], memo: '' } },
+            {
+              cosmos_tx: {
+                chain_id: 'columbus-5',
+                signer_address: multiTxArgs.fromAddress,
+                msgs: [],
+                memo: 'a'.repeat(256), // exactly at the cap, not over
+              },
+            },
+          ],
+          msgs: [],
+          min_amount_out: '118800',
+          route: { ...okRoute, txs_required: 2, chain_ids: chainIds, required_chain_addresses: chainIds },
+        },
+      },
+    ])
+
+    const out = await runSkipSwap(multiTxArgs)
+
+    expect(out.ok).toBe(true)
+    if (out.ok) expect(out.multi_tx).toBe(true)
+  })
+})
+
 describe('quoteSkipRoute (quote-only path)', () => {
   it('returns the raw route on success', async () => {
     mockFetchSequence([{ body: okRoute }])


### PR DESCRIPTION
Tackles VA-86 (txsafe/L0), a follow-up finding from reconciling vultisig-sdk's `skipSwap.ts` against agent-backend-ts's independent Skip integration (`skip-swap.ts`).

## what

The two aren't simple duplicates - they're built for different consumption models (env-var-driven Node service vs argument-driven portable library), and a full collapse into one is real multi-PR architecture work being parked separately. But one piece had genuinely drifted and regressed: the memo-length preflight.

`runSkipSwap`'s memo-cap check only ran `if (!isMultiTx)` and only inspected the FIRST cosmos leg. For a single-tx route that's harmless (there's only one leg to check anyway), but for ANY multi-tx route (`allowMultiTx:true`), the check never ran at all - a later leg whose memo exceeded its own chain's `MaxMemoCharacters` cap would sail through undetected and fail at broadcast (sdk error code 12, "memo too long") AFTER signing, burning the MPC ceremony.

agent-backend-ts's own Skip integration already runs this check unconditionally against every leg (its own comment there references a "previous fail-open" bug already fixed).

## how

Ports that same hardening into the SDK's copy: `getCosmosLegMemoInfos` now collects every cosmos leg, `firstCosmosLegOverMemoCap` checks each against its own chain's cap, and the call site no longer gates on `isMultiTx`. Also switches memo byte-counting from `Buffer.byteLength` to `TextEncoder` for RN/browser portability, matching the SDK's established pattern elsewhere.

## testing

- New regression tests prove the exact gap: a multi-tx route with an over-cap memo on the second (non-first) leg is now rejected - verified via `git stash` that it would have been silently accepted before this fix - and a multi-tx route where every leg fits is still accepted.
- `yarn workspace @vultisig/sdk test:unit` - 167 files / 2378 tests, all green
- `yarn typecheck` / `yarn lint` - clean
- Codex adversarial review: 1 real finding - removing the `isMultiTx` gate meant a malformed multi-tx leg (`cosmos_tx: null`) would now crash instead of falling through to the existing structured `skip_msgs_tx_malformed` error. Fixed with a guard + a third regression test proving the leg is skipped without crashing.

## risk

Low - additive hardening, no change for chains/routes that already fit their cap. Existing single-tx behavior is unchanged in substance (there was always only one leg to check there).