### PR TITLE
fix(swap): validate cowswap quote response against the request before signing (AGG-01)

### DIFF
--- a/.changeset/cowswap-quote-response-validation-agg01.md
+++ b/.changeset/cowswap-quote-response-validation-agg01.md
@@ -1,0 +1,7 @@
+---
+'@vultisig/sdk': patch
+---
+
+fix(swap): validate the CowSwap quote response against the request before signing (AGG-01)
+
+The CowSwap order is EIP-712-signed and POSTed with `sellToken`/`buyToken`/`kind`/`partiallyFillable` copied straight from the `/quote` API response. A compromised, buggy, or MITM'd `apiBase` could substitute a token (funds swap into an attacker-chosen asset) or flip `kind` sell↔buy. `assertCowSwapQuoteMatchesRequest` now asserts the response echoes the requested values on those fund-critical fields and throws on any mismatch before the order is built. `receiver` is unaffected — the order already uses the caller's own receiver, not the response's.

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -1492,6 +1492,11 @@
       "import": "./dist/swap/general/cowswap/api/submitCowSwapOrder.js",
       "default": "./dist/swap/general/cowswap/api/submitCowSwapOrder.js"
     },
+    "./swap/general/cowswap/api/validateCowSwapQuoteResponse": {
+      "types": "./dist/swap/general/cowswap/api/validateCowSwapQuoteResponse.d.ts",
+      "import": "./dist/swap/general/cowswap/api/validateCowSwapQuoteResponse.js",
+      "default": "./dist/swap/general/cowswap/api/validateCowSwapQuoteResponse.js"
+    },
     "./swap/general/cowswap/config": {
       "types": "./dist/swap/general/cowswap/config.d.ts",
       "import": "./dist/swap/general/cowswap/config.js",

--- a/packages/core/chain/swap/general/cowswap/api/__tests__/getCowSwapQuote.test.ts
+++ b/packages/core/chain/swap/general/cowswap/api/__tests__/getCowSwapQuote.test.ts
@@ -15,11 +15,19 @@ vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
   queryUrl: vi.fn(),
 }))
 
-function makeQuoteResponse(chainId: number, buyAmount = '990000000000000000') {
+// AGG-01: the CoW /quote API echoes the requested sellToken/buyToken; getCowSwapQuote now asserts that
+// before signing. Mock the same — default to WETH->USDC, but let a test that requests a different sellToken
+// (the permit-token cases) have the mock echo it, so the fixture reflects real API behaviour.
+function makeQuoteResponse(
+  chainId: number,
+  buyAmount = '990000000000000000',
+  sellToken = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+  buyToken = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+) {
   return {
     quote: {
-      sellToken: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-      buyToken: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      sellToken,
+      buyToken,
       receiver: '0xreceiver',
       sellAmount: '1000000000000000000',
       buyAmount,
@@ -160,7 +168,7 @@ describe('getCowSwapQuote', () => {
 
   it('sets permitRequired=true for USDC on Ethereum (known permit token)', async () => {
     const usdcEthereum = KNOWN_PERMIT_TOKENS[1][0]
-    vi.mocked(queryUrl).mockResolvedValueOnce(makeQuoteResponse(1))
+    vi.mocked(queryUrl).mockResolvedValueOnce(makeQuoteResponse(1, undefined, usdcEthereum))
 
     const quote = await getCowSwapQuote({
       ...baseInput,
@@ -200,7 +208,7 @@ describe('getCowSwapQuote', () => {
     ['mainnet DAI (Maker-style permit, not EIP-2612)', '0x6B175474E89094C44Da98b954EedeAC495271d0F'],
     ['mainnet USDT (no EIP-2612 permit)', '0xdAC17F958D2ee523a2206206994597C13D831ec7'],
   ])('does not flag permitRequired for %s', async (_label, sellToken) => {
-    vi.mocked(queryUrl).mockResolvedValueOnce(makeQuoteResponse(1))
+    vi.mocked(queryUrl).mockResolvedValueOnce(makeQuoteResponse(1, undefined, sellToken))
 
     const quote = await getCowSwapQuote({
       ...baseInput,

--- a/packages/core/chain/swap/general/cowswap/api/getCowSwapQuote.ts
+++ b/packages/core/chain/swap/general/cowswap/api/getCowSwapQuote.ts
@@ -9,6 +9,7 @@ import {
 } from '../config'
 import { buildCowSwapAppData, keccak256Hex } from '../sign/buildCowSwapOrder'
 import { CowSwapQuoteApiResponse } from '../types'
+import { assertCowSwapQuoteMatchesRequest } from './validateCowSwapQuoteResponse'
 
 type CowSwapQuoteRequest = {
   sellToken: string
@@ -65,6 +66,15 @@ export async function getCowSwapQuote({
   })
 
   const { quote } = response
+
+  // AGG-01: validate the response against the request (using the exact values we POSTed in `body`) before the
+  // order is signed/submitted. sellToken/buyToken come from the caller; kind/partiallyFillable from `body`.
+  assertCowSwapQuoteMatchesRequest(quote, {
+    sellToken,
+    buyToken,
+    kind: body.kind,
+    partiallyFillable: body.partiallyFillable,
+  })
 
   const permitRequired = KNOWN_PERMIT_TOKENS[chainConfig.chainId]?.some(
     addr => addr.toLowerCase() === sellToken.toLowerCase()

--- a/packages/core/chain/swap/general/cowswap/api/validateCowSwapQuoteResponse.test.ts
+++ b/packages/core/chain/swap/general/cowswap/api/validateCowSwapQuoteResponse.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import { assertCowSwapQuoteMatchesRequest } from './validateCowSwapQuoteResponse'
+
+// AGG-01 (audit r2): the CowSwap order copies sellToken/buyToken/kind/partiallyFillable from the /quote
+// response into an EIP-712-signed + POSTed order. A compromised apiBase could substitute a token or flip
+// kind. This guard asserts the response matches the request on those fund-critical fields before signing.
+describe('assertCowSwapQuoteMatchesRequest (AGG-01)', () => {
+  const req = {
+    sellToken: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH (mixed case on purpose)
+    buyToken: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', // USDC
+    kind: 'sell' as const,
+    partiallyFillable: false,
+  }
+  const matchingQuote = {
+    sellToken: req.sellToken.toLowerCase(),
+    buyToken: req.buyToken.toLowerCase(),
+    kind: 'sell' as const,
+    partiallyFillable: false,
+  }
+
+  it('passes when the response echoes the request (case-insensitive on addresses)', () => {
+    expect(() => assertCowSwapQuoteMatchesRequest(matchingQuote, req)).not.toThrow()
+  })
+
+  it('THROWS when the API substitutes the buyToken (funds redirected to an attacker asset)', () => {
+    expect(() =>
+      assertCowSwapQuoteMatchesRequest(
+        { ...matchingQuote, buyToken: '0x1111111111111111111111111111111111111111' },
+        req
+      )
+    ).toThrow(/buyToken .* != requested/)
+  })
+
+  it('THROWS when the API substitutes the sellToken', () => {
+    expect(() =>
+      assertCowSwapQuoteMatchesRequest(
+        { ...matchingQuote, sellToken: '0x2222222222222222222222222222222222222222' },
+        req
+      )
+    ).toThrow(/sellToken .* != requested/)
+  })
+
+  it('THROWS when the API flips kind sell -> buy', () => {
+    expect(() => assertCowSwapQuoteMatchesRequest({ ...matchingQuote, kind: 'buy' }, req)).toThrow(
+      /kind buy != requested sell/
+    )
+  })
+
+  it('THROWS when the API flips partiallyFillable', () => {
+    expect(() => assertCowSwapQuoteMatchesRequest({ ...matchingQuote, partiallyFillable: true }, req)).toThrow(
+      /partiallyFillable true != requested false/
+    )
+  })
+
+  it('reports ALL mismatched fields in one throw', () => {
+    expect(() =>
+      assertCowSwapQuoteMatchesRequest(
+        {
+          sellToken: '0x2222222222222222222222222222222222222222',
+          buyToken: '0x1111111111111111111111111111111111111111',
+          kind: 'buy',
+          partiallyFillable: true,
+        },
+        req
+      )
+    ).toThrow(/sellToken.*buyToken.*kind.*partiallyFillable/s)
+  })
+})

--- a/packages/core/chain/swap/general/cowswap/api/validateCowSwapQuoteResponse.ts
+++ b/packages/core/chain/swap/general/cowswap/api/validateCowSwapQuoteResponse.ts
@@ -1,0 +1,26 @@
+import type { CowSwapOrderKind, CowSwapQuoteObject } from '../types'
+
+// AGG-01 (audit r2): the CowSwap order is EIP-712-signed AND POSTed with sellToken/buyToken/kind/
+// partiallyFillable copied straight from the /quote RESPONSE. A compromised, buggy, or MITM'd apiBase could
+// substitute a token (funds swap into an attacker-chosen asset) or flip kind sell<->buy (wrong amount
+// semantics). Assert the response echoes what we REQUESTED on those fund-critical fields before anything is
+// signed; fail closed (throw) on any mismatch. `receiver` is excluded — the order already uses the caller's
+// own receiver, not the response's, so a substituted receiver can't reach the signed order. Kept in a
+// config-free module (types-only import) so it's unit-testable without the chain graph.
+export function assertCowSwapQuoteMatchesRequest(
+  quote: Pick<CowSwapQuoteObject, 'sellToken' | 'buyToken' | 'kind' | 'partiallyFillable'>,
+  req: { sellToken: string; buyToken: string; kind: CowSwapOrderKind; partiallyFillable: boolean }
+): void {
+  const mismatches: string[] = []
+  if (quote.sellToken.toLowerCase() !== req.sellToken.toLowerCase())
+    mismatches.push(`sellToken ${quote.sellToken} != requested ${req.sellToken}`)
+  if (quote.buyToken.toLowerCase() !== req.buyToken.toLowerCase())
+    mismatches.push(`buyToken ${quote.buyToken} != requested ${req.buyToken}`)
+  if (quote.kind !== req.kind) mismatches.push(`kind ${quote.kind} != requested ${req.kind}`)
+  if (quote.partiallyFillable !== req.partiallyFillable)
+    mismatches.push(`partiallyFillable ${quote.partiallyFillable} != requested ${req.partiallyFillable}`)
+  if (mismatches.length > 0)
+    throw new Error(
+      `CowSwap quote response does not match the request on fund-critical fields (compromised/buggy apiBase?): ${mismatches.join('; ')}`
+    )
+}


### PR DESCRIPTION
closes #1050

## tl;dr
The CowSwap order is **EIP-712-signed AND POSTed** with `sellToken`/`buyToken`/`kind`/`partiallyFillable` copied straight from the `/quote` API response (`getCowSwapQuote.ts`). A compromised, buggy, or MITM'd `apiBase` could **substitute a token** (funds swap into an attacker-chosen asset) or **flip `kind` sell↔buy** — the signed order carries the tampered values.

## Fix
`assertCowSwapQuoteMatchesRequest(quote, req)` asserts the response echoes the **requested** `sellToken`/`buyToken`/`kind`/`partiallyFillable` (the exact values POSTed in `body`) and **throws before the order is built**. `receiver` is excluded — the order already uses the caller's own receiver, not the response's, so a substituted receiver can't reach the signed order. Extracted to a config-free module (types-only import) so it's unit-testable in isolation.

## Runtime (SDK-CLI vitest, 6/6 pass)
Matching response passes (case-insensitive on addresses); substituted `sellToken`/`buyToken`, flipped `kind`, and flipped `partiallyFillable` each **throw**; a multi-field mismatch reports all. `tsc --noEmit` clean.

Changeset: `.changeset/cowswap-quote-response-validation-agg01.md` (`@vultisig/sdk` patch). Audit finding **AGG-01** (round 2). Codex degraded → manual review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)