### PR TITLE
feat(ripple): read XRP issued-currency (trust-line) token balances

### DIFF
--- a/.changeset/ripple-issued-currency-balances.md
+++ b/.changeset/ripple-issued-currency-balances.md
@@ -1,0 +1,10 @@
+---
+'@vultisig/core-chain': minor
+---
+
+Surface XRP issued-currency (trust-line) token balances.
+
+- `getRippleAccountLines` reads an account's trust lines, following `account_lines` pagination so a large set is not truncated.
+- `getRippleCoinBalance` now dispatches on the coin id: native XRP still returns the reserve-adjusted spendable balance, while an issued-currency coin returns that trust line's balance. Previously the resolver ignored the id and returned the XRP balance for *every* Ripple coin, so a token row displayed the account's XRP balance.
+- `findRippleCoins` discovers held trust lines for the coin finder, so XRPL tokens appear in the asset list. Lines with a negative balance (the account is the issuer and owes the counterparty) and zero-balance lines are excluded.
+- `rippleKnownIssuedTokens` (RLUSD) is now wired into `knownTokens`, so it is selectable before a trust line exists.

--- a/.changeset/ripple-issued-currency-balances.md
+++ b/.changeset/ripple-issued-currency-balances.md
@@ -1,5 +1,6 @@
 ---
 '@vultisig/core-chain': minor
+'@vultisig/sdk': patch
 ---
 
 Surface XRP issued-currency (trust-line) token balances.

--- a/packages/core/chain/chains/ripple/account/lines.ts
+++ b/packages/core/chain/chains/ripple/account/lines.ts
@@ -1,0 +1,34 @@
+import { AccountLinesTrustline } from 'xrpl'
+
+import { getRippleClient } from '../client'
+
+/**
+ * Every trust line held by `address`, following `account_lines` pagination to
+ * completion. The XRP Ledger returns trust lines in pages, so a single request
+ * would silently truncate the set of an account with many lines and hide token
+ * balances rather than fail.
+ *
+ * Balances are signed from `address`'s perspective: a negative balance means
+ * `address` is the issuer and owes the counterparty, not that it holds the token.
+ * @see https://xrpl.org/docs/references/http-websocket-apis/public-api-methods/account-methods/account_lines
+ */
+export const getRippleAccountLines = async (address: string): Promise<AccountLinesTrustline[]> => {
+  const client = await getRippleClient()
+
+  const lines: AccountLinesTrustline[] = []
+  let marker: unknown = undefined
+
+  do {
+    const { result } = await client.request({
+      command: 'account_lines',
+      account: address,
+      ledger_index: 'current',
+      ...(marker === undefined ? {} : { marker }),
+    })
+
+    lines.push(...result.lines)
+    marker = result.marker
+  } while (marker !== undefined)
+
+  return lines
+}

--- a/packages/core/chain/chains/ripple/issuedCurrency.test.ts
+++ b/packages/core/chain/chains/ripple/issuedCurrency.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatIssuedCurrencyValue, parseIssuedCurrencyValue, rippleIssuedCurrencyDecimals } from './issuedCurrency'
+
+describe('parseIssuedCurrencyValue', () => {
+  it('scales a whole number to base units', () => {
+    expect(parseIssuedCurrencyValue('12')).toBe(12_000_000_000_000_000n)
+  })
+
+  it('scales a decimal to base units', () => {
+    expect(parseIssuedCurrencyValue('12.5')).toBe(12_500_000_000_000_000n)
+  })
+
+  it('keeps full precision for a dust balance a float would corrupt', () => {
+    expect(parseIssuedCurrencyValue('0.00204230364')).toBe(2_042_303_640_000n)
+  })
+
+  it('parses scientific notation, which the ledger may return', () => {
+    expect(parseIssuedCurrencyValue('1e-8')).toBe(10_000_000n)
+    expect(parseIssuedCurrencyValue('1.5E3')).toBe(1_500_000_000_000_000_000n)
+  })
+
+  it('preserves the sign of an issued (negative) line', () => {
+    expect(parseIssuedCurrencyValue('-42')).toBe(-42_000_000_000_000_000n)
+  })
+
+  it('truncates rather than rounds beyond the modelled precision', () => {
+    // 16 fractional digits — the last is below our precision and must be dropped,
+    // never rounded up into a larger holding.
+    expect(parseIssuedCurrencyValue('0.0000000000000009')).toBe(0n)
+  })
+
+  it('rejects a malformed value instead of silently reading as zero', () => {
+    expect(() => parseIssuedCurrencyValue('not-a-number')).toThrow(/Invalid XRPL issued-currency value/)
+  })
+
+  it('round-trips with formatIssuedCurrencyValue', () => {
+    const values = ['0', '1', '12.5', '0.00204230364', '-42']
+
+    values.forEach(value => {
+      const parsed = parseIssuedCurrencyValue(value)
+
+      expect(formatIssuedCurrencyValue(parsed, rippleIssuedCurrencyDecimals)).toBe(value)
+    })
+  })
+})

--- a/packages/core/chain/chains/ripple/issuedCurrency.ts
+++ b/packages/core/chain/chains/ripple/issuedCurrency.ts
@@ -113,9 +113,41 @@ export const formatIssuedCurrencyValue = (amount: bigint, decimals: number): str
 export const rippleIssuedCurrencyDecimals = 15
 
 /**
- * Curated XRPL issued tokens surfaced in the "open trust line" flow. Not wired
- * into `knownTokens` — issued-currency balances / asset-list display are handled
- * separately (vultisig-windows#4307 / vultisig-sdk#997).
+ * Parses an XRPL issued-currency value string (as returned by `account_lines`)
+ * into a base-unit bigint at {@link rippleIssuedCurrencyDecimals}. The inverse of
+ * {@link formatIssuedCurrencyValue}.
+ *
+ * The ledger may return scientific notation (e.g. `1e-8`) as well as plain
+ * decimals, and values are signed — a negative balance means the account is the
+ * issuer of the line rather than a holder of it.
+ *
+ * Fractional digits beyond our modelled precision are truncated, never rounded
+ * up, so a dust balance can never be inflated into a larger holding.
+ */
+export const parseIssuedCurrencyValue = (value: string): bigint => {
+  const match = /^([+-]?)(\d+)(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/.exec(value.trim())
+  if (!match) {
+    throw new Error(`Invalid XRPL issued-currency value: "${value}"`)
+  }
+
+  const [, sign, intPart, fracPart = '', exponent = '0'] = match
+
+  // The literal is `digits * 10^(exponent - fracPart.length)`, so scaling it to
+  // base units shifts by that plus our modelled decimals. Shifting the digit
+  // string rather than round-tripping through a float keeps full precision.
+  const shift = Number(exponent) - fracPart.length + rippleIssuedCurrencyDecimals
+  const digits = BigInt(`${intPart}${fracPart}`)
+
+  const magnitude = shift >= 0 ? digits * 10n ** BigInt(shift) : digits / 10n ** BigInt(-shift)
+
+  return sign === '-' ? -magnitude : magnitude
+}
+
+/**
+ * Curated XRPL issued tokens, surfaced both in the "open trust line" flow and —
+ * via `knownTokens` — in the asset list. Trust lines the account already holds are
+ * discovered from the ledger by the Ripple coin finder; this list is what a user
+ * can pick before any trust line exists.
  */
 export const rippleKnownIssuedTokens: KnownCoin[] = [
   {

--- a/packages/core/chain/coin/balance/resolvers/ripple.test.ts
+++ b/packages/core/chain/coin/balance/resolvers/ripple.test.ts
@@ -1,0 +1,144 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { rippleTokenId } from '@vultisig/core-chain/chains/ripple/issuedCurrency'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const requestMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@vultisig/core-chain/chains/ripple/client', () => ({
+  getRippleClient: async () => ({ request: requestMock }),
+}))
+
+import { getRippleCoinBalance } from './ripple'
+
+const ADDRESS = 'rMwNibdiFaEzsTaFCG1NnmAM3Rv3vHUy5L'
+const ISSUER = 'rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De'
+
+// RLUSD is a non-standard code, so on-ledger it is the 160-bit hex form.
+const RLUSD_CURRENCY = '524C555344000000000000000000000000000000'
+
+type TrustLine = {
+  account: string
+  currency: string
+  balance: string
+}
+
+const accountInfo = (Balance: string, OwnerCount: number) => ({
+  result: { account_data: { Balance, OwnerCount } },
+})
+
+const serverState = () => ({
+  result: {
+    state: { validated_ledger: { reserve_base: 1_000_000, reserve_inc: 200_000 } },
+  },
+})
+
+const accountLines = (lines: TrustLine[], marker?: string) => ({
+  result: { lines, ...(marker === undefined ? {} : { marker }) },
+})
+
+/** Routes each mocked request by its XRPL command, so call order never matters. */
+const mockLedger = ({
+  balance = '25000000',
+  ownerCount = 0,
+  lines = [],
+  linePages,
+}: {
+  balance?: string
+  ownerCount?: number
+  lines?: TrustLine[]
+  linePages?: ReturnType<typeof accountLines>[]
+}) => {
+  const pages = linePages ? [...linePages] : [accountLines(lines)]
+
+  requestMock.mockImplementation(async ({ command }: { command: string }) => {
+    if (command === 'account_info') return accountInfo(balance, ownerCount)
+    if (command === 'server_state') return serverState()
+    if (command === 'account_lines') return pages.shift() ?? accountLines([])
+
+    throw new Error(`Unexpected command: ${command}`)
+  })
+}
+
+const nativeCoin = { chain: Chain.Ripple, id: undefined, address: ADDRESS }
+
+const tokenCoin = {
+  chain: Chain.Ripple,
+  id: rippleTokenId({ currency: 'RLUSD', issuer: ISSUER }),
+  address: ADDRESS,
+}
+
+describe('getRippleCoinBalance', () => {
+  beforeEach(() => {
+    requestMock.mockReset()
+  })
+
+  describe('native XRP', () => {
+    it('subtracts the base and owner reserves from the total balance', async () => {
+      mockLedger({ balance: '25000000', ownerCount: 3 })
+
+      // 25 XRP - (1 XRP base + 3 * 0.2 XRP owner) = 23.4 XRP
+      await expect(getRippleCoinBalance(nativeCoin)).resolves.toBe(23_400_000n)
+    })
+
+    it('floors at zero when the reserve exceeds the balance', async () => {
+      mockLedger({ balance: '500000', ownerCount: 0 })
+
+      await expect(getRippleCoinBalance(nativeCoin)).resolves.toBe(0n)
+    })
+  })
+
+  describe('issued currency', () => {
+    it('reads the trust-line balance for the coin id, not the XRP balance', async () => {
+      // The regression this guards: the resolver used to ignore `id` entirely and
+      // return spendable XRP for every coin, so a token row showed the XRP balance.
+      mockLedger({
+        balance: '25000000',
+        lines: [{ account: ISSUER, currency: RLUSD_CURRENCY, balance: '12.5' }],
+      })
+
+      await expect(getRippleCoinBalance(tokenCoin)).resolves.toBe(12_500_000_000_000_000n)
+    })
+
+    it('keeps full precision for a dust balance', async () => {
+      mockLedger({
+        lines: [{ account: ISSUER, currency: RLUSD_CURRENCY, balance: '0.00204230364' }],
+      })
+
+      await expect(getRippleCoinBalance(tokenCoin)).resolves.toBe(2_042_303_640_000n)
+    })
+
+    it('reports zero when the account holds no line for the token', async () => {
+      mockLedger({ lines: [] })
+
+      await expect(getRippleCoinBalance(tokenCoin)).resolves.toBe(0n)
+    })
+
+    it('does not match a line from a different issuer of the same currency', async () => {
+      mockLedger({
+        lines: [{ account: 'rSomeOtherIssuer', currency: RLUSD_CURRENCY, balance: '99' }],
+      })
+
+      await expect(getRippleCoinBalance(tokenCoin)).resolves.toBe(0n)
+    })
+
+    it('reports zero for a negative line rather than a negative asset', async () => {
+      // A negative balance means this account issued the token and owes the peer.
+      mockLedger({
+        lines: [{ account: ISSUER, currency: RLUSD_CURRENCY, balance: '-42' }],
+      })
+
+      await expect(getRippleCoinBalance(tokenCoin)).resolves.toBe(0n)
+    })
+
+    it('follows account_lines pagination instead of truncating at the first page', async () => {
+      mockLedger({
+        linePages: [
+          accountLines([{ account: 'rOther', currency: 'USD', balance: '1' }], 'next-page'),
+          accountLines([{ account: ISSUER, currency: RLUSD_CURRENCY, balance: '7' }]),
+        ],
+      })
+
+      await expect(getRippleCoinBalance(tokenCoin)).resolves.toBe(7_000_000_000_000_000n)
+    })
+  })
+})

--- a/packages/core/chain/coin/balance/resolvers/ripple.test.ts
+++ b/packages/core/chain/coin/balance/resolvers/ripple.test.ts
@@ -139,6 +139,16 @@ describe('getRippleCoinBalance', () => {
       })
 
       await expect(getRippleCoinBalance(tokenCoin)).resolves.toBe(7_000_000_000_000_000n)
+
+      // The follow-up request must carry the marker back, or the ledger would
+      // return the first page again forever — a bug the merged result alone hides.
+      const lineRequests = requestMock.mock.calls
+        .map(([request]) => request)
+        .filter(({ command }) => command === 'account_lines')
+
+      expect(lineRequests).toHaveLength(2)
+      expect(lineRequests[0]).not.toHaveProperty('marker')
+      expect(lineRequests[1]).toMatchObject({ marker: 'next-page' })
     })
   })
 })

--- a/packages/core/chain/coin/balance/resolvers/ripple.ts
+++ b/packages/core/chain/coin/balance/resolvers/ripple.ts
@@ -57,7 +57,7 @@ const getRippleNativeBalance = async (address: string): Promise<bigint> => {
   ])
 
   if ('error' in accountResult) {
-    if (isInError(accountResult.error, 'Account not found')) {
+    if (isInError(accountResult.error, 'Account not found', 'actNotFound')) {
       return BigInt(0)
     }
 

--- a/packages/core/chain/coin/balance/resolvers/ripple.ts
+++ b/packages/core/chain/coin/balance/resolvers/ripple.ts
@@ -1,14 +1,58 @@
 import { getRippleAccountInfo } from '@vultisig/core-chain/chains/ripple/account/info'
+import { getRippleAccountLines } from '@vultisig/core-chain/chains/ripple/account/lines'
+import {
+  parseIssuedCurrencyValue,
+  parseRippleTokenId,
+  toXrplCurrencyCode,
+} from '@vultisig/core-chain/chains/ripple/issuedCurrency'
 import { getRippleNetworkInfo } from '@vultisig/core-chain/chains/ripple/network/info'
+import { isFeeCoin } from '@vultisig/core-chain/coin/utils/isFeeCoin'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { attempt } from '@vultisig/lib-utils/attempt'
 import { isInError } from '@vultisig/lib-utils/error/isInError'
 
 import { CoinBalanceResolver } from '../resolver'
 
-export const getRippleCoinBalance: CoinBalanceResolver = async input => {
+/**
+ * Balance of a single XRPL issued currency (trust-line token), in base units at
+ * `rippleIssuedCurrencyDecimals`.
+ *
+ * A line with a negative balance means this account is the token's issuer and owes
+ * the counterparty, so it is not a holding — it is reported as zero rather than as
+ * a negative asset. An account with no line for the token has a zero balance too.
+ */
+const getRippleIssuedCurrencyBalance = async ({ address, id }: { address: string; id: string }): Promise<bigint> => {
+  const { currency, issuer } = parseRippleTokenId(id)
+
+  const linesResult = await attempt(getRippleAccountLines(address))
+
+  if ('error' in linesResult) {
+    // An unfunded account holds no trust lines — it is not an error state.
+    if (isInError(linesResult.error, 'Account not found', 'actNotFound')) {
+      return BigInt(0)
+    }
+
+    throw linesResult.error
+  }
+
+  const line = linesResult.data.find(
+    ({ account, currency: lineCurrency }) =>
+      account === issuer && toXrplCurrencyCode(lineCurrency) === toXrplCurrencyCode(currency)
+  )
+
+  if (!line) {
+    return BigInt(0)
+  }
+
+  const balance = parseIssuedCurrencyValue(line.balance)
+
+  return balance > 0 ? balance : BigInt(0)
+}
+
+/** Spendable native XRP: total balance minus the base and owner reserves. */
+const getRippleNativeBalance = async (address: string): Promise<bigint> => {
   const [accountResult, networkResult] = await Promise.all([
-    attempt(getRippleAccountInfo(input.address)),
+    attempt(getRippleAccountInfo(address)),
     attempt(getRippleNetworkInfo()),
   ])
 
@@ -34,8 +78,18 @@ export const getRippleCoinBalance: CoinBalanceResolver = async input => {
   const totalBalance = BigInt(account_data.Balance)
   const { reserve_base, reserve_inc } = shouldBePresent(validated_ledger)
 
+  // `OwnerCount` already counts every owned ledger object, trust lines included,
+  // so the trust-line count must not be added again here.
   const totalReserve = BigInt(reserve_base) + BigInt(account_data.OwnerCount) * BigInt(reserve_inc)
   const spendableBalance = totalBalance - totalReserve
 
   return spendableBalance > 0 ? spendableBalance : BigInt(0)
 }
+
+export const getRippleCoinBalance: CoinBalanceResolver = async input =>
+  isFeeCoin(input)
+    ? getRippleNativeBalance(input.address)
+    : getRippleIssuedCurrencyBalance({
+        address: input.address,
+        id: shouldBePresent(input.id, 'Ripple token id'),
+      })

--- a/packages/core/chain/coin/find/CoinFinderChainKind.ts
+++ b/packages/core/chain/coin/find/CoinFinderChainKind.ts
@@ -1,2 +1,2 @@
-export const coinFinderChainKinds = ['evm', 'cosmos', 'solana', 'cardano'] as const
+export const coinFinderChainKinds = ['evm', 'cosmos', 'solana', 'cardano', 'ripple'] as const
 export type CoinFinderChainKind = (typeof coinFinderChainKinds)[number]

--- a/packages/core/chain/coin/find/index.ts
+++ b/packages/core/chain/coin/find/index.ts
@@ -7,6 +7,7 @@ import { FindCoinsResolver } from './resolver'
 import { findCardanoCoins } from './resolvers/cardano'
 import { findCosmosCoins } from './resolvers/cosmos'
 import { findEvmCoins } from './resolvers/evm'
+import { findRippleCoins } from './resolvers/ripple'
 import { findSolanaCoins } from './resolvers/solana'
 
 const resolvers: Record<CoinFinderChainKind, FindCoinsResolver<any>> = {
@@ -14,6 +15,7 @@ const resolvers: Record<CoinFinderChainKind, FindCoinsResolver<any>> = {
   evm: findEvmCoins,
   solana: findSolanaCoins,
   cardano: findCardanoCoins,
+  ripple: findRippleCoins,
 }
 
 export const findCoins: FindCoinsResolver<Chain> = async input => {

--- a/packages/core/chain/coin/find/resolvers/ripple.test.ts
+++ b/packages/core/chain/coin/find/resolvers/ripple.test.ts
@@ -1,0 +1,110 @@
+import { Chain, OtherChain } from '@vultisig/core-chain/Chain'
+import { FindCoinsResolverInput } from '@vultisig/core-chain/coin/find/resolver'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const requestMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@vultisig/core-chain/chains/ripple/client', () => ({
+  getRippleClient: async () => ({ request: requestMock }),
+}))
+
+import { findRippleCoins } from './ripple'
+
+const ADDRESS = 'rMwNibdiFaEzsTaFCG1NnmAM3Rv3vHUy5L'
+const RLUSD_ISSUER = 'rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De'
+const RLUSD_CURRENCY = '524C555344000000000000000000000000000000'
+
+type TrustLine = { account: string; currency: string; balance: string }
+
+const mockLines = (...pages: { lines: TrustLine[]; marker?: string }[]) => {
+  const remaining = [...pages]
+
+  requestMock.mockImplementation(async () => {
+    const page = remaining.shift() ?? { lines: [] }
+
+    return { result: { lines: page.lines, ...(page.marker ? { marker: page.marker } : {}) } }
+  })
+}
+
+const input: FindCoinsResolverInput<OtherChain.Ripple> = {
+  chain: OtherChain.Ripple,
+  address: ADDRESS,
+}
+
+describe('findRippleCoins', () => {
+  beforeEach(() => {
+    requestMock.mockReset()
+  })
+
+  it('discovers a held trust line as an AccountCoin', async () => {
+    mockLines({ lines: [{ account: 'rIssuer', currency: 'USD', balance: '12.5' }] })
+
+    await expect(findRippleCoins(input)).resolves.toEqual([
+      {
+        id: 'USD.rIssuer',
+        chain: Chain.Ripple,
+        address: ADDRESS,
+        ticker: 'USD',
+        decimals: 15,
+      },
+    ])
+  })
+
+  it('decodes a hex currency code back to its human ticker', async () => {
+    mockLines({ lines: [{ account: 'rIssuer', currency: RLUSD_CURRENCY, balance: '1' }] })
+
+    const [coin] = await findRippleCoins(input)
+
+    expect(coin.ticker).toBe('RLUSD')
+  })
+
+  it('enriches a curated token with its logo and price provider', async () => {
+    mockLines({
+      lines: [{ account: RLUSD_ISSUER, currency: RLUSD_CURRENCY, balance: '5' }],
+    })
+
+    const [coin] = await findRippleCoins(input)
+
+    expect(coin).toMatchObject({
+      ticker: 'RLUSD',
+      logo: 'rlusd',
+      priceProviderId: 'ripple-usd',
+      address: ADDRESS,
+    })
+  })
+
+  it('excludes negative lines — the account issued the token, it does not hold it', async () => {
+    mockLines({ lines: [{ account: 'rPeer', currency: 'USD', balance: '-42' }] })
+
+    await expect(findRippleCoins(input)).resolves.toEqual([])
+  })
+
+  it('excludes zero-balance lines so empty trust lines do not clutter the asset list', async () => {
+    mockLines({ lines: [{ account: 'rIssuer', currency: 'JPY', balance: '0' }] })
+
+    await expect(findRippleCoins(input)).resolves.toEqual([])
+  })
+
+  it('follows pagination so a large trust-line set is not truncated', async () => {
+    mockLines(
+      { lines: [{ account: 'rIssuer1', currency: 'USD', balance: '1' }], marker: 'page-2' },
+      { lines: [{ account: 'rIssuer2', currency: 'EUR', balance: '2' }] }
+    )
+
+    const coins = await findRippleCoins(input)
+
+    expect(coins.map(({ id }) => id)).toEqual(['USD.rIssuer1', 'EUR.rIssuer2'])
+  })
+
+  it('returns no coins for an unfunded account instead of throwing', async () => {
+    requestMock.mockRejectedValue(new Error('Account not found.'))
+
+    await expect(findRippleCoins(input)).resolves.toEqual([])
+  })
+
+  it('propagates an unexpected ledger error rather than reporting an empty wallet', async () => {
+    requestMock.mockRejectedValue(new Error('actMalformed'))
+
+    await expect(findRippleCoins(input)).rejects.toThrow(/actMalformed/)
+  })
+})

--- a/packages/core/chain/coin/find/resolvers/ripple.test.ts
+++ b/packages/core/chain/coin/find/resolvers/ripple.test.ts
@@ -94,6 +94,13 @@ describe('findRippleCoins', () => {
     const coins = await findRippleCoins(input)
 
     expect(coins.map(({ id }) => id)).toEqual(['USD.rIssuer1', 'EUR.rIssuer2'])
+
+    // The follow-up request must carry the marker back. Without it the ledger
+    // would return the first page again forever, so asserting only on the merged
+    // result would let that bug through.
+    expect(requestMock).toHaveBeenCalledTimes(2)
+    expect(requestMock).toHaveBeenNthCalledWith(1, expect.not.objectContaining({ marker: expect.anything() }))
+    expect(requestMock).toHaveBeenNthCalledWith(2, expect.objectContaining({ marker: 'page-2' }))
   })
 
   it('returns no coins for an unfunded account instead of throwing', async () => {

--- a/packages/core/chain/coin/find/resolvers/ripple.ts
+++ b/packages/core/chain/coin/find/resolvers/ripple.ts
@@ -1,0 +1,65 @@
+import { OtherChain } from '@vultisig/core-chain/Chain'
+import { getRippleAccountLines } from '@vultisig/core-chain/chains/ripple/account/lines'
+import {
+  parseIssuedCurrencyValue,
+  rippleIssuedCurrencyDecimals,
+  rippleKnownIssuedTokens,
+  rippleTokenId,
+} from '@vultisig/core-chain/chains/ripple/issuedCurrency'
+import { areEqualCoins } from '@vultisig/core-chain/coin/Coin'
+import { FindCoinsResolver } from '@vultisig/core-chain/coin/find/resolver'
+import { attempt } from '@vultisig/lib-utils/attempt'
+import { isInError } from '@vultisig/lib-utils/error/isInError'
+
+/**
+ * Human-readable ticker for a trust line. Standard 3-character codes (`USD`) are
+ * already tickers; the 160-bit hex form encodes ASCII right-padded with zeros, so
+ * decoding it recovers the ticker a user would recognise (e.g. `RLUSD`).
+ */
+const toIssuedCurrencyTicker = (currency: string): string => {
+  if (currency.length !== 40) {
+    return currency
+  }
+
+  const ascii = Buffer.from(currency, 'hex').toString('ascii').replace(/\0+$/, '')
+
+  return /^[\x20-\x7e]+$/.test(ascii) ? ascii : currency
+}
+
+/**
+ * Discovers XRPL issued currencies (trust-line tokens) held at `address`.
+ *
+ * Only lines with a strictly positive balance are surfaced: a negative balance means
+ * the account is the token's issuer and owes the counterparty rather than holding it,
+ * and a zero balance is an open-but-empty trust line that would only clutter the
+ * asset list.
+ */
+export const findRippleCoins: FindCoinsResolver<OtherChain.Ripple> = async ({ address, chain }) => {
+  const linesResult = await attempt(getRippleAccountLines(address))
+
+  if ('error' in linesResult) {
+    // An unfunded account simply holds no trust lines.
+    if (isInError(linesResult.error, 'Account not found', 'actNotFound')) {
+      return []
+    }
+
+    throw linesResult.error
+  }
+
+  return linesResult.data
+    .filter(({ balance }) => parseIssuedCurrencyValue(balance) > 0)
+    .map(({ account, currency }) => {
+      const coin = {
+        id: rippleTokenId({ currency, issuer: account }),
+        chain,
+        address,
+        ticker: toIssuedCurrencyTicker(currency),
+        decimals: rippleIssuedCurrencyDecimals,
+      }
+
+      // Prefer curated metadata (logo, price provider) when we know the token.
+      const knownToken = rippleKnownIssuedTokens.find(token => areEqualCoins(token, coin))
+
+      return knownToken ? { ...coin, ...knownToken, address } : coin
+    })
+}

--- a/packages/core/chain/coin/knownTokens/index.ts
+++ b/packages/core/chain/coin/knownTokens/index.ts
@@ -1,4 +1,5 @@
 import { Chain } from '@vultisig/core-chain/Chain'
+import { rippleKnownIssuedTokens } from '@vultisig/core-chain/chains/ripple/issuedCurrency'
 import { makeRecord } from '@vultisig/lib-utils/record/makeRecord'
 import { omit } from '@vultisig/lib-utils/record/omit'
 
@@ -796,6 +797,7 @@ const leanTokens: Partial<LeanChainTokensRecord> = {
       priceProviderId: 'usd-coin',
     },
   },
+  [Chain.Ripple]: Object.fromEntries(rippleKnownIssuedTokens.map(token => [token.id, omit(token, 'id', 'chain')])),
   ...knownCosmosTokens,
 }
 

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -670,6 +670,11 @@
       "import": "./dist/chains/ripple/account/info.js",
       "default": "./dist/chains/ripple/account/info.js"
     },
+    "./chains/ripple/account/lines": {
+      "types": "./dist/chains/ripple/account/lines.d.ts",
+      "import": "./dist/chains/ripple/account/lines.js",
+      "default": "./dist/chains/ripple/account/lines.js"
+    },
     "./chains/ripple/client": {
       "types": "./dist/chains/ripple/client.d.ts",
       "import": "./dist/chains/ripple/client.js",
@@ -1109,6 +1114,11 @@
       "types": "./dist/coin/find/resolvers/evm/queryOneInch.d.ts",
       "import": "./dist/coin/find/resolvers/evm/queryOneInch.js",
       "default": "./dist/coin/find/resolvers/evm/queryOneInch.js"
+    },
+    "./coin/find/resolvers/ripple": {
+      "types": "./dist/coin/find/resolvers/ripple.d.ts",
+      "import": "./dist/coin/find/resolvers/ripple.js",
+      "default": "./dist/coin/find/resolvers/ripple.js"
     },
     "./coin/find/resolvers/solana": {
       "types": "./dist/coin/find/resolvers/solana/index.d.ts",


### PR DESCRIPTION
Relates to #997. Unblocks vultisig-windows#4307.

## What

Surfaces XRPL **issued-currency (trust-line) balances** on the `@vultisig/core-chain` rail, so XRP tokens appear in the wallet asset list with correct per-token balances.

The desktop/extension asset list reads balances through `getCoinBalance` → `coin/balance/resolvers/ripple.ts` and discovers tokens through `findCoins`. Neither was Ripple-aware, so XRPL tokens could never appear in the wallet.

## Fixes a live wrong-balance bug

`getRippleCoinBalance` ignored `input.id` entirely and returned native spendable XRP for **every** Ripple coin. Since the Open Trust Line flow already shipped (vultisig-windows#4325), an RLUSD row would have rendered the account's **XRP balance** — a wrong number, not merely a missing one. The resolver now dispatches on `isFeeCoin`.

## Changes

- **`chains/ripple/account/lines.ts`** (new) — `getRippleAccountLines`, following `account_lines` `marker` pagination to completion. A single request silently truncates accounts with many trust lines, hiding tokens rather than failing.
- **`chains/ripple/issuedCurrency.ts`** — `parseIssuedCurrencyValue`, the inverse of `formatIssuedCurrencyValue`. Handles the scientific notation the ledger can return, and truncates (never rounds up) below our 15-decimal precision so dust can't be inflated.
- **`coin/balance/resolvers/ripple.ts`** — native vs. issued-currency dispatch.
- **`coin/find/resolvers/ripple.ts`** (new) + `coinFinderChainKinds` — trust-line discovery for the coin finder. Excludes **negative** lines (the account is the *issuer* and owes the counterparty — not a holding) and **zero-balance** lines (open-but-empty trust lines that would only clutter the asset list). Hex currency codes decode back to human tickers.
- **`coin/knownTokens/index.ts`** — wires curated RLUSD in, so it is selectable before any trust line exists.

## Owner reserve — deliberate non-change

#997 asks to "include the trust-line count in the owner reserve". XRPL's `OwnerCount` **already counts trust lines** as owned ledger objects, so adding `trustLineCount` on top would double-count the reserve and understate spendable XRP. The existing `reserve_base + OwnerCount * reserve_inc` is already correct and is left alone.

## Verification

**Live XRPL mainnet**, account `rMwNibdiFaEzsTaFCG1NnmAM3Rv3vHUy5L`:

- native spendable = **31,423,332 drops**
- RLUSD = **0.00204230364** (cross-checked against the ledger)

Each token returns its *own* balance (RLUSD, USD, xShroom, XWORKS, SwissTech, TPR, Duck), demonstrating the id-dispatch fix. Hex tickers decode correctly.

**Consumer check:** built and patched into `vultisig-windows` — `yarn check` and the extension build both pass, and tokens flow through the existing `CoinFinder` + asset-list path with **zero UI changes** (vultisig-windows#4307's "reuses existing patterns, no bespoke states" criterion).

**Suite:** 24 new unit tests (pagination, negative/zero exclusion, precision, issuer matching, unfunded accounts). Full core suite 1695 passing; typecheck, lint, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ripple issued-currency (trust-line token) balance support with accurate coin-id resolution.
  * Added paginated discovery of held Ripple trust lines for coin detection.
  * Added spendable native XRP balance calculation using ledger reserves.
  * Added RLUSD to known Ripple tokens for selection.
  * Added Ripple coin discovery with optional curated token metadata and currency code decoding.

* **Bug Fixes**
  * Excluded zero/negative/unfounded token lines and correctly handled different issuers.
  * Prevented negative balances by clamping results to zero.
  * Improved trust-line and coin discovery to correctly follow pagination markers and handle “account not found” safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->