### PR TITLE
fix(mpc): keep keygen tracing off stdout so -o json output stays parseable

### DIFF
--- a/.changeset/mpc-keygen-stdout-debug.md
+++ b/.changeset/mpc-keygen-stdout-debug.md
@@ -14,6 +14,6 @@ the documented `create fast … -o json` agent flow produced unparseable stdout
 into terminals and CI logs.
 
 Route that tracing through a gated logger that writes to stderr only when
-`VULTISIG_DEBUG` is set, so stdout carries only the final JSON envelope while
+`VULTISIG_DEBUG=1`, so stdout carries only the final JSON envelope while
 the debug output stays available to humans on demand. No keygen behavior
 changes — only the log sink moves off stdout.

--- a/.changeset/mpc-keygen-stdout-debug.md
+++ b/.changeset/mpc-keygen-stdout-debug.md
@@ -1,0 +1,19 @@
+---
+'@vultisig/core-mpc': patch
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+fix(mpc): keep keygen tracing off stdout so `-o json` output stays parseable
+
+The DKLS and Schnorr keygen/reshare/key-import ceremonies logged progress
+(session ids, raw wire messages, "keygen complete", …) to stdout via ungated
+`console.log`. stdout is the machine channel for the CLI's `-o json` mode, so
+the documented `create fast … -o json` agent flow produced unparseable stdout
+(`JSON.parse(stdout)` failed on the leading garbage) and leaked MPC internals
+into terminals and CI logs.
+
+Route that tracing through a gated logger that writes to stderr only when
+`VULTISIG_DEBUG` is set, so stdout carries only the final JSON envelope while
+the debug output stays available to humans on demand. No keygen behavior
+changes — only the log sink moves off stdout.

--- a/packages/core/mpc/dkls/dkls.ts
+++ b/packages/core/mpc/dkls/dkls.ts
@@ -6,6 +6,7 @@ import { getKeygenThreshold } from '../getKeygenThreshold'
 import { getMessageHash } from '../getMessageHash'
 import { KeygenOperation } from '../keygen/KeygenOperation'
 import { initializeMpcLib } from '../lib/initialize'
+import { mpcDebugLog } from '../mpcDebugLog'
 import { MpcRelayMessage } from '../message/relay'
 import { deleteMpcRelayMessage } from '../message/relay/delete'
 import { getMpcRelayMessages } from '../message/relay/get'
@@ -78,14 +79,14 @@ export class DKLS {
       const message = session.outputMessage()
       if (message === undefined) {
         if (this.isKeygenComplete) {
-          console.log('stop processOutbound')
+          mpcDebugLog('stop processOutbound')
           return true
         } else {
           await sleep(100)
           return await this.processOutbound(session, messageId)
         }
       }
-      console.log('outbound message:', message)
+      mpcDebugLog('outbound message:', message)
       const body = toMpcServerMessage(message.body, this.hexEncryptionKey)
 
       message?.receivers.forEach(receiver => {
@@ -111,7 +112,7 @@ export class DKLS {
     } catch (error) {
       console.error('processOutbound error:', error)
       if (this.isKeygenComplete) {
-        console.log('stop processOutbound')
+        mpcDebugLog('stop processOutbound')
         return true
       }
       await sleep(100)
@@ -124,7 +125,7 @@ export class DKLS {
     // recurses indefinitely while HTTP stays "healthy" but no MPC messages arrive.
     // Uses last inbound activity — slow ceremonies keep receiving traffic and reset the clock.
     if (Date.now() - this.lastRelayProgressAt > this.timeoutMs * 2) {
-      console.log('timeout')
+      mpcDebugLog('timeout')
       this.isKeygenComplete = true
       return false
     }
@@ -146,13 +147,13 @@ export class DKLS {
         if (this.cache[cacheKey]) {
           continue
         }
-        console.log(`got message from: ${msg.from},to: ${msg.to},key:${cacheKey}`)
+        mpcDebugLog(`got message from: ${msg.from},to: ${msg.to},key:${cacheKey}`)
         const decryptedMessage = fromMpcServerMessage(msg.body, this.hexEncryptionKey)
         const isFinish = session.inputMessage(decryptedMessage)
         if (isFinish) {
           await sleep(1000) // wait for 1 second to make sure all messages are processed
           this.isKeygenComplete = true
-          console.log('keygen complete')
+          mpcDebugLog('keygen complete')
           return true
         }
         this.cache[cacheKey] = ''
@@ -200,7 +201,7 @@ export class DKLS {
           messageId,
         })
       }
-      console.log('uploaded setup message successfully')
+      mpcDebugLog('uploaded setup message successfully')
       return
     }
 
@@ -224,8 +225,8 @@ export class DKLS {
   }
 
   private async startKeygen(attempt: number, messageId?: string, setupMessageId?: string) {
-    console.log('startKeygen attempt:', attempt)
-    console.log('session id:', this.sessionId)
+    mpcDebugLog('startKeygen attempt:', attempt)
+    mpcDebugLog('session id:', this.sessionId)
     this.isKeygenComplete = false
     this.inboundSequenceNo = 0
     this.onInboundSequenceNoChange?.(this.inboundSequenceNo)
@@ -257,7 +258,7 @@ export class DKLS {
           Buffer.from(this.publicKey || '', 'hex'),
           Buffer.from(this.chainCode || '', 'hex')
         )
-        console.log('migrate session:', session)
+        mpcDebugLog('migrate session:', session)
       } else {
         throw new Error('Invalid keygen operation')
       }
@@ -309,7 +310,7 @@ export class DKLS {
     messageId?: string,
     setupMessageId?: string
   ) {
-    console.log('startReshare dkls, attempt:', attempt)
+    mpcDebugLog('startReshare dkls, attempt:', attempt)
     this.isKeygenComplete = false
     this.inboundSequenceNo = 0
     this.onInboundSequenceNoChange?.(this.inboundSequenceNo)
@@ -342,14 +343,14 @@ export class DKLS {
         )
         // upload setup message to server
         const encryptedSetupMsg = toMpcServerMessage(setupMessage, this.hexEncryptionKey)
-        console.log('encrypted setup message:', encryptedSetupMsg)
+        mpcDebugLog('encrypted setup message:', encryptedSetupMsg)
         await uploadMpcSetupMessage({
           serverUrl: this.serverURL,
           message: encryptedSetupMsg,
           sessionId: this.sessionId,
           messageId: setupMessageId,
         })
-        console.log('uploaded setup message successfully')
+        mpcDebugLog('uploaded setup message successfully')
       } else {
         const encodedEncryptedSetupMsg = await waitForSetupMessage({
           serverUrl: this.serverURL,
@@ -430,7 +431,7 @@ export class DKLS {
       sessionId: this.sessionId,
       messageId,
     })
-    console.log('uploaded setup message successfully')
+    mpcDebugLog('uploaded setup message successfully')
   }
 
   private async startKeyImport(
@@ -440,7 +441,7 @@ export class DKLS {
     setupMessageId?: string,
     protocolMessageId?: string
   ) {
-    console.log('startKeyImport attempt:', attempt)
+    mpcDebugLog('startKeyImport attempt:', attempt)
     this.isKeygenComplete = false
     const engine = (await ensureMpcEngine()).dkls
     try {
@@ -472,7 +473,7 @@ export class DKLS {
               sessionId: this.sessionId,
               messageId: setupMessageId,
             })
-            console.log('uploaded setup message successfully')
+            mpcDebugLog('uploaded setup message successfully')
           } catch (uploadError) {
             session.free?.()
             session = null

--- a/packages/core/mpc/mpcDebugLog.test.ts
+++ b/packages/core/mpc/mpcDebugLog.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'fs'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const here = dirname(fileURLToPath(import.meta.url))
+
+describe('mpcDebugLog', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete process.env.VULTISIG_DEBUG
+  })
+
+  it('writes to stderr (console.error), never stdout (console.log), when VULTISIG_DEBUG is set', async () => {
+    process.env.VULTISIG_DEBUG = '1'
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    const { mpcDebugLog } = await import('./mpcDebugLog')
+    mpcDebugLog('session id:', 'abc-123')
+
+    expect(errorSpy).toHaveBeenCalledWith('session id:', 'abc-123')
+    expect(logSpy).not.toHaveBeenCalled()
+  })
+
+  it('is silent when VULTISIG_DEBUG is unset', async () => {
+    delete process.env.VULTISIG_DEBUG
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    const { mpcDebugLog } = await import('./mpcDebugLog')
+    mpcDebugLog('outbound message:', { body: new Uint8Array([1, 2, 3]) })
+
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(logSpy).not.toHaveBeenCalled()
+  })
+})
+
+// Regression guard for sdk-cli keygen STDOUT spew: the keygen/reshare/key-import
+// ceremonies must never write tracing to STDOUT, or the CLI's `-o json` output
+// (a single JSON envelope on stdout) is corrupted and MPC internals leak into
+// CI logs. Tracing goes through mpcDebugLog -> stderr instead.
+describe('mpc keygen paths keep STDOUT clean', () => {
+  const keygenSources = ['dkls/dkls.ts', 'schnorr/schnorrKeygen.ts', 'mldsa/mldsaKeygen.ts']
+
+  it.each(keygenSources)('%s contains no stdout console.log', relPath => {
+    const source = readFileSync(join(here, relPath), 'utf8')
+    expect(source).not.toMatch(/console\.log\s*\(/)
+  })
+})

--- a/packages/core/mpc/mpcDebugLog.test.ts
+++ b/packages/core/mpc/mpcDebugLog.test.ts
@@ -35,6 +35,21 @@ describe('mpcDebugLog', () => {
     expect(errorSpy).not.toHaveBeenCalled()
     expect(logSpy).not.toHaveBeenCalled()
   })
+
+  // A disabling-looking value must disable, not enable: any non-empty string is
+  // truthy in JS, so a loose `if (process.env.VULTISIG_DEBUG)` gate would treat
+  // `VULTISIG_DEBUG=0` as "on". The `=== '1'` gate keeps it off.
+  it.each(['0', 'false', 'off'])('stays silent when VULTISIG_DEBUG=%s (not "1")', async value => {
+    process.env.VULTISIG_DEBUG = value
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    const { mpcDebugLog } = await import('./mpcDebugLog')
+    mpcDebugLog('session id:', 'abc-123')
+
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(logSpy).not.toHaveBeenCalled()
+  })
 })
 
 // Regression guard for sdk-cli keygen STDOUT spew: the keygen/reshare/key-import
@@ -44,8 +59,13 @@ describe('mpcDebugLog', () => {
 describe('mpc keygen paths keep STDOUT clean', () => {
   const keygenSources = ['dkls/dkls.ts', 'schnorr/schnorrKeygen.ts', 'mldsa/mldsaKeygen.ts']
 
-  it.each(keygenSources)('%s contains no stdout console.log', relPath => {
+  // Cover the whole class of stdout sinks, not just console.log: console.info /
+  // console.debug also route to stdout in Node, and process.stdout.write is the
+  // low-level escape hatch. Any of them would re-corrupt the `-o json` stream.
+  const stdoutSinks = /console\.(log|info|debug)\s*\(|process\.stdout\.write\s*\(/
+
+  it.each(keygenSources)('%s writes no tracing to stdout', relPath => {
     const source = readFileSync(join(here, relPath), 'utf8')
-    expect(source).not.toMatch(/console\.log\s*\(/)
+    expect(source).not.toMatch(stdoutSinks)
   })
 })

--- a/packages/core/mpc/mpcDebugLog.ts
+++ b/packages/core/mpc/mpcDebugLog.ts
@@ -8,13 +8,19 @@
  * failed on the leading garbage) AND leaked MPC internals into terminals/CI
  * logs.
  *
- * Route tracing to STDERR, and only when `VULTISIG_DEBUG` is set, so STDOUT
+ * Route tracing to STDERR, and only when `VULTISIG_DEBUG === '1'`, so STDOUT
  * stays a clean JSON-only stream while the debug output remains available to
- * humans on demand. This mirrors the existing `VULTISIG_DEBUG` convention used
- * by the CLI. Behavior is unchanged — only the log SINK moves off STDOUT.
+ * humans on demand. The `=== '1'` gate matches the CLI convention
+ * (`clients/cli/src/lib/config.ts`) so `VULTISIG_DEBUG=0` disables it rather
+ * than enabling it (any non-empty string is truthy in JS).
+ *
+ * The `typeof process` guard keeps this a no-op — never a throw — in runtimes
+ * without a global `process` (e.g. some browser bundles). This helper runs
+ * inside the keygen relay loop, so a throw here would change ceremony behavior;
+ * it must only ever move the log SINK, never fail.
  */
 export const mpcDebugLog = (...args: unknown[]): void => {
-  if (process.env.VULTISIG_DEBUG) {
+  if (typeof process !== 'undefined' && process.env?.VULTISIG_DEBUG === '1') {
     console.error(...args)
   }
 }

--- a/packages/core/mpc/mpcDebugLog.ts
+++ b/packages/core/mpc/mpcDebugLog.ts
@@ -1,0 +1,20 @@
+/**
+ * Gated tracing for the MPC keygen / reshare / key-import ceremonies.
+ *
+ * These paths previously wrote progress lines — session ids, raw wire messages,
+ * "keygen complete", etc. — to STDOUT via `console.log`. STDOUT is the machine
+ * channel for the CLI's `-o json` mode (the documented `create fast … -o json`
+ * agent flow), so that spew corrupted the JSON envelope (`JSON.parse(stdout)`
+ * failed on the leading garbage) AND leaked MPC internals into terminals/CI
+ * logs.
+ *
+ * Route tracing to STDERR, and only when `VULTISIG_DEBUG` is set, so STDOUT
+ * stays a clean JSON-only stream while the debug output remains available to
+ * humans on demand. This mirrors the existing `VULTISIG_DEBUG` convention used
+ * by the CLI. Behavior is unchanged — only the log SINK moves off STDOUT.
+ */
+export const mpcDebugLog = (...args: unknown[]): void => {
+  if (process.env.VULTISIG_DEBUG) {
+    console.error(...args)
+  }
+}

--- a/packages/core/mpc/package.json
+++ b/packages/core/mpc/package.json
@@ -721,6 +721,11 @@
       "import": "./dist/mldsa/mldsaKeysign.js",
       "default": "./dist/mldsa/mldsaKeysign.js"
     },
+    "./mpcDebugLog": {
+      "types": "./dist/mpcDebugLog.d.ts",
+      "import": "./dist/mpcDebugLog.js",
+      "default": "./dist/mpcDebugLog.js"
+    },
     "./mpcLib": {
       "types": "./dist/mpcLib.d.ts",
       "import": "./dist/mpcLib.js",

--- a/packages/core/mpc/schnorr/schnorrKeygen.ts
+++ b/packages/core/mpc/schnorr/schnorrKeygen.ts
@@ -6,6 +6,7 @@ import { getKeygenThreshold } from '../getKeygenThreshold'
 import { getMessageHash } from '../getMessageHash'
 import { KeygenOperation } from '../keygen/KeygenOperation'
 import { initializeMpcLib } from '../lib/initialize'
+import { mpcDebugLog } from '../mpcDebugLog'
 import { deleteMpcRelayMessage } from '../message/relay/delete'
 import { getMpcRelayMessages } from '../message/relay/get'
 import { sendMpcRelayMessage } from '../message/relay/send'
@@ -73,14 +74,14 @@ export class Schnorr {
       const message = session.outputMessage()
       if (message === undefined) {
         if (this.isKeygenComplete) {
-          console.log('stop processOutbound')
+          mpcDebugLog('stop processOutbound')
           return true
         } else {
           await sleep(100) // backoff for 100ms
           return await this.processOutbound(session, messageId)
         }
       }
-      console.log('outbound message:', message)
+      mpcDebugLog('outbound message:', message)
       const messageToSend = toMpcServerMessage(message.body, this.hexEncryptionKey)
       message?.receivers.forEach(receiver => {
         // send message to receiver
@@ -104,7 +105,7 @@ export class Schnorr {
     } catch (error) {
       console.error('processOutbound error:', error)
       if (this.isKeygenComplete) {
-        console.log('stop processOutbound')
+        mpcDebugLog('stop processOutbound')
         return true
       }
       await sleep(100)
@@ -115,7 +116,7 @@ export class Schnorr {
   private async processInbound(session: MpcSession<unknown>, start: number, messageId?: string): Promise<boolean> {
     // Same as DKLS: empty relay polls must honor elapsed time or we spin forever.
     if (Date.now() - start > this.timeoutMs) {
-      console.log('timeout')
+      mpcDebugLog('timeout')
       this.isKeygenComplete = true
       return false
     }
@@ -136,13 +137,13 @@ export class Schnorr {
         if (this.cache[cacheKey]) {
           continue
         }
-        console.log(`got message from: ${msg.from},to: ${msg.to},key:${cacheKey}`)
+        mpcDebugLog(`got message from: ${msg.from},to: ${msg.to},key:${cacheKey}`)
         const decryptedMessage = fromMpcServerMessage(msg.body, this.hexEncryptionKey)
         const isFinish = session.inputMessage(decryptedMessage)
         if (isFinish) {
           await sleep(1000) // wait for 1 second to make sure all messages are processed
           this.isKeygenComplete = true
-          console.log('keygen complete')
+          mpcDebugLog('keygen complete')
           return true
         }
         this.cache[cacheKey] = ''
@@ -167,8 +168,8 @@ export class Schnorr {
     if (this.setupMessage === undefined || this.setupMessage.length === 0) {
       throw new Error('setup message is empty')
     }
-    console.log('startKeygen attempt:', attempt)
-    console.log('session id:', this.sessionId)
+    mpcDebugLog('startKeygen attempt:', attempt)
+    mpcDebugLog('session id:', this.sessionId)
     this.isKeygenComplete = false
     try {
       const engine = (await ensureMpcEngine()).schnorr
@@ -225,7 +226,7 @@ export class Schnorr {
   }
 
   private async startReshare(rawSchnorrKeyshare: string | undefined, attempt: number, messageId?: string) {
-    console.log('startReshare schnorr, attempt:', attempt)
+    mpcDebugLog('startReshare schnorr, attempt:', attempt)
     this.isKeygenComplete = false
     const engine = (await ensureMpcEngine()).schnorr
     let localKeyshare: MpcKeyshare | null = null
@@ -262,7 +263,7 @@ export class Schnorr {
           sessionId: this.sessionId,
           messageId: setupMessageId,
         })
-        console.log('uploaded setup message successfully')
+        mpcDebugLog('uploaded setup message successfully')
       } else {
         const encodedEncryptedSetupMsg = await waitForSetupMessage({
           serverUrl: this.serverURL,
@@ -338,7 +339,7 @@ export class Schnorr {
       sessionId: this.sessionId,
       messageId: effectiveSetupId,
     })
-    console.log('uploaded setup message successfully')
+    mpcDebugLog('uploaded setup message successfully')
   }
 
   private async startKeyImport(
@@ -348,7 +349,7 @@ export class Schnorr {
     setupMessageId?: string,
     protocolMessageId?: string
   ) {
-    console.log('startKeyImport schnorr, attempt:', attempt)
+    mpcDebugLog('startKeyImport schnorr, attempt:', attempt)
     this.isKeygenComplete = false
     try {
       const engine = (await ensureMpcEngine()).schnorr
@@ -378,7 +379,7 @@ export class Schnorr {
             sessionId: this.sessionId,
             messageId: effectiveSetupId,
           })
-          console.log('uploaded setup message successfully')
+          mpcDebugLog('uploaded setup message successfully')
         }
       } else {
         const encodedEncryptedSetupMsg = await waitForSetupMessage({


### PR DESCRIPTION
## Problem

The DKLS and Schnorr keygen / reshare / key-import ceremonies wrote progress lines — session ids, raw wire messages, `outbound message: { body: Uint8Array(…) }`, `keygen complete`, etc. — to **stdout** via ungated `console.log`.

stdout is the machine channel for the CLI's `-o json` mode (the documented `create fast … -o json` flow, which the CLI auto-selects when piped). The debug spew therefore:

- **corrupted the JSON envelope** — `JSON.parse(stdout)` failed because garbage preceded the JSON, and
- **leaked MPC internals** (session ids, raw message bytes) into terminals and CI logs.

## Fix

Route that tracing through a small gated logger, `mpcDebugLog`, that writes to **stderr** and only when `VULTISIG_DEBUG` is set (the existing CLI debug convention). stdout now carries only the final JSON envelope, while the debug output stays available to humans on demand.

- No keygen behavior changes — only the log **sink** moves off stdout.
- `mldsaKeygen` already logged exclusively to stderr, so it needed no change.
- Added a regression guard test asserting the keygen sources (`dkls`, `schnorr`, `mldsa`) carry no stdout `console.log`, plus unit coverage that `mpcDebugLog` writes to stderr (never stdout) and stays silent unless `VULTISIG_DEBUG` is set.

## Testing

- `yarn workspace @vultisig/cli typecheck` — pass
- `yarn lint` — pass
- `yarn test:cli` — 586 pass
- core MPC vitest — 332 pass (includes the new guard)
- Verified red-then-green: the guard matches 16 `console.log` calls in `dkls.ts` and 13 in `schnorrKeygen.ts` on `main`, 0 after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Kept MPC keygen, reshare, and key-import debug messages out of standard output.
  - Improved `-o json` CLI output so it remains clean and parseable.

- **New Features**
  - Added optional MPC debug logging through `VULTISIG_DEBUG=1`, with diagnostics sent to standard error.

- **Tests**
  - Added coverage confirming debug logging behavior and protecting JSON output integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->