### PR TITLE
fix(mpc): RelaySigningService uses canonical keygen threshold (unbreak signing for 5/7/8/9/10/11/13/14+ signer vaults)

### DIFF
--- a/packages/sdk/src/services/RelaySigningService.ts
+++ b/packages/sdk/src/services/RelaySigningService.ts
@@ -15,6 +15,7 @@
 import type { WalletCore } from '@trustwallet/wallet-core'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { generateLocalPartyId } from '@vultisig/core-mpc/devices/localPartyId'
+import { getKeygenThreshold } from '@vultisig/core-mpc/getKeygenThreshold'
 import { keysign } from '@vultisig/core-mpc/keysign'
 import type { KeysignSignature } from '@vultisig/core-mpc/keysign/KeysignSignature'
 import { getJoinKeysignUrl } from '@vultisig/core-mpc/keysign/utils/getJoinKeysignUrl'
@@ -229,7 +230,7 @@ export class RelaySigningService {
         throw new Error('Vault key shares not loaded. Call ensureKeySharesLoaded() first.')
       }
 
-      const threshold = vault.signers.length > 2 ? Math.ceil((vault.signers.length + 1) / 2) : 2
+      const threshold = getKeygenThreshold(vault.signers.length)
 
       // Validate message hashes are provided
       if (!payload.messageHashes || payload.messageHashes.length === 0) {
@@ -420,7 +421,7 @@ export class RelaySigningService {
         throw new Error('Vault key shares not loaded.')
       }
 
-      const threshold = vault.signers.length > 2 ? Math.ceil((vault.signers.length + 1) / 2) : 2
+      const threshold = getKeygenThreshold(vault.signers.length)
 
       // Generate session params
       reportProgress('preparing', 10, 'Generating session parameters')

--- a/packages/sdk/tests/unit/services/RelaySigningService.test.ts
+++ b/packages/sdk/tests/unit/services/RelaySigningService.test.ts
@@ -1,3 +1,4 @@
+import { getKeygenThreshold } from '@vultisig/core-mpc/getKeygenThreshold'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { RelaySigningService } from '../../../src/services/RelaySigningService'
@@ -260,31 +261,87 @@ describe('RelaySigningService', () => {
 })
 
 describe('RelaySigningService threshold calculation', () => {
-  describe('threshold formula', () => {
-    it('should calculate 2-of-3 for 3 signers', () => {
-      // Threshold formula: ceil((signers.length + 1) / 2) when > 2
-      const signers = ['p1', 'p2', 'p3']
-      const threshold = signers.length > 2 ? Math.ceil((signers.length + 1) / 2) : 2
-      expect(threshold).toBe(2)
+  describe('threshold formula matches canonical getKeygenThreshold', () => {
+    // RelaySigningService MUST use the same threshold formula as keygen
+    // (getKeygenThreshold: ceil(signers * 2 / 3)). A prior regression used
+    // ceil((signers + 1) / 2), which silently diverges for vault sizes
+    // 5, 7, 8, 9, 10, 11, 12, 13, 14, 15+ and breaks the signing ceremony
+    // (waitForDevices requires the wrong number of parties).
+    it.each([
+      // [signers, expectedThreshold]
+      [2, 2],
+      [3, 2],
+      [4, 3],
+      [5, 4],
+      [6, 4],
+      [7, 5],
+      [8, 6],
+      [9, 6],
+      [10, 7],
+      [11, 8],
+      [12, 8],
+      [13, 9],
+      [14, 10],
+      [15, 10],
+    ])('for %i signers, threshold should be %i (canonical ceil(n*2/3))', (signers, expected) => {
+      expect(getKeygenThreshold(signers)).toBe(expected)
     })
 
-    it('should calculate 3-of-5 for 5 signers', () => {
-      const signers = ['p1', 'p2', 'p3', 'p4', 'p5']
-      const threshold = signers.length > 2 ? Math.ceil((signers.length + 1) / 2) : 2
-      expect(threshold).toBe(3)
+    it('regression: previously-correct sizes (2-of-2, 3-of-3) are unchanged', () => {
+      expect(getKeygenThreshold(2)).toBe(2)
+      expect(getKeygenThreshold(3)).toBe(2)
     })
 
-    it('should use 2 for 2 signers', () => {
-      const signers = ['p1', 'p2']
-      const threshold = signers.length > 2 ? Math.ceil((signers.length + 1) / 2) : 2
-      expect(threshold).toBe(2)
+    it('regression: previously-broken sizes now match canonical threshold', () => {
+      // These sizes diverged under the old ceil((n+1)/2) formula.
+      const previouslyBroken = [5, 7, 8, 9, 10, 11, 13, 14]
+      for (const n of previouslyBroken) {
+        const oldWrongFormula = n > 2 ? Math.ceil((n + 1) / 2) : 2
+        const canonical = getKeygenThreshold(n)
+        expect(canonical).not.toBe(oldWrongFormula)
+      }
     })
+  })
 
-    it('should calculate 4-of-7 for 7 signers', () => {
-      const signers = ['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7']
-      const threshold = signers.length > 2 ? Math.ceil((signers.length + 1) / 2) : 2
-      expect(threshold).toBe(4)
-    })
+  describe('RelaySigningService.signWithRelay uses canonical threshold', () => {
+    it.each([
+      [5, 4],
+      [7, 5],
+      [8, 6],
+    ])(
+      'waits for the canonical threshold (%i signers -> %i devices), not the legacy formula',
+      async (signerCount, expectedThreshold) => {
+        const service = new RelaySigningService()
+        const signers = Array.from({ length: signerCount }, (_, i) => `party-${i}`)
+
+        const mockVault = {
+          keyShares: { ecdsa: 'mock-key-share' },
+          signers,
+          publicKeys: { ecdsa: 'mock-ecdsa-key', eddsa: 'mock-eddsa-key' },
+        }
+
+        const payload = {
+          chain: 'Ethereum',
+          transaction: {},
+          messageHashes: ['hash1'],
+        }
+
+        const waitForDevicesSpy = vi
+          .spyOn(service as any, 'waitForDevices')
+          .mockRejectedValue(new Error('stop-before-mpc'))
+
+        await expect(service.signWithRelay(mockVault as any, payload as any, mockWalletCore)).rejects.toThrow(
+          'stop-before-mpc'
+        )
+
+        expect(waitForDevicesSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.any(String),
+          expectedThreshold,
+          expect.any(Object)
+        )
+      }
+    )
   })
 })
 

--- a/packages/sdk/tests/unit/services/RelaySigningService.test.ts
+++ b/packages/sdk/tests/unit/services/RelaySigningService.test.ts
@@ -25,6 +25,11 @@ vi.mock('../../../src/crypto', () => ({
   randomUUID: vi.fn(() => `test-uuid-${Math.random().toString(36).slice(2, 8)}`),
 }))
 
+// Mock the relay session join call so tests never hit a real network endpoint
+vi.mock('@vultisig/core-mpc/session/joinMpcSession', () => ({
+  joinMpcSession: vi.fn().mockResolvedValue(undefined),
+}))
+
 // Mock getChainSigningInfo adapter
 vi.mock('../../../src/adapters/getChainSigningInfo', () => ({
   getChainSigningInfo: vi.fn(() => ({
@@ -294,7 +299,7 @@ describe('RelaySigningService threshold calculation', () => {
 
     it('regression: previously-broken sizes now match canonical threshold', () => {
       // These sizes diverged under the old ceil((n+1)/2) formula.
-      const previouslyBroken = [5, 7, 8, 9, 10, 11, 13, 14]
+      const previouslyBroken = [5, 7, 8, 9, 10, 11, 12, 13, 14, 15]
       for (const n of previouslyBroken) {
         const oldWrongFormula = n > 2 ? Math.ceil((n + 1) / 2) : 2
         const canonical = getKeygenThreshold(n)
@@ -331,6 +336,46 @@ describe('RelaySigningService threshold calculation', () => {
           .mockRejectedValue(new Error('stop-before-mpc'))
 
         await expect(service.signWithRelay(mockVault as any, payload as any, mockWalletCore)).rejects.toThrow(
+          'stop-before-mpc'
+        )
+
+        expect(waitForDevicesSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.any(String),
+          expectedThreshold,
+          expect.any(Object)
+        )
+      }
+    )
+  })
+
+  describe('RelaySigningService.signBytesWithRelay uses canonical threshold', () => {
+    it.each([
+      [5, 4],
+      [7, 5],
+      [8, 6],
+    ])(
+      'waits for the canonical threshold (%i signers -> %i devices), not the legacy formula',
+      async (signerCount, expectedThreshold) => {
+        const service = new RelaySigningService()
+        const signers = Array.from({ length: signerCount }, (_, i) => `party-${i}`)
+
+        const mockVault = {
+          keyShares: { ecdsa: 'mock-key-share' },
+          signers,
+          publicKeys: { ecdsa: 'mock-ecdsa-key', eddsa: 'mock-eddsa-key' },
+        }
+
+        const bytesOptions = {
+          messageHashes: ['hash1'],
+          chain: 'Ethereum' as any,
+        }
+
+        const waitForDevicesSpy = vi
+          .spyOn(service as any, 'waitForDevices')
+          .mockRejectedValue(new Error('stop-before-mpc'))
+
+        await expect(service.signBytesWithRelay(mockVault as any, bytesOptions, mockWalletCore)).rejects.toThrow(
           'stop-before-mpc'
         )
 


### PR DESCRIPTION
## Summary

R4 fund-safety audit finding #11 flagged that `RelaySigningService` computes the MPC signing threshold with a different (wrong) formula than the rest of the codebase. **Verified real** — this is a P0 fund-access bug: for vault sizes 5, 7, 8, 9, 10, 11, 12, 13, 14, 15+, the wrong threshold breaks the relay signing ceremony entirely, meaning those vaults cannot sign / access funds via relay signing.

## Verification

**The bug (confirmed by reading the code, not assumed):**

`packages/sdk/src/services/RelaySigningService.ts` computed the threshold at two call sites (`signWithRelay:232`, `signBytesWithRelay:423`):

```ts
const threshold = vault.signers.length > 2 ? Math.ceil((vault.signers.length + 1) / 2) : 2
```

The canonical formula, used by every other keygen/threshold computation in the SDK (`packages/core/mpc/dkls.ts`, `schnorrKeygen.ts`, `mldsaKeygen.ts`, `packages/sdk/src/vault/SecureVault.ts`, `SecureVaultCreationService.ts`, `SecureVaultFromSeedphraseService.ts`), is:

```ts
// packages/core/mpc/getKeygenThreshold.ts
export const getKeygenThreshold = (signers: number) => Math.ceil((signers * 2) / 3)
```

**Divergence table** (wrong formula vs. canonical, old formula always *lower*):

| signers | wrong `ceil((n+1)/2)` | canonical `ceil(n*2/3)` | diverges |
|---|---|---|---|
| 2 | 2 | 2 | |
| 3 | 2 | 2 | |
| 4 | 3 | 3 | |
| **5** | 3 | **4** | YES |
| 6 | 4 | 4 | |
| **7** | 4 | **5** | YES |
| **8** | 5 | **6** | YES |
| **9** | 5 | **6** | YES |
| **10** | 6 | **7** | YES |
| **11** | 6 | **8** | YES |
| **12** | 7 | **8** | YES |
| **13** | 7 | **9** | YES |
| **14** | 8 | **10** | YES |
| **15** | 8 | **10** | YES |

Matches the audit's claimed sizes (5,7,8,9,10,11,13,14+) exactly, plus confirms 12 and 15 also diverge under "14+".

**Proof it's load-bearing, not cosmetic:** the computed `threshold` is passed directly into `waitForDevices(sessionId, localPartyId, threshold, ...)`, which polls the relay session in a loop and only returns (allowing `startMpcSession`/`keysign` to proceed) once `uniquePeers.length >= requiredDevices` — otherwise it throws a timeout error (`RelaySigningService.ts` `waitForDevices`, ~line 188). Since the old formula always under-counts for the affected sizes, the ceremony either:
- starts with fewer devices than the vault's keyshares were generated for (cryptographic threshold mismatch → keysign fails), or
- never reaches the correct participant count if devices join expecting the canonical threshold, and times out.

Either way: **signing breaks entirely** for the affected vault sizes. This is a real, confirmed fund-access bug — not dead code, not cosmetic.

## Fix

Replaced both hardcoded formulas with calls to the canonical `getKeygenThreshold()`:

```ts
import { getKeygenThreshold } from '@vultisig/core-mpc/getKeygenThreshold'
...
const threshold = getKeygenThreshold(vault.signers.length)
```

at both `signWithRelay` and `signBytesWithRelay`. This matches every other threshold computation in the codebase exactly — no new formula, no new divergence.

## Tests

- Parametrized test: `getKeygenThreshold(n)` for n = 2..15 matches expected canonical values.
- Regression test: previously-correct sizes (2, 3) unchanged.
- Regression test: previously-broken sizes (5,7,8,9,10,11,12,13,14,15) now diverge from the *old* wrong formula (i.e., confirmed fixed).
- Integration-level tests: `signWithRelay` and `signBytesWithRelay` both call `waitForDevices(..., expectedCanonicalThreshold, ...)` for signer counts 5, 7, 8 — proving the fix is wired through the real ceremony path, not just the standalone formula.
- Removed/replaced the pre-existing test block that had hardcoded and asserted the **wrong** formula (which had been masking this bug).
- Full SDK unit suite: **180 test files / 2766 tests pass**. Typecheck clean (`tsc --noEmit`). Lint clean. `yarn build:fast` succeeds.

## Codex verdict

Ran a Codex-gate review against the diff. Codex confirmed:
> "The service change is right: `getKeygenThreshold()` is the canonical helper... and it is what DKLS/Schnorr/MLDSA keygen and `SecureVault.threshold` use. The new values are correct for vault sizes 2-15 and continue correctly for 15+... `threshold` is load-bearing... the old lower value... could start an undersized ceremony and reliably break signing for larger vaults."

Codex flagged one blocking issue on the first test-only commit: the new integration test spied on `waitForDevices` but did not mock `joinMpcSession`, so it was making a real network call to the relay server before reaching the assertion (confirmed — test runtime dropped from ~450ms to ~1ms per case once mocked). Fixed in a follow-up commit, along with adding equivalent coverage for `signBytesWithRelay` (Codex nit) and completing the regression-list sizes (12, 15) to match the comment. Re-verified green after the fix.

## Not merged / not deployed

This PR is **not a draft** per the fund-safety severity of the finding, but has **not been merged or deployed**. Requesting @gomesalexandre for review before any merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
