### PR TITLE
fix(polkadot): hash-verify temporarily-banned broadcasts instead of assuming success

### DIFF
--- a/.changeset/polkadot-temporarily-banned-hash-verify.md
+++ b/.changeset/polkadot-temporarily-banned-hash-verify.md
@@ -1,0 +1,21 @@
+---
+'@vultisig/sdk': patch
+---
+
+fix(polkadot): hash-verify "temporarily banned" broadcasts instead of assuming success
+
+The Polkadot broadcast resolver treated a Substrate `temporarily banned` pool
+error as an idempotent success (peer-race duplicate) and returned without ever
+consulting `verifyBroadcastByHash`. Substrate bans a tx hash for a cool-off
+window whenever it is *removed* from the pool, which covers both a benign
+already-processed duplicate AND a genuine rejection (an invalid/dropped
+extrinsic banned to stop retry spam) — the string alone cannot tell them apart.
+Swallowing it therefore risked reporting a genuinely-rejected transaction as
+confirmed (a fund-safety false positive), unlike `bittensor.ts` which only
+fast-paths the unambiguous "Already Imported".
+
+`temporarily banned` is removed from the idempotent fast-path list; it now flows
+through `verifyBroadcastByHash`, which swallows the error only when the tx hash
+is actually observed on chain / in the pool and otherwise surfaces the real
+failure. `already imported` / `already known` (unambiguous duplicates) keep their
+fast-path.

--- a/.changeset/polkadot-temporarily-banned-hash-verify.md
+++ b/.changeset/polkadot-temporarily-banned-hash-verify.md
@@ -15,7 +15,15 @@ confirmed (a fund-safety false positive), unlike `bittensor.ts` which only
 fast-paths the unambiguous "Already Imported".
 
 `temporarily banned` is removed from the idempotent fast-path list; it now flows
-through `verifyBroadcastByHash`, which swallows the error only when the tx hash
-is actually observed on chain / in the pool and otherwise surfaces the real
-failure. `already imported` / `already known` (unambiguous duplicates) keep their
-fast-path.
+through `verifyBroadcastByHash`. `already imported` / `already known`
+(unambiguous duplicates) keep their fast-path.
+
+Note on current prod behaviour: for Polkadot the confirm branch of
+`verifyBroadcastByHash` is effectively inert today — its status lookup hits
+Subscan's `assethub-polkadot.api.subscan.io` endpoint, which requires an API key
+this codebase does not send, so the request 403s and the original error is
+always re-thrown. The net shipped effect of this change is therefore to make
+`temporarily banned` **fail closed** (surfaced as a failure) rather than be
+assumed a success — the fund-safe direction. Restoring true
+confirm-and-swallow of benign peer-race duplicates requires authenticated
+Subscan tx-status and is tracked as a separate follow-up (vultisig-sdk#1145).

--- a/packages/core/chain/tx/broadcast/resolvers/polkadot.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/polkadot.test.ts
@@ -46,15 +46,6 @@ describe('broadcastPolkadotTx', () => {
       expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
     })
 
-    it('swallows "Transaction is temporarily banned"', async () => {
-      mocks.queryUrl.mockResolvedValue({
-        error: { code: 1010, message: 'Transaction is temporarily banned' },
-      })
-
-      await expect(broadcastPolkadotTx({ chain, tx })).resolves.toBeUndefined()
-      expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
-    })
-
     it('swallows generic "Already known" Pool error variants', async () => {
       mocks.queryUrl.mockResolvedValue({
         error: { code: 1013, message: 'Already known' },
@@ -68,6 +59,50 @@ describe('broadcastPolkadotTx', () => {
       mocks.queryUrl.mockResolvedValue({
         error: { code: 1013, message: 'TRANSACTION ALREADY IMPORTED' },
       })
+
+      await expect(broadcastPolkadotTx({ chain, tx })).resolves.toBeUndefined()
+    })
+  })
+
+  describe('"temporarily banned" is ambiguous — hash-verify, never assume success', () => {
+    // Substrate bans a tx hash after it is removed from the pool, which covers
+    // BOTH a benign already-processed duplicate AND a genuine rejection. The
+    // string cannot disambiguate, so it must be routed through
+    // verifyBroadcastByHash rather than swallowed outright (#1136).
+
+    it('routes "temporarily banned" through verifyBroadcastByHash instead of swallowing it', async () => {
+      mocks.queryUrl.mockResolvedValue({
+        error: { code: 1010, message: 'Transaction is temporarily banned' },
+      })
+      mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+
+      await broadcastPolkadotTx({ chain, tx })
+
+      expect(mocks.verifyBroadcastByHash).toHaveBeenCalledOnce()
+      const callArg = mocks.verifyBroadcastByHash.mock.calls[0]![0]
+      expect((callArg.error as Error).message).toContain('temporarily banned')
+    })
+
+    it('surfaces "temporarily banned" as a failure when the tx is NOT observed on chain', async () => {
+      // A genuinely-rejected-then-banned extrinsic: verifyBroadcastByHash
+      // cannot confirm the hash and re-throws — the caller must see failure,
+      // not a false success.
+      const bannedErr = new Error('Polkadot broadcast failed: Transaction is temporarily banned')
+      mocks.queryUrl.mockResolvedValue({
+        error: { code: 1010, message: 'Transaction is temporarily banned' },
+      })
+      mocks.verifyBroadcastByHash.mockRejectedValue(bannedErr)
+
+      await expect(broadcastPolkadotTx({ chain, tx })).rejects.toThrow(/temporarily banned/)
+    })
+
+    it('swallows "temporarily banned" when verifyBroadcastByHash confirms the tx on chain', async () => {
+      // The benign duplicate sub-case: the tx really did land, so the slow MPC
+      // peer must not see an error.
+      mocks.queryUrl.mockResolvedValue({
+        error: { code: 1010, message: 'Transaction is temporarily banned' },
+      })
+      mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
 
       await expect(broadcastPolkadotTx({ chain, tx })).resolves.toBeUndefined()
     })

--- a/packages/core/chain/tx/broadcast/resolvers/polkadot.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/polkadot.ts
@@ -12,25 +12,29 @@ type RpcResponse = {
 }
 
 /**
- * Substrate Pool errors that mean "this extrinsic is already in the pool /
- * imported / banned because a peer just submitted it." In an MPC ceremony,
- * the initiator and the joiner both broadcast the same signed extrinsic; the
+ * Substrate Pool errors that UNAMBIGUOUSLY mean "this exact extrinsic is
+ * already in the pool because a peer just submitted it." In an MPC ceremony
+ * the initiator and joiner both broadcast the same signed extrinsic; the
  * slower device hits exactly these messages while the tx is in fact already
- * on chain. Treat them as idempotent successes — the alternative is showing
- * the slower device a "Signing Error" screen for a transaction that did
- * confirm. Fast path so we don't rely on `verifyBroadcastByHash`, which can't
- * help on Polkadot until tx-status polling moves off the gated Subscan API.
+ * accepted. Treat them as idempotent successes — the alternative is showing
+ * the slower device a "Signing Error" screen for a tx that did confirm.
+ *
+ * `temporarily banned` is deliberately NOT in this list. Substrate's pool
+ * bans a tx hash for a cool-off window whenever it was recently *removed* —
+ * which includes both a benign already-processed duplicate AND a genuine
+ * rejection (invalid/dropped extrinsic that got banned to stop retry spam).
+ * The string alone cannot tell those apart, so assuming success would report
+ * a genuinely-rejected tx as confirmed (fund-safety false positive). It is
+ * routed through `verifyBroadcastByHash` instead, which only swallows the
+ * error if the tx hash is actually observed on chain / in the pool and
+ * otherwise surfaces the real failure.
  *
  * Substrate sources for the exact strings:
  *   substrate/client/transaction-pool/api/src/error.rs (AlreadyImported,
  *   TemporarilyBanned, NoTagsProvided, ImmediatelyDropped) and
  *   primitives/runtime/src/transaction_validity.rs (Stale).
  */
-const idempotentBroadcastErrorPatterns: readonly RegExp[] = [
-  /already imported/i,
-  /already known/i,
-  /temporarily banned/i,
-]
+const idempotentBroadcastErrorPatterns: readonly RegExp[] = [/already imported/i, /already known/i]
 
 const isIdempotentBroadcastError = (text: string): boolean =>
   idempotentBroadcastErrorPatterns.some(pattern => pattern.test(text))

--- a/packages/core/chain/tx/broadcast/resolvers/polkadot.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/polkadot.ts
@@ -27,7 +27,10 @@ type RpcResponse = {
  * a genuinely-rejected tx as confirmed (fund-safety false positive). It is
  * routed through `verifyBroadcastByHash` instead, which only swallows the
  * error if the tx hash is actually observed on chain / in the pool and
- * otherwise surfaces the real failure.
+ * otherwise surfaces the real failure. (See the prod-behaviour note at the
+ * `verifyBroadcastByHash` call below: for Polkadot that confirm path is
+ * currently inert because Subscan tx-status needs an API key we don't send, so
+ * today this ships as fail-closed — surfaced, never confirm-and-swallowed.)
  *
  * Substrate sources for the exact strings:
  *   substrate/client/transaction-pool/api/src/error.rs (AlreadyImported,
@@ -84,6 +87,19 @@ export const broadcastPolkadotTx: BroadcastTxResolver<OtherChain.Polkadot> = asy
       throw new Error('Polkadot broadcast failed: missing extrinsic hash in RPC response')
     }
   } catch (error) {
+    // NOTE ON CURRENT PROD BEHAVIOUR: for Polkadot the confirm branch of
+    // `verifyBroadcastByHash` is effectively inert. Its status lookup
+    // (`getPolkadotTxStatus`) hits Subscan's `assethub-polkadot.api.subscan.io`
+    // endpoint, which requires an `X-API-Key` this codebase does not send — the
+    // request 403s, `getPolkadotTxStatus` returns `{ isKnown: false }`, and
+    // `verifyBroadcastByHash` therefore always re-throws the original error. So
+    // in practice everything routed here (including `temporarily banned`) ships
+    // as FAIL-CLOSED: surfaced as a failure, never confirm-and-swallowed. That
+    // is the fund-safe direction (a genuinely-rejected tx is never reported as
+    // success), but it means the benign peer-race duplicate of a `temporarily
+    // banned` tx currently surfaces as a signing error too. Restoring the
+    // confirm-and-swallow path needs authenticated Subscan tx-status — tracked
+    // as a follow-up (vultisig-sdk#1145).
     await verifyBroadcastByHash({ chain, tx, error })
   }
 }


### PR DESCRIPTION
Closes #1136

## what

The Polkadot broadcast resolver treated a Substrate `temporarily banned` pool error as an idempotent success and `return`ed without ever consulting `verifyBroadcastByHash`. That is a fund-safety false-positive risk: Substrate's pool bans a tx hash for a cool-off window whenever the hash is *removed* from the pool, and removal happens on BOTH a benign already-processed duplicate AND a genuine rejection (an invalid/dropped extrinsic banned to stop retry spam). The error string alone can't disambiguate, so assuming success could report a genuinely-rejected tx as confirmed.

By contrast the sibling `bittensor.ts` only fast-paths the unambiguous `"Already Imported"`.

## how

- Removed `/temporarily banned/i` from `idempotentBroadcastErrorPatterns`. It no longer short-circuits to success; the existing control flow then throws → the outer `catch` routes it through `verifyBroadcastByHash`, which swallows the error **only** when the tx hash is actually observed on chain / in the pool (`status === 'success'` or known-pending) and otherwise re-throws the real failure. Fail-safe by construction.
- `already imported` / `already known` (unambiguous peer-race duplicates) keep their fast-path.
- Rewrote the doc comment to explain why `temporarily banned` is deliberately excluded.

This intentionally errs toward surfacing failure over swallowing: for a signing/broadcast path, a false "it failed" (recoverable, user retries) is far safer than a false "it succeeded" (user believes funds moved when they did not).

## testing

`polkadot.test.ts` — updated the stale "swallows temporarily banned" assertion and added coverage for all three sub-cases:
- routes `temporarily banned` through `verifyBroadcastByHash` (no longer swallowed outright)
- surfaces it as a **failure** when the hash is NOT observed on chain (verify re-throws)
- still **swallows** it when `verifyBroadcastByHash` confirms the tx did land (benign duplicate sub-case)

Gates: `polkadot.test.ts` **13/13 passed**, `@vultisig/sdk typecheck` ✅, eslint ✅ (0 errors), prettier ✅ (unchanged).

## changeset

Included — `@vultisig/sdk: patch`.

## risk

Low, tightening-only. No existing guard weakened; the unambiguous duplicate fast-paths are untouched. Worst case is a slow MPC peer on a genuinely-confirmed tx briefly surfacing a failure if Polkadot tx-status polling is unavailable — recoverable and strictly safer than the prior false-success.

## known follow-up (out of scope here)

Review surfaced that for Polkadot the `verifyBroadcastByHash` confirm branch is **inert in prod today**: `getPolkadotTxStatus` hits Subscan's gated `assethub-polkadot.api.subscan.io` with no `X-API-Key`, so it 403s and always returns `isKnown: false` → the original error is always re-thrown. So the shipped effect of this PR is that `temporarily banned` **fails closed** (surfaced as failure), never confirm-and-swallowed. That is the fund-safe direction and matches the tests, but the "confirm a benign peer-race duplicate" path only becomes live once Subscan tx-status is authenticated.

Fixed in this PR (doc-honesty, no logic change): the resolver comment + changeset now state this fail-closed reality instead of implying a working confirm path, and the previously-deleted Subscan-limitation warning is restored inline.

Restoring true confirm-and-swallow is tracked as a follow-up: **vultisig/vultisig-sdk#1145** (route Polkadot Subscan tx-status through an authenticated path). Intentionally not fixed here.

🤖 Agent-generated
