### PR TITLE
Fix secure vault relay URL signing

### DIFF
--- a/.changeset/quiet-relays-sign.md
+++ b/.changeset/quiet-relays-sign.md
@@ -1,0 +1,6 @@
+---
+"@vultisig/sdk": patch
+"@vultisig/core-mpc": patch
+---
+
+Honor the configured message relay URL for secure vault transaction and raw-byte signing, including signing QR payloads.

--- a/packages/core/mpc/keysign/cosigner.ts
+++ b/packages/core/mpc/keysign/cosigner.ts
@@ -98,6 +98,11 @@ async function parseKeysignQrUrl(url: string) {
   return fromBinary(KeysignMessageSchema, await decompressData(match[1]))
 }
 
+function getQrQueryParam(url: string, param: string): string | undefined {
+  const match = url.match(new RegExp(`[?&]${param}=([^&]+)`))
+  return match ? decodeURIComponent(match[1]) : undefined
+}
+
 /** Poll GET /start/{sessionId} until the session starts. */
 async function waitForSessionStart(serverUrl: string, sessionId: string, timeoutMs = 120_000): Promise<string[]> {
   const t0 = Date.now()
@@ -135,7 +140,8 @@ async function main() {
   console.log(`   Session: ${keysignMsg.sessionId}`)
   console.log(`   Relay: ${keysignMsg.useVultisigRelay}`)
 
-  const serverUrl = keysignMsg.useVultisigRelay ? relayUrl : 'http://localhost:18080'
+  const qrRelayUrl = getQrQueryParam(qrUrl, 'serverUrl')
+  const serverUrl = keysignMsg.useVultisigRelay ? (qrRelayUrl ?? relayUrl) : 'http://localhost:18080'
 
   let keysignPayload = keysignMsg.keysignPayload
   if (!keysignPayload && keysignMsg.payloadId) {

--- a/packages/core/mpc/keysign/utils/getJoinKeysignUrl.test.ts
+++ b/packages/core/mpc/keysign/utils/getJoinKeysignUrl.test.ts
@@ -1,0 +1,55 @@
+import { randomBytes } from 'crypto'
+
+import { create } from '@bufbuild/protobuf'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { uploadPayloadToServer } from '@vultisig/core-mpc/keygen/server/uploadPayloadToServer'
+import { KeysignPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+
+import { getJoinKeysignUrl } from './getJoinKeysignUrl'
+
+vi.mock('@vultisig/core-mpc/keygen/server/uploadPayloadToServer', () => ({
+  uploadPayloadToServer: vi.fn().mockResolvedValue('uploaded-payload-id'),
+}))
+
+describe('getJoinKeysignUrl', () => {
+  const customRelayUrl = 'https://relay.example.test/router'
+  const baseParams = {
+    serverType: 'relay' as const,
+    serverUrl: customRelayUrl,
+    serviceName: 'sdk-party',
+    sessionId: 'session-id',
+    hexEncryptionKey: 'a'.repeat(64),
+    vaultId: 'vault-public-key',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('includes a custom relay URL in the signing deep link', async () => {
+    const qrUrl = await getJoinKeysignUrl(baseParams)
+
+    const url = new URL(qrUrl)
+    expect(url.searchParams.get('type')).toBe('SignTransaction')
+    expect(url.searchParams.get('serverUrl')).toBe(customRelayUrl)
+  })
+
+  it('uploads oversized payloads to the custom relay URL', async () => {
+    const payload = create(KeysignPayloadSchema, {
+      toAddress: `0x${randomBytes(5000).toString('hex')}`,
+      toAmount: '1',
+    })
+
+    const qrUrl = await getJoinKeysignUrl({
+      ...baseParams,
+      payload: { keysign: payload },
+    })
+
+    expect(uploadPayloadToServer).toHaveBeenCalledWith({
+      payload: expect.any(String),
+      serverUrl: customRelayUrl,
+    })
+    expect(new URL(qrUrl).searchParams.get('serverUrl')).toBe(customRelayUrl)
+  })
+})

--- a/packages/core/mpc/keysign/utils/getJoinKeysignUrl.ts
+++ b/packages/core/mpc/keysign/utils/getJoinKeysignUrl.ts
@@ -15,6 +15,7 @@ import { addQueryParams } from '@vultisig/lib-utils/query/addQueryParams'
 
 export type GetJoinKeysignUrlInput = {
   serverType: MpcServerType
+  serverUrl?: string
   serviceName: string
   sessionId: string
   hexEncryptionKey: string
@@ -28,6 +29,7 @@ const urlMaxLength = 2048
 
 export const getJoinKeysignUrl = async ({
   serverType,
+  serverUrl,
   serviceName,
   sessionId,
   hexEncryptionKey,
@@ -36,6 +38,7 @@ export const getJoinKeysignUrl = async ({
   customPayloadId,
   vaultId,
 }: GetJoinKeysignUrlInput): Promise<string> => {
+  const resolvedServerUrl = serverUrl ?? mpcServerUrl[serverType]
   const keysignMessage = create(KeysignMessageSchema, {
     sessionId,
     serviceName: serviceName,
@@ -65,11 +68,14 @@ export const getJoinKeysignUrl = async ({
     binary,
   })
 
-  const urlWithPayload = addQueryParams(deepLinkBaseUrl, {
+  const urlParams = {
     type: 'SignTransaction',
     vault: vaultId,
     jsonData,
-  })
+    ...(serverUrl ? { serverUrl } : {}),
+  }
+
+  const urlWithPayload = addQueryParams(deepLinkBaseUrl, urlParams)
 
   if (payload && urlWithPayload.length > urlMaxLength) {
     if ('keysign' in payload) {
@@ -80,11 +86,12 @@ export const getJoinKeysignUrl = async ({
       })
       const payloadId = await uploadPayloadToServer({
         payload: compressedPayload,
-        serverUrl: mpcServerUrl[serverType],
+        serverUrl: resolvedServerUrl,
       })
 
       return getJoinKeysignUrl({
         serverType,
+        serverUrl,
         serviceName,
         sessionId,
         hexEncryptionKey,
@@ -101,11 +108,12 @@ export const getJoinKeysignUrl = async ({
       })
       const customPayloadId = await uploadPayloadToServer({
         payload: compressedPayload,
-        serverUrl: mpcServerUrl[serverType],
+        serverUrl: resolvedServerUrl,
       })
 
       return getJoinKeysignUrl({
         serverType,
+        serverUrl,
         serviceName,
         sessionId,
         hexEncryptionKey,

--- a/packages/sdk/src/services/RelaySigningService.ts
+++ b/packages/sdk/src/services/RelaySigningService.ts
@@ -110,6 +110,7 @@ export class RelaySigningService {
     // - Consistent behavior with other Vultisig relay clients
     return getJoinKeysignUrl({
       serverType: 'relay',
+      serverUrl: this.relayUrl,
       serviceName: params.localPartyId,
       sessionId: params.sessionId,
       hexEncryptionKey: params.hexEncryptionKey,

--- a/packages/sdk/src/vault/SecureVault.ts
+++ b/packages/sdk/src/vault/SecureVault.ts
@@ -108,7 +108,7 @@ export class SecureVault extends VaultBase {
     const walletCore = await this.wasmProvider.getWalletCore()
 
     // Create relay signing service
-    const relaySigningService = new RelaySigningService()
+    const relaySigningService = new RelaySigningService(this.context.serverManager.messageRelay)
 
     // Sign using relay service with event emission
     const signature = await relaySigningService.signWithRelay(this.coreVault, payload, walletCore, {
@@ -209,7 +209,7 @@ export class SecureVault extends VaultBase {
       const walletCore = await this.wasmProvider.getWalletCore()
 
       // Create relay signing service
-      const relaySigningService = new RelaySigningService()
+      const relaySigningService = new RelaySigningService(this.context.serverManager.messageRelay)
 
       // Sign using relay service with event emission
       const signature = await relaySigningService.signBytesWithRelay(

--- a/packages/sdk/tests/unit/services/RelaySigningService.test.ts
+++ b/packages/sdk/tests/unit/services/RelaySigningService.test.ts
@@ -1,3 +1,4 @@
+import { getJoinKeysignUrl } from '@vultisig/core-mpc/keysign/utils/getJoinKeysignUrl'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { RelaySigningService } from '../../../src/services/RelaySigningService'
@@ -151,6 +152,26 @@ describe('RelaySigningService', () => {
       expect(url.searchParams.get('type')).toBe('SignTransaction')
       expect(url.searchParams.get('vault')).toBe('test-ecdsa-key')
       expect(url.searchParams.get('jsonData')).toBeDefined()
+    })
+
+    it('passes the configured relay URL to the QR payload generator', async () => {
+      const customRelayUrl = 'https://relay.example.test/router'
+      const customService = new RelaySigningService(customRelayUrl)
+
+      await customService.generateQRPayload({
+        sessionId: 'session-custom',
+        hexEncryptionKey: 'c'.repeat(64),
+        localPartyId: 'party-custom',
+        vaultPublicKeyEcdsa: 'test-ecdsa-key',
+      })
+
+      expect(getJoinKeysignUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serverType: 'relay',
+          serverUrl: customRelayUrl,
+          sessionId: 'session-custom',
+        })
+      )
     })
   })
 

--- a/packages/sdk/tests/unit/vault/SecureVault.test.ts
+++ b/packages/sdk/tests/unit/vault/SecureVault.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import { RelaySigningService } from '../../../src/services/RelaySigningService'
 import { SecureVault } from '../../../src/vault/SecureVault'
 import { VaultError, VaultErrorCode } from '../../../src/vault/VaultError'
 
@@ -254,6 +255,37 @@ describe('SecureVault type safety', () => {
 })
 
 describe('SecureVault signing', () => {
+  const customRelayUrl = 'https://relay.example.test/router'
+
+  const makeSecureVault = () =>
+    new (SecureVault as any)(
+      'secure-vault-id',
+      'Secure Vault',
+      '',
+      {
+        storage: {} as any,
+        config: {},
+        serverManager: { messageRelay: customRelayUrl },
+        passwordCache: {} as any,
+        wasmProvider: {
+          getWalletCore: vi.fn().mockResolvedValue({}),
+        },
+        pushNotificationService: {} as any,
+      },
+      {
+        name: 'Secure Vault',
+        publicKeys: { ecdsa: 'ecdsa-public-key', eddsa: 'eddsa-public-key' },
+        signers: ['local-party-1', 'remote-party-2', 'remote-party-3'],
+        hexChainCode: 'b'.repeat(64),
+        localPartyId: 'local-party-1',
+        createdAt: Date.now(),
+        libType: 'DKLS',
+        isBackedUp: true,
+        order: 0,
+        keyShares: { ecdsa: 'ecdsa-key-share', eddsa: 'eddsa-key-share' },
+      }
+    ) as SecureVault
+
   describe('sign() method interface', () => {
     it('should accept SigningPayload with messageHashes', () => {
       const payload = {
@@ -297,6 +329,18 @@ describe('SecureVault signing', () => {
       const options = {}
       expect(options).toBeDefined()
     })
+
+    it('passes the configured relay URL to the relay signing service', async () => {
+      vi.mocked(RelaySigningService).mockClear()
+
+      await makeSecureVault().sign({
+        chain: 'Ethereum',
+        transaction: { to: '0x123', value: '1000000000000000000' },
+        messageHashes: ['abc123def456'],
+      })
+
+      expect(RelaySigningService).toHaveBeenCalledWith(customRelayUrl)
+    })
   })
 
   describe('signBytes() method interface', () => {
@@ -338,6 +382,17 @@ describe('SecureVault signing', () => {
 
       expect(typeof signingOptions.onQRCodeReady).toBe('function')
       expect(typeof signingOptions.onDeviceJoined).toBe('function')
+    })
+
+    it('passes the configured relay URL to raw-bytes relay signing', async () => {
+      vi.mocked(RelaySigningService).mockClear()
+
+      await makeSecureVault().signBytes({
+        data: '0xabcdef123456',
+        chain: 'Ethereum',
+      })
+
+      expect(RelaySigningService).toHaveBeenCalledWith(customRelayUrl)
     })
   })
 


### PR DESCRIPTION
Closes #953
Runtime proof: SecureVault.sign() and SecureVault.signBytes() constructed RelaySigningService with https://relay.example.test/router, and generated signing QR payloads included serverUrl=https://relay.example.test/router before external relay/MPC participation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Configured relay URLs are now honored for secure vault transaction signing and raw-byte signing.
  * QR signing payloads now retain the selected relay endpoint, including when payloads are uploaded due to size limits.
  * Local signing behavior remains unchanged when relay usage is disabled.

* **Tests**
  * Added coverage confirming custom relay URLs are preserved across QR generation and secure vault signing flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->