### PR TITLE
fix(broadcast): UTXO/Cardano no longer report false success on a real failure

### DIFF
--- a/.changeset/fix-utxo-cardano-broadcast-false-success.md
+++ b/.changeset/fix-utxo-cardano-broadcast-false-success.md
@@ -1,0 +1,12 @@
+---
+"@vultisig/sdk": patch
+---
+
+fix: UTXO/Cardano broadcast no longer reports false success on a genuine failure
+
+`broadcastCardanoTx`/`broadcastUtxoTx` bucketed `BadInputsUTxO` (a genuine failure — spent/invalid inputs)
+together with benign MPC-race duplicates (`txn-mempool-conflict`/`already known`) and returned success
+unconditionally for all three, bypassing the on-chain hash verification safety net. Every ambiguous submit
+error now routes through `verifyBroadcastByHash`, and `getUtxoTxStatus` now sets `isKnown: false` when the
+hash is genuinely not found (matching the existing convention already used by the cosmos/evm/polkadot/
+ripple/solana resolvers) so a real failure correctly rethrows instead of being swallowed as success.

--- a/packages/core/chain/tx/broadcast/resolvers/cardano.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/cardano.test.ts
@@ -100,13 +100,40 @@ describe('broadcastCardanoTx', () => {
     await expect(broadcastCardanoTx({ chain, tx })).rejects.toBe(verifyError)
   })
 
-  it('continues swallowing duplicate Cardano broadcast errors without hash verification', async () => {
+  it('routes an "already known" duplicate through hash verification instead of blanket-swallowing it (false-success fix)', async () => {
+    // Before the fix, 'txn-mempool-conflict'/'already known'/'BadInputsUTxO' were bucketed together and
+    // returned null unconditionally — but BadInputsUTxO is a GENUINE failure (spent/invalid inputs), not
+    // an MPC-race duplicate. Verification is now mandatory for every ambiguous submit error.
     const tx = txWithTtl(1_000)
     mocks.getCardanoCurrentSlot.mockResolvedValue(939n)
     mocks.submitCardanoCbor.mockResolvedValue({ errorMessage: 'txn-mempool-conflict' })
+    mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
 
     await expect(broadcastCardanoTx({ chain, tx })).resolves.toBeNull()
 
-    expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
+    expect(mocks.verifyBroadcastByHash).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects a BadInputsUTxO error when the tx is NOT actually on chain (the false-success bug this fixes)', async () => {
+    const tx = txWithTtl(1_000)
+    const verifyError = new Error('Failed to broadcast transaction: BadInputsUTxO')
+    mocks.getCardanoCurrentSlot.mockResolvedValue(939n)
+    mocks.submitCardanoCbor.mockResolvedValue({ errorMessage: 'BadInputsUTxO' })
+    // verifyBroadcastByHash rethrows the original error when the tx isn't confirmed on-chain — see its
+    // own contract in verifyBroadcastByHash.ts.
+    mocks.verifyBroadcastByHash.mockRejectedValue(verifyError)
+
+    await expect(broadcastCardanoTx({ chain, tx })).rejects.toBe(verifyError)
+  })
+
+  it('still succeeds on a genuine MPC-race "already known" when hash verification confirms the tx IS on chain', async () => {
+    const tx = txWithTtl(1_000)
+    mocks.getCardanoCurrentSlot.mockResolvedValue(939n)
+    mocks.submitCardanoCbor.mockResolvedValue({ errorMessage: 'already known' })
+    mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+
+    await expect(broadcastCardanoTx({ chain, tx })).resolves.toBeNull()
+
+    expect(mocks.verifyBroadcastByHash).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/core/chain/tx/broadcast/resolvers/cardano.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/cardano.ts
@@ -3,7 +3,6 @@ import { getCardanoTxTtl } from '@vultisig/core-chain/chains/cardano/cip30/carda
 import { getCardanoCurrentSlot } from '@vultisig/core-chain/chains/cardano/client/currentSlot'
 import { cardanoBroadcastTtlSafetyMargin } from '@vultisig/core-chain/chains/cardano/config'
 import { getCardanoTxHash } from '@vultisig/core-chain/tx/hash/resolvers/cardano'
-import { isInError } from '@vultisig/lib-utils/error/isInError'
 
 import { submitCardanoCbor } from '../../../chains/cardano/submit/submitCardanoCbor'
 import { BroadcastTxResolver } from '../resolver'
@@ -44,10 +43,10 @@ export const broadcastCardanoTx: BroadcastTxResolver<OtherChain.Cardano> = async
 
   const error = errorMessage ?? 'unknown broadcast failure'
 
-  if (isInError(error, 'BadInputsUTxO', 'txn-mempool-conflict', 'already known')) {
-    return null
-  }
-
+  // Any submit error past this point is ambiguous — it could be a benign MPC-race duplicate (another
+  // device already broadcast the same signed tx) OR a genuine failure (e.g. BadInputsUTxO: spent/invalid
+  // inputs). String-matching alone can't tell them apart, so verify against the real chain: the hash
+  // either resolves on-chain (the race case — success) or it doesn't (the real failure — rethrows).
   const broadcastError = new Error(`Failed to broadcast transaction: ${error}`)
   await verifyBroadcastByHash({ chain, tx, error: broadcastError })
   return null

--- a/packages/core/chain/tx/broadcast/resolvers/utxo.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/utxo.test.ts
@@ -54,14 +54,43 @@ describe('broadcastUtxoTx', () => {
     await expect(broadcastUtxoTx({ chain, tx })).rejects.toBe(verifyError)
   })
 
-  it('continues swallowing duplicate UTXO broadcast errors without hash verification', async () => {
+  it('routes an "already known" duplicate through hash verification instead of blanket-swallowing it (false-success fix)', async () => {
+    // Before the fix, 'txn-mempool-conflict'/'already known'/'BadInputsUTxO' were bucketed together and
+    // returned null unconditionally — but BadInputsUTxO is a GENUINE failure (spent/invalid inputs), not
+    // an MPC-race duplicate. Verification is now mandatory for every ambiguous submit error.
     mocks.queryUrl.mockResolvedValue({
       data: null,
       context: { error: 'txn-mempool-conflict' },
     })
+    mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
 
     await expect(broadcastUtxoTx({ chain, tx })).resolves.toBeNull()
 
-    expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
+    expect(mocks.verifyBroadcastByHash).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects a BadInputsUTxO error when the tx is NOT actually on chain (the false-success bug this fixes)', async () => {
+    const verifyError = new Error('Failed to broadcast transaction: BadInputsUTxO')
+    mocks.queryUrl.mockResolvedValue({
+      data: null,
+      context: { error: 'BadInputsUTxO' },
+    })
+    // verifyBroadcastByHash rethrows the original error when the tx isn't confirmed on-chain — see its
+    // own contract in verifyBroadcastByHash.ts.
+    mocks.verifyBroadcastByHash.mockRejectedValue(verifyError)
+
+    await expect(broadcastUtxoTx({ chain, tx })).rejects.toBe(verifyError)
+  })
+
+  it('still succeeds on a genuine MPC-race "already known" when hash verification confirms the tx IS on chain', async () => {
+    mocks.queryUrl.mockResolvedValue({
+      data: null,
+      context: { error: 'already known' },
+    })
+    mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+
+    await expect(broadcastUtxoTx({ chain, tx })).resolves.toBeNull()
+
+    expect(mocks.verifyBroadcastByHash).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/core/chain/tx/broadcast/resolvers/utxo.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/utxo.ts
@@ -1,7 +1,6 @@
 import { OtherChain, UtxoBasedChain, UtxoChain } from '@vultisig/core-chain/Chain'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { extractErrorMsg } from '@vultisig/lib-utils/error/extractErrorMsg'
-import { isInError } from '@vultisig/lib-utils/error/isInError'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
 import { getChainKind } from '../../../ChainKind'
@@ -41,10 +40,10 @@ export const broadcastUtxoTx: BroadcastTxResolver<UtxoBasedChain> = async ({ cha
 
   const error = 'context' in response ? response.context.error : extractErrorMsg(response)
 
-  if (isInError(error, 'BadInputsUTxO', 'txn-mempool-conflict', 'already known')) {
-    return null
-  }
-
+  // Any submit error past this point is ambiguous — it could be a benign MPC-race duplicate (another
+  // device already broadcast the same signed tx) OR a genuine failure (e.g. BadInputsUTxO: spent/invalid
+  // inputs). String-matching alone can't tell them apart, so verify against the real chain: the hash
+  // either resolves on-chain (the race case — success) or it doesn't (the real failure — rethrows).
   const broadcastError = new Error(`Failed to broadcast transaction: ${extractErrorMsg(error)}`)
   await verifyBroadcastByHash({ chain, tx, error: broadcastError })
   return null

--- a/packages/core/chain/tx/status/resolvers/utxo.test.ts
+++ b/packages/core/chain/tx/status/resolvers/utxo.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  queryUrl: vi.fn(),
+}))
+
+vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
+  queryUrl: mocks.queryUrl,
+}))
+
+import { UtxoChain } from '../../../Chain'
+import { getUtxoTxStatus } from './utxo'
+
+describe('getUtxoTxStatus', () => {
+  const hash = 'abc123'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns isKnown:false when Blockchair has no record of the hash at all — verify-by-hash MUST NOT swallow broadcast errors for unknown hashes', async () => {
+    // Regression for the false-success bug (VA-88 broadcast-verify audit, 2026-07-08):
+    // broadcastUtxoTx/broadcastCardanoTx fall through to verifyBroadcastByHash on an
+    // ambiguous submit error (BadInputsUTxO/txn-mempool-conflict/already known). That
+    // safety net swallows the error iff getUtxoTxStatus reports status:'pending' AND
+    // isKnown !== false. Pre-fix this resolver returned plain `{status:'pending'}` for
+    // a hash Blockchair has NEVER seen, so undefined isKnown passed the guard and a
+    // genuine broadcast failure (e.g. spent/invalid inputs, tx never reached the
+    // network) was reported as success — the app showed a "done" screen with a
+    // locally computed hash that had no on-chain counterpart. Mirrors cosmos.ts:15 /
+    // evm.ts:52 / polkadot.ts:36 / ripple.ts:25.
+    mocks.queryUrl.mockResolvedValue({ data: {} })
+
+    const result = await getUtxoTxStatus({ chain: UtxoChain.Bitcoin, hash })
+    expect(result).toEqual({ status: 'pending', isKnown: false })
+  })
+
+  it('returns isKnown:false on network/API error', async () => {
+    mocks.queryUrl.mockRejectedValue(new Error('network failure'))
+
+    const result = await getUtxoTxStatus({ chain: UtxoChain.Bitcoin, hash })
+    expect(result).toEqual({ status: 'pending', isKnown: false })
+  })
+
+  it('returns isKnown:true when Blockchair has indexed the hash in the mempool (block_id: -1) — the genuine MPC-race case verify-by-hash SHOULD swallow', async () => {
+    mocks.queryUrl.mockResolvedValue({
+      data: { [hash]: { transaction: { block_id: -1 } } },
+    })
+
+    const result = await getUtxoTxStatus({ chain: UtxoChain.Bitcoin, hash })
+    expect(result).toEqual({ status: 'pending', isKnown: true })
+  })
+
+  it('returns isKnown:true when Blockchair reports block_id: null (also mempool, per the existing convention)', async () => {
+    mocks.queryUrl.mockResolvedValue({
+      data: { [hash]: { transaction: { block_id: null } } },
+    })
+
+    const result = await getUtxoTxStatus({ chain: UtxoChain.Bitcoin, hash })
+    expect(result).toEqual({ status: 'pending', isKnown: true })
+  })
+
+  it('returns status:success with receipt when mined', async () => {
+    mocks.queryUrl.mockResolvedValue({
+      data: { [hash]: { transaction: { block_id: 800000, fee: 1500 } } },
+    })
+
+    const result = await getUtxoTxStatus({ chain: UtxoChain.Bitcoin, hash })
+    expect(result.status).toBe('success')
+    expect(result.receipt).toMatchObject({ feeAmount: BigInt(1500), feeTicker: 'BTC' })
+  })
+
+  it('omits receipt when fee is missing on a mined tx', async () => {
+    mocks.queryUrl.mockResolvedValue({
+      data: { [hash]: { transaction: { block_id: 800000 } } },
+    })
+
+    const result = await getUtxoTxStatus({ chain: UtxoChain.Bitcoin, hash })
+    expect(result.status).toBe('success')
+    expect(result.receipt).toBeUndefined()
+  })
+})

--- a/packages/core/chain/tx/status/resolvers/utxo.ts
+++ b/packages/core/chain/tx/status/resolvers/utxo.ts
@@ -25,13 +25,23 @@ export const getUtxoTxStatus: TxStatusResolver<UtxoBasedChain> = async ({ chain,
   const { data: response, error } = await attempt(queryUrl<BlockchairTxResponse>(url))
 
   if (error || !response || !response.data[hash]) {
-    return { status: 'pending' }
+    // Transient RPC/network failure OR Blockchair affirmatively has no record of this
+    // hash at all — either way we can't confirm the tx is genuinely known. isKnown:false
+    // so verifyBroadcastByHash's safety net does NOT swallow a real broadcast failure as
+    // success (mirrors the isKnown convention every other chain resolver already uses —
+    // cosmos.ts/evm.ts/polkadot.ts/ripple.ts/solana.ts). Before this, a genuinely-failed
+    // broadcast (e.g. BadInputsUTxO, tx never reached the network) and a real in-flight
+    // tx were indistinguishable here — both returned bare `{status:'pending'}`, which
+    // verifyBroadcastByHash's `isKnown !== false` check treated as a confirmed positive.
+    return { status: 'pending', isKnown: false }
   }
 
   const tx = response.data[hash].transaction
 
   if (tx.block_id === null || tx.block_id === -1) {
-    return { status: 'pending' }
+    // Blockchair HAS indexed this hash (mempool, not yet mined) — a real positive signal
+    // the tx exists, unlike the "not found at all" branch above.
+    return { status: 'pending', isKnown: true }
   }
 
   const feeCoin = chainFeeCoin[chain]


### PR DESCRIPTION
tl;dr a genuine broadcast failure (spent/invalid UTXO inputs) on Bitcoin/Litecoin/Dogecoin/Bitcoin-Cash/Dash/Zcash/Cardano could be silently reported as success with a fabricated tx hash. Fund-safety-critical broadcast path — do NOT merge, this needs review.

## root cause (2 layers, both fixed)

**Layer 1 — the broadcast resolvers bucketed a real failure with benign duplicates.** `broadcastCardanoTx`/`broadcastUtxoTx` matched `BadInputsUTxO` (spent/invalid inputs — a genuine failure) together with `txn-mempool-conflict`/`already known` (benign MPC-race duplicates — another device already broadcast the identical signed tx) and returned success (`null`, later fabricated into a local hash downstream) unconditionally for all three, bypassing `verifyBroadcastByHash` — the safety net that re-checks the real chain before treating an ambiguous error as a race.

Fix: removed the early-return bucket entirely. Every ambiguous submit error now routes through `verifyBroadcastByHash`, which either confirms the tx is genuinely on-chain (the race case — still succeeds) or rethrows the real error.

**Layer 2 — `verifyBroadcastByHash` itself couldn't tell "genuinely missing" from "confirmed" for UTXO/Cardano.** Layer 1 alone wasn't sufficient: `getUtxoTxStatus` (shared by Cardano's status dispatch) never set `isKnown`, so `verifyBroadcastByHash`'s `isKnown !== false` guard treated a hash Blockchair has *never seen* as a confirmed-pending tx — silently re-swallowing the exact failure Layer 1 was supposed to catch.

Fix: `getUtxoTxStatus` now sets `isKnown: false` on a genuinely-missing hash or network error, and `isKnown: true` when Blockchair has indexed it in the mempool (`block_id: null` or `-1`) — the same convention already used by `cosmos.ts`/`evm.ts`/`polkadot.ts`/`ripple.ts`/`solana.ts`'s status resolvers (this one was simply missed when the convention was introduced elsewhere).

## test plan

- [x] Fail-before/pass-after proven via `git stash` isolation, separately for the broadcast-resolver change and the status-resolver change
- [x] New tests: a genuine `BadInputsUTxO` with the tx NOT on chain now rejects; an `already known` with the tx confirmed IS on chain still succeeds; `getUtxoTxStatus` returns `isKnown:false`/`isKnown:true` correctly for not-found/mempool-indexed hashes
- [x] `npx vitest run --config .config/vitest.core.config.ts` (packages/core/chain, all touched suites) — 26/26 passing
- [x] `npx tsc --project .config/tsconfig.json --noEmit` clean
- [x] Codex adversarial review, 2 rounds — round 1 caught the Layer 2 gap (this PR includes both fixes), round 2 clean

🤖 Agent-generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved broadcast handling for UTXO and Cardano transactions so ambiguous submit errors are verified on-chain before being treated as successful.
  * Fixed cases where genuine failures could be reported as success.
  * Clarified transaction status results by distinguishing between unknown hashes and pending-but-known transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->