### PR TITLE
fix(cosmos): refuse to sign a no-timeout ibc transfer + validate channel (COSMOS-01/03)

### DIFF
--- a/.changeset/cosmos-ibc-notimeout-channel.md
+++ b/.changeset/cosmos-ibc-notimeout-channel.md
@@ -1,0 +1,7 @@
+---
+'@vultisig/sdk': patch
+---
+
+fix(cosmos): refuse to sign a no-timeout IBC transfer and validate the source channel
+
+The Cosmos `IBC_TRANSFER` signing-input resolver built a `MsgTransfer` with an all-zero timeout (`timeoutTimestamp=0` and `timeoutHeight={0,0}`) whenever the IBC denom trace was missing. Relayers accept a no-timeout packet, but it never expires, so a failed transfer can leave funds stuck indefinitely instead of unwinding. The resolver now fails closed and refuses to build when neither timeout is usable (COSMOS-01). It also validates that the source channel parsed out of the memo (`<prefix>:channel-<n>[:...]`) is well-formed, refusing to sign with an undefined/empty/malformed channel instead of dispatching a broken `MsgTransfer` (COSMOS-03).

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ibcTransfer.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ibcTransfer.test.ts
@@ -1,0 +1,141 @@
+import { Buffer } from 'buffer'
+
+import { create } from '@bufbuild/protobuf'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { initWasm, type WalletCore } from '@trustwallet/wallet-core'
+import {
+  CosmosIbcDenomTraceSchema,
+  CosmosSpecificSchema,
+  TransactionType,
+} from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
+import { CoinSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/coin_pb'
+import { KeysignPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import { getCosmosSigningInputs } from './index'
+
+// COSMOS-01 / COSMOS-03: an ibc-enabled Cosmos chain's IBC_TRANSFER
+// resolver must refuse to build a no-timeout MsgTransfer (missing
+// ibcDenomTraces => timeoutTimestamp falls back to 0, and
+// timeoutHeight is always {0,0} here) and must refuse a malformed
+// sourceChannel parsed out of the memo.
+describe('getCosmosSigningInputs IBC transfer guards', () => {
+  let walletCore: WalletCore
+  let sender: string
+  let recipient: string
+  let publicKeyHex: string
+
+  beforeAll(async () => {
+    walletCore = await initWasm()
+
+    const privateKey = walletCore.PrivateKey.createWithData(new Uint8Array(32).fill(1))
+    const recipientPrivateKey = walletCore.PrivateKey.createWithData(new Uint8Array(32).fill(2))
+    const publicKey = privateKey.getPublicKeySecp256k1(false)
+    const recipientPublicKey = recipientPrivateKey.getPublicKeySecp256k1(false)
+
+    sender = walletCore.AnyAddress.createWithPublicKey(publicKey, walletCore.CoinType.cosmos).description()
+    recipient = walletCore.AnyAddress.createWithPublicKey(recipientPublicKey, walletCore.CoinType.cosmos).description()
+    publicKeyHex = Buffer.from(publicKey.data()).toString('hex')
+  })
+
+  const buildPayload = ({
+    memo,
+    ibcDenomTraces,
+  }: {
+    memo: string
+    ibcDenomTraces?: { path: string; baseDenom: string; latestBlock: string }
+  }) =>
+    create(KeysignPayloadSchema, {
+      coin: create(CoinSchema, {
+        chain: Chain.Cosmos,
+        ticker: 'ATOM',
+        address: sender,
+        contractAddress: '',
+        decimals: 6,
+        isNativeToken: true,
+        hexPublicKey: publicKeyHex,
+      }),
+      toAddress: recipient,
+      toAmount: '12345',
+      memo,
+      blockchainSpecific: {
+        case: 'cosmosSpecific',
+        value: create(CosmosSpecificSchema, {
+          accountNumber: 7n,
+          sequence: 3n,
+          gas: 2500n,
+          transactionType: TransactionType.IBC_TRANSFER,
+          ibcDenomTraces: ibcDenomTraces ? create(CosmosIbcDenomTraceSchema, ibcDenomTraces) : undefined,
+        }),
+      },
+    })
+
+  it('refuses to build a no-timeout MsgTransfer when ibcDenomTraces is missing (COSMOS-01)', () => {
+    expect(() =>
+      getCosmosSigningInputs({
+        keysignPayload: buildPayload({ memo: 'transfer:channel-141' }),
+        walletCore,
+      })
+    ).toThrow(/refusing to build a no-timeout MsgTransfer/)
+  })
+
+  it('refuses to build when ibcDenomTraces.latestBlock is present but empty (COSMOS-01)', () => {
+    expect(() =>
+      getCosmosSigningInputs({
+        keysignPayload: buildPayload({
+          memo: 'transfer:channel-141',
+          ibcDenomTraces: { path: 'transfer/channel-141', baseDenom: 'uatom', latestBlock: '' },
+        }),
+        walletCore,
+      })
+    ).toThrow(/refusing to build a no-timeout MsgTransfer/)
+  })
+
+  it('builds successfully with a non-zero timeout when the denom trace is present (regression guard)', async () => {
+    const [input] = await getCosmosSigningInputs({
+      keysignPayload: buildPayload({
+        memo: 'transfer:channel-141',
+        ibcDenomTraces: { path: 'transfer/channel-141', baseDenom: 'uatom', latestBlock: '12345_1751328000000000000' },
+      }),
+      walletCore,
+    })
+
+    const transfer = input.messages[0].transferTokensMessage
+    expect(transfer).toBeDefined()
+    expect(transfer!.sourceChannel).toBe('channel-141')
+    expect(transfer!.timeoutTimestamp.toString()).toBe('1751328000000000000')
+    expect(transfer!.timeoutTimestamp.isZero()).toBe(false)
+  })
+
+  it('refuses to build when the memo channel is malformed (COSMOS-03)', () => {
+    expect(() =>
+      getCosmosSigningInputs({
+        keysignPayload: buildPayload({
+          memo: 'transfer:not-a-channel',
+          ibcDenomTraces: {
+            path: 'transfer/channel-141',
+            baseDenom: 'uatom',
+            latestBlock: '12345_1751328000000000000',
+          },
+        }),
+        walletCore,
+      })
+    ).toThrow(/well-formed source channel/)
+  })
+
+  it('refuses to build when the memo has no channel segment at all (COSMOS-03)', () => {
+    expect(() =>
+      getCosmosSigningInputs({
+        keysignPayload: buildPayload({
+          memo: 'transfer',
+          ibcDenomTraces: {
+            path: 'transfer/channel-141',
+            baseDenom: 'uatom',
+            latestBlock: '12345_1751328000000000000',
+          },
+        }),
+        walletCore,
+      })
+    ).toThrow(/well-formed source channel/)
+  })
+})

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
@@ -85,7 +85,35 @@ export const getCosmosSigningInputs: SigningInputsResolver<'cosmos'> = ({ keysig
         const memo = shouldBePresent(keysignPayload.memo)
         const [, channel] = memo.split(':')
 
+        // COSMOS-03: sourceChannel is derived from an unvalidated memo
+        // split. An undefined/empty/malformed channel would sign a
+        // MsgTransfer that either fails on-chain or (worse) routes
+        // through an unintended channel. Fail closed.
+        if (!channel || !/^channel-\d+$/.test(channel)) {
+          throw new Error(
+            `Cosmos signing input: IBC transfer memo "${memo}" does not contain a well-formed source channel (expected "<prefix>:channel-<n>[:...]").`
+          )
+        }
+
         const timeoutTimestamp = Long.fromString(ibcDenomTraces?.latestBlock?.split('_')?.[1] || '0')
+        const timeoutHeight = {
+          revisionNumber: Long.fromString('0'),
+          revisionHeight: Long.fromString('0'),
+        }
+
+        // COSMOS-01: a missing ibcDenomTraces (or missing latestBlock)
+        // previously fell back to timeoutTimestamp=0, and timeoutHeight
+        // is always {0,0} here, so the packet ended up with NO expiry.
+        // Relayers accept a no-timeout MsgTransfer, but the destination
+        // side never gets a chance to unwind on failure, leaving funds
+        // stuck indefinitely. Mirror the app's guard
+        // (vultiagent-app/src/services/cosmosTx.ts) and refuse to build.
+        const heightDisabled = timeoutHeight.revisionNumber.isZero() && timeoutHeight.revisionHeight.isZero()
+        if (timeoutTimestamp.isZero() && heightDisabled) {
+          throw new Error(
+            'Cosmos signing input: IBC transfer has no usable timeout (missing ibcDenomTraces.latestBlock and no timeoutHeight set); refusing to build a no-timeout MsgTransfer (relayers accept it but the packet has no expiry, leaving funds stuck).'
+          )
+        }
 
         return {
           messages: [
@@ -96,10 +124,7 @@ export const getCosmosSigningInputs: SigningInputsResolver<'cosmos'> = ({ keysig
                 token: getCosmosCoinAmount(keysignPayload),
                 sender: coin.address,
                 receiver: toAddress,
-                timeoutHeight: {
-                  revisionNumber: Long.fromString('0'),
-                  revisionHeight: Long.fromString('0'),
-                },
+                timeoutHeight,
                 timeoutTimestamp,
               }),
             }),


### PR DESCRIPTION
closes #1052

## Finding

The Cosmos IBC-transfer signing-input resolver (`packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts`, `ibcEnabled` -> `IBC_TRANSFER` branch) built a `MsgTransfer` with an ALL-ZERO timeout whenever the IBC denom trace was missing:

- `timeoutTimestamp = Long.fromString(ibcDenomTraces?.latestBlock?.split('_')?.[1] || '0')` -> `0` with NO guard when the trace/latestBlock is absent.
- `timeoutHeight: { revisionNumber: 0, revisionHeight: 0 }` was hardcoded.

Net: trace missing -> `timeoutTimestamp=0` AND `timeoutHeight={0,0}` -> an all-zero-timeout `MsgTransfer` (no expiry). Relayers accept a no-timeout packet, but it never gets a chance to unwind on the destination side, leaving funds stuck indefinitely. The app already refuses to build exactly this case (`vultiagent-app/src/services/cosmosTx.ts:2383`, `buildSignBroadcastCosmosIbcTransfer`) -- the SDK resolver had no equivalent guard.

Also flagged (COSMOS-03, folded into this PR): `sourceChannel` was taken from an unvalidated `memo.split(':')` (`const [, channel] = memo.split(':')`), so an undefined/empty/malformed channel would sign a `MsgTransfer` with a bogus `sourceChannel`.

## Fix

- **COSMOS-01**: fail closed (throw) before building when both `timeoutTimestamp` is zero/empty AND `timeoutHeight` is `{0,0}` -- mirrors the app's exact refusal message ("... refusing to build a no-timeout MsgTransfer (relayers accept it but the packet has no expiry, leaving funds stuck)").
- **COSMOS-03**: validate `channel` against `/^channel-\d+$/` before building; reject empty/undefined/malformed channels instead of signing with a bad `sourceChannel`.

The legit path (trace present + valid `channel-N` in memo) is unaffected -- verified with a regression test.

## Runtime verification (SDK-CLI vitest)

New colocated test: `packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ibcTransfer.test.ts`

```
 RUN  v4.1.8 vultisig-sdk

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

Covers:
- missing `ibcDenomTraces` -> throws (no-timeout refused)
- `ibcDenomTraces.latestBlock` present but empty -> throws
- valid trace + valid `channel-141` in memo -> builds successfully with non-zero `timeoutTimestamp` (regression guard for the legit path)
- malformed channel (`not-a-channel`) in memo -> throws
- no channel segment in memo at all -> throws

Existing `cosmos.test.ts` (gas-limit regression suite) still green (3/3), no regression:

```
 Test Files  2 passed (2)
      Tests  8 passed (8)
```

`tsc --project .config/tsconfig.json --noEmit` clean. `eslint` on the touched files clean. Changeset added (`@vultisig/sdk` patch).

🤖 Agent-generated