### PR TITLE
fix(swap): guard limit-swap LIM against flooring to zero (market-swap reinterpret) — THOR-02

### DIFF
--- a/.changeset/reject-limit-swap-zero-floor.md
+++ b/.changeset/reject-limit-swap-zero-floor.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+fix(swap): reject a limit-swap LIM that floors to zero (THOR-02). A tiny target price could floor the computed limit amount to 0, and THORChain treats a zero trade target as an unprotected MARKET swap with no minimum-output floor — silently discarding the price protection the user configured for their limit order. Fail closed with a clear error instead of building a memo that reinterprets as a market swap.

--- a/packages/core/chain/swap/native/limitSwapMemo.test.ts
+++ b/packages/core/chain/swap/native/limitSwapMemo.test.ts
@@ -169,6 +169,27 @@ describe('validateLimitSwapInputs', () => {
     ).toBe(1n)
   })
 
+  it('rejects source_amount/target_price combinations that floor LIM to 0 (THOR-02)', () => {
+    // 1_000_000 * 1 (scaled target_price) / 1e8 = 0.01, floors to 0.
+    // A zero trade target is treated by THORChain as an unprotected market
+    // order, so this must fail closed rather than silently reinterpreting
+    // the user's limit swap as a market swap.
+    expect(() =>
+      getLimitSwapLimitAmount({
+        source_amount: 1_000_000,
+        target_price: 0.00000001,
+      })
+    ).toThrow(/floors to 0/)
+
+    expect(() =>
+      buildLimitSwapMemo({
+        ...validInput,
+        source_amount: 1_000_000,
+        target_price: 0.00000001,
+      })
+    ).toThrow(/floors to 0/)
+  })
+
   it('rejects unsupported expiries', () => {
     expect(() =>
       validateLimitSwapInputs({

--- a/packages/core/chain/swap/native/limitSwapMemo.ts
+++ b/packages/core/chain/swap/native/limitSwapMemo.ts
@@ -140,7 +140,22 @@ export const getLimitSwapLimitAmount = ({
   const sourceAmount = parsePositiveInteger(source_amount, 'source_amount')
   const targetPrice = parsePositiveDecimal(target_price, 'target_price')
 
-  return (sourceAmount * targetPrice) / priceScale
+  const limit = (sourceAmount * targetPrice) / priceScale
+
+  if (limit === 0n) {
+    // THORChain treats a zero trade target (LIM) in a limit-swap memo as an
+    // unprotected market order. source_amount/target_price combinations
+    // that floor to 0 here can't be honestly expressed as a limit order at
+    // this price scale, so we fail closed instead of silently reinterpreting
+    // the user's price-protected limit swap as a market swap.
+    throw new Error(
+      'source_amount and target_price combination is too small to express as a limit swap: ' +
+        'the computed minimum-received amount (LIM) floors to 0, which THORChain treats as an ' +
+        'unprotected market order. Increase source_amount or target_price.'
+    )
+  }
+
+  return limit
 }
 
 export const assertMemoByteLength = (memo: string, sourceChainKind: LimitSwapSourceChainKind): void => {


### PR DESCRIPTION
closes vultisig/vultisig-sdk#1048

## Finding (fund-safety, HIGH — audit THOR-02)

`limitSwapMemo.ts:143` — `getLimitSwapLimitAmount` computed `(sourceAmount * targetPrice) / priceScale` with plain bigint division and **no `> 0` check**. A valid tiny target price (e.g. `source_amount=1_000_000, target_price=0.00000001`) floors to `0`, and per THORChain docs a zero trade target is treated as a **MARKET swap with no minimum-output floor**. The regular-swap path already bumps a floored-to-zero limit to `'1'` (`nativeSwapQuoteToSwapPayload.ts:55`) — the limit-swap path had no equivalent guard.

Impact: a user who thinks they placed a price-protected limit order gets an immediate market execution with **zero slippage protection** (full MEV/bad-price exposure) — the opposite of intent.

## Decision: reject, not bump

Went with **reject** over bumping to `'1'` (mirroring the regular-swap path). Bumping to 1 base unit still gives ~zero real protection and misrepresents the user's stated limit — a LIM that floors to 0 at this price scale can't be honestly expressed as *this user's* limit order. Failing closed with a clear error is safer than silently degrading a limit order into a de-facto market order under a false "protected" label. No open PR duplicates this (checked `gh pr list` for limitSwap/LIM/getLimitSwapLimitAmount — clean), and there's only one call site (`buildMemo` inside the same file), so the blast radius of the stricter behavior is contained to `buildLimitSwapMemo`/`getLimitSwapLimitAmount` callers.

## Fix

`getLimitSwapLimitAmount` now throws when the computed LIM floors to `0n`, before a memo can ever be built with a zero trade target.

## Runtime evidence (vitest, `.config/vitest.core.config.ts`)

**BEFORE** (scratch repro, not committed):
```
getLimitSwapLimitAmount({ source_amount: 1_000_000, target_price: 0.00000001 }) === 0n   // TRUE
buildLimitSwapMemo(...) memo contains ":0/"                                              // TRUE (zero trade target)
```

**AFTER** (committed regression test, `limitSwapMemo.test.ts`):
```
getLimitSwapLimitAmount({ source_amount: 1_000_000, target_price: 0.00000001 })
  → throws /floors to 0/

buildLimitSwapMemo({ ...validInput, source_amount: 1_000_000, target_price: 0.00000001 })
  → throws /floors to 0/

// boundary unchanged — smallest valid non-zero LIM still works:
getLimitSwapLimitAmount({ source_amount: 100_000_000, target_price: 0.00000001 }) === 1n
```

Test command: `yarn vitest run --config .config/vitest.core.config.ts limitSwapMemo` → **33 passed (33)**.
Full core suite (`yarn vitest run --config .config/vitest.core.config.ts`, after `yarn build:shared`): **1434 passed | 1 skipped**.
`yarn tsc --project .config/tsconfig.json --noEmit` → clean.
Lint (`node scripts/run-eslint.mjs --config .config/eslint.config.mjs` on the two touched files) → clean.

## Self-review note

Codex CLI auth was degraded in this environment, so this went through manual self-review only (no `/codex-review` pass). Diff is small and contained to `limitSwapMemo.ts` + its test file — flagging for a human second pair of eyes given the fund-safety nature of the finding.

## Risk

Low — adds a fail-closed guard on a path with a single internal call site. No existing fixture in `limit-swap-memos.json` hits the zero-floor case, so no behavior change for any currently-passing scenario; only newly-rejected inputs are ones that previously silently degraded to an unprotected market order.