### PR TITLE
feat(sdk): notify registered devices when a keysign QR is ready

### DIFF
--- a/packages/sdk/src/vault/SecureVault.ts
+++ b/packages/sdk/src/vault/SecureVault.ts
@@ -8,6 +8,7 @@ import { decryptVaultBackupWithPassword } from '@vultisig/lib-utils/encryption/v
 import { fromBase64 } from '@vultisig/lib-utils/fromBase64'
 
 import type { SdkContext, VaultContext } from '../context/SdkContext'
+import { computeNotificationVaultId } from '../utils/computeNotificationVaultId'
 import { RelaySigningService } from '../services/RelaySigningService'
 import { SecureVaultCreationService, type SecureVaultCreationStep } from '../services/SecureVaultCreationService'
 import type {
@@ -121,6 +122,10 @@ export class SecureVault extends VaultBase {
           action: 'keysign',
           sessionId: '',
         })
+        // ponytail: push the keysign QR to the vault's registered devices so
+        // co-signers get a native notification instead of having to watch for
+        // the QR. Best-effort — never blocks/fails the sign.
+        void this.notifyDevices(qrPayload)
         if (options.onQRCodeReady) {
           options.onQRCodeReady(qrPayload)
         }
@@ -137,6 +142,33 @@ export class SecureVault extends VaultBase {
     this.emit('transactionSigned', { signature, payload })
 
     return signature
+  }
+
+  /**
+   * ponytail: notify the vault's registered devices (mobile/laptop) that a
+   * keysign QR is ready, so a co-signer gets a native push instead of manually
+   * watching for the QR. The keysign path (RelaySigningService) never called
+   * this; it only generated the QR + polled the relay. Best-effort: swallows
+   * errors and no-ops when no push service / keys / registered devices.
+   * vault_id MUST be computeNotificationVaultId (SHA256(utf8(ecdsa+chainCode))),
+   * NOT the raw pubkey — that mismatch was why pushes never landed.
+   */
+  private async notifyDevices(qrPayload: string): Promise<void> {
+    try {
+      const push = this.context.pushNotificationService
+      const ecdsa = this.coreVault.publicKeys?.ecdsa
+      const chainCode = this.coreVault.hexChainCode
+      if (!push || !ecdsa || !chainCode) return
+      const vaultId = await computeNotificationVaultId(ecdsa, chainCode)
+      await push.notifyVaultMembers({
+        vaultId,
+        vaultName: this.coreVault.name,
+        localPartyId: this.coreVault.localPartyId,
+        qrCodeData: qrPayload,
+      })
+    } catch {
+      // push is a convenience layer — never let it break signing
+    }
   }
 
   /**
@@ -198,6 +230,8 @@ export class SecureVault extends VaultBase {
               action: 'keysign',
               sessionId: '',
             })
+            // ponytail: push the keysign QR to registered devices (see notifyDevices).
+            void this.notifyDevices(qrPayload)
             if (signingOptions.onQRCodeReady) {
               signingOptions.onQRCodeReady(qrPayload)
             }


### PR DESCRIPTION
## Problem

A secure-vault keysign generates the QR and then just polls the relay (`waitForDevices`). The co-signing device gets no signal — a person has to be actively watching to scan the QR within the relay window. In practice this is a frequent cause of `Timeout waiting for devices. Got 1/2 devices.`

The SDK already ships `PushNotificationService.notifyVaultMembers` (→ `POST /notification/notify`), and devices already register with that server (a phone and laptop on the same vault already push each other on keysign). It was simply never called from the signing path.

## Change

Call `notifyVaultMembers` from **both** `SecureVault` sign paths the moment the QR is ready, so the vault's registered devices get a native push (APNs/FCM/WebPush) prompting them to co-sign.

- **Best-effort**: wrapped in `try/catch`, never blocks or fails the sign, and no-ops when there is no push service or no registered devices.
- **`vault_id`** uses `computeNotificationVaultId` = `SHA256(utf8(ecdsaHex + hexChainCode))`, matching how devices register — **not** the raw ecdsa pubkey. (Passing the raw pubkey is why ad-hoc attempts silently never landed.)
- The QR is still emitted as before via `onQRCodeReady`; nothing changes for existing consumers.

## Testing

Verified live against `api.vultisig.com/notification`: `GET /notification/vault/<computed-id>` returns `200` for a registered vault, and a secure-vault send now pushes to the paired device — the co-sign completed in ~2s (device tapped the notification) versus the usual manual-scan wait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Signing QR codes can now be sent to registered devices as a best-effort notification, helping users receive signing prompts more quickly across their vault devices.
  * This behavior applies to both message signing and byte signing flows.

* **Bug Fixes**
  * Notification delivery issues will no longer interrupt signing. If push delivery is unavailable or fails, signing continues normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->