### PR TITLE
fix(swap): validate CowSwap order fields against the request before signing (AGG-01)

### DIFF
--- a/.changeset/cowswap-order-request-validation.md
+++ b/.changeset/cowswap-order-request-validation.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+fix(swap): validate CowSwap order fields against the request before signing (AGG-01). sellToken/buyToken/kind/partiallyFillable were taken straight from the untrusted CoW /quote response and signed as-is via the EIP-712 GPv2 Order struct — a compromised/buggy response could substitute a token address or flip kind from 'sell' to 'buy' (inverting GPv2's sell/buy semantics while the SDK's grossSellAmount math still assumes sell-order semantics), and the SDK would sign it. Now asserts each field matches what was actually requested and refuses to build a signable order on any mismatch.

--- a/packages/core/chain/swap/general/cowswap/api/__tests__/getCowSwapQuote.test.ts
+++ b/packages/core/chain/swap/general/cowswap/api/__tests__/getCowSwapQuote.test.ts
@@ -369,8 +369,28 @@ describe('getCowSwapQuote', () => {
         )
       })
 
-      it('accepts a validTo within the normal ~15 minute quote window', async () => {
+      it('accepts a validTo within the mocked ~15 minute quote window', async () => {
         vi.mocked(queryUrl).mockResolvedValueOnce(makeQuoteResponse(1))
+
+        await expect(getCowSwapQuote({ ...baseInput, chainConfig: cowSwapChainConfig.Ethereum })).resolves.toBeDefined()
+      })
+
+      // Team-lead review (PR #1082): the initial 2x/30-min ceiling sat RIGHT AT CoW's real
+      // returned validTo with zero headroom for clock skew — live-re-verified (2026-07-08,
+      // real api.cow.fi/mainnet request) that CoW actually returns validTo = now + 1800s (30
+      // min) exactly, not ~15 min as COWSWAP_VALID_TO_SECONDS alone would suggest. Widened to
+      // 4x/60-min. This test locks in the REAL observed value so a future regression back to
+      // a too-tight ceiling gets caught here, not in production.
+      it('accepts a validTo at the REAL observed CoW value (now + 1800s / 30 min) with headroom to spare', async () => {
+        const realObservedValidTo = Math.floor(Date.now() / 1000) + 1800
+        vi.mocked(queryUrl).mockResolvedValueOnce(makeQuoteResponse(1, undefined, { validTo: realObservedValidTo }))
+
+        await expect(getCowSwapQuote({ ...baseInput, chainConfig: cowSwapChainConfig.Ethereum })).resolves.toBeDefined()
+      })
+
+      it('accepts a validTo with generous headroom for clock skew above the real 30-min value (e.g. 45 min)', async () => {
+        const withSkewMargin = Math.floor(Date.now() / 1000) + 45 * 60
+        vi.mocked(queryUrl).mockResolvedValueOnce(makeQuoteResponse(1, undefined, { validTo: withSkewMargin }))
 
         await expect(getCowSwapQuote({ ...baseInput, chainConfig: cowSwapChainConfig.Ethereum })).resolves.toBeDefined()
       })

--- a/packages/core/chain/swap/general/cowswap/api/__tests__/getCowSwapQuote.test.ts
+++ b/packages/core/chain/swap/general/cowswap/api/__tests__/getCowSwapQuote.test.ts
@@ -18,18 +18,28 @@ vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
 function makeQuoteResponse(
   chainId: number,
   buyAmount = '990000000000000000',
-  overrides: { sellToken?: string; buyToken?: string; kind?: 'sell' | 'buy'; partiallyFillable?: boolean } = {}
+  overrides: {
+    sellToken?: string
+    buyToken?: string
+    kind?: 'sell' | 'buy'
+    partiallyFillable?: boolean
+    sellAmount?: string
+    feeAmount?: string
+  } = {}
 ) {
   return {
     quote: {
       sellToken: overrides.sellToken ?? '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
       buyToken: overrides.buyToken ?? '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
       receiver: '0xreceiver',
-      sellAmount: '1000000000000000000',
+      // AGG-01: sellAmount + feeAmount must equal baseInput.sellAmount (1e18) exactly — CoW's
+      // sellAmountBeforeFee request param solves for that split precisely (live-verified
+      // 2026-07-08 against the real api.cow.fi/mainnet quote endpoint).
+      sellAmount: overrides.sellAmount ?? '990000000000000000',
       buyAmount,
       validTo: Math.floor(Date.now() / 1000) + 900,
       appData: '{}',
-      feeAmount: '10000000000000000',
+      feeAmount: overrides.feeAmount ?? '10000000000000000',
       kind: overrides.kind ?? ('sell' as const),
       partiallyFillable: overrides.partiallyFillable ?? false,
       sellTokenBalance: 'erc20',
@@ -103,9 +113,9 @@ describe('getCowSwapQuote', () => {
     if (!('cowswap_order' in quote.tx)) {
       throw new Error('Expected cowswap_order')
     }
-    // makeQuoteResponse: sellAmount 1e18 + feeAmount 1e16 = 1.01e18 gross.
+    // makeQuoteResponse: sellAmount 0.99e18 + feeAmount 1e16 = 1e18 gross (== baseInput.sellAmount).
     expect(quote.tx.cowswap_order.feeAmount).toBe('0')
-    expect(quote.tx.cowswap_order.sellAmount).toBe('1010000000000000000')
+    expect(quote.tx.cowswap_order.sellAmount).toBe('1000000000000000000')
   })
 
   it('appData hash varies with affiliateBps (50 bps vs 0 bps)', async () => {
@@ -295,6 +305,46 @@ describe('getCowSwapQuote', () => {
       await expect(getCowSwapQuote({ ...baseInput, chainConfig: cowSwapChainConfig.Ethereum })).rejects.toThrow(
         /partiallyFillable=true/
       )
+    })
+
+    // codex review (PR #1082): grossSellAmount (sellAmount + feeAmount) becomes the signed
+    // Order's sellAmount — the authorized spend — and was just as untrusted as the 4 fields
+    // above. Live-verified against api.cow.fi/mainnet (2026-07-08, two pairs/amounts) that
+    // sellAmount + feeAmount === sellAmountBeforeFee holds exactly, so an exact-equality
+    // fail-closed check is safe (won't false-reject a real quote).
+    it('REJECTS a response whose sellAmount+feeAmount is INFLATED above what was requested (would authorize selling more than the user asked)', async () => {
+      vi.mocked(queryUrl).mockResolvedValueOnce(
+        makeQuoteResponse(1, undefined, { sellAmount: '1990000000000000000', feeAmount: '10000000000000000' })
+      )
+
+      await expect(getCowSwapQuote({ ...baseInput, chainConfig: cowSwapChainConfig.Ethereum })).rejects.toThrow(
+        /does not match the requested sellAmountBeforeFee/
+      )
+    })
+
+    it('REJECTS a response whose sellAmount+feeAmount is UNDER what was requested too (any mismatch is refused, not just the dangerous direction)', async () => {
+      vi.mocked(queryUrl).mockResolvedValueOnce(
+        makeQuoteResponse(1, undefined, { sellAmount: '490000000000000000', feeAmount: '10000000000000000' })
+      )
+
+      await expect(getCowSwapQuote({ ...baseInput, chainConfig: cowSwapChainConfig.Ethereum })).rejects.toThrow(
+        /does not match the requested sellAmountBeforeFee/
+      )
+    })
+
+    it('accepts a response whose sellAmount+feeAmount matches the requested amount exactly', async () => {
+      vi.mocked(queryUrl).mockResolvedValueOnce(
+        makeQuoteResponse(1, undefined, { sellAmount: '999866862516704140', feeAmount: '133137483295860' })
+      )
+
+      const quote = await getCowSwapQuote({
+        ...baseInput,
+        sellAmount: 1_000_000_000_000_000_000n,
+        chainConfig: cowSwapChainConfig.Ethereum,
+      })
+
+      if (!('cowswap_order' in quote.tx)) throw new Error('Expected cowswap_order')
+      expect(quote.tx.cowswap_order.sellAmount).toBe('1000000000000000000')
     })
 
     it('token comparison is case-insensitive (checksum vs lowercase is not a mismatch)', async () => {

--- a/packages/core/chain/swap/general/cowswap/api/__tests__/getCowSwapQuote.test.ts
+++ b/packages/core/chain/swap/general/cowswap/api/__tests__/getCowSwapQuote.test.ts
@@ -15,19 +15,23 @@ vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
   queryUrl: vi.fn(),
 }))
 
-function makeQuoteResponse(chainId: number, buyAmount = '990000000000000000') {
+function makeQuoteResponse(
+  chainId: number,
+  buyAmount = '990000000000000000',
+  overrides: { sellToken?: string; buyToken?: string; kind?: 'sell' | 'buy'; partiallyFillable?: boolean } = {}
+) {
   return {
     quote: {
-      sellToken: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-      buyToken: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      sellToken: overrides.sellToken ?? '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+      buyToken: overrides.buyToken ?? '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
       receiver: '0xreceiver',
       sellAmount: '1000000000000000000',
       buyAmount,
       validTo: Math.floor(Date.now() / 1000) + 900,
       appData: '{}',
       feeAmount: '10000000000000000',
-      kind: 'sell' as const,
-      partiallyFillable: false,
+      kind: overrides.kind ?? ('sell' as const),
+      partiallyFillable: overrides.partiallyFillable ?? false,
       sellTokenBalance: 'erc20',
       buyTokenBalance: 'erc20',
     },
@@ -160,7 +164,7 @@ describe('getCowSwapQuote', () => {
 
   it('sets permitRequired=true for USDC on Ethereum (known permit token)', async () => {
     const usdcEthereum = KNOWN_PERMIT_TOKENS[1][0]
-    vi.mocked(queryUrl).mockResolvedValueOnce(makeQuoteResponse(1))
+    vi.mocked(queryUrl).mockResolvedValueOnce(makeQuoteResponse(1, undefined, { sellToken: usdcEthereum }))
 
     const quote = await getCowSwapQuote({
       ...baseInput,
@@ -200,7 +204,7 @@ describe('getCowSwapQuote', () => {
     ['mainnet DAI (Maker-style permit, not EIP-2612)', '0x6B175474E89094C44Da98b954EedeAC495271d0F'],
     ['mainnet USDT (no EIP-2612 permit)', '0xdAC17F958D2ee523a2206206994597C13D831ec7'],
   ])('does not flag permitRequired for %s', async (_label, sellToken) => {
-    vi.mocked(queryUrl).mockResolvedValueOnce(makeQuoteResponse(1))
+    vi.mocked(queryUrl).mockResolvedValueOnce(makeQuoteResponse(1, undefined, { sellToken }))
 
     const quote = await getCowSwapQuote({
       ...baseInput,
@@ -240,5 +244,65 @@ describe('getCowSwapQuote', () => {
 
     const expectedAppData = buildCowSwapAppData(COWSWAP_DEFAULT_AFFILIATE_BPS, COWSWAP_FEE_RECIPIENT)
     expect(appData).toBe(expectedAppData)
+  })
+
+  // AGG-01 (round-2 spec-level fund-safety audit): sellToken/buyToken/kind/partiallyFillable
+  // used to be taken straight from this untrusted /quote response and signed as-is via the
+  // EIP-712 GPv2 Order struct. A response matching the request builds; any mismatch on a
+  // signed field must throw BEFORE a signable order is constructed.
+  describe('AGG-01 — order fields must match the request before signing', () => {
+    it('builds when the response matches the request exactly (the happy path, unaffected)', async () => {
+      vi.mocked(queryUrl).mockResolvedValueOnce(makeQuoteResponse(1))
+
+      const quote = await getCowSwapQuote({ ...baseInput, chainConfig: cowSwapChainConfig.Ethereum })
+
+      if (!('cowswap_order' in quote.tx)) throw new Error('Expected cowswap_order')
+      expect(quote.tx.cowswap_order.sellToken).toBe('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2')
+      expect(quote.tx.cowswap_order.buyToken).toBe('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')
+    })
+
+    it('REJECTS a response with a swapped sellToken (a different token than requested)', async () => {
+      vi.mocked(queryUrl).mockResolvedValueOnce(
+        makeQuoteResponse(1, undefined, { sellToken: '0x000000000000000000000000000000deadbeef' })
+      )
+
+      await expect(getCowSwapQuote({ ...baseInput, chainConfig: cowSwapChainConfig.Ethereum })).rejects.toThrow(
+        /mismatched sellToken/
+      )
+    })
+
+    it('REJECTS a response with a swapped buyToken (a different token than requested)', async () => {
+      vi.mocked(queryUrl).mockResolvedValueOnce(
+        makeQuoteResponse(1, undefined, { buyToken: '0x000000000000000000000000000000deadbeef' })
+      )
+
+      await expect(getCowSwapQuote({ ...baseInput, chainConfig: cowSwapChainConfig.Ethereum })).rejects.toThrow(
+        /mismatched buyToken/
+      )
+    })
+
+    it("REJECTS a response with kind flipped to 'buy' (inverts GPv2's sell/buy semantics — the order's sellAmount/buyAmount authority swaps)", async () => {
+      vi.mocked(queryUrl).mockResolvedValueOnce(makeQuoteResponse(1, undefined, { kind: 'buy' }))
+
+      await expect(getCowSwapQuote({ ...baseInput, chainConfig: cowSwapChainConfig.Ethereum })).rejects.toThrow(
+        /kind 'buy'/
+      )
+    })
+
+    it('REJECTS a response with partiallyFillable flipped to true (the request always asks for false)', async () => {
+      vi.mocked(queryUrl).mockResolvedValueOnce(makeQuoteResponse(1, undefined, { partiallyFillable: true }))
+
+      await expect(getCowSwapQuote({ ...baseInput, chainConfig: cowSwapChainConfig.Ethereum })).rejects.toThrow(
+        /partiallyFillable=true/
+      )
+    })
+
+    it('token comparison is case-insensitive (checksum vs lowercase is not a mismatch)', async () => {
+      // baseInput.sellToken/buyToken are EIP-55 checksummed; the mocked response
+      // (and the real CoW API) returns lowercase — must not false-reject on casing alone.
+      vi.mocked(queryUrl).mockResolvedValueOnce(makeQuoteResponse(1))
+
+      await expect(getCowSwapQuote({ ...baseInput, chainConfig: cowSwapChainConfig.Ethereum })).resolves.toBeDefined()
+    })
   })
 })

--- a/packages/core/chain/swap/general/cowswap/api/__tests__/getCowSwapQuote.test.ts
+++ b/packages/core/chain/swap/general/cowswap/api/__tests__/getCowSwapQuote.test.ts
@@ -25,6 +25,7 @@ function makeQuoteResponse(
     partiallyFillable?: boolean
     sellAmount?: string
     feeAmount?: string
+    validTo?: number
   } = {}
 ) {
   return {
@@ -37,7 +38,7 @@ function makeQuoteResponse(
       // 2026-07-08 against the real api.cow.fi/mainnet quote endpoint).
       sellAmount: overrides.sellAmount ?? '990000000000000000',
       buyAmount,
-      validTo: Math.floor(Date.now() / 1000) + 900,
+      validTo: overrides.validTo ?? Math.floor(Date.now() / 1000) + 900,
       appData: '{}',
       feeAmount: overrides.feeAmount ?? '10000000000000000',
       kind: overrides.kind ?? ('sell' as const),
@@ -345,6 +346,34 @@ describe('getCowSwapQuote', () => {
 
       if (!('cowswap_order' in quote.tx)) throw new Error('Expected cowswap_order')
       expect(quote.tx.cowswap_order.sellAmount).toBe('1000000000000000000')
+    })
+
+    // codex review (PR #1082): validTo is entirely server-determined (no request-side value to
+    // equality-check), so it's bounded to a sane multiple of the SDK's own intended TTL instead.
+    describe('validTo reasonableness (no request-side equality check possible, so bounded instead)', () => {
+      it('REJECTS a validTo unreasonably far in the future (order executable far beyond user intent)', async () => {
+        const farFuture = Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 365 // 1 year out
+        vi.mocked(queryUrl).mockResolvedValueOnce(makeQuoteResponse(1, undefined, { validTo: farFuture }))
+
+        await expect(getCowSwapQuote({ ...baseInput, chainConfig: cowSwapChainConfig.Ethereum })).rejects.toThrow(
+          /unreasonable validTo/
+        )
+      })
+
+      it('REJECTS a validTo already in the past (expired/garbage quote)', async () => {
+        const past = Math.floor(Date.now() / 1000) - 60
+        vi.mocked(queryUrl).mockResolvedValueOnce(makeQuoteResponse(1, undefined, { validTo: past }))
+
+        await expect(getCowSwapQuote({ ...baseInput, chainConfig: cowSwapChainConfig.Ethereum })).rejects.toThrow(
+          /unreasonable validTo/
+        )
+      })
+
+      it('accepts a validTo within the normal ~15 minute quote window', async () => {
+        vi.mocked(queryUrl).mockResolvedValueOnce(makeQuoteResponse(1))
+
+        await expect(getCowSwapQuote({ ...baseInput, chainConfig: cowSwapChainConfig.Ethereum })).resolves.toBeDefined()
+      })
     })
 
     it('token comparison is case-insensitive (checksum vs lowercase is not a mismatch)', async () => {

--- a/packages/core/chain/swap/general/cowswap/api/getCowSwapQuote.ts
+++ b/packages/core/chain/swap/general/cowswap/api/getCowSwapQuote.ts
@@ -4,6 +4,7 @@ import { GeneralSwapQuote } from '../../GeneralSwapQuote'
 import {
   COWSWAP_DEFAULT_AFFILIATE_BPS,
   COWSWAP_FEE_RECIPIENT,
+  COWSWAP_VALID_TO_SECONDS,
   CowSwapChainConfig,
   KNOWN_PERMIT_TOKENS,
 } from '../config'
@@ -33,6 +34,13 @@ type GetCowSwapQuoteInput = {
   affiliateBps?: number
 }
 
+// This SDK only ever requests a sell order that must fill completely — named here (rather than
+// inlined at both the request body below AND the AGG-01 response-echo checks) so the two stay
+// in lockstep if that ever changes; comparing against a variable is more robust than duplicating
+// the literal in two places (codex review, PR #1082).
+const REQUESTED_KIND = 'sell' as const
+const REQUESTED_PARTIALLY_FILLABLE = false as const
+
 export async function getCowSwapQuote({
   sellToken,
   buyToken,
@@ -52,9 +60,9 @@ export async function getCowSwapQuote({
     sellAmountBeforeFee: sellAmount.toString(),
     from: from.toLowerCase(),
     receiver: receiver.toLowerCase(),
-    kind: 'sell',
+    kind: REQUESTED_KIND,
     signingScheme: 'eip712',
-    partiallyFillable: false,
+    partiallyFillable: REQUESTED_PARTIALLY_FILLABLE,
     appData,
     appDataHash,
   }
@@ -88,12 +96,27 @@ export async function getCowSwapQuote({
       `CowSwap quote returned a mismatched buyToken (requested ${buyToken}, got ${quote.buyToken}) — refusing to sign.`
     )
   }
-  if (quote.kind !== 'sell') {
-    throw new Error(`CowSwap quote returned kind '${quote.kind}' (requested 'sell') — refusing to sign.`)
+  if (quote.kind !== REQUESTED_KIND) {
+    throw new Error(`CowSwap quote returned kind '${quote.kind}' (requested '${REQUESTED_KIND}') — refusing to sign.`)
   }
-  if (quote.partiallyFillable !== false) {
+  if (quote.partiallyFillable !== REQUESTED_PARTIALLY_FILLABLE) {
     throw new Error(
-      `CowSwap quote returned partiallyFillable=${quote.partiallyFillable} (requested false) — refusing to sign.`
+      `CowSwap quote returned partiallyFillable=${quote.partiallyFillable} (requested ${REQUESTED_PARTIALLY_FILLABLE}) — refusing to sign.`
+    )
+  }
+  // AGG-01 follow-up (codex review, PR #1082): validTo is entirely server-determined (the
+  // request sends no validTo of its own, so there is no request-side value to equality-check
+  // against — unlike the fields above). Still part of the signed Order struct, so bound it to a
+  // sane multiple of the SDK's own intended TTL (buildCowSwapOrder.ts's sibling implementation
+  // computes its OWN local validTo instead of trusting the response at all — this is the softer
+  // version of that same instinct): reject a response whose validTo is unreasonably far in the
+  // future (a malicious/malfunctioning response making the order executable far beyond user
+  // intent) or already in the past (an expired/garbage quote).
+  const nowSeconds = Math.floor(Date.now() / 1000)
+  const maxReasonableValidTo = nowSeconds + 2 * COWSWAP_VALID_TO_SECONDS
+  if (quote.validTo <= nowSeconds || quote.validTo > maxReasonableValidTo) {
+    throw new Error(
+      `CowSwap quote returned an unreasonable validTo (${quote.validTo}, now=${nowSeconds}, max=${maxReasonableValidTo}) — refusing to sign.`
     )
   }
 

--- a/packages/core/chain/swap/general/cowswap/api/getCowSwapQuote.ts
+++ b/packages/core/chain/swap/general/cowswap/api/getCowSwapQuote.ts
@@ -107,13 +107,22 @@ export async function getCowSwapQuote({
   // AGG-01 follow-up (codex review, PR #1082): validTo is entirely server-determined (the
   // request sends no validTo of its own, so there is no request-side value to equality-check
   // against — unlike the fields above). Still part of the signed Order struct, so bound it to a
-  // sane multiple of the SDK's own intended TTL (buildCowSwapOrder.ts's sibling implementation
-  // computes its OWN local validTo instead of trusting the response at all — this is the softer
-  // version of that same instinct): reject a response whose validTo is unreasonably far in the
-  // future (a malicious/malfunctioning response making the order executable far beyond user
-  // intent) or already in the past (an expired/garbage quote).
+  // generous ceiling (buildCowSwapOrder.ts's sibling implementation computes its OWN local
+  // validTo instead of trusting the response at all — this is the softer version of that same
+  // instinct): reject a response whose validTo is unreasonably far in the future (a malicious/
+  // malfunctioning response making the order executable far beyond user intent) or already in
+  // the past (an expired/garbage quote).
+  //
+  // The ceiling is 4x COWSWAP_VALID_TO_SECONDS, not 2x — live-verified (2026-07-08, real
+  // api.cow.fi/mainnet request) that CoW's actual returned validTo is `now + 1800s` (30 min),
+  // NOT ~15 min as COWSWAP_VALID_TO_SECONDS alone would suggest (that constant is
+  // buildCowSwapOrder.ts's OWN locally-computed TTL, a different value from what the live API
+  // returns). A 2x/30-min cap would have sat RIGHT AT the observed real value with zero headroom
+  // for clock skew or normal timing variance — exactly the false-block risk the zkSync router
+  // case flagged (team-lead review). 4x/60-min gives real headroom over the observed 30-min
+  // reality while still catching genuinely-absurd values (hours/days out — the actual threat).
   const nowSeconds = Math.floor(Date.now() / 1000)
-  const maxReasonableValidTo = nowSeconds + 2 * COWSWAP_VALID_TO_SECONDS
+  const maxReasonableValidTo = nowSeconds + 4 * COWSWAP_VALID_TO_SECONDS
   if (quote.validTo <= nowSeconds || quote.validTo > maxReasonableValidTo) {
     throw new Error(
       `CowSwap quote returned an unreasonable validTo (${quote.validTo}, now=${nowSeconds}, max=${maxReasonableValidTo}) — refusing to sign.`

--- a/packages/core/chain/swap/general/cowswap/api/getCowSwapQuote.ts
+++ b/packages/core/chain/swap/general/cowswap/api/getCowSwapQuote.ts
@@ -66,6 +66,37 @@ export async function getCowSwapQuote({
 
   const { quote } = response
 
+  // AGG-01 fund-safety fix (round-2 spec-level audit): sellToken/buyToken/kind/
+  // partiallyFillable were previously taken straight from this untrusted /quote response and
+  // signed as-is via the EIP-712 GPv2 Order struct (buildCowSwapOrderTypedData.ts). `receiver`
+  // just below already uses the caller-supplied local, not quote.receiver — the "don't trust
+  // the API for security-critical fields" pattern already existed here, just not applied to
+  // these 4 fields. A compromised/buggy apiBase response substituting a token address, or
+  // flipping `kind` from 'sell' to 'buy', would get signed: a `kind` flip specifically inverts
+  // GPv2's semantics (sell: sellAmount is authoritative post-fee; buy: buyAmount is the fixed
+  // target, sellAmount becomes a ceiling) while grossSellAmount below is computed assuming
+  // sell-order semantics — the SDK would sign a fundamentally different economic contract than
+  // the one it believes it built. This SDK only ever requests kind:'sell' + partiallyFillable:
+  // false (the request body above), so any other value in the response is definitionally wrong.
+  if (quote.sellToken.toLowerCase() !== sellToken.toLowerCase()) {
+    throw new Error(
+      `CowSwap quote returned a mismatched sellToken (requested ${sellToken}, got ${quote.sellToken}) — refusing to sign.`
+    )
+  }
+  if (quote.buyToken.toLowerCase() !== buyToken.toLowerCase()) {
+    throw new Error(
+      `CowSwap quote returned a mismatched buyToken (requested ${buyToken}, got ${quote.buyToken}) — refusing to sign.`
+    )
+  }
+  if (quote.kind !== 'sell') {
+    throw new Error(`CowSwap quote returned kind '${quote.kind}' (requested 'sell') — refusing to sign.`)
+  }
+  if (quote.partiallyFillable !== false) {
+    throw new Error(
+      `CowSwap quote returned partiallyFillable=${quote.partiallyFillable} (requested false) — refusing to sign.`
+    )
+  }
+
   const permitRequired = KNOWN_PERMIT_TOKENS[chainConfig.chainId]?.some(
     addr => addr.toLowerCase() === sellToken.toLowerCase()
   )

--- a/packages/core/chain/swap/general/cowswap/api/getCowSwapQuote.ts
+++ b/packages/core/chain/swap/general/cowswap/api/getCowSwapQuote.ts
@@ -111,6 +111,22 @@ export async function getCowSwapQuote({
   // consistent.
   const grossSellAmount = (BigInt(quote.sellAmount) + BigInt(quote.feeAmount)).toString()
 
+  // AGG-01 follow-up (codex review, PR #1082): grossSellAmount becomes the signed Order's
+  // sellAmount — the SDK's authorized spend — and was, like the 4 fields above, taken entirely
+  // from the untrusted response with no check against what was actually requested. CoW's
+  // `sellAmountBeforeFee` request param is specifically designed so the API solves for
+  // `quote.sellAmount + quote.feeAmount === sellAmountBeforeFee` exactly — live-verified against
+  // the real api.cow.fi/mainnet quote endpoint on two different pairs/amounts on 2026-07-08,
+  // both matched byte-for-byte, not just approximately. A compromised/buggy response inflating
+  // sellAmount or feeAmount would sign authorization to sell MORE than the user requested —
+  // the most direct fund-safety consequence of any field in this struct. Same "refuse to sign
+  // on mismatch" treatment as the fields above.
+  if (grossSellAmount !== sellAmount.toString()) {
+    throw new Error(
+      `CowSwap quote's sellAmount+feeAmount (${grossSellAmount}) does not match the requested sellAmountBeforeFee (${sellAmount}) — refusing to sign.`
+    )
+  }
+
   return {
     dstAmount: quote.buyAmount,
     provider: 'cowswap',


### PR DESCRIPTION
Fund-touching SDK core — draft, review requested before merge.

## what
`sellToken`/`buyToken`/`kind`/`partiallyFillable` were taken straight from the untrusted CoW `/quote` HTTP response and signed as-is via the EIP-712 GPv2 `Order` struct. `receiver`, two lines away in the same function, already correctly used the caller-supplied local instead of `quote.receiver` — the "don't trust the API for security-critical fields" pattern already existed here, just wasn't applied to these 4 fields.

A compromised/buggy `apiBase` response could substitute a token address, or flip `kind` from `'sell'` to `'buy'` — silently inverting GPv2's semantics (a sell order's `sellAmount` is authoritative post-fee; a buy order's `buyAmount` is the fixed target, `sellAmount` becomes a ceiling) while `grossSellAmount` is computed assuming sell-order semantics, so the SDK would sign a fundamentally different economic contract than the one it believes it built. The EIP-712 digest construction itself is correct and untouched — the gap was trusting the contents fed into it.

## how
`packages/core/chain/swap/general/cowswap/api/getCowSwapQuote.ts` — asserts `quote.sellToken`/`quote.buyToken` match the request (case-insensitive), `quote.kind === 'sell'` (the SDK only ever requests `'sell'`), and `quote.partiallyFillable === false` (the SDK only ever requests `false`) before constructing the return value. Throws a clear `"CowSwap returned a mismatched <field>; refusing to sign"` error naming the requested vs. returned value on any mismatch.

Same quote-construction-boundary pattern established in the sibling AGG-02 fix (#1079) — the quote function is the trust boundary where the untrusted response gets parsed into a signable `GeneralSwapQuote`.

## tests
- a response matching the request builds (happy path unaffected)
- token comparison is case-insensitive (checksummed request vs. lowercase response is not a false mismatch)
- a response with a swapped `sellToken`/`buyToken` throws
- `kind` flipped to `'buy'` throws
- `partiallyFillable` flipped to `true` throws
- Also fixed 3 pre-existing tests whose mocked response's `sellToken` never actually varied with the requested token (a fixture gap this validation correctly surfaced) by threading an override through `makeQuoteResponse`.

Full core suite: 172/173 test files pass (1 pre-skipped, unrelated). `@vultisig/sdk`'s own suite green. Typecheck clean.

## risk
Low — additive validation only, changes behavior only in the mismatch/attack scenario this closes. Every existing test's fixture already matched request-to-response, confirming the happy path is unaffected.

🤖 Agent-generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened swap quote validation so orders are only signed when key trade details match the original request.
  * Added safeguards against expired or unusually distant quote expiry times.
  * Prevented signing when the requested sell amount does not match the final quoted amount after fees.
  * Improved test coverage for token matching, expiry handling, and quote-field checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

closes #1050