### PR TITLE
fix(cli): honor VULTISIG_CONFIG_DIR for vault storage

### DIFF
--- a/.changeset/cli-config-dir-vault-storage.md
+++ b/.changeset/cli-config-dir-vault-storage.md
@@ -1,0 +1,14 @@
+---
+'@vultisig/cli': patch
+---
+
+fix(cli): honor VULTISIG_CONFIG_DIR for vault storage
+
+The documented `VULTISIG_CONFIG_DIR` env var was a no-op for vault storage: the
+CLI constructed the SDK without a storage override, so vaults, the active-vault
+pointer and cache always resolved to `~/.vultisig` even when the var pointed
+elsewhere — only `config.json` and the agent journal honored it, producing a
+split-brain config location that broke CI/container isolation and multi-tenant
+use. The CLI now roots SDK vault storage at `getConfigDir()` via a shared
+`createVaultStorage()` helper. When the var is unset it falls back to
+`~/.vultisig`, so the default location is unchanged.

--- a/.config/vitest.cli.config.ts
+++ b/.config/vitest.cli.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       '@vultisig/lib-mldsa': resolve(root, 'packages/lib/mldsa'),
       '@vultisig/lib-schnorr': resolve(root, 'packages/lib/schnorr'),
       '@vultisig/mpc-types': resolve(root, 'packages/mpc-types/src'),
+      '@vultisig/sdk/node': resolve(root, 'packages/sdk/src/platforms/node/index.ts'),
       '@vultisig/sdk': resolve(root, 'packages/sdk/src/index.ts'),
     },
   },

--- a/.config/vitest.cli.config.ts
+++ b/.config/vitest.cli.config.ts
@@ -20,7 +20,13 @@ export default defineConfig({
       '@vultisig/lib-mldsa': resolve(root, 'packages/lib/mldsa'),
       '@vultisig/lib-schnorr': resolve(root, 'packages/lib/schnorr'),
       '@vultisig/mpc-types': resolve(root, 'packages/mpc-types/src'),
-      '@vultisig/sdk/node': resolve(root, 'packages/sdk/src/platforms/node/index.ts'),
+      // Point at the leaf FileStorage module, NOT the node platform entry
+      // (platforms/node/index.ts), which runs import-time side effects
+      // (installs globalThis.crypto/fetch, configures MPC + WASM). config.ts is
+      // imported by nearly every CLI test, so aliasing to the entry would leak
+      // those side effects into every worker. storage.ts is the only thing the
+      // '@vultisig/sdk/node' subpath is used for here (FileStorage).
+      '@vultisig/sdk/node': resolve(root, 'packages/sdk/src/platforms/node/storage.ts'),
       '@vultisig/sdk': resolve(root, 'packages/sdk/src/index.ts'),
     },
   },

--- a/clients/cli/src/index.ts
+++ b/clients/cli/src/index.ts
@@ -64,6 +64,7 @@ import { findChainByName } from './interactive'
 import { ShellSession } from './interactive'
 import {
   checkForUpdates,
+  createVaultStorage,
   error,
   formatVersionDetailed,
   formatVersionShort,
@@ -209,7 +210,12 @@ async function init(vaultOverride?: string, unlockPassword?: string, passwordTTL
     }>()
     const serverEndpoints = resolveServerEndpoints(globalOptions)
 
+    // Honor VULTISIG_CONFIG_DIR for vault storage. createVaultStorage() falls
+    // back to ~/.vultisig when the env var is unset, so the default location is
+    // unchanged; when set, vaults/active-vault/cache land in the same dir as
+    // config.json instead of leaking to the home directory.
     const sdk = new Vultisig({
+      storage: createVaultStorage(),
       onPasswordRequired: createPasswordCallback(),
       ...(serverEndpoints ? { serverEndpoints } : {}),
       ...(passwordTTL !== undefined ? { passwordCache: { defaultTTL: passwordTTL } } : {}),
@@ -1643,6 +1649,7 @@ program
 async function startInteractiveMode(): Promise<void> {
   const serverEndpoints = resolveServerEndpoints(parseServerEndpointOverridesFromArgv(process.argv.slice(2)))
   const sdk = new Vultisig({
+    storage: createVaultStorage(),
     onPasswordRequired: createPasswordCallback(),
     ...(serverEndpoints ? { serverEndpoints } : {}),
   })

--- a/clients/cli/src/lib/__tests__/config.test.ts
+++ b/clients/cli/src/lib/__tests__/config.test.ts
@@ -1,0 +1,47 @@
+/**
+ * VULTISIG_CONFIG_DIR storage wiring — regression for sdkcli2-07.
+ *
+ * The documented VULTISIG_CONFIG_DIR env var used to be a no-op for vault
+ * storage: the CLI constructed `new Vultisig(...)` without a storage override,
+ * so vaults/active-vault/cache always resolved to ~/.vultisig regardless of the
+ * env var (only config.json + the agent journal honored it — a split-brain
+ * config location). createVaultStorage() is the seam the CLI now uses to root
+ * SDK vault storage at getConfigDir(); these tests pin that contract.
+ */
+import { mkdtempSync, rmSync } from 'node:fs'
+import { homedir, tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { createVaultStorage, getConfigDir } from '../config'
+
+describe('createVaultStorage (VULTISIG_CONFIG_DIR)', () => {
+  const original = process.env.VULTISIG_CONFIG_DIR
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'vultisig-cfg-'))
+  })
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.VULTISIG_CONFIG_DIR
+    } else {
+      process.env.VULTISIG_CONFIG_DIR = original
+    }
+    rmSync(tmp, { recursive: true, force: true })
+  })
+
+  it('roots vault storage at VULTISIG_CONFIG_DIR when set', () => {
+    process.env.VULTISIG_CONFIG_DIR = tmp
+    expect(getConfigDir()).toBe(tmp)
+    expect(createVaultStorage().basePath).toBe(tmp)
+  })
+
+  it('falls back to ~/.vultisig when the env var is unset (unchanged default)', () => {
+    delete process.env.VULTISIG_CONFIG_DIR
+    const expected = join(homedir(), '.vultisig')
+    expect(createVaultStorage().basePath).toBe(expected)
+  })
+})

--- a/clients/cli/src/lib/__tests__/config.test.ts
+++ b/clients/cli/src/lib/__tests__/config.test.ts
@@ -44,4 +44,12 @@ describe('createVaultStorage (VULTISIG_CONFIG_DIR)', () => {
     const expected = join(homedir(), '.vultisig')
     expect(createVaultStorage().basePath).toBe(expected)
   })
+
+  it('treats an empty/whitespace VULTISIG_CONFIG_DIR as unset (no mkdir("") failure)', () => {
+    const expected = join(homedir(), '.vultisig')
+    process.env.VULTISIG_CONFIG_DIR = ''
+    expect(createVaultStorage().basePath).toBe(expected)
+    process.env.VULTISIG_CONFIG_DIR = '   '
+    expect(createVaultStorage().basePath).toBe(expected)
+  })
 })

--- a/clients/cli/src/lib/config.ts
+++ b/clients/cli/src/lib/config.ts
@@ -42,7 +42,11 @@ const DEFAULT_CONFIG: CLIConfig = {
  * Get the configuration directory path
  */
 export function getConfigDir(): string {
-  return process.env.VULTISIG_CONFIG_DIR ?? join(homedir(), '.vultisig')
+  // Treat an empty/whitespace-only VULTISIG_CONFIG_DIR as unset. `??` alone only
+  // catches null/undefined, so `VULTISIG_CONFIG_DIR=` would otherwise resolve to
+  // '' and make every config.json / vault storage op fail on `mkdir('')`.
+  const override = process.env.VULTISIG_CONFIG_DIR?.trim()
+  return override ? override : join(homedir(), '.vultisig')
 }
 
 /**

--- a/clients/cli/src/lib/config.ts
+++ b/clients/cli/src/lib/config.ts
@@ -3,6 +3,7 @@
  *
  * Handles CLI configuration files and environment variables
  */
+import { FileStorage } from '@vultisig/sdk/node'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
 import { homedir } from 'os'
 import { join } from 'path'
@@ -49,6 +50,16 @@ export function getConfigDir(): string {
  */
 export function getConfigPath(): string {
   return join(getConfigDir(), 'config.json')
+}
+
+/**
+ * Build the SDK vault storage rooted at the CLI config directory so that
+ * vaults, active-vault pointer and cache honor VULTISIG_CONFIG_DIR the same
+ * way config.json does. When the env var is unset getConfigDir() falls back to
+ * ~/.vultisig, matching the SDK's own default (unchanged behavior).
+ */
+export function createVaultStorage(): FileStorage {
+  return new FileStorage({ basePath: getConfigDir() })
 }
 
 /**


### PR DESCRIPTION
## Summary

`VULTISIG_CONFIG_DIR` is documented as the way to relocate the CLI's on-disk state, but it was a no-op for vault storage. The CLI constructed the SDK without a storage override, so vaults, the active-vault pointer, and the cache always resolved to `~/.vultisig` — only `config.json` and the agent journal honored the variable. The result was a split-brain config location that broke CI/container isolation and any "point at a scratch config" workflow.

This roots SDK vault storage at `getConfigDir()` through a small shared `createVaultStorage()` helper, wired into both the command entry point (`init`) and interactive mode. When the variable is unset, `getConfigDir()` falls back to `~/.vultisig`, so the default location is unchanged.

## Changes

- `createVaultStorage()` in `lib/config.ts` returns `new FileStorage({ basePath: getConfigDir() })`, imported from the `@vultisig/sdk/node` subpath.
- Both `new Vultisig(...)` call sites now pass `storage: createVaultStorage()`.
- Regression test pinning the resolution: env set → temp dir, unset → `~/.vultisig`.
- Vitest CLI config gains a `@vultisig/sdk/node` alias so the test runner resolves the node-platform subpath the helper imports.

## Testing

- `yarn workspace @vultisig/cli typecheck`, `yarn lint`, `yarn test:cli` (588 passing) — all green.
- Manual: `VULTISIG_CONFIG_DIR=<tmp> vultisig vaults` creates and reads only `<tmp>` (empty list, no leak from `~/.vultisig`); unset lists the home-dir vaults as before. Verified against both the `tsx` dev path and the built `dist/index.js`.

## Notes

Scoped to vault storage (the main gap). A few CLI-local paths still hardcode `~/.vultisig` and don't yet honor the override — shell-completion vault lookup, the update-check cache, and the agent vault-state store — left for a follow-up to keep this change focused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vault data, active-vault information, and cache files now use the directory set by `VULTISIG_CONFIG_DIR`.
  * Empty or whitespace-only configuration values safely fall back to `~/.vultisig`.
  * CLI and interactive modes now consistently use the same vault storage location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->