### PR TITLE
fix(swap): pass 1inch native-ETH sentinel (0xEeee) instead of 'ETH' as dst

### DIFF
--- a/.changeset/1inch-native-eth-sentinel.md
+++ b/.changeset/1inch-native-eth-sentinel.md
@@ -1,0 +1,19 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/sdk': patch
+---
+
+Fix 1inch swap quotes to native ETH (and other EVM chains' native assets) failing route resolution.
+
+`findSwapQuote`'s 1inch fetcher passed `from.id ?? from.ticker` / `to.id ?? to.ticker` into
+`getOneInchSwapQuote`, so a native asset (no `.id`) fell back to its ticker string (e.g. `"ETH"`).
+`getOneInchSwapQuote`'s `isFeeCoin` check relies on `undefined` to detect the native asset and
+substitute 1inch's `0xEeee...` sentinel address (EIP-7528) — a truthy ticker string defeated that
+check, so 1inch received `dst=ETH` (or `src=ETH`) instead of the sentinel and rejected the request
+with `dst must be an Ethereum address`. This silently removed 1inch as a route for any swap
+involving a chain's native asset (e.g. USDC→ETH), even though 1inch could otherwise fill it.
+
+Now `findSwapQuote` forwards the coin's raw `.id` (`undefined` for the native asset) so
+`getOneInchSwapQuote`'s existing sentinel-mapping logic works as designed. ERC-20↔ERC-20 quotes
+are unaffected; other providers (Kyber, LiFi, SwapKit) construct their own requests and are not
+touched by this change.

--- a/packages/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.test.ts
+++ b/packages/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.test.ts
@@ -101,6 +101,65 @@ describe('getOneInchSwapQuote — AGG-02 router allowlist', () => {
   })
 })
 
+describe('getOneInchSwapQuote — native asset sentinel (EIP-7528)', () => {
+  const mockResponse = {
+    dstAmount: '1000000',
+    tx: {
+      from: '0xsender',
+      to: '0x111111125421ca6dc452d289314280a0f8842a65',
+      data: '0xswap',
+      value: '0',
+      gasPrice: '1000000000',
+      gas: 210000,
+    },
+  }
+
+  it('maps a native destination (toCoinId undefined) to the 0xEeee sentinel, not a ticker string', async () => {
+    vi.mocked(queryUrl).mockResolvedValueOnce(mockResponse)
+
+    await getOneInchSwapQuote({
+      account,
+      fromCoinId: '0xsrc',
+      toCoinId: undefined,
+      amount: 1_000_000n,
+    })
+
+    const calledUrl = vi.mocked(queryUrl).mock.calls.at(-1)![0] as string
+    expect(calledUrl).toContain('dst=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee')
+    expect(calledUrl).not.toContain('dst=ETH')
+  })
+
+  it('maps a native source (fromCoinId undefined) to the 0xEeee sentinel, not a ticker string', async () => {
+    vi.mocked(queryUrl).mockResolvedValueOnce(mockResponse)
+
+    await getOneInchSwapQuote({
+      account,
+      fromCoinId: undefined,
+      toCoinId: '0xdst',
+      amount: 1_000_000n,
+    })
+
+    const calledUrl = vi.mocked(queryUrl).mock.calls.at(-1)![0] as string
+    expect(calledUrl).toContain('src=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee')
+    expect(calledUrl).not.toContain('src=ETH')
+  })
+
+  it('leaves an ERC-20 destination untouched (non-native dst is not remapped)', async () => {
+    vi.mocked(queryUrl).mockResolvedValueOnce(mockResponse)
+
+    await getOneInchSwapQuote({
+      account,
+      fromCoinId: '0xsrc',
+      toCoinId: '0xdst',
+      amount: 1_000_000n,
+    })
+
+    const calledUrl = vi.mocked(queryUrl).mock.calls.at(-1)![0] as string
+    expect(calledUrl).toContain('dst=0xdst')
+    expect(calledUrl).toContain('src=0xsrc')
+  })
+})
+
 describe('getOneInchSwapQuote — affiliateFee display (AGG-05)', () => {
   it('populates affiliateFee grossed up from the post-fee dstAmount, matching the Kyber convention', async () => {
     vi.mocked(queryUrl).mockResolvedValueOnce({

--- a/packages/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.ts
+++ b/packages/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.ts
@@ -19,8 +19,11 @@ export type OneInchAffiliateConfig = typeof oneInchAffiliateConfig
 
 type Input = {
   account: ChainAccount
-  fromCoinId: string
-  toCoinId: string
+  /** The coin's `.id` (contract address), or `undefined` for the chain's native/fee coin.
+   * Must NOT be substituted with a ticker fallback by the caller — `isFeeCoin` below relies
+   * on `undefined` to detect the native asset and map it to 1inch's `0xEeee...` sentinel. */
+  fromCoinId: string | undefined
+  toCoinId: string | undefined
   /** Destination coin metadata. When set alongside affiliateBps, populates a display-only
    * affiliateFee (AGG-05) matching the Kyber/LiFi convention. */
   to?: AccountCoin<EvmChain>
@@ -32,6 +35,13 @@ type Input = {
 }
 
 const getBaseUrl = (chainId: number) => `${rootApiUrl}/1inch/swap/v6.0/${chainId}/swap`
+
+// 1inch's classic swap API requires the chain's native asset to be represented by its
+// `0xEeee...` sentinel address (EIP-7528), not a ticker string or the zero address. A coin
+// with no `.id` (contract address) is the native/fee coin — undefined is the correct signal
+// here, not a ticker fallback, which would be a truthy string and defeat this check.
+const resolveOneInchCoinAddress = (coinId: string | undefined, chain: EvmChain): string =>
+  isFeeCoin({ id: coinId, chain }) ? evmNativeCoinAddress : (coinId as string)
 
 // 1inch's `fee` param deducts the affiliate cut from dstAmount before returning it — same
 // convention as Kyber's /route/build. Gross the net amount back up to derive the fee for
@@ -75,8 +85,8 @@ export const getOneInchSwapQuote = async ({
   const chainId = hexToNumber(getEvmChainId(chain))
 
   const params = {
-    src: isFeeCoin({ id: fromCoinId, chain: account.chain }) ? evmNativeCoinAddress : fromCoinId,
-    dst: isFeeCoin({ id: toCoinId, chain: account.chain }) ? evmNativeCoinAddress : toCoinId,
+    src: resolveOneInchCoinAddress(fromCoinId, chain),
+    dst: resolveOneInchCoinAddress(toCoinId, chain),
     amount: amount.toString(),
     from: account.address,
     slippage,

--- a/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
@@ -325,6 +325,31 @@ describe('findSwapQuote parallel selection', () => {
     expect(quote.quote.general.provider).toBe('kyber')
   })
 
+  it('forwards a native-ETH destination to 1inch as toCoinId=undefined, not a ticker string (bug: 1inch requires the 0xEeee sentinel)', async () => {
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
+    vi.mocked(getSwapKitQuote).mockRejectedValue(new Error('skip swapkit'))
+    vi.mocked(getKyberSwapQuote).mockRejectedValue(new Error('skip kyber'))
+    vi.mocked(getNativeSwapQuote).mockRejectedValue(new Error('skip native'))
+    vi.mocked(getOneInchSwapQuote).mockResolvedValue(minimalGeneralQuote('200', '1inch'))
+
+    const nativeEthDestination = {
+      chain: Chain.Ethereum,
+      address: '0xsender',
+      decimals: 18,
+      ticker: 'ETH',
+    } as const
+
+    await findSwapQuote({
+      from: evmSameChainCoins.from,
+      to: nativeEthDestination,
+      amount: 1n,
+    })
+
+    expect(getOneInchSwapQuote).toHaveBeenCalledWith(
+      expect.objectContaining({ toCoinId: undefined, fromCoinId: '0xsrc' })
+    )
+  })
+
   it('tie-break: SwapKit wins over 1inch on equal output by declared provider preference', async () => {
     // SwapKit now sits above the EVM aggregators in providerPreferenceOrder.
     // On an equal-output tie, it must win regardless of fetcher array order

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -753,8 +753,13 @@ export const findSwapQuote = async ({
         fetch: async (): Promise<SwapQuote> => {
           const general = await getOneInchSwapQuote({
             account: pick(from, ['address', 'chain']),
-            fromCoinId: from.id ?? from.ticker,
-            toCoinId: to.id ?? to.ticker,
+            // Pass the raw `.id` (undefined for a chain's native/fee coin) — NOT a ticker
+            // fallback. `getOneInchSwapQuote`'s `isFeeCoin` check relies on `undefined` to
+            // map the native asset to 1inch's `0xEeee...` sentinel; a ticker string like
+            // "ETH" is truthy and would defeat that check, sending the literal ticker as
+            // `dst`/`src` to 1inch's API (which requires the sentinel address).
+            fromCoinId: from.id,
+            toCoinId: to.id,
             to: {
               ...to,
               chain: to.chain as EvmChain,


### PR DESCRIPTION
🤖 Agent-generated

## Summary

`findSwapQuote`'s 1inch fetcher passed `from.id ?? from.ticker` / `to.id ?? to.ticker` into `getOneInchSwapQuote` as `fromCoinId`/`toCoinId`. For a chain's native asset (which has no `.id`), that fell back to the ticker string (e.g. `"ETH"`) — a truthy value.

`getOneInchSwapQuote` maps a coin to 1inch's `0xEeee...EEeE` native sentinel (EIP-7528) via `isFeeCoin({ id: coinId, chain }) ? evmNativeCoinAddress : coinId`, where `isFeeCoin = (coin) => !coin.id`. That check relies on `coinId` being `undefined` for the native asset. A ticker string like `"ETH"` is truthy, so the check evaluated `false` and the raw ticker was sent to 1inch as `dst` (or `src`) instead of the sentinel.

1inch's classic swap API rejects a non-address `dst`/`src` outright:
```
{"error":"Bad Request","description":"dst must be an Ethereum address","statusCode":400,"code":"VALIDATION_FAILED"}
```

This silently removed 1inch as a usable route for any swap touching a chain's native asset (e.g. USDC→ETH — a chronically flaky pair for agent-backend-ts that needs 1inch as an alternative to Kyber/SwapKit) — independent of allowance or balance. ERC-20↔ERC-20 pairs were unaffected because both sides already have a real `.id`.

## Root cause

- `packages/core/chain/swap/quote/findSwapQuote.ts` (1inch fetcher registration): coerced `from.id`/`to.id` to a ticker fallback before handing off to the 1inch quote builder.
- `packages/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.ts`: the sentinel-mapping logic itself (`isFeeCoin` check) was correct — it just never saw the `undefined` it needed because the caller had already replaced it with a ticker string.

## Fix

- `findSwapQuote.ts`: forward `from.id` / `to.id` directly (raw, possibly `undefined`) — no ticker fallback.
- `getOneInchSwapQuote.ts`: widen `fromCoinId`/`toCoinId` to `string | undefined` (matching what a native coin's `.id` actually is) and extract a small `resolveOneInchCoinAddress` helper so the `isFeeCoin`-driven sentinel mapping is properly typed against `addQueryParams`'s `Record<string, string | number | boolean>` signature.

Scope: only the 1inch provider's request construction changes. Kyber, LiFi, SwapKit, CowSwap, Jupiter each build their own requests independently and are untouched. Every EVM chain 1inch supports (Ethereum, Arbitrum, Zksync, BSC, Avalanche, Optimism, Polygon, Base) uses the same `0xEeee...` sentinel for its native asset, so this fix is chain-agnostic within the 1inch provider.

## Before / after (live proxy call, no auth needed via Vultisig's `api.vultisig.com/1inch` proxy)

**Before (bug — `dst=ETH`, USDC→ETH on Ethereum mainnet):**
```
$ curl "https://api.vultisig.com/1inch/swap/v6.0/1/quote?src=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48&dst=ETH&amount=1000000"
{"error":"Bad Request","description":"dst must be an Ethereum address","statusCode":400,"code":"VALIDATION_FAILED"}
```

**After (fix — `dst=0xEeee...`, same pair/amount):**
```
$ curl "https://api.vultisig.com/1inch/swap/v6.0/1/quote?src=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48&dst=0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE&amount=1000000"
{"dstAmount":"551700000000000"}
```

**Control — ERC-20→ERC-20 (USDC→USDT) is unaffected either way:**
```
$ curl ".../quote?src=0xA0b86991...&dst=0xdAC17F958D2ee523a2206206994597C13D831ec7&amount=1000000"
{"dstAmount":"1000529"}
```

**Control — native-ETH as `src` has the same bug/fix (also exercised by the new tests):**
```
src=ETH        -> {"error":"Bad Request","description":"src must be an Ethereum address",...}
src=0xEeee...  -> {"dstAmount":"1812135540"}
```

## Test plan
- [x] `yarn typecheck` — no new errors (pre-existing, unrelated CLI errors confirmed present on `main` too)
- [x] `yarn lint` (scoped to changed files) — clean
- [x] `yarn test:core` — 1699 passed, 1 skipped (4 new tests added)
- [x] New regression test in `getOneInchSwapQuote.test.ts`: native src/dst map to the `0xEeee` sentinel; non-native dst is untouched
- [x] New regression test in `findSwapQuote.selection.test.ts`: a native-ETH `to` coin is forwarded to the 1inch fetcher as `toCoinId: undefined`, not a ticker string — **this test fails against the pre-fix code** (verified by stashing the fix and re-running: `toCoinId: "ETH"` vs expected `undefined`)
- [x] Live 1inch quote proof (before/after) via Vultisig's public proxy, no API key needed
- [x] Changeset added (`@vultisig/core-chain` patch, `@vultisig/sdk` patch)

## QA Guide

**Intent:** USDC→ETH (and any ERC-20→native-asset swap on Ethereum/Arbitrum/Zksync/BSC/Avalanche/Optimism/Polygon/Base) can now resolve a 1inch quote instead of silently losing 1inch as a candidate provider. This restores provider diversity for a chronically flaky pair in agent-backend-ts.

**Verify steps:**
1. `yarn test:core` from repo root — confirm the two new describe blocks pass: `getOneInchSwapQuote — native asset sentinel (EIP-7528)` and the new test in `findSwapQuote parallel selection`.
2. Direct API proof (no vault/funds needed): run the curl commands above against `https://api.vultisig.com/1inch/swap/v6.0/1/quote` — confirm `dst=ETH` 400s and `dst=0xEeee...` returns a `dstAmount`.
3. Optional integration check: once this SDK version is consumed by agent-backend-ts, a USDC→ETH swap quote request (`execute_swap` tool, `from_chain=ethereum from_token=USDC to_chain=ethereum to_token=ETH`) should now be able to select 1inch as a provider (subject to it winning the best-quote comparison against Kyber/SwapKit/LiFi — this fix makes 1inch *eligible*, not necessarily the *winner*, for that pair).

**Expected outcomes:** 1inch quote requests for native-destination or native-source pairs on any of the 8 1inch-enabled EVM chains resolve successfully instead of erroring with `VALIDATION_FAILED`.

**Edge cases:**
- Native→native isn't a real case (same-chain same-asset swap doesn't route through 1inch), not applicable.
- Chains not in `oneInchSwapEnabledChains` (e.g. Solana, Cosmos) are unaffected — 1inch fetcher never registers for them.
- I did not verify every one of the 8 EVM chains' native sentinel individually beyond Ethereum mainnet (the sentinel address is documented as identical across EVM chains per EIP-7528 and 1inch's own docs, and the code path is chain-agnostic — no per-chain branching), so if any 1inch deployment on a specific chain uses a different sentinel, that chain's native-asset routing would still be broken. I did not have API access to verify all 8 chains directly.

**Prereqs:** None for the unit tests or the curl proof — the Vultisig 1inch proxy is public and needs no auth for a `/quote` GET.

**Suggested flows:** No Maestro/app-level flow applies — this is an SDK/core-chain layer fix, exercised via unit tests and direct API calls only.

Bead: vultisig-ops-ipvz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed 1inch swap quotes involving a chain’s native asset.
  - Native assets are now correctly recognized in swap requests, preventing quote failures caused by ticker values being sent as addresses.
  - ERC-20 token swap behavior remains unchanged.

- **Tests**
  - Added coverage for native-asset sentinel handling and standard ERC-20 address requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->