### PR TITLE
fix(utxo): raise litecoin dust threshold to the real p2wpkh standard (UTXO-02)

### DIFF
--- a/.changeset/ltc-dust-threshold-utxo02.md
+++ b/.changeset/ltc-dust-threshold-utxo02.md
@@ -1,0 +1,7 @@
+---
+'@vultisig/sdk': patch
+---
+
+fix(utxo): raise the Litecoin dust threshold to the real P2WPKH standard (~2_940 litoshi)
+
+Litecoin's DUST_RELAY_TX_FEE is ~10x Bitcoin's, so LTC's real standard dust threshold is ~2_940 litoshi for a P2WPKH output, not the hardcoded 1_000n. At 1_000n a change output of 1_001..2_939 litoshi was treated as spendable but is non-standard dust, so the transaction could be rejected by relays or stall. Bumped in both dust maps (core `minUtxo` + sdk `UTXO_SPECS`) and kept in sync. LTC-scoped (UTXO-02); BCH/Dash/Zcash 1_000n already sits at/above their real dust.

--- a/packages/core/chain/chains/utxo/minUtxo.test.ts
+++ b/packages/core/chain/chains/utxo/minUtxo.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { Chain } from '../../Chain'
+import { minUtxo } from './minUtxo'
+
+// UTXO-02 (audit r2): Litecoin's dust threshold was hardcoded 1_000n — ~3x below the real P2WPKH standard
+// (~2_940 litoshi; LTC's DUST_RELAY_TX_FEE is ~10x Bitcoin's). A change output of 1_001..2_939 was treated
+// as spendable but is non-standard dust -> the tx can be rejected by relays / stall. This pins the corrected
+// value + the dust-boundary semantics used by the change-output guard (`change > dustLimit`).
+describe('minUtxo — Litecoin dust threshold (UTXO-02)', () => {
+  const ltcDust = minUtxo[Chain.Litecoin]
+
+  it('is the P2WPKH standard ~2_940 litoshi, NOT the old dangerous 1_000n', () => {
+    expect(ltcDust).toBe(2_940n)
+    expect(ltcDust).toBeGreaterThan(1_000n) // the pre-fix value that under-counted dust
+  })
+
+  it('treats a 1_001..2_939 change output as DUST (change > dustLimit is false)', () => {
+    // these were spendable at the old 1_000n limit; now correctly below the standard dust floor
+    for (const change of [1_001n, 2_000n, 2_939n]) {
+      expect(change > ltcDust).toBe(false)
+    }
+  })
+
+  it('treats a change output strictly above the threshold as spendable', () => {
+    expect(2_941n > ltcDust).toBe(true)
+    expect(2_940n > ltcDust).toBe(false) // exactly at the limit is not "> limit" -> absorbed to fee, safe
+  })
+
+  it('leaves the other UTXO chains unchanged (LTC-scoped fix)', () => {
+    expect(minUtxo[Chain.Bitcoin]).toBe(546n)
+    expect(minUtxo[Chain.Dogecoin]).toBe(1_000_000n)
+    // BCH/Dash/Zcash 1_000n is already >= their ~546 BTC-like dust (conservative, not dangerous) — left as-is.
+    expect(minUtxo[Chain.BitcoinCash]).toBe(1_000n)
+    expect(minUtxo[Chain.Dash]).toBe(1_000n)
+    expect(minUtxo[Chain.Zcash]).toBe(1_000n)
+  })
+})

--- a/packages/core/chain/chains/utxo/minUtxo.ts
+++ b/packages/core/chain/chains/utxo/minUtxo.ts
@@ -4,7 +4,13 @@ export const minUtxo: Record<UtxoBasedChain, bigint> = {
   [Chain.Cardano]: 1_400_000n,
   [Chain.Bitcoin]: 546n,
   [Chain.Dogecoin]: 1_000_000n,
-  [Chain.Litecoin]: 1_000n,
+  // UTXO-02 (audit r2): Litecoin's DUST_RELAY_TX_FEE is ~10x Bitcoin's, so its real standard dust threshold
+  // is ~2_940 litoshi for a P2WPKH output (the scriptType LTC uses), ~5_460 legacy P2PKH — NOT 1_000. At the
+  // old 1_000n, a change output of 1_001..2_939 litoshi was treated as spendable but is non-standard dust, so
+  // the tx could be rejected by relays / get stuck. Use the P2WPKH standard (2_940). KEEP IN SYNC with the
+  // per-chain dustLimit map in packages/sdk/src/chains/utxo/tx.ts (UTXO_SPECS). BCH/Dash/Zcash stay at 1_000n
+  // — that's already at/above their real ~546 dust (BTC-like relay fee), so it's conservative, not dangerous.
+  [Chain.Litecoin]: 2_940n,
   [Chain.BitcoinCash]: 1_000n,
   [Chain.Dash]: 1_000n,
   [Chain.Zcash]: 1_000n,

--- a/packages/sdk/src/chains/utxo/tx.dustLimit.test.ts
+++ b/packages/sdk/src/chains/utxo/tx.dustLimit.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { getUtxoChainSpec } from './tx'
+
+// UTXO-02 (audit r2): the sdk keeps its OWN per-chain dustLimit map (UTXO_SPECS) separate from core's
+// minUtxo. Both must carry the corrected Litecoin P2WPKH dust — the shared standard 2_940n litoshi (LTC's
+// DUST_RELAY_TX_FEE is ~10x BTC's), not the old 1_000n. This asserts the sdk map; the identical 2_940n
+// literal is pinned on core's side by packages/core/chain/chains/utxo/minUtxo.test.ts, so the two can't
+// silently drift below the standard. (A cross-package import here would resolve the BUILT core-chain, not
+// the source, so each package asserts the shared constant independently.)
+describe('getUtxoChainSpec — Litecoin dust threshold (UTXO-02)', () => {
+  const LTC_P2WPKH_DUST = 2_940n // shared standard; keep === minUtxo[Chain.Litecoin] in core
+
+  it('uses the P2WPKH standard 2_940n, not the old dangerous 1_000n', () => {
+    expect(getUtxoChainSpec('Litecoin').dustLimit).toBe(LTC_P2WPKH_DUST)
+    expect(getUtxoChainSpec('Litecoin').dustLimit).toBeGreaterThan(1_000n)
+  })
+
+  it('treats a 1_001..2_939 change output as DUST (change > dustLimit is false)', () => {
+    const { dustLimit } = getUtxoChainSpec('Litecoin')
+    for (const change of [1_001n, 2_000n, 2_939n]) expect(change > dustLimit).toBe(false)
+    expect(2_941n > dustLimit).toBe(true)
+  })
+
+  it('leaves Bitcoin unchanged', () => {
+    expect(getUtxoChainSpec('Bitcoin').dustLimit).toBe(546n)
+  })
+})

--- a/packages/sdk/src/chains/utxo/tx.ts
+++ b/packages/sdk/src/chains/utxo/tx.ts
@@ -55,7 +55,10 @@ type UtxoChainSpec = {
 
 const UTXO_SPECS: Record<UtxoChainName, UtxoChainSpec> = {
   Bitcoin: { scriptType: 'p2wpkh', dustLimit: 546n, slip44: 0, bipPurpose: 84 },
-  Litecoin: { scriptType: 'p2wpkh', dustLimit: 1_000n, slip44: 2, bipPurpose: 84 },
+  // UTXO-02 (audit r2): LTC's DUST_RELAY_TX_FEE is ~10x BTC's -> real P2WPKH dust ~2_940 litoshi, not 1_000.
+  // At 1_000 a 1_001..2_939 change output is non-standard dust that can stall the tx. KEEP IN SYNC with
+  // packages/core/chain/chains/utxo/minUtxo.ts (minUtxo[Chain.Litecoin]).
+  Litecoin: { scriptType: 'p2wpkh', dustLimit: 2_940n, slip44: 2, bipPurpose: 84 },
   Dogecoin: { scriptType: 'p2pkh', dustLimit: 1_000_000n, slip44: 3, bipPurpose: 44 },
   'Bitcoin-Cash': { scriptType: 'p2pkh', dustLimit: 1_000n, slip44: 145, bipPurpose: 44 },
   Dash: { scriptType: 'p2pkh', dustLimit: 1_000n, slip44: 5, bipPurpose: 44 },


### PR DESCRIPTION
closes #1054

## tl;dr
Litecoin's `DUST_RELAY_TX_FEE` is ~10x Bitcoin's, so LTC's real standard dust threshold is **~2_940 litoshi** for a P2WPKH output — not the hardcoded `1_000n`. At `1_000n`, a change output of **1_001..2_939 litoshi** was treated as spendable but is **non-standard dust** → the tx can be rejected by relays or stall.

## Fix
Bump LTC `1_000n → 2_940n` in **both** dust maps (kept in sync via comments):
- `packages/core/chain/chains/utxo/minUtxo.ts` — core send / keysign paths
- `packages/sdk/src/chains/utxo/tx.ts` `UTXO_SPECS` — sdk tx builder (`change > dustLimit`)

LTC-scoped per the finding: BCH/Dash/Zcash `1_000n` already sits at/above their real ~546 (BTC-like relay fee) dust → conservative, not dangerous → left as-is.

## Runtime (SDK-CLI vitest, 7/7 pass)
Dust-boundary tests pin `2_940n` on both maps and assert a 1_001..2_939 change output is now **DUST** (`change > dustLimit` is false) while `>2_940` stays spendable; Bitcoin/Dogecoin/etc unchanged.

Note for reviewer: please sanity-check the **10x multiplier** (→ 2_940 P2WPKH / ~5_460 legacy). I used the P2WPKH standard since LTC's spec is p2wpkh; if LTC's dust relay fee is actually higher (some sources cite up to 100x historically), a more conservative bump only absorbs marginally more tiny change to fee (never a stuck tx), so err higher if unsure.

Changeset: `.changeset/ltc-dust-threshold-utxo02.md` (`@vultisig/sdk` patch). Audit finding **UTXO-02** (round 2). Codex degraded → manual review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)