### PR TITLE
Read XRP issued currency balances

### DIFF
--- a/.changeset/xrp-account-lines-balances.md
+++ b/.changeset/xrp-account-lines-balances.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Surface XRP issued-currency trust-line balances and reserve-aware spendable XRP.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -599,6 +599,7 @@ export type {
   VaultIdentity,
   Verdict,
   XrpBalance,
+  XrpIssuedCurrencyBalance,
   YieldActionResponse,
   YieldArgs,
   YieldBalance,

--- a/packages/sdk/src/tools/balance/index.ts
+++ b/packages/sdk/src/tools/balance/index.ts
@@ -7,7 +7,7 @@
  */
 
 // XRP
-export type { XrpBalance } from './otherBalance'
+export type { XrpBalance, XrpIssuedCurrencyBalance } from './otherBalance'
 export { getXrpBalance } from './otherBalance'
 
 // TRON

--- a/packages/sdk/src/tools/balance/otherBalance.ts
+++ b/packages/sdk/src/tools/balance/otherBalance.ts
@@ -7,6 +7,7 @@
  * Each chain is not wired through the EVM `getEvmClient` rail, so these talk to
  * public RPC / API endpoints (and the Vultisig proxy) directly via `fetchJson`.
  */
+import { rippleIssuedCurrencyDecimals, rippleTokenId } from '@vultisig/core-chain/chains/ripple/issuedCurrency'
 import bs58check from 'bs58check'
 
 import { fetchJson, formatBalance, ROOT_API_URL } from './rpc'
@@ -81,8 +82,31 @@ export type XrpBalance = {
   // account) — keep it a string and parse with BigInt.
   balanceDrops: string
   balanceXrp: string
+  spendableDrops: string
+  spendableXrp: string
+  ownerCount: number
+  minimumReserveDrops: string
+  minimumReserveXrp: string
+  reserveIncrementDrops: string
+  reserveIncrementXrp: string
+  trustLineCount: number
+  issuedCurrencyBalances: XrpIssuedCurrencyBalance[]
   note?: string
   asOf: string
+}
+
+export type XrpIssuedCurrencyBalance = {
+  issuer: string
+  currency: string
+  tokenId: string
+  balance: string
+  limit: string
+  limitPeer: string
+  decimals: number
+  noRipple: boolean
+  noRipplePeer: boolean
+  authorized: boolean
+  peerAuthorized: boolean
 }
 
 // 1 XRP = 1e6 drops. Format via BigInt so a >2^53-drop balance never rounds.
@@ -92,10 +116,102 @@ function formatXrp(drops: bigint): string {
   return `${whole}.${frac.toString().padStart(6, '0')}`
 }
 
+type XrplAccountLine = {
+  account: string
+  balance: string
+  currency: string
+  limit: string
+  limit_peer: string
+  no_ripple?: boolean
+  no_ripple_peer?: boolean
+  authorized?: boolean
+  peer_authorized?: boolean
+}
+
+function hasPositiveIssuedCurrencyBalance(balance: string): boolean {
+  const unsigned = balance.trim().replace(/^\+/, '')
+  if (unsigned.startsWith('-')) return false
+  if (!/^\d+(\.\d+)?$/.test(unsigned)) return false
+
+  return unsigned
+    .replace('.', '')
+    .split('')
+    .some(char => char !== '0')
+}
+
+async function getXrpAccountLines(address: string): Promise<XrplAccountLine[]> {
+  const lines: XrplAccountLine[] = []
+  let marker: unknown
+
+  do {
+    const response = await fetchJson<{
+      result: {
+        lines?: XrplAccountLine[]
+        marker?: unknown
+        error?: string
+        error_message?: string
+      }
+    }>('https://xrplcluster.com', {
+      method: 'account_lines',
+      params: [
+        {
+          account: address,
+          ledger_index: 'current',
+          limit: 400,
+          ...(marker === undefined ? {} : { marker }),
+        },
+      ],
+    })
+
+    if (response.result?.error) {
+      const msg = response.result.error_message ?? response.result.error
+      throw new Error(`XRPL account_lines error (${response.result.error}): ${msg}`)
+    }
+
+    lines.push(...(response.result?.lines ?? []))
+    marker = response.result?.marker
+  } while (marker !== undefined)
+
+  return lines
+}
+
+async function getXrpReserveInfo(): Promise<{
+  reserveBase: bigint
+  reserveInc: bigint
+}> {
+  const response = await fetchJson<{
+    result: {
+      state?: {
+        validated_ledger?: {
+          reserve_base?: number | string
+          reserve_inc?: number | string
+        }
+      }
+      error?: string
+      error_message?: string
+    }
+  }>('https://xrplcluster.com', { method: 'server_state' })
+
+  if (response.result?.error) {
+    const msg = response.result.error_message ?? response.result.error
+    throw new Error(`XRPL server_state error (${response.result.error}): ${msg}`)
+  }
+
+  const reserve = response.result?.state?.validated_ledger
+  if (reserve?.reserve_base == null || reserve.reserve_inc == null) {
+    throw new Error('XRPL server_state returned no validated_ledger reserve data.')
+  }
+
+  return {
+    reserveBase: BigInt(reserve.reserve_base),
+    reserveInc: BigInt(reserve.reserve_inc),
+  }
+}
+
 /**
  * Query the native XRP balance of an XRP Ledger address.
  *
- * Only `actNotFound` (valid-shape but unfunded — 10 XRP reserve requirement)
+ * Only `actNotFound` (valid-shape but unfunded account)
  * resolves to a zero balance. Other XRPL error types (actMalformed, actBadSeed,
  * invalidParams) mean the caller passed something broken and are surfaced as
  * errors, so a mistyped address never reads as "you have 0 XRP".
@@ -103,7 +219,11 @@ function formatXrp(drops: bigint): string {
 export async function getXrpBalance(address: string): Promise<XrpBalance> {
   if (!address) throw new Error('No XRP address provided.')
   const response = await fetchJson<{
-    result: { account_data?: { Balance?: string }; error?: string; error_message?: string }
+    result: {
+      account_data?: { Balance?: string; OwnerCount?: number }
+      error?: string
+      error_message?: string
+    }
   }>('https://xrplcluster.com', {
     method: 'account_info',
     params: [{ account: address, ledger_index: 'current' }],
@@ -114,7 +234,16 @@ export async function getXrpBalance(address: string): Promise<XrpBalance> {
       address,
       balanceDrops: '0',
       balanceXrp: '0.000000',
-      note: 'Account not found on XRP Ledger. It may be unfunded (requires 10 XRP minimum reserve).',
+      spendableDrops: '0',
+      spendableXrp: '0.000000',
+      ownerCount: 0,
+      minimumReserveDrops: '0',
+      minimumReserveXrp: '0.000000',
+      reserveIncrementDrops: '0',
+      reserveIncrementXrp: '0.000000',
+      trustLineCount: 0,
+      issuedCurrencyBalances: [],
+      note: 'Account not found on XRP Ledger. It may be unfunded.',
       asOf: new Date().toISOString(),
     }
   }
@@ -137,10 +266,39 @@ export async function getXrpBalance(address: string): Promise<XrpBalance> {
   } catch {
     throw new Error(`XRPL returned a non-integer Balance ("${rawDrops}") — malformed upstream response.`)
   }
+
+  const ownerCount = response.result.account_data.OwnerCount ?? 0
+  const accountLines = await getXrpAccountLines(address)
+  const reserveInfo = await getXrpReserveInfo()
+  const minimumReserveDrops = reserveInfo.reserveBase + BigInt(ownerCount) * reserveInfo.reserveInc
+  const spendableDrops = drops > minimumReserveDrops ? drops - minimumReserveDrops : 0n
+  const positiveIssuedCurrencyLines = accountLines.filter(line => hasPositiveIssuedCurrencyBalance(line.balance))
+
   return {
     address,
     balanceDrops: drops.toString(),
     balanceXrp: formatXrp(drops),
+    spendableDrops: spendableDrops.toString(),
+    spendableXrp: formatXrp(spendableDrops),
+    ownerCount,
+    minimumReserveDrops: minimumReserveDrops.toString(),
+    minimumReserveXrp: formatXrp(minimumReserveDrops),
+    reserveIncrementDrops: reserveInfo.reserveInc.toString(),
+    reserveIncrementXrp: formatXrp(reserveInfo.reserveInc),
+    trustLineCount: accountLines.length,
+    issuedCurrencyBalances: positiveIssuedCurrencyLines.map(line => ({
+      issuer: line.account,
+      currency: line.currency,
+      tokenId: rippleTokenId({ currency: line.currency, issuer: line.account }),
+      balance: line.balance,
+      limit: line.limit,
+      limitPeer: line.limit_peer,
+      decimals: rippleIssuedCurrencyDecimals,
+      noRipple: line.no_ripple ?? false,
+      noRipplePeer: line.no_ripple_peer ?? false,
+      authorized: line.authorized ?? false,
+      peerAuthorized: line.peer_authorized ?? false,
+    })),
     asOf: new Date().toISOString(),
   }
 }
@@ -190,7 +348,10 @@ export async function getTronAccountResources(address: string): Promise<TronAcco
     EnergyLimit?: number
     NetUsed?: number
     NetLimit?: number
-  }>('https://tron-rpc.publicnode.com/wallet/getaccountresource', { address, visible: true })
+  }>('https://tron-rpc.publicnode.com/wallet/getaccountresource', {
+    address,
+    visible: true,
+  })
 
   return {
     address,
@@ -295,7 +456,10 @@ export type TonBalance = {
  */
 export async function getTonBalance(address: string): Promise<TonBalance> {
   const extResp = await fetchJson<{
-    result: { balance?: string; account_state?: { seqno?: number; '@type'?: string } }
+    result: {
+      balance?: string
+      account_state?: { seqno?: number; '@type'?: string }
+    }
   }>(`${ROOT_API_URL}/ton/v2/getExtendedAddressInformation?address=${encodeURIComponent(address)}`)
 
   const nanotons = extResp.result?.balance ?? '0'
@@ -400,8 +564,20 @@ export async function getSuiTokenBalance(address: string, coinType: string): Pro
 }
 
 export type SuiAllBalancesResult =
-  | { ok: true; address: string; chain: 'Sui'; balances: SuiCoinBalance[]; asOf: string }
-  | { ok: false; error: 'tokens_unavailable'; chain: 'Sui'; address: string; detail: string }
+  | {
+      ok: true
+      address: string
+      chain: 'Sui'
+      balances: SuiCoinBalance[]
+      asOf: string
+    }
+  | {
+      ok: false
+      error: 'tokens_unavailable'
+      chain: 'Sui'
+      address: string
+      detail: string
+    }
 
 export type SuiCoinBalance = {
   coinType: string
@@ -426,7 +602,11 @@ const SUI_NATIVE_TYPES = new Set([
  */
 export async function getSuiAllBalances(address: string): Promise<SuiAllBalancesResult> {
   let response: {
-    result?: Array<{ coinType: string; totalBalance: string; coinObjectCount: number }>
+    result?: Array<{
+      coinType: string
+      totalBalance: string
+      coinObjectCount: number
+    }>
     error?: { code?: number; message?: string }
   }
   try {
@@ -497,7 +677,13 @@ export async function getSuiAllBalances(address: string): Promise<SuiAllBalances
     })
   }
 
-  return { ok: true, address, chain: 'Sui', balances, asOf: new Date().toISOString() }
+  return {
+    ok: true,
+    address,
+    chain: 'Sui',
+    balances,
+    asOf: new Date().toISOString(),
+  }
 }
 
 // ── Cardano ─────────────────────────────────────────────────────────────────
@@ -528,10 +714,16 @@ export async function getCardanoBalance(address: string): Promise<CardanoBalance
     fetchJson<{ address: string; balance: string }[]>(`${ROOT_API_URL}/cardano/address_info`, {
       _addresses: [address],
     }),
-    fetchJson<{ address: string; asset_list: { policy_id: string; asset_name: string; quantity: string }[] }[]>(
-      `${ROOT_API_URL}/cardano/address_assets`,
-      { _addresses: [address] }
-    ),
+    fetchJson<
+      {
+        address: string
+        asset_list: {
+          policy_id: string
+          asset_name: string
+          quantity: string
+        }[]
+      }[]
+    >(`${ROOT_API_URL}/cardano/address_assets`, { _addresses: [address] }),
   ])
 
   const lovelaceStr = infoRes[0]?.balance ?? '0'

--- a/packages/sdk/src/tools/index.ts
+++ b/packages/sdk/src/tools/index.ts
@@ -92,6 +92,7 @@ export type {
   TronAccountResources,
   TrxBalance,
   XrpBalance,
+  XrpIssuedCurrencyBalance,
 } from './balance'
 export {
   assertBittensorAddress,

--- a/packages/sdk/tests/unit/tools/balance/otherBalance.test.ts
+++ b/packages/sdk/tests/unit/tools/balance/otherBalance.test.ts
@@ -58,13 +58,31 @@ describe('decodeBittensorAddress (fund-safety)', () => {
 describe('getXrpBalance', () => {
   beforeEach(() => mockFetchJson.mockReset())
 
+  const mockXrpReserveInfo = () =>
+    mockFetchJson.mockResolvedValueOnce({
+      result: {
+        state: {
+          validated_ledger: { reserve_base: 1_000_000, reserve_inc: 200_000 },
+        },
+      },
+    })
+
+  const mockXrpAccountLines = (lines: unknown[] = []) =>
+    mockFetchJson.mockResolvedValueOnce({
+      result: { lines },
+    })
+
   it('parses funded balance from drops', async () => {
     mockFetchJson.mockResolvedValueOnce({
-      result: { account_data: { Balance: '25000000' } },
+      result: { account_data: { Balance: '25000000', OwnerCount: 0 } },
     })
+    mockXrpAccountLines()
+    mockXrpReserveInfo()
     const r = await getXrpBalance('rXYZ')
     expect(r.balanceDrops).toBe('25000000')
     expect(r.balanceXrp).toBe('25.000000')
+    expect(r.spendableDrops).toBe('24000000')
+    expect(r.minimumReserveDrops).toBe('1000000')
   })
 
   it('keeps full precision for a >2^53-drop balance (no Number() rounding)', async () => {
@@ -72,8 +90,10 @@ describe('getXrpBalance', () => {
     // A Number() round-trip would corrupt this to ...3460 — assert it does not.
     const raw = '90000000000123456'
     mockFetchJson.mockResolvedValueOnce({
-      result: { account_data: { Balance: raw } },
+      result: { account_data: { Balance: raw, OwnerCount: 0 } },
     })
+    mockXrpAccountLines()
+    mockXrpReserveInfo()
     const r = await getXrpBalance('rXYZ')
     expect(r.balanceDrops).toBe(raw)
     expect(r.balanceXrp).toBe('90000000000.123456')
@@ -83,7 +103,7 @@ describe('getXrpBalance', () => {
 
   it('rejects a non-integer Balance instead of silently NaN-ing', async () => {
     mockFetchJson.mockResolvedValueOnce({
-      result: { account_data: { Balance: 'not-a-number' } },
+      result: { account_data: { Balance: 'not-a-number', OwnerCount: 0 } },
     })
     await expect(getXrpBalance('rXYZ')).rejects.toThrow(/non-integer Balance/)
   })
@@ -93,6 +113,7 @@ describe('getXrpBalance', () => {
     const r = await getXrpBalance('rXYZ')
     expect(r.balanceDrops).toBe('0')
     expect(r.balanceXrp).toBe('0.000000')
+    expect(r.issuedCurrencyBalances).toEqual([])
     expect(r.note).toMatch(/unfunded/i)
   })
 
@@ -101,6 +122,143 @@ describe('getXrpBalance', () => {
       result: { error: 'actMalformed', error_message: 'Account malformed.' },
     })
     await expect(getXrpBalance('garbage')).rejects.toThrow(/actMalformed/)
+  })
+
+  it('reads issued-currency trust lines and includes owner reserve in spendable XRP', async () => {
+    mockFetchJson.mockResolvedValueOnce({
+      result: { account_data: { Balance: '2500000', OwnerCount: 3 } },
+    })
+    mockXrpAccountLines([
+      {
+        account: 'rIssuer',
+        balance: '12.5',
+        currency: 'USD',
+        limit: '100',
+        limit_peer: '0',
+        no_ripple: true,
+        no_ripple_peer: false,
+        authorized: true,
+        peer_authorized: false,
+      },
+    ])
+    mockXrpReserveInfo()
+
+    const r = await getXrpBalance('rXYZ')
+
+    expect(r.ownerCount).toBe(3)
+    expect(r.minimumReserveDrops).toBe('1600000')
+    expect(r.spendableDrops).toBe('900000')
+    expect(r.trustLineCount).toBe(1)
+    expect(r.reserveIncrementDrops).toBe('200000')
+    expect(r.issuedCurrencyBalances).toEqual([
+      {
+        issuer: 'rIssuer',
+        currency: 'USD',
+        tokenId: 'USD.rIssuer',
+        balance: '12.5',
+        limit: '100',
+        limitPeer: '0',
+        decimals: 15,
+        noRipple: true,
+        noRipplePeer: false,
+        authorized: true,
+        peerAuthorized: false,
+      },
+    ])
+  })
+
+  it('paginates account_lines so large trust-line sets are not truncated', async () => {
+    mockFetchJson
+      .mockResolvedValueOnce({
+        result: { account_data: { Balance: '2000000', OwnerCount: 2 } },
+      })
+      .mockResolvedValueOnce({
+        result: {
+          lines: [
+            {
+              account: 'rIssuer1',
+              balance: '1',
+              currency: 'USD',
+              limit: '10',
+              limit_peer: '0',
+            },
+          ],
+          marker: 'next-page',
+        },
+      })
+      .mockResolvedValueOnce({
+        result: {
+          lines: [
+            {
+              account: 'rIssuer2',
+              balance: '2',
+              currency: 'EUR',
+              limit: '20',
+              limit_peer: '0',
+            },
+          ],
+        },
+      })
+    mockXrpReserveInfo()
+
+    const r = await getXrpBalance('rXYZ')
+
+    expect(r.trustLineCount).toBe(2)
+    expect(r.reserveIncrementDrops).toBe('200000')
+    expect(r.issuedCurrencyBalances.map(({ tokenId }) => tokenId)).toEqual(['USD.rIssuer1', 'EUR.rIssuer2'])
+    expect(mockFetchJson).toHaveBeenCalledWith('https://xrplcluster.com', {
+      method: 'account_lines',
+      params: [
+        {
+          account: 'rXYZ',
+          ledger_index: 'current',
+          limit: 400,
+          marker: 'next-page',
+        },
+      ],
+    })
+  })
+
+  it('does not expose negative trust-line balances as held issued currencies', async () => {
+    mockFetchJson.mockResolvedValueOnce({
+      result: { account_data: { Balance: '2500000', OwnerCount: 1 } },
+    })
+    mockXrpAccountLines([
+      {
+        account: 'rPeer',
+        balance: '-42',
+        currency: 'USD',
+        limit: '0',
+        limit_peer: '100',
+      },
+      {
+        account: 'rIssuer',
+        balance: '0.000001',
+        currency: 'EUR',
+        limit: '100',
+        limit_peer: '0',
+      },
+      {
+        account: 'rZero',
+        balance: '0',
+        currency: 'JPY',
+        limit: '100',
+        limit_peer: '0',
+      },
+    ])
+    mockXrpReserveInfo()
+
+    const r = await getXrpBalance('rXYZ')
+
+    expect(r.trustLineCount).toBe(3)
+    expect(r.issuedCurrencyBalances).toEqual([
+      expect.objectContaining({
+        issuer: 'rIssuer',
+        currency: 'EUR',
+        tokenId: 'EUR.rIssuer',
+        balance: '0.000001',
+      }),
+    ])
   })
 })
 
@@ -126,8 +284,12 @@ describe('getTrc20TokenBalance', () => {
   it('decodes balanceOf / decimals / symbol from hex constant_result', async () => {
     // balanceOf -> 1_000_000 (0xf4240), decimals -> 6, symbol -> "USDT"
     mockFetchJson
-      .mockResolvedValueOnce({ constant_result: ['00000000000000000000000000000000000000000000000000000000000f4240'] })
-      .mockResolvedValueOnce({ constant_result: ['0000000000000000000000000000000000000000000000000000000000000006'] })
+      .mockResolvedValueOnce({
+        constant_result: ['00000000000000000000000000000000000000000000000000000000000f4240'],
+      })
+      .mockResolvedValueOnce({
+        constant_result: ['0000000000000000000000000000000000000000000000000000000000000006'],
+      })
       .mockResolvedValueOnce({
         constant_result: [
           '0000000000000000000000000000000000000000000000000000000000000020' + // offset
@@ -145,7 +307,9 @@ describe('getTrc20TokenBalance', () => {
     let balanceParam: string | undefined
     mockFetchJson.mockImplementation(async (_url: string, body: { function_selector?: string; parameter?: string }) => {
       if (body?.function_selector === 'balanceOf(address)') balanceParam = body.parameter
-      return { constant_result: ['0000000000000000000000000000000000000000000000000000000000000000'] }
+      return {
+        constant_result: ['0000000000000000000000000000000000000000000000000000000000000000'],
+      }
     })
     await getTrc20TokenBalance(TRON_ADDR, TRON_ADDR)
     // Must be a clean 64-char hex word. The old `addr.replace(/^T/, '41')` path
@@ -158,7 +322,9 @@ describe('getTrc20TokenBalance', () => {
   it('fails closed (throws) when balanceOf returns no constant_result — never a false zero', async () => {
     mockFetchJson.mockImplementation(async (_url: string, body: { function_selector?: string }) => {
       if (body?.function_selector === 'balanceOf(address)') return { result: { code: 'OTHER_ERROR' } }
-      return { constant_result: ['0000000000000000000000000000000000000000000000000000000000000006'] }
+      return {
+        constant_result: ['0000000000000000000000000000000000000000000000000000000000000006'],
+      }
     })
     await expect(getTrc20TokenBalance(TRON_ADDR, TRON_ADDR)).rejects.toThrow(/no constant_result/i)
   })
@@ -169,7 +335,10 @@ describe('getTonBalance', () => {
 
   it('maps account_state and formats nanotons', async () => {
     mockFetchJson.mockResolvedValueOnce({
-      result: { balance: '2500000000', account_state: { seqno: 7, '@type': 'raw.accountState' } },
+      result: {
+        balance: '2500000000',
+        account_state: { seqno: 7, '@type': 'raw.accountState' },
+      },
     })
     const r = await getTonBalance('EQabc')
     expect(r.balance).toBe('2.5')
@@ -182,7 +351,9 @@ describe('getSuiBalance / getSuiAllBalances', () => {
   beforeEach(() => mockFetchJson.mockReset())
 
   it('formats native SUI mist', async () => {
-    mockFetchJson.mockResolvedValueOnce({ result: { totalBalance: '3000000000' } })
+    mockFetchJson.mockResolvedValueOnce({
+      result: { totalBalance: '3000000000' },
+    })
     const r = await getSuiBalance(SUI_ADDR)
     expect(r.balance).toBe('3')
     expect(r.balanceMist).toBe('3000000000')
@@ -191,21 +362,39 @@ describe('getSuiBalance / getSuiAllBalances', () => {
   it('flags native vs token and drops zero holdings', async () => {
     mockFetchJson.mockResolvedValueOnce({
       result: [
-        { coinType: '0x2::sui::SUI', totalBalance: '1000000000', coinObjectCount: 1 },
-        { coinType: '0xabc::usdc::USDC', totalBalance: '5000000', coinObjectCount: 1 },
-        { coinType: '0xdef::dust::DUST', totalBalance: '0', coinObjectCount: 1 },
+        {
+          coinType: '0x2::sui::SUI',
+          totalBalance: '1000000000',
+          coinObjectCount: 1,
+        },
+        {
+          coinType: '0xabc::usdc::USDC',
+          totalBalance: '5000000',
+          coinObjectCount: 1,
+        },
+        {
+          coinType: '0xdef::dust::DUST',
+          totalBalance: '0',
+          coinObjectCount: 1,
+        },
       ],
     })
     const r = await getSuiAllBalances(SUI_ADDR)
     expect(r.ok).toBe(true)
     if (!r.ok) throw new Error('expected ok')
     expect(r.balances).toHaveLength(2)
-    expect(r.balances[0]).toMatchObject({ ticker: 'SUI', isNative: true, balance: '1' })
+    expect(r.balances[0]).toMatchObject({
+      ticker: 'SUI',
+      isNative: true,
+      balance: '1',
+    })
     expect(r.balances[1]).toMatchObject({ ticker: 'USDC', isNative: false })
   })
 
   it('returns tokens_unavailable on a JSON-RPC error (typo address != empty wallet)', async () => {
-    mockFetchJson.mockResolvedValueOnce({ error: { code: -32602, message: 'Invalid params' } })
+    mockFetchJson.mockResolvedValueOnce({
+      error: { code: -32602, message: 'Invalid params' },
+    })
     const r = await getSuiAllBalances('0xbad')
     expect(r.ok).toBe(false)
     if (r.ok) throw new Error('expected not ok')
@@ -217,11 +406,12 @@ describe('getCardanoBalance', () => {
   beforeEach(() => mockFetchJson.mockReset())
 
   it('formats lovelaces to ADA and maps native tokens', async () => {
-    mockFetchJson
-      .mockResolvedValueOnce([{ address: 'addr1', balance: '4200000' }])
-      .mockResolvedValueOnce([
-        { address: 'addr1', asset_list: [{ policy_id: 'aa', asset_name: '4d494c4b', quantity: '42' }] },
-      ])
+    mockFetchJson.mockResolvedValueOnce([{ address: 'addr1', balance: '4200000' }]).mockResolvedValueOnce([
+      {
+        address: 'addr1',
+        asset_list: [{ policy_id: 'aa', asset_name: '4d494c4b', quantity: '42' }],
+      },
+    ])
     const r = await getCardanoBalance('addr1xyz')
     expect(r.balanceAda).toBe('4.200000')
     expect(r.nativeTokens).toHaveLength(1)


### PR DESCRIPTION
Closes #997
Runtime proof: live read-only SDK getXrpBalance('rMwNibdiFaEzsTaFCG1NnmAM3Rv3vHUy5L') returned balanceDrops=35223332, spendableDrops=31423332, ownerCount=14, minimumReserveDrops=3800000, reserveIncrementDrops=200000, trustLineCount=11, and positive issued-currency balance 524C555344000000000000000000000000000000.rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De = 0.00204230364. CLI runtime proof on rebased commit 9b7e9717: branch-built clients/cli/dist/index.js balance Ripple --tokens --raw --output json returned success for Ripple with 0 XRP; branch-built agent ask against the real backend/test vault returned success, no tool calls, no transactions, and no XRP/trust-line data for that vault.