### PR TITLE
feat(ripple): XRP trust-line (TrustSet) support for issued tokens

### DIFF
--- a/.changeset/ripple-trustset-issued-tokens.md
+++ b/.changeset/ripple-trustset-issued-tokens.md
@@ -1,0 +1,17 @@
+---
+'@vultisig/core-chain': minor
+'@vultisig/core-mpc': minor
+'@vultisig/sdk': minor
+---
+
+feat(ripple): XRP trust-line (TrustSet) support for issued tokens
+
+Add support for opening/modifying an XRPL trust line so a vault can hold issued
+currencies (e.g. RLUSD). `getRippleSigningInputs` now emits a WalletCore
+`OperationTrustSet` (LimitAmount = { currency, issuer, value }) when the keysign
+coin is an issued currency, and falls through to the existing Payment path for
+native XRP. New `chains/ripple/issuedCurrency` helpers encode the composite
+`currency.issuer` token id, normalise human tickers to on-ledger currency codes,
+format issued-currency values, and expose the 0.2 XRP owner-reserve delta
+(`rippleOwnerReserveDrops`). `isValidTokenId` validates XRPL `currency.issuer`
+ids.

--- a/packages/core/chain/chains/ripple/issuedCurrency.ts
+++ b/packages/core/chain/chains/ripple/issuedCurrency.ts
@@ -1,0 +1,122 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { KnownCoin } from '@vultisig/core-chain/coin/Coin'
+
+/**
+ * Owner-reserve locked by each XRP Ledger object a wallet owns, including every
+ * trust line. Opening a trust line raises the account's required reserve by this
+ * amount (it is locked, not spent). Current mainnet value is 0.2 XRP.
+ * @see https://xrpl.org/docs/concepts/accounts/reserves
+ */
+export const rippleOwnerReserveDrops = 200000n
+
+/** XRPL "standard" (ISO-4217-like) currency codes are exactly 3 characters. */
+const standardCurrencyCodeLength = 3
+
+/** Non-standard XRPL currency codes are a 160-bit value, i.e. 40 hex chars. */
+const hexCurrencyCodeLength = 40
+
+const hexCurrencyCodeRegex = /^[0-9a-fA-F]{40}$/
+
+const asciiToHexCurrencyCode = (currency: string): string => {
+  const bytes = Buffer.from(currency, 'ascii')
+  if (bytes.length > 20) {
+    throw new Error(`XRPL currency code too long: "${currency}" (max 20 bytes)`)
+  }
+
+  return Buffer.concat([bytes, Buffer.alloc(20 - bytes.length)])
+    .toString('hex')
+    .toUpperCase()
+}
+
+/**
+ * Normalises a human currency ticker to the on-ledger XRPL currency code.
+ *
+ * - 3-character codes (e.g. `USD`) are standard codes and are used verbatim.
+ * - An already-encoded 40-char hex code passes through (upper-cased).
+ * - Anything else (e.g. `RLUSD`) is encoded as the 160-bit form: the ASCII bytes
+ *   right-padded with zeros to 20 bytes, hex-encoded. This is what the XRP Ledger
+ *   and WalletCore's Ripple signer expect for non-standard currencies.
+ */
+export const toXrplCurrencyCode = (currency: string): string => {
+  const value = currency.trim()
+
+  if (value.length === standardCurrencyCodeLength) {
+    return value
+  }
+
+  if (value.length === hexCurrencyCodeLength && hexCurrencyCodeRegex.test(value)) {
+    return value.toUpperCase()
+  }
+
+  return asciiToHexCurrencyCode(value)
+}
+
+const tokenIdSeparator = '.'
+
+type RippleIssuedCurrency = {
+  currency: string
+  issuer: string
+}
+
+/**
+ * Composite identifier for an XRPL issued currency: `<currencyCode>.<issuer>`.
+ * XRPL tokens are identified by the (currency, issuer) pair rather than a single
+ * contract address, so both are encoded into the coin `id`.
+ */
+export const rippleTokenId = ({ currency, issuer }: RippleIssuedCurrency): string =>
+  `${toXrplCurrencyCode(currency)}${tokenIdSeparator}${issuer}`
+
+/** Splits a {@link rippleTokenId} back into its `currency` code and `issuer`. */
+export const parseRippleTokenId = (id: string): RippleIssuedCurrency => {
+  const index = id.indexOf(tokenIdSeparator)
+  if (index <= 0 || index === id.length - 1) {
+    throw new Error(`Invalid Ripple token id: "${id}"`)
+  }
+
+  return {
+    currency: id.slice(0, index),
+    issuer: id.slice(index + 1),
+  }
+}
+
+/**
+ * Formats an issued-currency base-unit amount as an XRPL value string: a plain
+ * decimal (never scientific notation) with trailing-zero fractional digits
+ * trimmed. XRPL issued amounts allow up to 15 significant digits.
+ */
+export const formatIssuedCurrencyValue = (amount: bigint, decimals: number): string => {
+  const negative = amount < 0n
+  const digits = (negative ? -amount : amount).toString().padStart(decimals + 1, '0')
+
+  const intPart = digits.slice(0, digits.length - decimals) || '0'
+  const fracPart = decimals > 0 ? digits.slice(digits.length - decimals).replace(/0+$/, '') : ''
+
+  const magnitude = fracPart ? `${intPart}.${fracPart}` : intPart
+
+  return negative && magnitude !== '0' ? `-${magnitude}` : magnitude
+}
+
+/**
+ * XRPL issued currencies carry up to 15 significant decimal digits rather than a
+ * fixed on-chain decimal count. We model them internally with this many decimals.
+ */
+export const rippleIssuedCurrencyDecimals = 15
+
+/**
+ * Curated XRPL issued tokens surfaced in the "open trust line" flow. Not wired
+ * into `knownTokens` — issued-currency balances / asset-list display are handled
+ * separately (vultisig-windows#4307 / vultisig-sdk#997).
+ */
+export const rippleKnownIssuedTokens: KnownCoin[] = [
+  {
+    chain: Chain.Ripple,
+    id: rippleTokenId({
+      currency: 'RLUSD',
+      issuer: 'rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De',
+    }),
+    ticker: 'RLUSD',
+    logo: 'rlusd',
+    decimals: rippleIssuedCurrencyDecimals,
+    priceProviderId: 'ripple-usd',
+  },
+]

--- a/packages/core/chain/chains/ripple/issuedCurrency.ts
+++ b/packages/core/chain/chains/ripple/issuedCurrency.ts
@@ -51,6 +51,16 @@ export const toXrplCurrencyCode = (currency: string): string => {
   return asciiToHexCurrencyCode(value)
 }
 
+/**
+ * True if `currency` is already a valid on-ledger XRPL currency code: either a
+ * 3-character standard code or the 40-char hex (160-bit) non-standard form.
+ * A human ticker like `RLUSD` is NOT valid here - it must first be normalised
+ * via {@link toXrplCurrencyCode} before being used in a token id or TrustSet.
+ */
+export const isValidXrplCurrencyCode = (currency: string): boolean =>
+  currency.length === standardCurrencyCodeLength ||
+  (currency.length === hexCurrencyCodeLength && hexCurrencyCodeRegex.test(currency))
+
 const tokenIdSeparator = '.'
 
 type RippleIssuedCurrency = {

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -660,6 +660,11 @@
       "import": "./dist/chains/ripple/client.js",
       "default": "./dist/chains/ripple/client.js"
     },
+    "./chains/ripple/issuedCurrency": {
+      "types": "./dist/chains/ripple/issuedCurrency.d.ts",
+      "import": "./dist/chains/ripple/issuedCurrency.js",
+      "default": "./dist/chains/ripple/issuedCurrency.js"
+    },
     "./chains/ripple/network/info": {
       "types": "./dist/chains/ripple/network/info.d.ts",
       "import": "./dist/chains/ripple/network/info.js",

--- a/packages/core/chain/utils/isValidTokenId.test.ts
+++ b/packages/core/chain/utils/isValidTokenId.test.ts
@@ -1,0 +1,59 @@
+import { initWasm, type WalletCore } from '@trustwallet/wallet-core'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { rippleTokenId } from '@vultisig/core-chain/chains/ripple/issuedCurrency'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import { isValidTokenId } from './isValidTokenId'
+
+const RLUSD_ISSUER = 'rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De'
+
+describe('isValidTokenId - Ripple issued currencies', () => {
+  let walletCore: WalletCore
+
+  beforeAll(async () => {
+    walletCore = await initWasm()
+  })
+
+  it('rejects an unencoded non-standard currency ticker (e.g. "RLUSD.<issuer>")', () => {
+    expect(
+      isValidTokenId({
+        chain: Chain.Ripple,
+        id: `RLUSD.${RLUSD_ISSUER}`,
+        walletCore,
+      })
+    ).toBe(false)
+  })
+
+  it('accepts a properly encoded (40-char hex) non-standard currency id', () => {
+    const id = rippleTokenId({ currency: 'RLUSD', issuer: RLUSD_ISSUER })
+
+    expect(id).toBe(`524C555344000000000000000000000000000000.${RLUSD_ISSUER}`)
+    expect(
+      isValidTokenId({
+        chain: Chain.Ripple,
+        id,
+        walletCore,
+      })
+    ).toBe(true)
+  })
+
+  it('accepts a standard 3-character currency code', () => {
+    expect(
+      isValidTokenId({
+        chain: Chain.Ripple,
+        id: `USD.${RLUSD_ISSUER}`,
+        walletCore,
+      })
+    ).toBe(true)
+  })
+
+  it('rejects a valid currency paired with an invalid issuer address', () => {
+    expect(
+      isValidTokenId({
+        chain: Chain.Ripple,
+        id: 'USD.not-a-valid-xrpl-address',
+        walletCore,
+      })
+    ).toBe(false)
+  })
+})

--- a/packages/core/chain/utils/isValidTokenId.ts
+++ b/packages/core/chain/utils/isValidTokenId.ts
@@ -1,7 +1,7 @@
 import { isValidStructTag } from '@mysten/sui/utils'
 import { WalletCore } from '@trustwallet/wallet-core'
 import { Chain } from '@vultisig/core-chain/Chain'
-import { parseRippleTokenId } from '@vultisig/core-chain/chains/ripple/issuedCurrency'
+import { isValidXrplCurrencyCode, parseRippleTokenId } from '@vultisig/core-chain/chains/ripple/issuedCurrency'
 import { attempt } from '@vultisig/lib-utils/attempt'
 
 import { isValidAddress } from './isValidAddress'
@@ -33,7 +33,7 @@ export const isValidTokenId = ({ chain, id, walletCore }: Input) => {
     }
     const { currency, issuer } = parsed.data
 
-    return currency.length > 0 && isValidAddress({ chain, address: issuer, walletCore })
+    return isValidXrplCurrencyCode(currency) && isValidAddress({ chain, address: issuer, walletCore })
   }
 
   return isValidAddress({ chain, address: id, walletCore })

--- a/packages/core/chain/utils/isValidTokenId.ts
+++ b/packages/core/chain/utils/isValidTokenId.ts
@@ -1,6 +1,8 @@
 import { isValidStructTag } from '@mysten/sui/utils'
 import { WalletCore } from '@trustwallet/wallet-core'
 import { Chain } from '@vultisig/core-chain/Chain'
+import { parseRippleTokenId } from '@vultisig/core-chain/chains/ripple/issuedCurrency'
+import { attempt } from '@vultisig/lib-utils/attempt'
 
 import { isValidAddress } from './isValidAddress'
 
@@ -16,11 +18,22 @@ type Input = {
  * For most chains a token is identified by an address (contract/mint), so this
  * delegates to {@link isValidAddress}. SUI tokens are identified by their fully
  * qualified coin type (e.g. `0x2::sui::SUI`), which is a Move struct tag rather
- * than an account address, so it is validated separately.
+ * than an account address, so it is validated separately. XRPL issued currencies
+ * are identified by a composite `currency.issuer` id and validated as such.
  */
 export const isValidTokenId = ({ chain, id, walletCore }: Input) => {
   if (chain === Chain.Sui) {
     return isValidStructTag(id.trim())
+  }
+
+  if (chain === Chain.Ripple) {
+    const parsed = attempt(() => parseRippleTokenId(id.trim()))
+    if ('error' in parsed) {
+      return false
+    }
+    const { currency, issuer } = parsed.data
+
+    return currency.length > 0 && isValidAddress({ chain, address: issuer, walletCore })
   }
 
   return isValidAddress({ chain, address: id, walletCore })

--- a/packages/core/mpc/keysign/signingInputs/resolvers/ripple.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/ripple.test.ts
@@ -81,6 +81,22 @@ describe('getRippleSigningInputs -- TrustSet build path (issued currency)', () =
     expect(limit?.value).toBe('1.5')
   })
 
+  it('normalizes an unencoded non-standard currency stored in contractAddress before signing', async () => {
+    // Defense-in-depth: a `contractAddress` built without going through
+    // `rippleTokenId()` (e.g. a raw "RLUSD.<issuer>" id) must still resolve to
+    // the on-ledger 40-char hex form rather than being forwarded verbatim.
+    const payload = buildTrustSetPayload('1000000000000000')
+    payload.coin!.contractAddress = `RLUSD.${RLUSD_ISSUER}`
+
+    const [input] = await getRippleSigningInputs({
+      keysignPayload: payload,
+      walletCore,
+    })
+
+    expect(input.opTrustSet?.limitAmount?.currency).toBe('524C555344000000000000000000000000000000')
+    expect(input.opTrustSet?.limitAmount?.issuer).toBe(RLUSD_ISSUER)
+  })
+
   it('formats whole-number limits without a fractional part', async () => {
     const [input] = await getRippleSigningInputs({
       keysignPayload: buildTrustSetPayload('1000000000000000'),

--- a/packages/core/mpc/keysign/signingInputs/resolvers/ripple.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/ripple.test.ts
@@ -1,0 +1,114 @@
+import { create } from '@bufbuild/protobuf'
+import { type WalletCore } from '@trustwallet/wallet-core'
+import { Chain } from '@vultisig/core-chain/Chain'
+import {
+  rippleIssuedCurrencyDecimals,
+  rippleTokenId,
+  toXrplCurrencyCode,
+} from '@vultisig/core-chain/chains/ripple/issuedCurrency'
+import { RippleSpecificSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
+import { CoinSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/coin_pb'
+import { KeysignPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { describe, expect, it } from 'vitest'
+
+import { getRippleSigningInputs } from './ripple'
+
+// getRippleSigningInputs does not touch walletCore.
+const walletCore = {} as unknown as WalletCore
+
+const ACCOUNT = 'rExampleAccountAddressForTests1234567'
+const RLUSD_ISSUER = 'rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De'
+// Dummy 33-byte secp256k1 public key (hex) for getKeysignTwPublicKey.
+const HEX_PUBLIC_KEY = `02${'ab'.repeat(32)}`
+
+const makeRippleSpecific = () =>
+  create(RippleSpecificSchema, {
+    sequence: 100n,
+    gas: 15n,
+    lastLedgerSequence: 200n,
+  })
+
+const buildTrustSetPayload = (toAmount: string) =>
+  create(KeysignPayloadSchema, {
+    coin: create(CoinSchema, {
+      chain: Chain.Ripple,
+      ticker: 'RLUSD',
+      address: ACCOUNT,
+      decimals: rippleIssuedCurrencyDecimals,
+      isNativeToken: false,
+      contractAddress: rippleTokenId({
+        currency: 'RLUSD',
+        issuer: RLUSD_ISSUER,
+      }),
+      hexPublicKey: HEX_PUBLIC_KEY,
+    }),
+    toAddress: RLUSD_ISSUER,
+    toAmount,
+    blockchainSpecific: { case: 'rippleSpecific', value: makeRippleSpecific() },
+  })
+
+const buildPaymentPayload = () =>
+  create(KeysignPayloadSchema, {
+    coin: create(CoinSchema, {
+      chain: Chain.Ripple,
+      ticker: 'XRP',
+      address: ACCOUNT,
+      decimals: 6,
+      isNativeToken: true,
+      hexPublicKey: HEX_PUBLIC_KEY,
+    }),
+    toAddress: 'rDestinationAddressForTests9876543210',
+    toAmount: '1000000',
+    blockchainSpecific: { case: 'rippleSpecific', value: makeRippleSpecific() },
+  })
+
+describe('getRippleSigningInputs -- TrustSet build path (issued currency)', () => {
+  it('builds an OperationTrustSet with the on-ledger currency code, issuer and value', async () => {
+    // 1.5 RLUSD at 15 decimals.
+    const [input] = await getRippleSigningInputs({
+      keysignPayload: buildTrustSetPayload('1500000000000000'),
+      walletCore,
+    })
+
+    expect(input.opTrustSet).toBeTruthy()
+    expect(input.opPayment).toBeFalsy()
+
+    const limit = input.opTrustSet?.limitAmount
+    expect(limit?.currency).toBe(toXrplCurrencyCode('RLUSD'))
+    // RLUSD is non-standard (>3 chars) so it must be the 160-bit hex form.
+    expect(limit?.currency).toBe('524C555344000000000000000000000000000000')
+    expect(limit?.issuer).toBe(RLUSD_ISSUER)
+    expect(limit?.value).toBe('1.5')
+  })
+
+  it('formats whole-number limits without a fractional part', async () => {
+    const [input] = await getRippleSigningInputs({
+      keysignPayload: buildTrustSetPayload('1000000000000000'),
+      walletCore,
+    })
+
+    expect(input.opTrustSet?.limitAmount?.value).toBe('1')
+  })
+
+  it('carries the network fee and sequence through unchanged', async () => {
+    const [input] = await getRippleSigningInputs({
+      keysignPayload: buildTrustSetPayload('1000000000000000'),
+      walletCore,
+    })
+
+    expect(input.fee.toString()).toBe('15')
+    expect(input.sequence).toBe(100)
+    expect(input.lastLedgerSequence).toBe(200)
+    expect(input.account).toBe(ACCOUNT)
+  })
+
+  it('native XRP still builds a Payment, never a TrustSet', async () => {
+    const [input] = await getRippleSigningInputs({
+      keysignPayload: buildPaymentPayload(),
+      walletCore,
+    })
+
+    expect(input.opPayment).toBeTruthy()
+    expect(input.opTrustSet).toBeFalsy()
+  })
+})

--- a/packages/core/mpc/keysign/signingInputs/resolvers/ripple.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/ripple.ts
@@ -1,5 +1,9 @@
 import { Buffer } from 'buffer'
-import { formatIssuedCurrencyValue, parseRippleTokenId } from '@vultisig/core-chain/chains/ripple/issuedCurrency'
+import {
+  formatIssuedCurrencyValue,
+  parseRippleTokenId,
+  toXrplCurrencyCode,
+} from '@vultisig/core-chain/chains/ripple/issuedCurrency'
 import { assertField } from '@vultisig/lib-utils/record/assertField'
 import { TW } from '@trustwallet/wallet-core'
 import Long from 'long'
@@ -31,7 +35,7 @@ export const getRippleSigningInputs: SigningInputsResolver<'ripple'> = ({ keysig
     return {
       opTrustSet: TW.Ripple.Proto.OperationTrustSet.create({
         limitAmount: TW.Ripple.Proto.CurrencyAmount.create({
-          currency,
+          currency: toXrplCurrencyCode(currency),
           issuer,
           value: formatIssuedCurrencyValue(BigInt(keysignPayload.toAmount), coin.decimals),
         }),

--- a/packages/core/mpc/keysign/signingInputs/resolvers/ripple.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/ripple.ts
@@ -1,4 +1,5 @@
 import { Buffer } from 'buffer'
+import { formatIssuedCurrencyValue, parseRippleTokenId } from '@vultisig/core-chain/chains/ripple/issuedCurrency'
 import { assertField } from '@vultisig/lib-utils/record/assertField'
 import { TW } from '@trustwallet/wallet-core'
 import Long from 'long'
@@ -16,6 +17,27 @@ export const getRippleSigningInputs: SigningInputsResolver<'ripple'> = ({ keysig
   const coin = assertField(keysignPayload, 'coin')
 
   const account = coin.address
+
+  // An issued-currency coin (non-native, with a `currency.issuer` contract
+  // address) signals a TrustSet: open/modify the trust line whose limit is the
+  // keysign amount. Native XRP falls through to the Payment path below.
+  const getTrustSet = (): Pick<TW.Ripple.Proto.ISigningInput, 'opTrustSet'> | undefined => {
+    if (coin.isNativeToken || !coin.contractAddress) {
+      return undefined
+    }
+
+    const { currency, issuer } = parseRippleTokenId(coin.contractAddress)
+
+    return {
+      opTrustSet: TW.Ripple.Proto.OperationTrustSet.create({
+        limitAmount: TW.Ripple.Proto.CurrencyAmount.create({
+          currency,
+          issuer,
+          value: formatIssuedCurrencyValue(BigInt(keysignPayload.toAmount), coin.decimals),
+        }),
+      }),
+    }
+  }
 
   const getPayment = (): Pick<TW.Ripple.Proto.ISigningInput, 'opPayment' | 'rawJson'> => {
     if (keysignPayload.memo) {
@@ -71,7 +93,7 @@ export const getRippleSigningInputs: SigningInputsResolver<'ripple'> = ({ keysig
     sequence: Number(sequence),
     lastLedgerSequence: Number(lastLedgerSequence),
     publicKey: getKeysignTwPublicKey(keysignPayload),
-    ...getPayment(),
+    ...(getTrustSet() ?? getPayment()),
   })
 
   return [input]


### PR DESCRIPTION
Closes #995

## What
XRP was Payment/native-only. To hold an issued currency on the XRPL (e.g. RLUSD) an account must first open a **trust line** via a `TrustSet`. This adds that support to the shared SDK.

## Changes
- **`getRippleSigningInputs`** — emits a WalletCore `OperationTrustSet` (`LimitAmount = { currency, issuer, value }`) when the keysign coin is an issued currency; native XRP keeps the existing Payment path. Signs via secp256k1 (unchanged).
- **`chains/ripple/issuedCurrency.ts`** (new) — composite `currency.issuer` token id (`rippleTokenId`/`parseRippleTokenId`), `toXrplCurrencyCode` (3-char ISO vs 160-bit hex), `formatIssuedCurrencyValue`, the **0.2 XRP owner-reserve** constant (`rippleOwnerReserveDrops`), and a curated RLUSD entry.
- **`isValidTokenId`** — validates XRPL `currency.issuer` ids.
- Unit test on the TrustSet build path (currency-code encoding, issuer, value formatting, + native-XRP Payment no-regression).

## Acceptance
- [x] TrustSet (set/modify limit) builds + signs + broadcasts
- [x] Owner-reserve delta (0.2 XRP/line) exposed to apps
- [x] Unit test on the TrustSet build path

## Verification
End-to-end: a Vultisig-signed TrustSet **confirmed on XRPL mainnet (`tesSUCCESS`)** opening an RLUSD trust line (currency hex `524C555344…` = `toXrplCurrencyCode('RLUSD')`, issuer `rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De`, limit 1,000,000,000):
https://xrpscan.com/transaction/E4D515E149EB9A8A8A0A65D94488020A132E153562384C243D19D942BA102ED5

## Notes
- Issued-currency **balances** / asset-list are out of scope (#997).
- Consumed by vultisig-windows#4308 (Open-Trust-Line UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)