### PR TITLE
fix(evm): sanity-cap RPC-reported priority fee (SDK2-01)

### DIFF
--- a/.changeset/evm-priority-fee-sanity-ceiling.md
+++ b/.changeset/evm-priority-fee-sanity-ceiling.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+fix(evm): sanity-cap RPC-reported priority fee (SDK2-01). EVM fee estimation trusted `maxPriorityFeePerGas` from the RPC verbatim into the signed tx (Solana already had a ceiling for this, EVM didn't) — a compromised or anomalous RPC could inflate it and drain the user's balance to gas. Added a generous per-chain sanity ceiling (`clampEvmPriorityFee`) that only fires on orders-of-magnitude inflation; normal congestion on any chain passes through unchanged.

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -1857,6 +1857,11 @@
       "import": "./dist/tx/fee/evm/baseFee.js",
       "default": "./dist/tx/fee/evm/baseFee.js"
     },
+    "./tx/fee/evm/clampEvmPriorityFee": {
+      "types": "./dist/tx/fee/evm/clampEvmPriorityFee.d.ts",
+      "import": "./dist/tx/fee/evm/clampEvmPriorityFee.js",
+      "default": "./dist/tx/fee/evm/clampEvmPriorityFee.js"
+    },
     "./tx/fee/evm/evmGasLimit": {
       "types": "./dist/tx/fee/evm/evmGasLimit.d.ts",
       "import": "./dist/tx/fee/evm/evmGasLimit.js",

--- a/packages/core/chain/tx/fee/evm/clampEvmPriorityFee.test.ts
+++ b/packages/core/chain/tx/fee/evm/clampEvmPriorityFee.test.ts
@@ -1,0 +1,58 @@
+import { EvmChain } from '@vultisig/core-chain/Chain'
+import { describe, expect, it } from 'vitest'
+
+import { clampEvmPriorityFee } from './clampEvmPriorityFee'
+
+const gwei = (n: number) => BigInt(n) * 1_000_000_000n
+
+describe('clampEvmPriorityFee', () => {
+  it.each([
+    ['Ethereum', EvmChain.Ethereum, gwei(80)], // heavy L1 congestion tip
+    ['Polygon', EvmChain.Polygon, gwei(400)], // congestion spike
+    ['Arbitrum', EvmChain.Arbitrum, gwei(1)], // typical L2 tip
+    ['Base', EvmChain.Base, gwei(1)],
+    ['Optimism', EvmChain.Optimism, gwei(1)],
+    ['Blast', EvmChain.Blast, gwei(1)],
+    ['Zksync', EvmChain.Zksync, gwei(1)],
+    ['Mantle', EvmChain.Mantle, gwei(1)],
+    ['Avalanche', EvmChain.Avalanche, gwei(25)],
+    ['BSC', EvmChain.BSC, gwei(3)],
+    ['CronosChain', EvmChain.CronosChain, gwei(5)],
+    ['Hyperliquid', EvmChain.Hyperliquid, gwei(1)],
+    ['Sei', EvmChain.Sei, gwei(5)],
+  ])('passes a normal %s priority fee through unchanged (legit-path regression guard)', (_label, chain, fee) => {
+    expect(clampEvmPriorityFee(chain, fee)).toBe(fee)
+  })
+
+  it.each([
+    ['Ethereum', EvmChain.Ethereum, gwei(10_000)],
+    ['Polygon', EvmChain.Polygon, gwei(50_000)],
+    ['Arbitrum', EvmChain.Arbitrum, gwei(5_000)],
+    ['Avalanche', EvmChain.Avalanche, gwei(10_000)],
+    ['BSC', EvmChain.BSC, gwei(10_000)],
+  ])(
+    'clamps an absurdly inflated %s priority fee (compromised-RPC attack) to the sanity ceiling',
+    (_label, chain, fee) => {
+      const clamped = clampEvmPriorityFee(chain, fee)
+
+      expect(clamped).toBeLessThan(fee)
+      expect(clamped).toBeGreaterThan(0n)
+    }
+  )
+
+  it('clamps a chain without an explicit ceiling entry using the generous default', () => {
+    const absurd = gwei(1_000_000)
+
+    expect(clampEvmPriorityFee(EvmChain.Sei, absurd)).toBe(500n * 1_000_000_000n)
+  })
+
+  it('never clamps a fee that sits exactly at the ceiling', () => {
+    expect(clampEvmPriorityFee(EvmChain.Ethereum, gwei(500))).toBe(gwei(500))
+  })
+
+  it('clamps a fee one wei above the ceiling', () => {
+    const oneOverCeiling = gwei(500) + 1n
+
+    expect(clampEvmPriorityFee(EvmChain.Ethereum, oneOverCeiling)).toBe(gwei(500))
+  })
+})

--- a/packages/core/chain/tx/fee/evm/clampEvmPriorityFee.ts
+++ b/packages/core/chain/tx/fee/evm/clampEvmPriorityFee.ts
@@ -1,0 +1,58 @@
+import { EvmChain } from '@vultisig/core-chain/Chain'
+
+const GWEI = 1_000_000_000n
+
+/**
+ * Sanity ceiling (wei) on the RPC-reported maxPriorityFeePerGas, per chain.
+ *
+ * This is NOT a fee optimizer — it exists solely to catch a compromised or
+ * anomalous RPC returning a wildly inflated priority fee (10x-1000x normal)
+ * that would otherwise be trusted verbatim into the signed tx and drain the
+ * user's balance to gas. Ceilings are deliberately generous — several times
+ * above any chain's realistic p99 congestion fee — so legitimate network
+ * congestion is never mistaken for an attack and clamped.
+ *
+ * Sourcing (directional, not a live oracle):
+ * - Ethereum L1: priority fees rarely exceed ~50-100 gwei even during heavy
+ *   congestion (NFT mints, MEV bursts) -> 500 gwei ceiling, 5-10x margin.
+ * - Polygon PoS: gas has historically spiked into the hundreds of gwei
+ *   during congestion -> 3,000 gwei ceiling, well above any observed spike.
+ * - Rollup L2s (Arbitrum, Base, Blast, Optimism, Zksync, Mantle): sequencer
+ *   priority fees are typically ~0-2 gwei -> 50 gwei ceiling. Still 25x+
+ *   normal, but tight enough to catch an order-of-magnitude inflation on a
+ *   chain where fees are otherwise negligible.
+ * - Avalanche C-Chain, BSC, CronosChain, Hyperliquid, Sei, and any future
+ *   EVM chain: no well-documented extreme-congestion fee history -> fall
+ *   back to the generous default ceiling below.
+ */
+const priorityFeeCeilingWeiByChain: Partial<Record<EvmChain, bigint>> = {
+  [EvmChain.Ethereum]: 500n * GWEI,
+  [EvmChain.Polygon]: 3_000n * GWEI,
+  [EvmChain.Arbitrum]: 50n * GWEI,
+  [EvmChain.Base]: 50n * GWEI,
+  [EvmChain.Blast]: 50n * GWEI,
+  [EvmChain.Optimism]: 50n * GWEI,
+  [EvmChain.Zksync]: 50n * GWEI,
+  [EvmChain.Mantle]: 50n * GWEI,
+}
+
+const defaultPriorityFeeCeilingWei = 500n * GWEI
+
+/**
+ * Clamps an RPC-reported EVM maxPriorityFeePerGas to a generous per-chain
+ * sanity ceiling. Never throws — a clamp still lets the tx go through at a
+ * safe fee, whereas rejecting it would strand the user mid-flow.
+ */
+export const clampEvmPriorityFee = (chain: EvmChain, rpcPriorityFeeWei: bigint): bigint => {
+  const ceiling = priorityFeeCeilingWeiByChain[chain] ?? defaultPriorityFeeCeilingWei
+
+  if (rpcPriorityFeeWei <= ceiling) {
+    return rpcPriorityFeeWei
+  }
+
+  console.warn(
+    `[evm] RPC-reported maxPriorityFeePerGas for ${chain} (${rpcPriorityFeeWei} wei) exceeds the sanity ceiling (${ceiling} wei); clamping to the ceiling.`
+  )
+
+  return ceiling
+}

--- a/packages/core/mpc/keysign/fee/resolvers/evm/getEvmFeeQuote.test.ts
+++ b/packages/core/mpc/keysign/fee/resolvers/evm/getEvmFeeQuote.test.ts
@@ -186,6 +186,32 @@ describe('getEvmFeeQuote gas limit buffering', () => {
     expect(mocks.getEvmBaseFee).not.toHaveBeenCalled()
   })
 
+  it('floors the ZkSync base fee at 0 for a malformed compromised-RPC tuple (maxFee < priority > ceiling) — SDK2-01 preferably-blocking', async () => {
+    // The exact clamp-attack case NeOMakinG flagged on #1078: a compromised RPC
+    // returns a malformed tuple where maxFeePerGas < maxPriorityFeePerGas and the
+    // priority fee exceeds the 50 gwei ZkSync ceiling. baseFeePerGas is derived
+    // from the RAW split (maxFee - priority), which would go negative; downstream
+    // maxFeePerGas = baseFeePerGas + clamp(priority) must NOT become negative.
+    mocks.getKeysignCoin.mockReturnValue(makeCoin(EvmChain.Zksync))
+    mocks.zksyncFeeClient.estimateFee.mockResolvedValue({
+      gasLimit: 700_001n,
+      maxFeePerGas: 1n, // 1 wei — absurdly below the tip (malformed)
+      maxPriorityFeePerGas: 200n * 1_000_000_000n, // 200 gwei, > 50 gwei ZkSync ceiling
+    })
+
+    const quote = await getEvmFeeQuote({
+      keysignPayload: {} as never,
+      minimumGasLimit: 600_000n,
+    })
+
+    // Raw split would be 1n - 200_000_000_000n (negative); floored to 0n.
+    expect(quote.baseFeePerGas).toBe(0n)
+    // Priority still clamped down to the 50 gwei ZkSync ceiling.
+    expect(quote.maxPriorityFeePerGas).toBe(50n * 1_000_000_000n)
+    // Rebuilt maxFeePerGas (base + clamped priority) is therefore non-negative.
+    expect(quote.baseFeePerGas + quote.maxPriorityFeePerGas).toBeGreaterThanOrEqual(0n)
+  })
+
   it('passes a normal RPC-reported priority fee through unchanged (SDK2-01 legit-path guard)', async () => {
     // 80 gwei — a realistic heavy-congestion Ethereum L1 tip, well under the 500 gwei ceiling.
     mocks.getEvmMaxPriorityFeePerGas.mockResolvedValue(80n * 1_000_000_000n)

--- a/packages/core/mpc/keysign/fee/resolvers/evm/getEvmFeeQuote.test.ts
+++ b/packages/core/mpc/keysign/fee/resolvers/evm/getEvmFeeQuote.test.ts
@@ -185,4 +185,48 @@ describe('getEvmFeeQuote gas limit buffering', () => {
     expect(quote.maxPriorityFeePerGas).toBe(3n)
     expect(mocks.getEvmBaseFee).not.toHaveBeenCalled()
   })
+
+  it('passes a normal RPC-reported priority fee through unchanged (SDK2-01 legit-path guard)', async () => {
+    // 80 gwei — a realistic heavy-congestion Ethereum L1 tip, well under the 500 gwei ceiling.
+    mocks.getEvmMaxPriorityFeePerGas.mockResolvedValue(80n * 1_000_000_000n)
+
+    const quote = await getEvmFeeQuote({
+      keysignPayload: {} as never,
+      minimumGasLimit: 600_000n,
+    })
+
+    expect(quote.maxPriorityFeePerGas).toBe(80n * 1_000_000_000n)
+  })
+
+  it('clamps an absurdly inflated RPC-reported priority fee to the sanity ceiling (SDK2-01)', async () => {
+    // A compromised/anomalous RPC reporting 10,000 gwei — orders of magnitude above any
+    // legitimate Ethereum L1 congestion tip.
+    mocks.getEvmMaxPriorityFeePerGas.mockResolvedValue(10_000n * 1_000_000_000n)
+
+    const quote = await getEvmFeeQuote({
+      keysignPayload: {} as never,
+      minimumGasLimit: 600_000n,
+    })
+
+    expect(quote.maxPriorityFeePerGas).toBe(500n * 1_000_000_000n)
+  })
+
+  it('clamps an absurdly inflated ZkSync priority fee to the sanity ceiling (SDK2-01)', async () => {
+    mocks.getKeysignCoin.mockReturnValue(makeCoin(EvmChain.Zksync))
+    mocks.zksyncFeeClient.estimateFee.mockResolvedValue({
+      gasLimit: 700_001n,
+      maxFeePerGas: 6_000n * 1_000_000_000n,
+      maxPriorityFeePerGas: 5_000n * 1_000_000_000n,
+    })
+
+    const quote = await getEvmFeeQuote({
+      keysignPayload: {} as never,
+      minimumGasLimit: 600_000n,
+    })
+
+    // Zksync's 50 gwei L2 ceiling still catches an order-of-magnitude inflation.
+    expect(quote.maxPriorityFeePerGas).toBe(50n * 1_000_000_000n)
+    // baseFeePerGas is still derived from the raw (unclamped) split.
+    expect(quote.baseFeePerGas).toBe(6_000n * 1_000_000_000n - 5_000n * 1_000_000_000n)
+  })
 })

--- a/packages/core/mpc/keysign/fee/resolvers/evm/getEvmFeeQuote.ts
+++ b/packages/core/mpc/keysign/fee/resolvers/evm/getEvmFeeQuote.ts
@@ -2,6 +2,7 @@ import { Chain, EvmChain } from '@vultisig/core-chain/Chain'
 import { evmChainInfo } from '@vultisig/core-chain/chains/evm/chainInfo'
 import { getEvmClient } from '@vultisig/core-chain/chains/evm/client'
 import { getEvmBaseFee } from '@vultisig/core-chain/tx/fee/evm/baseFee'
+import { clampEvmPriorityFee } from '@vultisig/core-chain/tx/fee/evm/clampEvmPriorityFee'
 import { getEvmMaxPriorityFeePerGas } from '@vultisig/core-chain/tx/fee/evm/maxPriorityFeePerGas'
 import { FeeSettings } from '@vultisig/core-mpc/keysign/chainSpecific/FeeSettings'
 import { getKeysignSwapPayload } from '@vultisig/core-mpc/keysign/swap/getKeysignSwapPayload'
@@ -154,7 +155,7 @@ export const getEvmFeeQuote = async ({
           return {
             gasLimit: capGasLimit(gasLimit),
             baseFeePerGas: maxFeePerGas - maxPriorityFeePerGas,
-            maxPriorityFeePerGas,
+            maxPriorityFeePerGas: clampEvmPriorityFee(chain, maxPriorityFeePerGas),
           }
         }
       }
@@ -179,7 +180,7 @@ export const getEvmFeeQuote = async ({
 
     const baseFeePerGas = baseFeeMultiplier(await getEvmBaseFee(chain))
 
-    const maxPriorityFeePerGas = await getEvmMaxPriorityFeePerGas(chain)
+    const maxPriorityFeePerGas = clampEvmPriorityFee(chain, await getEvmMaxPriorityFeePerGas(chain))
 
     return {
       gasLimit,

--- a/packages/core/mpc/keysign/fee/resolvers/evm/getEvmFeeQuote.ts
+++ b/packages/core/mpc/keysign/fee/resolvers/evm/getEvmFeeQuote.ts
@@ -154,7 +154,15 @@ export const getEvmFeeQuote = async ({
           const { gasLimit, maxFeePerGas, maxPriorityFeePerGas } = result.data
           return {
             gasLimit: capGasLimit(gasLimit),
-            baseFeePerGas: maxFeePerGas - maxPriorityFeePerGas,
+            // Floor at 0: on the zkSync path baseFeePerGas is derived from the
+            // raw split, but downstream maxFeePerGas is rebuilt as
+            // baseFeePerGas + clamp(priority). A compromised RPC returning a
+            // malformed tuple (maxFee < priority, the exact clamp-attack case)
+            // would otherwise yield a negative baseFeePerGas and a negative
+            // signed maxFeePerGas. Flooring keeps the rebuilt maxFee >= the
+            // clamped tip and preserves the "never emits a malformed value"
+            // contract (NeOMakinG preferably-blocking on #1078 / SDK2-01).
+            baseFeePerGas: bigIntMax(0n, maxFeePerGas - maxPriorityFeePerGas),
             maxPriorityFeePerGas: clampEvmPriorityFee(chain, maxPriorityFeePerGas),
           }
         }


### PR DESCRIPTION
closes #1055

## Finding (SDK2-01, HIGH, fund-safety)

EVM fee estimation had no sanity ceiling on the RPC-reported priority fee — Solana already has one (`solanaConfig.priorityFeeLimit`), EVM didn't. `getEvmMaxPriorityFeePerGas(chain)` returned `estimateMaxPriorityFeePerGas()` verbatim, and `getEvmFeeQuote` then signed `maxFeePerGas = baseFeePerGas + maxPriorityFeePerGas` uncapped into the tx. A compromised or anomalous EVM RPC could inflate `maxPriorityFeePerGas` and drain the user's balance to gas — the tx would still "succeed" from the wallet's point of view, just at a ruinous fee.

Same gap existed on the zkSync L2 path (`client.extend(publicActionsL2()).estimateFee()`), which derives `maxPriorityFeePerGas` independently via viem and wasn't covered by the generic-path fix alone.

## Fix

Added `clampEvmPriorityFee(chain, rpcPriorityFeeWei): bigint` (`packages/core/chain/tx/fee/evm/clampEvmPriorityFee.ts`) — a per-chain sanity ceiling, applied at both `getEvmFeeQuote` read sites:
- the generic path (`maxPriorityFeePerGas = clampEvmPriorityFee(chain, await getEvmMaxPriorityFeePerGas(chain))`)
- the zkSync `estimateFee` L2 path (clamps the priority-fee component only; `baseFeePerGas` is still derived from the raw, unclamped `maxFeePerGas - maxPriorityFeePerGas` split so the implied base fee stays accurate)

On breach it `console.warn`s (chain + rpc value + ceiling) and **clamps, never throws** — a clamp still lets the tx go through at a safe fee; a reject would strand the user mid-flow.

## Ceiling table (generous by design — sanity bound, not a fee optimizer)

| Chain | Ceiling | Sourcing rationale |
|---|---|---|
| Ethereum | 500 gwei | L1 priority fees rarely exceed ~50-100 gwei even during heavy congestion (NFT mints, MEV bursts) → 5-10x margin above realistic p99 |
| Polygon | 3,000 gwei | PoS gas has historically spiked into the hundreds of gwei during congestion → several-x margin above any observed spike |
| Arbitrum, Base, Blast, Optimism, Zksync, Mantle | 50 gwei | Rollup sequencer-priced priority fees typically sit ~0-2 gwei → 25x+ normal, but still tight enough to catch an order-of-magnitude inflation on a chain where fees are otherwise negligible |
| Avalanche, BSC, CronosChain, Hyperliquid, Sei, and any future/unlisted EVM chain | 500 gwei (default) | No well-documented extreme-congestion fee history for these → fall back to the same generous default as Ethereum so a new chain never false-blocks |

Bias is deliberately HIGH: the attack this guards against is orders-of-magnitude inflation (10x-1000x), so even a "too generous" ceiling still catches it while guaranteeing zero false-blocks on legitimate congestion.

## Runtime verification

Colocated `clampEvmPriorityFee.test.ts` (21 tests) proves both:
1. **Legit-path regression guard** — a normal/heavy-congestion priority fee for every represented chain (incl. an 80 gwei Ethereum congestion tip, a 400 gwei Polygon spike) passes through **unchanged**.
2. **Attack-path guard** — an absurdly inflated fee (10,000 gwei on Ethereum, 50,000 gwei on Polygon, 5,000 gwei on Arbitrum/Avalanche/BSC — all orders of magnitude above the ceiling) gets **clamped** to the ceiling, plus edge cases (exactly-at-ceiling passes, one-wei-over clamps, unlisted chain uses the default).

Also added 3 integration tests directly in `getEvmFeeQuote.test.ts` exercising the real `getEvmFeeQuote` wiring (not just the isolated helper) — one legit-pass, one clamp on the generic path, one clamp on the zkSync L2 `estimateFee` path (confirming `baseFeePerGas` still derives from the raw split).

```
$ yarn vitest run packages/core/chain/tx/fee/evm/clampEvmPriorityFee.test.ts --reporter=verbose

 ✓ passes a normal Ethereum priority fee through unchanged (legit-path regression guard) 1ms
 ✓ passes a normal Polygon priority fee through unchanged (legit-path regression guard) 0ms
 ✓ passes a normal Arbitrum priority fee through unchanged (legit-path regression guard) 0ms
 ✓ passes a normal Base priority fee through unchanged (legit-path regression guard) 0ms
 ✓ passes a normal Optimism priority fee through unchanged (legit-path regression guard) 0ms
 ✓ passes a normal Blast priority fee through unchanged (legit-path regression guard) 0ms
 ✓ passes a normal Zksync priority fee through unchanged (legit-path regression guard) 0ms
 ✓ passes a normal Mantle priority fee through unchanged (legit-path regression guard) 0ms
 ✓ passes a normal Avalanche priority fee through unchanged (legit-path regression guard) 0ms
 ✓ passes a normal BSC priority fee through unchanged (legit-path regression guard) 0ms
 ✓ passes a normal CronosChain priority fee through unchanged (legit-path regression guard) 0ms
 ✓ passes a normal Hyperliquid priority fee through unchanged (legit-path regression guard) 0ms
 ✓ passes a normal Sei priority fee through unchanged (legit-path regression guard) 0ms
 ✓ clamps an absurdly inflated Ethereum priority fee (compromised-RPC attack) to the sanity ceiling 1ms
 ✓ clamps an absurdly inflated Polygon priority fee (compromised-RPC attack) to the sanity ceiling 0ms
 ✓ clamps an absurdly inflated Arbitrum priority fee (compromised-RPC attack) to the sanity ceiling 0ms
 ✓ clamps an absurdly inflated Avalanche priority fee (compromised-RPC attack) to the sanity ceiling 0ms
 ✓ clamps an absurdly inflated BSC priority fee (compromised-RPC attack) to the sanity ceiling 0ms
 ✓ clamps a chain without an explicit ceiling entry using the generous default 0ms
 ✓ never clamps a fee that sits exactly at the ceiling 0ms
 ✓ clamps a fee one wei above the ceiling 0ms

stderr (expected, on the clamp cases):
[evm] RPC-reported maxPriorityFeePerGas for Ethereum (500000000001 wei) exceeds the sanity ceiling (500000000000 wei); clamping to the ceiling.

 Test Files  1 passed (1)
      Tests  21 passed (21)
```

`getEvmFeeQuote.test.ts` (11 tests, incl. the 3 new SDK2-01 cases) — all green, unaffected pre-existing gas-limit-buffering tests untouched.

`npx tsc --project .config/tsconfig.json --noEmit` — clean. Lint (`eslint --config .config/eslint.config.mjs`) — clean.

## Risk

Low — additive clamp on an existing read path, defaults to a no-op on any normal fee, never throws.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EVM transaction fee handling to prevent unusually high priority fee estimates from being used as-is.
  * Added per-network safeguards so fee quotes stay within reasonable limits, while normal values continue unchanged.
  * Applied the same protection across supported EVM fee estimation paths, including ZkSync.
* **Tests**
  * Expanded coverage for normal, boundary, and inflated fee scenarios to verify the new behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->