### PR TITLE
fix(swap): allowlist aggregator router addresses at quote construction (AGG-02)

### DIFF
--- a/.changeset/aggregator-router-allowlist.md
+++ b/.changeset/aggregator-router-allowlist.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+fix(swap): validate aggregator router addresses at quote construction (AGG-02). 1inch/Kyber/LiFi/SwapKit's tx.to was trusted with no allowlist, and fed both the ERC-20 approval spender and the swap transaction's on-chain destination — a compromised/spoofed aggregator response could get both approved and swapped against. 1inch/Kyber now fail closed (throw) if the returned router isn't their live-confirmed address; LiFi/SwapKit log the destination (never throw, since they route through many different contracts by design) so a future allowlist has real usage data if a pattern emerges.

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -1562,6 +1562,11 @@
       "import": "./dist/swap/general/jupiter/JupiterSwapEnabledChains.js",
       "default": "./dist/swap/general/jupiter/JupiterSwapEnabledChains.js"
     },
+    "./swap/general/knownAggregatorRouters": {
+      "types": "./dist/swap/general/knownAggregatorRouters.d.ts",
+      "import": "./dist/swap/general/knownAggregatorRouters.js",
+      "default": "./dist/swap/general/knownAggregatorRouters.js"
+    },
     "./swap/general/kyber/api/baseUrl": {
       "types": "./dist/swap/general/kyber/api/baseUrl.d.ts",
       "import": "./dist/swap/general/kyber/api/baseUrl.js",

--- a/packages/core/chain/swap/general/knownAggregatorRouters.test.ts
+++ b/packages/core/chain/swap/general/knownAggregatorRouters.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  assertKnownAggregatorRouter,
+  KYBER_ROUTER_ADDRESSES,
+  logUnenforcedAggregatorDestination,
+  ONE_INCH_ROUTER_ADDRESSES,
+} from './knownAggregatorRouters'
+
+const ONE_INCH_V6 = '0x111111125421ca6dc452d289314280a0f8842a65'
+const ONE_INCH_V5 = '0x1111111254eeb25477b68fb85ed929f73a960582'
+const KYBER_V2 = '0x6131b5fae19ea4f9d964eac0408e4408b66337b5'
+
+describe('assertKnownAggregatorRouter — AGG-02 fund-safety allowlist', () => {
+  it('accepts 1inch V6 (live-confirmed against the real quote API)', () => {
+    expect(() => assertKnownAggregatorRouter('1inch', ONE_INCH_V6)).not.toThrow()
+  })
+
+  it('accepts 1inch V5 (legacy, still in the allowlist)', () => {
+    expect(() => assertKnownAggregatorRouter('1inch', ONE_INCH_V5)).not.toThrow()
+  })
+
+  it('accepts a mixed-case / checksummed address (case-insensitive match)', () => {
+    expect(() => assertKnownAggregatorRouter('1inch', '0x111111125421CA6dc452D289314280a0F8842A65')).not.toThrow()
+  })
+
+  it('accepts KyberSwap MetaAggregationRouterV2 (live-confirmed against the real /routes API)', () => {
+    expect(() => assertKnownAggregatorRouter('kyber', KYBER_V2)).not.toThrow()
+  })
+
+  it("REJECTS a 1inch response carrying Kyber's router (cross-provider mismatch)", () => {
+    expect(() => assertKnownAggregatorRouter('1inch', KYBER_V2)).toThrow(/unrecognized router address/)
+  })
+
+  it('REJECTS a spoofed/attacker-controlled address for 1inch', () => {
+    expect(() => assertKnownAggregatorRouter('1inch', '0x000000000000000000000000000000deadbeef')).toThrow(
+      /unrecognized router address/
+    )
+  })
+
+  it('REJECTS a spoofed/attacker-controlled address for Kyber', () => {
+    expect(() => assertKnownAggregatorRouter('kyber', '0x000000000000000000000000000000deadbeef')).toThrow(
+      /unrecognized router address/
+    )
+  })
+
+  it('the error message names the provider and the rejected address (diagnosable, not silent)', () => {
+    expect(() => assertKnownAggregatorRouter('kyber', '0xbad')).toThrow(/kyber.*0xbad/)
+  })
+})
+
+describe('logUnenforcedAggregatorDestination — LiFi/SwapKit, never throws', () => {
+  it('never throws regardless of the address', () => {
+    expect(() => logUnenforcedAggregatorDestination('li.fi', '0x000000000000000000000000000000deadbeef')).not.toThrow()
+    expect(() => logUnenforcedAggregatorDestination('swapkit', 'not-even-an-address')).not.toThrow()
+  })
+
+  it('logs provider + address so a future allowlist has real usage data to build from', () => {
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {})
+    logUnenforcedAggregatorDestination('li.fi', '0xabc')
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('swap-router-telemetry'), {
+      provider: 'li.fi',
+      address: '0xabc',
+    })
+    spy.mockRestore()
+  })
+})
+
+describe('allowlist contents — sanity (catches an accidental edit widening the fund-safety gate)', () => {
+  it('1inch allowlist has exactly V5 + V6, nothing else', () => {
+    expect([...ONE_INCH_ROUTER_ADDRESSES].sort()).toEqual([ONE_INCH_V5, ONE_INCH_V6].sort())
+  })
+
+  it('Kyber allowlist has exactly the v2 router, nothing else', () => {
+    expect([...KYBER_ROUTER_ADDRESSES]).toEqual([KYBER_V2])
+  })
+})

--- a/packages/core/chain/swap/general/knownAggregatorRouters.test.ts
+++ b/packages/core/chain/swap/general/knownAggregatorRouters.test.ts
@@ -1,51 +1,87 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import {
-  assertKnownAggregatorRouter,
-  KYBER_ROUTER_ADDRESSES,
-  logUnenforcedAggregatorDestination,
-  ONE_INCH_ROUTER_ADDRESSES,
-} from './knownAggregatorRouters'
+import { Chain } from '../../Chain'
+import { assertKnownAggregatorRouter, logUnenforcedAggregatorDestination } from './knownAggregatorRouters'
 
 const ONE_INCH_V6 = '0x111111125421ca6dc452d289314280a0f8842a65'
 const ONE_INCH_V5 = '0x1111111254eeb25477b68fb85ed929f73a960582'
+const ONE_INCH_V6_ZKSYNC = '0x6fd4383cb451173d5f9304f041c7bcbf27d561ff'
 const KYBER_V2 = '0x6131b5fae19ea4f9d964eac0408e4408b66337b5'
 
 describe('assertKnownAggregatorRouter — AGG-02 fund-safety allowlist', () => {
-  it('accepts 1inch V6 (live-confirmed against the real quote API)', () => {
-    expect(() => assertKnownAggregatorRouter('1inch', ONE_INCH_V6)).not.toThrow()
+  it('accepts 1inch V6 on Ethereum (live-confirmed against the real quote API)', () => {
+    expect(() => assertKnownAggregatorRouter('1inch', ONE_INCH_V6, Chain.Ethereum)).not.toThrow()
   })
 
-  it('accepts 1inch V5 (legacy, still in the allowlist)', () => {
-    expect(() => assertKnownAggregatorRouter('1inch', ONE_INCH_V5)).not.toThrow()
+  it('accepts 1inch V6 on every non-zkSync EVM chain it supports (live-confirmed)', () => {
+    for (const chain of [Chain.Arbitrum, Chain.BSC, Chain.Base, Chain.Optimism, Chain.Avalanche, Chain.Polygon]) {
+      expect(() => assertKnownAggregatorRouter('1inch', ONE_INCH_V6, chain)).not.toThrow()
+    }
+  })
+
+  it('accepts 1inch V5 (legacy, unscoped)', () => {
+    expect(() => assertKnownAggregatorRouter('1inch', ONE_INCH_V5, Chain.Ethereum)).not.toThrow()
   })
 
   it('accepts a mixed-case / checksummed address (case-insensitive match)', () => {
-    expect(() => assertKnownAggregatorRouter('1inch', '0x111111125421CA6dc452D289314280a0F8842A65')).not.toThrow()
+    expect(() =>
+      assertKnownAggregatorRouter('1inch', '0x111111125421CA6dc452D289314280a0F8842A65', Chain.Ethereum)
+    ).not.toThrow()
   })
 
-  it('accepts KyberSwap MetaAggregationRouterV2 (live-confirmed against the real /routes API)', () => {
-    expect(() => assertKnownAggregatorRouter('kyber', KYBER_V2)).not.toThrow()
+  // codex review (PR #1079): 1inch's V6 router is NOT the same address on zkSync Era —
+  // confirmed live via a real quote request. A chain-agnostic allowlist would have
+  // hard-blocked every legitimate zkSync 1inch swap.
+  describe('1inch zkSync Era — a genuinely different router (chain-scoping)', () => {
+    it('accepts the zkSync-specific router ONLY on zkSync', () => {
+      expect(() => assertKnownAggregatorRouter('1inch', ONE_INCH_V6_ZKSYNC, Chain.Zksync)).not.toThrow()
+    })
+
+    it('REJECTS the standard V6 router on zkSync (the exact bug this fixes)', () => {
+      expect(() => assertKnownAggregatorRouter('1inch', ONE_INCH_V6, Chain.Zksync)).toThrow(
+        /unrecognized router address/
+      )
+    })
+
+    it('REJECTS the zkSync-specific router on a DIFFERENT chain (Ethereum) — scoping is not accidentally global', () => {
+      expect(() => assertKnownAggregatorRouter('1inch', ONE_INCH_V6_ZKSYNC, Chain.Ethereum)).toThrow(
+        /unrecognized router address/
+      )
+    })
+  })
+
+  it('accepts KyberSwap MetaAggregationRouterV2 (live-confirmed against the real /routes API, unscoped — no chain variance found)', () => {
+    for (const chain of [
+      Chain.Ethereum,
+      Chain.BSC,
+      Chain.Arbitrum,
+      Chain.Optimism,
+      Chain.Avalanche,
+      Chain.Base,
+      Chain.Polygon,
+    ]) {
+      expect(() => assertKnownAggregatorRouter('kyber', KYBER_V2, chain)).not.toThrow()
+    }
   })
 
   it("REJECTS a 1inch response carrying Kyber's router (cross-provider mismatch)", () => {
-    expect(() => assertKnownAggregatorRouter('1inch', KYBER_V2)).toThrow(/unrecognized router address/)
+    expect(() => assertKnownAggregatorRouter('1inch', KYBER_V2, Chain.Ethereum)).toThrow(/unrecognized router address/)
   })
 
   it('REJECTS a spoofed/attacker-controlled address for 1inch', () => {
-    expect(() => assertKnownAggregatorRouter('1inch', '0x000000000000000000000000000000deadbeef')).toThrow(
-      /unrecognized router address/
-    )
+    expect(() =>
+      assertKnownAggregatorRouter('1inch', '0x000000000000000000000000000000deadbeef', Chain.Ethereum)
+    ).toThrow(/unrecognized router address/)
   })
 
   it('REJECTS a spoofed/attacker-controlled address for Kyber', () => {
-    expect(() => assertKnownAggregatorRouter('kyber', '0x000000000000000000000000000000deadbeef')).toThrow(
-      /unrecognized router address/
-    )
+    expect(() =>
+      assertKnownAggregatorRouter('kyber', '0x000000000000000000000000000000deadbeef', Chain.Ethereum)
+    ).toThrow(/unrecognized router address/)
   })
 
-  it('the error message names the provider and the rejected address (diagnosable, not silent)', () => {
-    expect(() => assertKnownAggregatorRouter('kyber', '0xbad')).toThrow(/kyber.*0xbad/)
+  it('the error message names the provider, chain, and the rejected address (diagnosable, not silent)', () => {
+    expect(() => assertKnownAggregatorRouter('kyber', '0xbad', Chain.Ethereum)).toThrow(/kyber.*0xbad.*Ethereum/)
   })
 })
 
@@ -63,15 +99,5 @@ describe('logUnenforcedAggregatorDestination — LiFi/SwapKit, never throws', ()
       address: '0xabc',
     })
     spy.mockRestore()
-  })
-})
-
-describe('allowlist contents — sanity (catches an accidental edit widening the fund-safety gate)', () => {
-  it('1inch allowlist has exactly V5 + V6, nothing else', () => {
-    expect([...ONE_INCH_ROUTER_ADDRESSES].sort()).toEqual([ONE_INCH_V5, ONE_INCH_V6].sort())
-  })
-
-  it('Kyber allowlist has exactly the v2 router, nothing else', () => {
-    expect([...KYBER_ROUTER_ADDRESSES]).toEqual([KYBER_V2])
   })
 })

--- a/packages/core/chain/swap/general/knownAggregatorRouters.ts
+++ b/packages/core/chain/swap/general/knownAggregatorRouters.ts
@@ -1,0 +1,74 @@
+/**
+ * Fund-safety allowlist for the general-purpose EVM swap aggregators (AGG-02, round-2
+ * spec-level fund-safety audit, 2026-07-08).
+ *
+ * Each aggregator's quote-construction function (getOneInchSwapQuote.ts, kyber/api/tx.ts,
+ * getLifiSwapQuote.ts, getSwapKitQuote.ts) is the TRUST BOUNDARY where an untrusted HTTP
+ * response gets parsed into an internal GeneralSwapQuote. That quote's `tx.evm.to` goes on
+ * to become BOTH the ERC-20 approval spender (getSwapDestinationAddress ->
+ * mpc/keysign/swap/build.ts's allowance check) AND, independently, the actual on-chain swap
+ * transaction's destination (build.ts's own txMsg construction -> signingInputs/resolvers/
+ * evm/index.ts's WalletCore SigningInput). Two SEPARATE downstream reads of the same field —
+ * so validating at either downstream site alone would leave the other unguarded. Validating
+ * HERE, at construction, means every consumer (present and future) inherits an
+ * already-verified address by construction, instead of needing its own check.
+ *
+ * 1inch and Kyber can be enforced (fail closed / throw) because their router is a small,
+ * stable, deterministically-deployed constant — verified against each provider's OWN live
+ * quote API (not just docs/explorers) on Ethereum, Arbitrum, BSC, Base (1inch) and Ethereum,
+ * BSC, Arbitrum (Kyber) on 2026-07-08, matching byte-for-byte.
+ *
+ * LiFi and SwapKit CANNOT be enforced the same way — they route through many different
+ * bridge/DEX contracts by design (diamond routing, multi-hop, chain-specific deployments),
+ * so a hard allowlist would false-block legitimate routes. Those two are logged (never
+ * thrown) via logUnenforcedAggregatorDestination so an anomaly is queryable, and so a future
+ * allowlist has real usage data to build from if a pattern emerges.
+ */
+
+// 1inch Aggregation Router — V5 (legacy) + V6 (current). Same addresses as the display-only
+// registry in chains/evm/contract/knownContracts.ts; kept as an explicit, separate list here
+// since THIS one gates signing (throw on mismatch), not just UI labeling — the two lists are
+// allowed to drift independently (e.g. a future display-only addition shouldn't silently
+// widen what this allowlist accepts).
+export const ONE_INCH_ROUTER_ADDRESSES: ReadonlySet<string> = new Set([
+  '0x1111111254eeb25477b68fb85ed929f73a960582', // V5
+  '0x111111125421ca6dc452d289314280a0f8842a65', // V6 — live-confirmed 2026-07-08 (Ethereum/Arbitrum/BSC/Base)
+])
+
+// KyberSwap MetaAggregationRouterV2 — same address on every EVM chain KyberSwap supports
+// (deterministic CREATE2 deploy). Live-confirmed 2026-07-08 (Ethereum/BSC/Arbitrum) against
+// aggregator-api.kyberswap.com's own /routes response, not just docs/explorers.
+export const KYBER_ROUTER_ADDRESSES: ReadonlySet<string> = new Set(['0x6131b5fae19ea4f9d964eac0408e4408b66337b5'])
+
+/** Providers whose router is validated against a fund-safety allowlist (fail closed). */
+export const ENFORCED_ROUTER_PROVIDERS = ['1inch', 'kyber'] as const
+export type EnforcedRouterProvider = (typeof ENFORCED_ROUTER_PROVIDERS)[number]
+
+const ALLOWLIST_BY_PROVIDER: Record<EnforcedRouterProvider, ReadonlySet<string>> = {
+  '1inch': ONE_INCH_ROUTER_ADDRESSES,
+  kyber: KYBER_ROUTER_ADDRESSES,
+}
+
+/**
+ * Throws if `address` isn't the known router for `provider`. Call this at quote construction,
+ * before a GeneralSwapQuote carrying `address` as `tx.evm.to` can exist.
+ */
+export function assertKnownAggregatorRouter(provider: EnforcedRouterProvider, address: string): void {
+  if (!ALLOWLIST_BY_PROVIDER[provider].has(address.toLowerCase())) {
+    throw new Error(
+      `${provider} swap quote returned an unrecognized router address (${address}) — refusing to build a signable transaction against it.`
+    )
+  }
+}
+
+/**
+ * Log-only (never throws) — for LiFi/SwapKit, whose legitimate routes span many different
+ * contracts. Structured so the data is queryable (provider + address) and a future allowlist
+ * is easy to build if a stable pattern emerges from real usage.
+ */
+export function logUnenforcedAggregatorDestination(provider: 'li.fi' | 'swapkit', address: string): void {
+  console.info('[swap-router-telemetry] general-swap destination (not enforced, logged for future analysis):', {
+    provider,
+    address,
+  })
+}

--- a/packages/core/chain/swap/general/knownAggregatorRouters.ts
+++ b/packages/core/chain/swap/general/knownAggregatorRouters.ts
@@ -34,12 +34,12 @@ import { Chain } from '../../Chain'
  * allowlist has real usage data to build from if a pattern emerges.
  */
 
-// 1inch Aggregation Router — V5 (legacy, unscoped) + V6 (current, chain-scoped). V5's
-// address is the same as chains/evm/contract/knownContracts.ts's display-only registry;
-// kept separate here since THIS one gates signing, not just UI labeling. V5 is unscoped
-// even though it likely has the same zkSync quirk as V6 (per knownContracts.ts's existing
-// comment) — getOneInchSwapQuote.ts only calls the v6.0 API today, so a V5 address is never
-// actually seen through this path; harmless defense-in-depth.
+// 1inch Aggregation Router V5 (legacy). Same address as
+// chains/evm/contract/knownContracts.ts's display-only registry; kept separate here since
+// THIS one gates signing, not just UI labeling. NOTE: the implementation below only accepts
+// this on non-zkSync chains (same exclusive branch as V6) — getOneInchSwapQuote.ts only
+// calls the v6.0 API today, so a V5 address is never actually seen through this path
+// regardless; harmless defense-in-depth either way.
 const ONE_INCH_V5_ROUTER = '0x1111111254eeb25477b68fb85ed929f73a960582'
 
 // V6's standard address — live-confirmed 2026-07-08 on Ethereum, Arbitrum, BSC, Base,

--- a/packages/core/chain/swap/general/knownAggregatorRouters.ts
+++ b/packages/core/chain/swap/general/knownAggregatorRouters.ts
@@ -1,3 +1,5 @@
+import { Chain } from '../../Chain'
+
 /**
  * Fund-safety allowlist for the general-purpose EVM swap aggregators (AGG-02, round-2
  * spec-level fund-safety audit, 2026-07-08).
@@ -14,9 +16,16 @@
  * already-verified address by construction, instead of needing its own check.
  *
  * 1inch and Kyber can be enforced (fail closed / throw) because their router is a small,
- * stable, deterministically-deployed constant — verified against each provider's OWN live
- * quote API (not just docs/explorers) on Ethereum, Arbitrum, BSC, Base (1inch) and Ethereum,
- * BSC, Arbitrum (Kyber) on 2026-07-08, matching byte-for-byte.
+ * stable, deterministically-deployed constant on almost every chain — verified against each
+ * provider's OWN live quote API (not just docs/explorers), chain by chain, on 2026-07-08.
+ *
+ * CHAIN-SCOPING MATTERS (codex review, PR #1079): 1inch's V6 router is NOT the same address
+ * on zkSync Era — confirmed live (a real 200 response from a real quote request returned a
+ * DIFFERENT contract there). This is exactly the caveat chains/evm/contract/knownContracts.ts
+ * already documents for 1inch V5 ("not zkSync Era — different V5 router"); it turns out to
+ * also hold for V6. A flat, chain-agnostic allowlist would have hard-blocked every legitimate
+ * zkSync 1inch swap. Kyber showed no such variance on every chain that returned a live
+ * response (see the per-chain notes below) — its allowlist stays flat.
  *
  * LiFi and SwapKit CANNOT be enforced the same way — they route through many different
  * bridge/DEX contracts by design (diamond routing, multi-hop, chain-specific deployments),
@@ -25,38 +34,50 @@
  * allowlist has real usage data to build from if a pattern emerges.
  */
 
-// 1inch Aggregation Router — V5 (legacy) + V6 (current). Same addresses as the display-only
-// registry in chains/evm/contract/knownContracts.ts; kept as an explicit, separate list here
-// since THIS one gates signing (throw on mismatch), not just UI labeling — the two lists are
-// allowed to drift independently (e.g. a future display-only addition shouldn't silently
-// widen what this allowlist accepts).
-export const ONE_INCH_ROUTER_ADDRESSES: ReadonlySet<string> = new Set([
-  '0x1111111254eeb25477b68fb85ed929f73a960582', // V5
-  '0x111111125421ca6dc452d289314280a0f8842a65', // V6 — live-confirmed 2026-07-08 (Ethereum/Arbitrum/BSC/Base)
-])
+// 1inch Aggregation Router — V5 (legacy, unscoped) + V6 (current, chain-scoped). V5's
+// address is the same as chains/evm/contract/knownContracts.ts's display-only registry;
+// kept separate here since THIS one gates signing, not just UI labeling. V5 is unscoped
+// even though it likely has the same zkSync quirk as V6 (per knownContracts.ts's existing
+// comment) — getOneInchSwapQuote.ts only calls the v6.0 API today, so a V5 address is never
+// actually seen through this path; harmless defense-in-depth.
+const ONE_INCH_V5_ROUTER = '0x1111111254eeb25477b68fb85ed929f73a960582'
 
-// KyberSwap MetaAggregationRouterV2 — same address on every EVM chain KyberSwap supports
-// (deterministic CREATE2 deploy). Live-confirmed 2026-07-08 (Ethereum/BSC/Arbitrum) against
-// aggregator-api.kyberswap.com's own /routes response, not just docs/explorers.
-export const KYBER_ROUTER_ADDRESSES: ReadonlySet<string> = new Set(['0x6131b5fae19ea4f9d964eac0408e4408b66337b5'])
+// V6's standard address — live-confirmed 2026-07-08 on Ethereum, Arbitrum, BSC, Base,
+// Optimism, Avalanche, Polygon (7 of 8 oneInchSwapEnabledChains chains).
+const ONE_INCH_V6_STANDARD_ROUTER = '0x111111125421ca6dc452d289314280a0f8842a65'
 
-/** Providers whose router is validated against a fund-safety allowlist (fail closed). */
-export const ENFORCED_ROUTER_PROVIDERS = ['1inch', 'kyber'] as const
-export type EnforcedRouterProvider = (typeof ENFORCED_ROUTER_PROVIDERS)[number]
+// V6 on zkSync Era ONLY — live-confirmed 2026-07-08 via a real api.vultisig.com/1inch
+// v6.0 quote request returning this address (NOT the standard one above).
+const ONE_INCH_V6_ZKSYNC_ROUTER = '0x6fd4383cb451173d5f9304f041c7bcbf27d561ff'
 
-const ALLOWLIST_BY_PROVIDER: Record<EnforcedRouterProvider, ReadonlySet<string>> = {
-  '1inch': ONE_INCH_ROUTER_ADDRESSES,
-  kyber: KYBER_ROUTER_ADDRESSES,
-}
+// KyberSwap MetaAggregationRouterV2 — same address confirmed live 2026-07-08 on every chain
+// that returned a response through aggregator-api.kyberswap.com's /routes (Ethereum, BSC,
+// Arbitrum, Optimism, Avalanche, Base, Polygon — 7 of 9 kyberSwapEnabledChains chains).
+// zkSync/Blast 404'd on this exact API path during verification — that looks like those two
+// chains aren't actually live through this aggregator endpoint today (a pre-existing,
+// separate question from this fix — kyberSwapEnabledChains may be ahead of what the live API
+// serves), not evidence of a differing router address. No chain-scoping needed unless that
+// changes.
+const KYBER_STANDARD_ROUTER = '0x6131b5fae19ea4f9d964eac0408e4408b66337b5'
+
+export type EnforcedRouterProvider = '1inch' | 'kyber'
 
 /**
- * Throws if `address` isn't the known router for `provider`. Call this at quote construction,
- * before a GeneralSwapQuote carrying `address` as `tx.evm.to` can exist.
+ * Throws if `address` isn't the known router for `provider` on `chain`. Call this at quote
+ * construction, before a GeneralSwapQuote carrying `address` as `tx.evm.to` can exist.
  */
-export function assertKnownAggregatorRouter(provider: EnforcedRouterProvider, address: string): void {
-  if (!ALLOWLIST_BY_PROVIDER[provider].has(address.toLowerCase())) {
+export function assertKnownAggregatorRouter(provider: EnforcedRouterProvider, address: string, chain: Chain): void {
+  const normalized = address.toLowerCase()
+  const isKnown =
+    provider === 'kyber'
+      ? normalized === KYBER_STANDARD_ROUTER
+      : chain === Chain.Zksync
+        ? normalized === ONE_INCH_V6_ZKSYNC_ROUTER
+        : normalized === ONE_INCH_V5_ROUTER || normalized === ONE_INCH_V6_STANDARD_ROUTER
+
+  if (!isKnown) {
     throw new Error(
-      `${provider} swap quote returned an unrecognized router address (${address}) — refusing to build a signable transaction against it.`
+      `${provider} swap quote returned an unrecognized router address (${address}) on ${chain} — refusing to build a signable transaction against it.`
     )
   }
 }

--- a/packages/core/chain/swap/general/kyber/api/quote.test.ts
+++ b/packages/core/chain/swap/general/kyber/api/quote.test.ts
@@ -15,7 +15,7 @@ describe('getKyberSwapQuote', () => {
       .mockResolvedValueOnce({
         data: {
           routeSummary: { amountOut: '10000000' },
-          routerAddress: '0xrouter',
+          routerAddress: '0x6131B5fae19EA4f9D964eAc0408E4408b66337b5', // real KyberSwap MetaAggregationRouterV2 (AGG-02 allowlist)
         },
       })
       .mockResolvedValueOnce({
@@ -24,7 +24,7 @@ describe('getKyberSwapQuote', () => {
           amountOut: '10000000',
           data: '0xswap',
           gas: '210000',
-          routerAddress: '0xrouter',
+          routerAddress: '0x6131B5fae19EA4f9D964eAc0408E4408b66337b5', // real KyberSwap MetaAggregationRouterV2 (AGG-02 allowlist)
         },
       })
 
@@ -102,7 +102,7 @@ describe('getKyberSwapQuote', () => {
       .mockResolvedValueOnce({
         data: {
           routeSummary: { amountOut: rawAmountOut },
-          routerAddress: '0xrouter',
+          routerAddress: '0x6131B5fae19EA4f9D964eAc0408E4408b66337b5', // real KyberSwap MetaAggregationRouterV2 (AGG-02 allowlist)
         },
       })
       .mockResolvedValueOnce({
@@ -111,7 +111,7 @@ describe('getKyberSwapQuote', () => {
           amountOut: rawAmountOut,
           data: '0xswap',
           gas: '456836',
-          routerAddress: '0xrouter',
+          routerAddress: '0x6131B5fae19EA4f9D964eAc0408E4408b66337b5', // real KyberSwap MetaAggregationRouterV2 (AGG-02 allowlist)
         },
       })
 
@@ -151,7 +151,7 @@ describe('getKyberSwapQuote', () => {
       .mockResolvedValueOnce({
         data: {
           routeSummary: { amountOut: rawAmountOut },
-          routerAddress: '0xrouter',
+          routerAddress: '0x6131B5fae19EA4f9D964eAc0408E4408b66337b5', // real KyberSwap MetaAggregationRouterV2 (AGG-02 allowlist)
         },
       })
       .mockResolvedValueOnce({
@@ -160,7 +160,7 @@ describe('getKyberSwapQuote', () => {
           amountOut: rawAmountOut,
           data: '0xswap',
           gas: '350000',
-          routerAddress: '0xrouter',
+          routerAddress: '0x6131B5fae19EA4f9D964eAc0408E4408b66337b5', // real KyberSwap MetaAggregationRouterV2 (AGG-02 allowlist)
         },
       })
 
@@ -191,5 +191,65 @@ describe('getKyberSwapQuote', () => {
     const amountOutHuman = Number(rawAmountOut) / 10 ** 6
     const impliedRate = amountOutHuman / amountInHuman
     expect(impliedRate).toBeGreaterThan(1.05) // >5% above 1:1 — implausible for USDC->USDT
+  })
+
+  // AGG-02 (round-2 spec-level fund-safety audit): Kyber's /routes response routerAddress
+  // was trusted with no allowlist, becoming both the swap tx destination and the ERC-20
+  // approval spender. See knownAggregatorRouters.ts for the fix + full rationale.
+  describe('AGG-02 router allowlist', () => {
+    it('REJECTS a routerAddress that is not the real Kyber MetaAggregationRouterV2 (spoofed/compromised aggregator)', async () => {
+      vi.mocked(queryUrl)
+        .mockResolvedValueOnce({
+          data: {
+            routeSummary: { amountOut: '10000000' },
+            routerAddress: '0x000000000000000000000000000000deadbeef', // NOT Kyber's router
+          },
+        })
+        .mockResolvedValueOnce({
+          code: 0,
+          data: {
+            amountOut: '10000000',
+            data: '0xswap',
+            gas: '210000',
+            routerAddress: '0x000000000000000000000000000000deadbeef',
+          },
+        })
+
+      await expect(
+        getKyberSwapQuote({
+          from: { chain: Chain.Ethereum, address: '0xsender', id: '0xsrc', decimals: 18, ticker: 'SRC' },
+          to: { chain: Chain.Ethereum, address: '0xsender', id: '0xdst', decimals: 6, ticker: 'DST' },
+          amount: 1_000_000n,
+        })
+      ).rejects.toThrow(/unrecognized router address/)
+    })
+
+    it('accepts the real Kyber MetaAggregationRouterV2', async () => {
+      const realRouter = '0x6131B5fae19EA4f9D964eAc0408E4408b66337b5'
+      vi.mocked(queryUrl)
+        .mockResolvedValueOnce({
+          data: {
+            routeSummary: { amountOut: '10000000' },
+            routerAddress: realRouter,
+          },
+        })
+        .mockResolvedValueOnce({
+          code: 0,
+          data: {
+            amountOut: '10000000',
+            data: '0xswap',
+            gas: '210000',
+            routerAddress: realRouter,
+          },
+        })
+
+      const quote = await getKyberSwapQuote({
+        from: { chain: Chain.Ethereum, address: '0xsender', id: '0xsrc', decimals: 18, ticker: 'SRC' },
+        to: { chain: Chain.Ethereum, address: '0xsender', id: '0xdst', decimals: 6, ticker: 'DST' },
+        amount: 1_000_000n,
+      })
+
+      expect('evm' in quote.tx ? quote.tx.evm.to : undefined).toBe(realRouter)
+    })
   })
 })

--- a/packages/core/chain/swap/general/kyber/api/quote.test.ts
+++ b/packages/core/chain/swap/general/kyber/api/quote.test.ts
@@ -251,5 +251,33 @@ describe('getKyberSwapQuote', () => {
 
       expect('evm' in quote.tx ? quote.tx.evm.to : undefined).toBe(realRouter)
     })
+
+    it("REJECTS when /route/build's OWN routerAddress differs from /routes' (API drift — calldata may target a different router than tx.to claims), even though /routes returned the real one", async () => {
+      const realRouter = '0x6131B5fae19EA4f9D964eAc0408E4408b66337b5'
+      vi.mocked(queryUrl)
+        .mockResolvedValueOnce({
+          data: {
+            routeSummary: { amountOut: '10000000' },
+            routerAddress: realRouter,
+          },
+        })
+        .mockResolvedValueOnce({
+          code: 0,
+          data: {
+            amountOut: '10000000',
+            data: '0xswap',
+            gas: '210000',
+            routerAddress: '0x000000000000000000000000000000deadbeef',
+          },
+        })
+
+      await expect(
+        getKyberSwapQuote({
+          from: { chain: Chain.Ethereum, address: '0xsender', id: '0xsrc', decimals: 18, ticker: 'SRC' },
+          to: { chain: Chain.Ethereum, address: '0xsender', id: '0xdst', decimals: 6, ticker: 'DST' },
+          amount: 1_000_000n,
+        })
+      ).rejects.toThrow(/unrecognized router address/)
+    })
   })
 })

--- a/packages/core/chain/swap/general/kyber/api/tx.ts
+++ b/packages/core/chain/swap/general/kyber/api/tx.ts
@@ -8,6 +8,7 @@ import { AccountCoin } from '../../../../coin/AccountCoin'
 import { isFeeCoin } from '../../../../coin/utils/isFeeCoin'
 import { SwapFee } from '../../../SwapFee'
 import { GeneralSwapQuote } from '../../GeneralSwapQuote'
+import { assertKnownAggregatorRouter } from '../../knownAggregatorRouters'
 import { KyberSwapEnabledChain } from '../chains'
 import {
   getKyberSwapAffiliateParams,
@@ -118,6 +119,12 @@ export const getKyberSwapTx = async ({
   }
 
   const { amountOut, data, gas } = buildResponse.data
+
+  // AGG-02 fund-safety fix: verify routerAddress (sourced from Kyber's /routes response,
+  // route.ts) is Kyber's actual router before this untrusted value can become a signable
+  // GeneralSwapQuote. See knownAggregatorRouters.ts.
+  assertKnownAggregatorRouter('kyber', routerAddress)
+
   return {
     dstAmount: amountOut,
     provider: 'kyber',

--- a/packages/core/chain/swap/general/kyber/api/tx.ts
+++ b/packages/core/chain/swap/general/kyber/api/tx.ts
@@ -118,12 +118,22 @@ export const getKyberSwapTx = async ({
     throw new Error('Failed to build transaction')
   }
 
-  const { amountOut, data, gas } = buildResponse.data
+  const { amountOut, data, gas, routerAddress: buildRouterAddress } = buildResponse.data
 
-  // AGG-02 fund-safety fix: verify routerAddress (sourced from Kyber's /routes response,
-  // route.ts) is Kyber's actual router before this untrusted value can become a signable
-  // GeneralSwapQuote. See knownAggregatorRouters.ts.
-  assertKnownAggregatorRouter('kyber', routerAddress)
+  // AGG-02 fund-safety fix: verify BOTH the /routes response's routerAddress (route.ts,
+  // threaded in as the `routerAddress` param) AND /route/build's OWN routerAddress field
+  // are Kyber's actual router before this untrusted data can become a signable
+  // GeneralSwapQuote. The two calls are separate HTTP round-trips; if they ever disagree
+  // (API drift/version mismatch), `data` (the calldata /route/build just generated) may
+  // have been built against a DIFFERENT router than the one this quote's tx.to claims —
+  // codex review finding, PR #1079. See knownAggregatorRouters.ts.
+  assertKnownAggregatorRouter('kyber', routerAddress, from.chain)
+  assertKnownAggregatorRouter('kyber', buildRouterAddress, from.chain)
+  if (buildRouterAddress.toLowerCase() !== routerAddress.toLowerCase()) {
+    throw new Error(
+      `Kyber /route and /route/build disagree on the router address (${routerAddress} vs ${buildRouterAddress}) — refusing to build a signable transaction against mismatched calldata.`
+    )
+  }
 
   return {
     dstAmount: amountOut,

--- a/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.routerTelemetry.test.ts
+++ b/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.routerTelemetry.test.ts
@@ -6,6 +6,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 // knownAggregatorRouters.ts's logUnenforcedAggregatorDestination. This proves that behavior:
 // an unrecognized `to` never blocks the quote, and gets logged for future analysis.
 
+// jscpd:ignore-start — the LiFi module-mock + fixture scaffolding below is intentionally
+// shared with getLifiSwapQuote.integrator.test.ts (same core module under test); the
+// meaningful assertions are the telemetry cases further down. Follows the repo's existing
+// convention for shared test mock boilerplate (cf. tests/integration/swap/swap-quote.test.ts).
 vi.mock('@lifi/sdk', () => ({
   ChainId: {},
   createClient: () => ({ config: {}, providers: [] }),
@@ -64,6 +68,7 @@ const baseInput = {
   amount: 1_000_000n,
   affiliateBps: 30,
 }
+// jscpd:ignore-end
 
 describe('getLifiSwapQuote — AGG-02 router telemetry (log-only, never enforced)', () => {
   let infoSpy: ReturnType<typeof vi.spyOn>

--- a/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.routerTelemetry.test.ts
+++ b/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.routerTelemetry.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// AGG-02 (round-2 spec-level fund-safety audit): LiFi routes through many different
+// bridge/DEX contracts by design (diamond routing, multi-hop, chain-specific deployments),
+// so — unlike 1inch/Kyber — its destination is logged (never enforced/thrown) via
+// knownAggregatorRouters.ts's logUnenforcedAggregatorDestination. This proves that behavior:
+// an unrecognized `to` never blocks the quote, and gets logged for future analysis.
+
+vi.mock('@lifi/sdk', () => ({
+  ChainId: {},
+  createClient: () => ({ config: {}, providers: [] }),
+  getQuote: () =>
+    Promise.resolve({
+      transactionRequest: {
+        value: '0',
+        gasLimit: '0',
+        data: '0x',
+        from: '0xfrom',
+        to: '0x000000000000000000000000000000deadbeef', // NOT a known router — never enforced for LiFi
+        chainId: 1,
+      },
+      estimate: {
+        toAmount: '999000',
+        gasCosts: [{ amount: '0' }],
+        feeCosts: [{ name: 'LIFI Fixed Fee', amount: '0', token: { decimals: 6, address: 'USDT', chainId: 1 } }],
+      },
+    }),
+}))
+vi.mock('@vultisig/core-chain/ChainKind', () => ({
+  getChainKind: () => 'evm',
+  DeriveChainKind: {},
+}))
+vi.mock('@vultisig/core-chain/chains/solana/solanaConfig', () => ({
+  solanaConfig: { ataRentLamports: 0 },
+}))
+vi.mock('@vultisig/core-chain/coin/chainFeeCoin', () => ({
+  chainFeeCoin: new Proxy({}, { get: () => ({ ticker: 'ETH', id: 'ETH' }) }),
+}))
+vi.mock('@vultisig/core-chain/swap/general/lifi/LifiSwapEnabledChains', () => ({
+  lifiSwapChainId: new Proxy({}, { get: () => 1 }),
+}))
+vi.mock('@vultisig/core-chain/swap/general/lifi/api/injectSolanaAtaIfMissing', () => ({
+  injectSolanaAtaIfMissing: () => ({ data: '', ataInjected: false }),
+}))
+vi.mock('@vultisig/lib-utils/assert/shouldBePresent', () => ({
+  shouldBePresent: <T>(v: T): T => v,
+}))
+vi.mock('@vultisig/lib-utils/match', () => ({
+  match: (_kind: string, handlers: Record<string, () => unknown>) => handlers.evm(),
+}))
+vi.mock('@vultisig/lib-utils/memoize', () => ({
+  memoize: <T extends (...a: unknown[]) => unknown>(fn: T) => fn,
+}))
+vi.mock('@vultisig/lib-utils/record/mirrorRecord', () => ({
+  mirrorRecord: () => ({}),
+}))
+vi.mock('@vultisig/lib-utils/TransferDirection', () => ({
+  TransferDirection: { from: 'from', to: 'to' },
+}))
+
+const baseInput = {
+  from: { id: 'USDC', chain: 'Ethereum', address: '0xfrom', ticker: 'USDC' },
+  to: { id: 'USDT', chain: 'Ethereum', address: '0xto', ticker: 'USDT' },
+  amount: 1_000_000n,
+  affiliateBps: 30,
+}
+
+describe('getLifiSwapQuote — AGG-02 router telemetry (log-only, never enforced)', () => {
+  let infoSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.resetModules()
+    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    infoSpy.mockRestore()
+  })
+
+  it('does NOT throw for an unrecognized destination — LiFi is never enforced', async () => {
+    const { getLifiSwapQuote } = await import('./getLifiSwapQuote')
+    await expect(getLifiSwapQuote(baseInput as never)).resolves.toBeDefined()
+  })
+
+  it('logs the destination via swap-router-telemetry for future analysis', async () => {
+    const { getLifiSwapQuote } = await import('./getLifiSwapQuote')
+    await getLifiSwapQuote(baseInput as never)
+    expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('swap-router-telemetry'), {
+      provider: 'li.fi',
+      address: '0x000000000000000000000000000000deadbeef',
+    })
+  })
+})

--- a/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
+++ b/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
@@ -17,6 +17,7 @@ import { TransferDirection } from '@vultisig/lib-utils/TransferDirection'
 
 import { AccountCoinKey } from '../../../../coin/AccountCoin'
 import { GeneralSwapQuote } from '../../GeneralSwapQuote'
+import { logUnenforcedAggregatorDestination } from '../../knownAggregatorRouters'
 import { injectSolanaAtaIfMissing } from './injectSolanaAtaIfMissing'
 
 type Input = Record<TransferDirection, AccountCoinKey<LifiSwapEnabledChain> & { ticker?: string }> & {
@@ -313,10 +314,16 @@ export const getLifiSwapQuote = async ({
           swapFee &&
           ([fromToken, toToken].find(token => token.toLowerCase() === swapFeeAddress) ||
             chainFeeCoin[transfer.from.chain].id)
+        const evmTo = shouldBePresent(to)
+        // AGG-02: LiFi routes through many different bridge/DEX contracts by design
+        // (diamond routing, multi-hop, chain-specific deployments) — a hard allowlist
+        // would false-block legitimate routes, so log (never throw). See
+        // knownAggregatorRouters.ts.
+        logUnenforcedAggregatorDestination('li.fi', evmTo)
         return {
           evm: {
             from: shouldBePresent(from),
-            to: shouldBePresent(to),
+            to: evmTo,
             data: shouldBePresent(data),
             value: BigInt(shouldBePresent(value)).toString(),
             gasLimit: gasLimit ? BigInt(gasLimit) : undefined,

--- a/packages/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.test.ts
+++ b/packages/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.test.ts
@@ -1,0 +1,59 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+import { describe, expect, it, vi } from 'vitest'
+
+import { getOneInchSwapQuote } from './getOneInchSwapQuote'
+
+vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
+  queryUrl: vi.fn(),
+}))
+
+const account = { chain: Chain.Ethereum, address: '0xsender' }
+
+describe('getOneInchSwapQuote — AGG-02 router allowlist', () => {
+  it('REJECTS a response whose tx.to is not the real 1inch router (spoofed/compromised aggregator)', async () => {
+    vi.mocked(queryUrl).mockResolvedValueOnce({
+      dstAmount: '1000000',
+      tx: {
+        from: '0xsender',
+        to: '0x000000000000000000000000000000deadbeef', // NOT 1inch's router
+        data: '0xswap',
+        value: '0',
+        gasPrice: '1000000000',
+        gas: 210000,
+      },
+    })
+
+    await expect(
+      getOneInchSwapQuote({
+        account,
+        fromCoinId: '0xsrc',
+        toCoinId: '0xdst',
+        amount: 1_000_000n,
+      })
+    ).rejects.toThrow(/unrecognized router address/)
+  })
+
+  it('accepts a response whose tx.to is the real 1inch V6 router', async () => {
+    vi.mocked(queryUrl).mockResolvedValueOnce({
+      dstAmount: '1000000',
+      tx: {
+        from: '0xsender',
+        to: '0x111111125421ca6dc452d289314280a0f8842a65', // real 1inch V6 router
+        data: '0xswap',
+        value: '0',
+        gasPrice: '1000000000',
+        gas: 210000,
+      },
+    })
+
+    const quote = await getOneInchSwapQuote({
+      account,
+      fromCoinId: '0xsrc',
+      toCoinId: '0xdst',
+      amount: 1_000_000n,
+    })
+
+    expect('evm' in quote.tx ? quote.tx.evm.to : undefined).toBe('0x111111125421ca6dc452d289314280a0f8842a65')
+  })
+})

--- a/packages/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.test.ts
+++ b/packages/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.test.ts
@@ -56,4 +56,47 @@ describe('getOneInchSwapQuote — AGG-02 router allowlist', () => {
 
     expect('evm' in quote.tx ? quote.tx.evm.to : undefined).toBe('0x111111125421ca6dc452d289314280a0f8842a65')
   })
+
+  // codex review (PR #1079): 1inch's router differs on zkSync Era — confirmed live. The
+  // allowlist is chain-scoped; prove the real function threads account.chain through
+  // correctly rather than just trusting the allowlist unit tests in isolation.
+  describe('zkSync Era — a genuinely different router (chain-scoped allowlist)', () => {
+    const zksyncAccount = { chain: Chain.Zksync, address: '0xsender' }
+    const ZKSYNC_ROUTER = '0x6fd4383cb451173d5f9304f041c7bcbf27d561ff'
+    const STANDARD_V6_ROUTER = '0x111111125421ca6dc452d289314280a0f8842a65'
+
+    it('accepts the zkSync-specific router when account.chain is Zksync', async () => {
+      vi.mocked(queryUrl).mockResolvedValueOnce({
+        dstAmount: '1000000',
+        tx: { from: '0xsender', to: ZKSYNC_ROUTER, data: '0xswap', value: '0', gasPrice: '1000000000', gas: 210000 },
+      })
+
+      const quote = await getOneInchSwapQuote({
+        account: zksyncAccount,
+        fromCoinId: '0xsrc',
+        toCoinId: '0xdst',
+        amount: 1_000_000n,
+      })
+
+      expect('evm' in quote.tx ? quote.tx.evm.to : undefined).toBe(ZKSYNC_ROUTER)
+    })
+
+    it('REJECTS the standard V6 router when account.chain is Zksync (the exact bug this fixes)', async () => {
+      vi.mocked(queryUrl).mockResolvedValueOnce({
+        dstAmount: '1000000',
+        tx: {
+          from: '0xsender',
+          to: STANDARD_V6_ROUTER,
+          data: '0xswap',
+          value: '0',
+          gasPrice: '1000000000',
+          gas: 210000,
+        },
+      })
+
+      await expect(
+        getOneInchSwapQuote({ account: zksyncAccount, fromCoinId: '0xsrc', toCoinId: '0xdst', amount: 1_000_000n })
+      ).rejects.toThrow(/unrecognized router address/)
+    })
+  })
 })

--- a/packages/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.ts
+++ b/packages/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.ts
@@ -3,6 +3,7 @@ import { ChainAccount } from '@vultisig/core-chain/ChainAccount'
 import { getEvmChainId } from '@vultisig/core-chain/chains/evm/chainInfo'
 import { isFeeCoin } from '@vultisig/core-chain/coin/utils/isFeeCoin'
 import { GeneralSwapQuote } from '@vultisig/core-chain/swap/general/GeneralSwapQuote'
+import { assertKnownAggregatorRouter } from '@vultisig/core-chain/swap/general/knownAggregatorRouters'
 import { OneInchSwapQuoteResponse } from '@vultisig/core-chain/swap/general/oneInch/api/OneInchSwapQuoteResponse'
 import { oneInchAffiliateConfig } from '@vultisig/core-chain/swap/general/oneInch/oneInchAffiliateConfig'
 import { rootApiUrl } from '@vultisig/core-config'
@@ -58,6 +59,10 @@ export const getOneInchSwapQuote = async ({
   const url = addQueryParams(getBaseUrl(chainId), params)
 
   const { dstAmount, tx }: OneInchSwapQuoteResponse = await queryUrl<OneInchSwapQuoteResponse>(url)
+
+  // AGG-02 fund-safety fix: verify tx.to is 1inch's actual router before this untrusted
+  // response can become a signable GeneralSwapQuote. See knownAggregatorRouters.ts.
+  assertKnownAggregatorRouter('1inch', tx.to)
 
   return {
     dstAmount,

--- a/packages/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.ts
+++ b/packages/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.ts
@@ -61,8 +61,9 @@ export const getOneInchSwapQuote = async ({
   const { dstAmount, tx }: OneInchSwapQuoteResponse = await queryUrl<OneInchSwapQuoteResponse>(url)
 
   // AGG-02 fund-safety fix: verify tx.to is 1inch's actual router before this untrusted
-  // response can become a signable GeneralSwapQuote. See knownAggregatorRouters.ts.
-  assertKnownAggregatorRouter('1inch', tx.to)
+  // response can become a signable GeneralSwapQuote. Chain-scoped: 1inch's router differs
+  // on zkSync Era. See knownAggregatorRouters.ts.
+  assertKnownAggregatorRouter('1inch', tx.to, chain)
 
   return {
     dstAmount,

--- a/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.routerTelemetry.test.ts
+++ b/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.routerTelemetry.test.ts
@@ -1,0 +1,82 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { configureSwapKit } from '@vultisig/core-chain/swap/general/swapkit/config'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { getSwapKitQuote } from './getSwapKitQuote'
+
+// AGG-02 (round-2 spec-level fund-safety audit): SwapKit routes through many different
+// bridge/DEX contracts by design (diamond routing, multi-hop, chain-specific deployments),
+// so — unlike 1inch/Kyber — its destination is logged (never enforced/thrown) via
+// knownAggregatorRouters.ts's logUnenforcedAggregatorDestination. This proves that behavior:
+// an unrecognized `to` never blocks the quote, and gets logged for future analysis.
+
+const response = (body: unknown) => {
+  const serialized = JSON.stringify(body)
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    text: vi.fn(async () => serialized),
+    json: vi.fn(async () => body),
+  } as unknown as Response
+}
+
+describe('getSwapKitQuote — AGG-02 router telemetry (log-only, never enforced)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    configureSwapKit({ apiKey: undefined, baseUrl: 'https://api.vultisig.com/swapkit-win' })
+  })
+
+  const evmRouteFixtures = () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        response({
+          routes: [{ routeId: 'near-route', providers: ['NEAR'], expectedBuyAmount: '12.5' }],
+        })
+      )
+      .mockResolvedValueOnce(
+        response({
+          expectedBuyAmount: '12.4',
+          providers: ['NEAR'],
+          tx: {
+            from: '0xsender',
+            to: '0x000000000000000000000000000000deadbeef', // NOT a known router — never enforced for SwapKit
+            data: '0xabcdef',
+            value: '0',
+            gas: '21000',
+          },
+        })
+      )
+    vi.stubGlobal('fetch', fetchMock)
+    configureSwapKit({ apiKey: 'test-key', baseUrl: 'https://swapkit.example' })
+  }
+
+  it('does NOT throw for an unrecognized destination — SwapKit is never enforced', async () => {
+    evmRouteFixtures()
+    await expect(
+      getSwapKitQuote({
+        from: { chain: Chain.Ethereum, address: '0xsender', ticker: 'ETH', decimals: 18 },
+        to: { chain: Chain.Solana, address: 'sol-destination', ticker: 'USDC', id: 'sol-usdc-mint', decimals: 6 },
+        amount: 10_000_000_000_000_000n,
+      })
+    ).resolves.toBeDefined()
+  })
+
+  it('logs the destination via swap-router-telemetry for future analysis', async () => {
+    evmRouteFixtures()
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+
+    await getSwapKitQuote({
+      from: { chain: Chain.Ethereum, address: '0xsender', ticker: 'ETH', decimals: 18 },
+      to: { chain: Chain.Solana, address: 'sol-destination', ticker: 'USDC', id: 'sol-usdc-mint', decimals: 6 },
+      amount: 10_000_000_000_000_000n,
+    })
+
+    expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('swap-router-telemetry'), {
+      provider: 'swapkit',
+      address: '0x000000000000000000000000000000deadbeef',
+    })
+    infoSpy.mockRestore()
+  })
+})

--- a/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.ts
+++ b/packages/core/chain/swap/general/swapkit/api/getSwapKitQuote.ts
@@ -4,6 +4,7 @@ import { Chain } from '@vultisig/core-chain/Chain'
 import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { GeneralSwapQuote, GeneralSwapTx } from '@vultisig/core-chain/swap/general/GeneralSwapQuote'
+import { logUnenforcedAggregatorDestination } from '@vultisig/core-chain/swap/general/knownAggregatorRouters'
 import { getSwapKitConfig } from '@vultisig/core-chain/swap/general/swapkit/config'
 import { SwapKitEnabledChain, SwapKitSourceChain } from '@vultisig/core-chain/swap/general/swapkit/SwapKitEnabledChains'
 import {
@@ -350,6 +351,11 @@ const buildEvmTx = (tx: unknown, fromAddress: string): GeneralSwapTx => {
   if (!evmTx.to) {
     throw new Error('SwapKit EVM transaction is missing a required to field.')
   }
+
+  // AGG-02: SwapKit routes through many different bridge/DEX contracts by design
+  // (diamond routing, multi-hop, chain-specific deployments) — a hard allowlist would
+  // false-block legitimate routes, so log (never throw). See knownAggregatorRouters.ts.
+  logUnenforcedAggregatorDestination('swapkit', evmTx.to)
 
   const gas = evmTx.gasLimit ?? evmTx.gas
 

--- a/packages/core/mpc/keysign/swap/build.agg02RouterCoverage.test.ts
+++ b/packages/core/mpc/keysign/swap/build.agg02RouterCoverage.test.ts
@@ -1,0 +1,100 @@
+import { create } from '@bufbuild/protobuf'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { SwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
+import { getBlockchainSpecificValue } from '@vultisig/core-mpc/keysign/chainSpecific/KeysignChainSpecific'
+import { EthereumSpecificSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
+import { describe, expect, it, vi } from 'vitest'
+
+// AGG-02 (round-2 spec-level fund-safety audit): the aggregator-returned tx.to used to be
+// trusted with NO allowlist, and it fed TWO INDEPENDENT downstream consumers — the ERC-20
+// approval spender (this file, buildSwapKeysignPayload's allowance check) AND the actual
+// swap transaction's on-chain destination (swapPayload.value.quote.tx.to, read by
+// packages/core/mpc/keysign/signingInputs/resolvers/evm/index.ts:65's WalletCore
+// SigningInput). Fixing only one would have left the other unguarded — that's why the real
+// fix (getOneInchSwapQuote.ts / kyber tx.ts / getLifiSwapQuote.ts / getSwapKitQuote.ts) is at
+// QUOTE CONSTRUCTION, so a GeneralSwapQuote literally cannot exist with a bad tx.to for an
+// enforced provider (1inch/Kyber). This test proves BOTH downstream fields agree once that's
+// true — i.e. that build.ts has no THIRD, independent path that could diverge from the
+// validated address.
+const ONE_INCH_V6_ROUTER = '0x111111125421ca6dc452d289314280a0f8842a65'
+
+const mocks = vi.hoisted(() => ({
+  getChainSpecific: vi.fn(async () => ({
+    case: 'ethereumSpecific' as const,
+    value: create(EthereumSpecificSchema, {
+      maxFeePerGasWei: '1000000000',
+      priorityFee: '100000000',
+      nonce: 0n,
+      gasLimit: '210000',
+    }),
+  })),
+  getKeysignUtxoInfo: vi.fn(async () => []),
+  getErc20Allowance: vi.fn(async () => 0n), // force the approve-payload branch (allowance < chainAmount)
+}))
+
+vi.mock('@vultisig/core-mpc/keysign/chainSpecific', () => ({
+  getChainSpecific: mocks.getChainSpecific,
+}))
+vi.mock('@vultisig/core-mpc/keysign/utxo/getKeysignUtxoInfo', () => ({
+  getKeysignUtxoInfo: mocks.getKeysignUtxoInfo,
+}))
+vi.mock('@vultisig/core-chain/chains/evm/erc20/getErc20Allowance', () => ({
+  getErc20Allowance: mocks.getErc20Allowance,
+}))
+
+import { buildSwapKeysignPayload } from './build'
+
+const publicKey = { data: () => new Uint8Array([1, 2, 3]) } as never
+
+describe('buildSwapKeysignPayload — AGG-02: both downstream router consumers agree', () => {
+  it('the ERC-20 approval spender AND the swap tx destination (read by the evm signingInputs resolver) both carry the SAME validated router address', async () => {
+    // This quote shape is exactly what getOneInchSwapQuote returns AFTER its AGG-02
+    // allowlist check passes — production code can never construct this object with
+    // an unrecognized tx.to for provider '1inch' (see getOneInchSwapQuote.test.ts).
+    const swapQuote: SwapQuote = {
+      quote: {
+        general: {
+          provider: '1inch',
+          dstAmount: '1000000',
+          tx: { evm: { from: '0xsender', to: ONE_INCH_V6_ROUTER, data: '0xabc', value: '0' } },
+        },
+      },
+      discounts: [],
+    } as never
+
+    const payload = await buildSwapKeysignPayload({
+      fromCoin: { chain: Chain.Ethereum, address: '0xsender', id: '0xusdc', ticker: 'USDC', decimals: 6 },
+      toCoin: { chain: Chain.Ethereum, address: '0xdest', id: '0xdai', ticker: 'DAI', decimals: 18 },
+      amount: 1,
+      swapQuote,
+      vaultId: 'vault-id',
+      localPartyId: 'local-party',
+      fromPublicKey: publicKey,
+      toPublicKey: publicKey,
+      libType: 'DKLS' as const,
+      walletCore: {} as never,
+    })
+
+    // Consumer 1: the ERC-20 approval spender (build.ts's allowance check reads
+    // keysignPayload.toAddress as the spender when allowance is insufficient).
+    expect(payload.toAddress).toBe(ONE_INCH_V6_ROUTER)
+    expect(payload.erc20ApprovePayload?.spender).toBe(ONE_INCH_V6_ROUTER)
+
+    // Consumer 2: the actual swap transaction's destination — this is the SEPARATE,
+    // independent field signingInputs/resolvers/evm/index.ts:65 reads
+    // (`quote?.tx?.to`) to build the real WalletCore SigningInput.toAddress for the
+    // on-chain swap. It must match consumer 1 exactly, or the two-path gap AGG-02
+    // found is still open.
+    expect(payload.swapPayload?.case).toBe('oneinchSwapPayload')
+    expect(payload.swapPayload?.case === 'oneinchSwapPayload' && payload.swapPayload.value.quote?.tx?.to).toBe(
+      ONE_INCH_V6_ROUTER
+    )
+
+    // Sanity: both consumers really did read the same underlying value (not two
+    // coincidentally-equal constants) — confirm getErc20Allowance was called with
+    // exactly this spender, proving the flow used through build.ts's real branch.
+    expect(mocks.getErc20Allowance).toHaveBeenCalledWith(
+      expect.objectContaining({ chain: Chain.Ethereum, address: '0xsender', spender: ONE_INCH_V6_ROUTER })
+    )
+  })
+})

--- a/packages/core/mpc/keysign/swap/build.agg02RouterCoverage.test.ts
+++ b/packages/core/mpc/keysign/swap/build.agg02RouterCoverage.test.ts
@@ -2,7 +2,11 @@ import { create } from '@bufbuild/protobuf'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { SwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
 import { getBlockchainSpecificValue } from '@vultisig/core-mpc/keysign/chainSpecific/KeysignChainSpecific'
+import { getKeysignSwapPayload } from '@vultisig/core-mpc/keysign/swap/getKeysignSwapPayload'
+import { KeysignSwapPayload } from '@vultisig/core-mpc/keysign/swap/KeysignSwapPayload'
 import { EthereumSpecificSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
+import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
+import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
 import { describe, expect, it, vi } from 'vitest'
 
 // AGG-02 (round-2 spec-level fund-safety audit): the aggregator-returned tx.to used to be
@@ -96,5 +100,22 @@ describe('buildSwapKeysignPayload — AGG-02: both downstream router consumers a
     expect(mocks.getErc20Allowance).toHaveBeenCalledWith(
       expect.objectContaining({ chain: Chain.Ethereum, address: '0xsender', spender: ONE_INCH_V6_ROUTER })
     )
+
+    // Codex review (PR #1079): don't just assert on the payload's field path — replicate
+    // the EXACT resolution signingInputs/resolvers/evm/index.ts:60-66's getToAddress()
+    // performs, using the SAME real helper functions it imports (getKeysignSwapPayload,
+    // matchRecordUnion, shouldBePresent — none mocked here), so this proves what the
+    // WalletCore SigningInput.toAddress will actually be built from, not just what this
+    // test assumes the resolver reads.
+    const swapPayload = shouldBePresent(getKeysignSwapPayload(payload))
+    const toAddressTheEvmResolverWouldUse = matchRecordUnion<KeysignSwapPayload, string>(swapPayload, {
+      // Not exercised by this test (a 1inch general quote never takes this arm) —
+      // present only because matchRecordUnion requires exhaustive handling.
+      native: () => {
+        throw new Error('unreachable in this test — quote is a general/1inch swap')
+      },
+      general: ({ quote }) => shouldBePresent(quote?.tx?.to),
+    })
+    expect(toAddressTheEvmResolverWouldUse).toBe(ONE_INCH_V6_ROUTER)
   })
 })

--- a/packages/sdk/src/platforms/react-native/overrides/getLifiSwapQuote.ts
+++ b/packages/sdk/src/platforms/react-native/overrides/getLifiSwapQuote.ts
@@ -26,6 +26,7 @@ import { solanaConfig } from '@vultisig/core-chain/chains/solana/solanaConfig'
 import { AccountCoinKey } from '@vultisig/core-chain/coin/AccountCoin'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { GeneralSwapQuote } from '@vultisig/core-chain/swap/general/GeneralSwapQuote'
+import { logUnenforcedAggregatorDestination } from '@vultisig/core-chain/swap/general/knownAggregatorRouters'
 import { injectSolanaAtaIfMissing } from '@vultisig/core-chain/swap/general/lifi/api/injectSolanaAtaIfMissing'
 import {
   getLifiClient,
@@ -235,10 +236,17 @@ export const getLifiSwapQuote = async ({
           swapFee &&
           ([fromToken, toToken].find(token => token.toLowerCase() === swapFeeAddress) ||
             chainFeeCoin[transfer.from.chain].id)
+        const evmTo = shouldBePresent(to)
+        // AGG-02: mirrors core's getLifiSwapQuote.ts — LiFi routes through many different
+        // bridge/DEX contracts by design, so this is logged (never enforced/thrown). See
+        // core's knownAggregatorRouters.ts for the full rationale. This RN override is a
+        // SEPARATE build target (rollup.platforms.config.js redirects core's
+        // getLifiSwapQuote.ts here), so it needs its own call, not just core's.
+        logUnenforcedAggregatorDestination('li.fi', evmTo)
         return {
           evm: {
             from: shouldBePresent(from),
-            to: shouldBePresent(to),
+            to: evmTo,
             data: shouldBePresent(data),
             value: BigInt(shouldBePresent(value)).toString(),
             gasLimit: gasLimit ? BigInt(gasLimit) : undefined,


### PR DESCRIPTION
Fund-touching SDK core — highest bar review requested, draft only.

## what
1inch/Kyber/LiFi/SwapKit's `tx.to` was trusted straight from each aggregator's HTTP response with no validation, and fed **two independent downstream consumers**: the ERC-20 approval spender (`mpc/keysign/swap/build.ts`'s allowance check) AND, separately, the actual swap transaction's on-chain destination (`build.ts`'s own txMsg construction → `signingInputs/resolvers/evm/index.ts`'s WalletCore `SigningInput`). A compromised/spoofed aggregator response would get BOTH an ERC-20 approval AND the swap signed against it — CowSwap is the only provider that already hardcodes a verified target.

## how
Validates at **quote construction** — the trust boundary where the untrusted HTTP response gets parsed into a `GeneralSwapQuote` — rather than at a downstream consumption site. Tracing the code turned up that a single downstream check would have left the OTHER independent read unguarded (see the commit message for the full trace); validating at the source means every consumer (present and future) inherits an already-verified address by construction.

- **1inch** (`getOneInchSwapQuote.ts`) / **Kyber** (`kyber/api/tx.ts`): fail **CLOSED** (throw) if the returned router isn't the provider's known address. Both addresses verified against each provider's **own live quote API** (not just docs/explorers) on Ethereum/Arbitrum/BSC/Base (1inch) and Ethereum/BSC/Arbitrum (Kyber), matching byte-for-byte.
- **LiFi** (`getLifiSwapQuote.ts`) / **SwapKit** (`getSwapKitQuote.ts`): **log** (never throw) — these route through many different bridge/DEX contracts by design (diamond routing, multi-hop, chain-specific deployments), so a hard allowlist would false-block legitimate routes. Structured telemetry (`provider` + `address`) so a future allowlist has real usage data if a pattern emerges.

New shared module `packages/core/chain/swap/general/knownAggregatorRouters.ts` is now the natural home for AGG-01 (CowSwap tokens/kind from response vs request) and any future untrusted-aggregator-field validation.

## tests
- `knownAggregatorRouters.test.ts` — allowlist accept/reject, cross-provider mismatch (1inch response carrying Kyber's router), log-only never throws.
- `getOneInchSwapQuote.test.ts` + `kyber/api/quote.test.ts` — reject a spoofed router, accept the real one.
- `getLifiSwapQuote.routerTelemetry.test.ts` + `getSwapKitQuote.routerTelemetry.test.ts` — prove log-only never blocks a route.
- `build.agg02RouterCoverage.test.ts` — the test that matters: proves BOTH downstream consumers (the ERC-20 approval spender AND the field `signingInputs/resolvers/evm/index.ts` reads for the actual swap tx) receive the identical validated address from one real `buildSwapKeysignPayload` call — closing the two-path gap, not just one side of it.

Full core suite: 176 test files / 1511 tests pass, typecheck clean.

## risk
Fund-safety fix, narrow blast radius: 1inch/Kyber enforcement only changes behavior when the router doesn't match (i.e. only in the attack/anomaly scenario this closes) — the happy path is unaffected since both addresses are confirmed against the live APIs today. LiFi/SwapKit are log-only, zero behavior change.

🤖 Agent-generated

closes #1051

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap safety by validating aggregator router addresses before building transactions.
  * Prevents swaps from using unrecognized or mismatched router destinations for supported providers.
  * Added chain-specific handling for certain routes and safer logging for providers that use multiple contracts.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->