### PR TITLE
fix(coin): findByTicker throws on cross-chain ambiguity, not a silent first-match (SDK2-02)

### DIFF
--- a/.changeset/findbyticker-ambiguity-guard.md
+++ b/.changeset/findbyticker-ambiguity-guard.md
@@ -1,0 +1,7 @@
+---
+'@vultisig/sdk': patch
+---
+
+fix(coin): findByTicker throws on cross-chain ambiguity instead of a silent first-match (SDK2-02)
+
+`findByTicker` resolved a bare ticker via `coins.find(c => c.ticker === ticker)` — array-order first match, no chain scoping. A symbol like "USDC" exists on many chains, so if this (currently-unreferenced public) helper were wired into a fund path it would silently resolve to whichever chain was first, sending to the wrong network. It now returns the unique match (or null when absent) and throws when the ticker is ambiguous across more than one chain, forcing the caller to disambiguate.

--- a/packages/core/chain/coin/utils/findByTicker.test.ts
+++ b/packages/core/chain/coin/utils/findByTicker.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { Chain } from '../../Chain'
+import type { Coin } from '../Coin'
+import { findByTicker } from './findByTicker'
+
+const coin = (chain: Chain, ticker: string): Coin => ({ chain, ticker }) as Coin
+
+describe('findByTicker (SDK2-02 — no silent cross-chain first-match)', () => {
+  it('returns the unique match when the ticker is on a single chain', () => {
+    const coins = [coin(Chain.Ethereum, 'ETH'), coin(Chain.Ethereum, 'USDC')]
+    expect(findByTicker({ coins, ticker: 'USDC' })?.chain).toBe(Chain.Ethereum)
+  })
+
+  it('returns null when the ticker is absent', () => {
+    expect(findByTicker({ coins: [coin(Chain.Ethereum, 'ETH')], ticker: 'USDC' })).toBeNull()
+  })
+
+  it('THROWS on a ticker ambiguous across chains instead of silently picking the array-first one', () => {
+    const coins = [coin(Chain.Ethereum, 'USDC'), coin(Chain.Polygon, 'USDC'), coin(Chain.Base, 'USDC')]
+    expect(() => findByTicker({ coins, ticker: 'USDC' })).toThrow(/ambiguous across 3 chains/)
+  })
+})

--- a/packages/core/chain/coin/utils/findByTicker.ts
+++ b/packages/core/chain/coin/utils/findByTicker.ts
@@ -5,5 +5,19 @@ type FindByTickerInput<T extends Coin> = {
   ticker: string
 }
 
-export const findByTicker = <T extends Coin>({ coins, ticker }: FindByTickerInput<T>): T | null =>
-  coins.find(c => c.ticker === ticker) ?? null
+// SDK2-02 (audit r2): a bare ticker like "USDC" exists on many chains (Ethereum/Polygon/Arbitrum/Base/…).
+// The old `coins.find(c => c.ticker === ticker)` returned the ARRAY-ORDER first match — if this ever got
+// wired into a fund path, "USDC" would silently resolve to whichever chain happened to be first, sending to
+// the wrong network. Refuse to guess: return the unique match (or null when absent), and THROW when the
+// ticker is ambiguous across more than one chain so the caller must disambiguate by chain.
+export const findByTicker = <T extends Coin>({ coins, ticker }: FindByTickerInput<T>): T | null => {
+  const matches = coins.filter(c => c.ticker === ticker)
+  if (matches.length === 0) return null
+  const chains = new Set(matches.map(c => c.chain))
+  if (chains.size > 1) {
+    throw new Error(
+      `findByTicker: ticker "${ticker}" is ambiguous across ${chains.size} chains (${[...chains].join(', ')}); pass a chain-scoped lookup instead of a bare ticker`
+    )
+  }
+  return matches[0] ?? null
+}


### PR DESCRIPTION
Part of #1066 (audit SDK2-02; SDK2-03 + BE-05 tracked separately — do NOT auto-close).

## tl;dr
`findByTicker` resolved a bare ticker via `coins.find(c => c.ticker === ticker)` — **array-order first match, no chain scoping**. `USDC` exists on many chains, so if this (currently-unreferenced, but *published*) helper were wired into a fund path it would silently resolve to whichever chain was first → send to the wrong network.

## Fix
Return the **unique** match (or `null` when absent); **throw** when the ticker is ambiguous across >1 chain, forcing the caller to disambiguate. Kept as a **patch** (signature unchanged, non-breaking) rather than deleting a published export.

## Runtime (vitest, 3/3)
single-chain ticker → returns it; absent → null; cross-chain ambiguous (`USDC` on Eth/Polygon/Base) → **throws**.

Changeset: `@vultisig/sdk` patch. Low-risk (the export has zero in-repo callers today) — this is preventive hardening before it's wired into a fund path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)