### PR TITLE
fix(encoding): reject empty/malformed amounts in the 5 resolvers #1140 missed

### DIFF
--- a/.changeset/bounded-bigint-residual-resolvers.md
+++ b/.changeset/bounded-bigint-residual-resolvers.md
@@ -1,0 +1,24 @@
+---
+'@vultisig/sdk': patch
+---
+
+fix(encoding): reject empty/malformed amounts in the 5 resolvers #1140 missed
+
+#1140 closed the `BigInt('') -> 0n` fail-open class (proto3 defaults an unset
+`toAmount` string to `''`, so a bare `BigInt()` silently builds a zero-amount
+transfer) for the resolvers whose amounts feed proto 64-bit fields via
+`toBoundedLong`. The same unguarded `BigInt(toAmount)` pattern remained in five
+resolvers whose amounts are NOT proto 64-bit integers: Tron TRC20 (uint256
+calldata bytes), Polkadot (u128 balance bytes), Bittensor (SCALE-compact u64),
+Solana send (uint64, was still raw `BigInt` + `Long.fromString`) and Ripple
+issued-currency trust lines (decimal-string value).
+
+Adds `toBoundedBigInt` (`@vultisig/lib-utils/bigint/toBoundedBigInt`), the
+bigint-returning sibling of `toBoundedLong` (which now delegates to it), with an
+explicit bit width per target field so wide fields don't false-reject: Tron
+TRC20 bounds at uint256, Polkadot at u128, Bittensor at u64 (subtensor `Balance`
+is u64), Ripple issued-currency at u128, and Solana send routes through
+`toBoundedLong { unsigned: true }`. Ripple's raw-JSON memo payment path, which
+inlined `toAmount` unvalidated into the tx JSON, is guarded the same way as its
+sibling Payment proto path. An unset/negative/non-decimal amount now throws a
+`RangeError` instead of being silently co-signed as a zero-value transfer.

--- a/packages/core/mpc/keysign/signingInputs/resolvers/bittensor.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/bittensor.test.ts
@@ -231,3 +231,33 @@ describe('getBittensorSigningInputs — custom tx-input framing round-trips', ()
     expect(hex(decoded.payload)).toBe(hex(payload))
   })
 })
+
+describe('getBittensorSigningInputs -- amount strict parse (#1147)', () => {
+  let walletCore: WalletCore
+
+  beforeAll(async () => {
+    walletCore = await initWasm()
+  })
+
+  it("rejects an unset ('') amount instead of building a zero-value transfer", () => {
+    const payload = buildPayload()
+    payload.toAmount = ''
+    // Pre-fix: BigInt('') -> 0n -> compactEncode(0n) silently co-signed.
+    expect(() => getBittensorSigningInputs({ keysignPayload: payload, walletCore })).toThrow(RangeError)
+  })
+
+  it('rejects an amount above the u64 balance range (subtensor Balance is u64)', () => {
+    const payload = buildPayload()
+    payload.toAmount = (2n ** 64n).toString()
+    expect(() => getBittensorSigningInputs({ keysignPayload: payload, walletCore })).toThrow(RangeError)
+  })
+
+  it('still builds a transfer at the u64 max (no false-reject)', () => {
+    const payload = buildPayload()
+    payload.toAmount = (2n ** 64n - 1n).toString()
+    const [txInputData] = getBittensorSigningInputs({ keysignPayload: payload, walletCore })
+    const { callData } = decodeBittensorTxInput(txInputData)
+    // callData ends with the SCALE-compact-encoded amount.
+    expect(hex(callData).endsWith(hex(compactEncode(2n ** 64n - 1n)))).toBe(true)
+  })
+})

--- a/packages/core/mpc/keysign/signingInputs/resolvers/bittensor.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/bittensor.ts
@@ -4,6 +4,7 @@ import {
 } from '@vultisig/core-chain/chains/bittensor/signing/buildExtrinsic'
 import { concatBytes } from '@vultisig/core-chain/chains/bittensor/signing/scale'
 import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { toBoundedBigInt } from '@vultisig/lib-utils/bigint/toBoundedBigInt'
 import { WalletCore } from '@trustwallet/wallet-core'
 
 import { getBlockchainSpecificValue } from '../../chainSpecific/KeysignChainSpecific'
@@ -63,7 +64,7 @@ export const getBittensorSigningInputs = ({
 
   const params: BittensorSigningParams = {
     toAddress,
-    amount: BigInt(keysignPayload.toAmount),
+    amount: toBoundedBigInt(keysignPayload.toAmount, { bits: 64, signed: false }),
     nonce: Number(nonce),
     blockNumber: Number(currentBlockNumber),
     blockHash: recentBlockHash,

--- a/packages/core/mpc/keysign/signingInputs/resolvers/polkadot.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/polkadot.test.ts
@@ -153,3 +153,31 @@ describe('getPolkadotSigningInputs', () => {
     expect(callIndexOffsets).toEqual([CALL_INDICES_OFFSET])
   })
 })
+
+describe('getPolkadotSigningInputs -- amount strict parse (#1147)', () => {
+  let walletCore: WalletCore
+
+  beforeAll(async () => {
+    walletCore = await initWasm()
+  })
+
+  it("rejects an unset ('') amount instead of building a zero-value transfer", () => {
+    const payload = buildPayload()
+    payload.toAmount = ''
+    // Pre-fix: BigInt('') -> 0n -> a 0x00 value byte silently co-signed.
+    expect(() => getPolkadotSigningInputs({ keysignPayload: payload, walletCore })).toThrow(RangeError)
+  })
+
+  it('rejects an amount above the u128 balance range', () => {
+    const payload = buildPayload()
+    payload.toAmount = (2n ** 128n).toString()
+    expect(() => getPolkadotSigningInputs({ keysignPayload: payload, walletCore })).toThrow(RangeError)
+  })
+
+  it('still builds a transfer above 64 bits (u128 balances must not false-reject)', async () => {
+    const payload = buildPayload()
+    payload.toAmount = (2n ** 64n).toString()
+    const [input] = await getPolkadotSigningInputs({ keysignPayload: payload, walletCore })
+    expect(hex(input.balanceCall?.assetTransfer?.value ?? new Uint8Array())).toBe('010000000000000000')
+  })
+})

--- a/packages/core/mpc/keysign/signingInputs/resolvers/polkadot.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/polkadot.ts
@@ -1,6 +1,7 @@
 import { Buffer } from 'buffer'
 import { getCoinType } from '@vultisig/core-chain/coin/coinType'
 import { bigIntToHex } from '@vultisig/lib-utils/bigint/bigIntToHex'
+import { toBoundedBigInt } from '@vultisig/lib-utils/bigint/toBoundedBigInt'
 import { stripHexPrefix } from '@vultisig/lib-utils/hex/stripHexPrefix'
 import { TW } from '@trustwallet/wallet-core'
 import Long from 'long'
@@ -21,7 +22,10 @@ export const getPolkadotSigningInputs: SigningInputsResolver<'polkadot'> = ({ ke
     getBlockchainSpecificValue(keysignPayload.blockchainSpecific, 'polkadotSpecific')
 
   // Amount: converted to hexadecimal, stripped of '0x'
-  const amountHex = Buffer.from(stripHexPrefix(bigIntToHex(BigInt(keysignPayload.toAmount))), 'hex')
+  const amountHex = Buffer.from(
+    stripHexPrefix(bigIntToHex(toBoundedBigInt(keysignPayload.toAmount, { bits: 128, signed: false }))),
+    'hex'
+  )
 
   // methodIndex 3 = transfer_keep_alive on Asset Hub (statemint pallet_balances).
   // method 0 = transfer_allow_death which can reap the sender's account when the

--- a/packages/core/mpc/keysign/signingInputs/resolvers/ripple.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/ripple.test.ts
@@ -171,6 +171,20 @@ describe('getRippleSigningInputs -- amount strict parse (#1147)', () => {
     ).toThrow(RangeError)
   })
 
+  it('rejects a negative amount on the raw-JSON memo payment path', () => {
+    // XRP drops are non-negative; unsigned bound throws pre-ceremony instead
+    // of building JSON that XRPL would reject post-sign.
+    const payload = buildPaymentPayload()
+    payload.memo = 'not-a-destination-tag'
+    payload.toAmount = '-1'
+    expect(() =>
+      getRippleSigningInputs({
+        keysignPayload: payload,
+        walletCore,
+      })
+    ).toThrow(RangeError)
+  })
+
   it('keeps the raw-JSON memo payment amount unchanged for a valid value', async () => {
     const payload = buildPaymentPayload()
     payload.memo = 'not-a-destination-tag'

--- a/packages/core/mpc/keysign/signingInputs/resolvers/ripple.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/ripple.test.ts
@@ -128,3 +128,56 @@ describe('getRippleSigningInputs -- TrustSet build path (issued currency)', () =
     expect(input.opTrustSet).toBeFalsy()
   })
 })
+
+describe('getRippleSigningInputs -- amount strict parse (#1147)', () => {
+  it("rejects an unset ('') issued-currency amount instead of a zero trust-line limit", () => {
+    // Pre-fix: BigInt('') -> 0n -> formatIssuedCurrencyValue(0n) -> a '0' limit
+    // silently co-signed.
+    expect(() =>
+      getRippleSigningInputs({
+        keysignPayload: buildTrustSetPayload(''),
+        walletCore,
+      })
+    ).toThrow(RangeError)
+  })
+
+  it('rejects a negative issued-currency amount', () => {
+    expect(() =>
+      getRippleSigningInputs({
+        keysignPayload: buildTrustSetPayload('-1'),
+        walletCore,
+      })
+    ).toThrow(RangeError)
+  })
+
+  it('still builds an issued-currency limit above 64 bits (XRPL IOU values are not 64-bit)', async () => {
+    const [input] = await getRippleSigningInputs({
+      keysignPayload: buildTrustSetPayload((2n ** 64n).toString()),
+      walletCore,
+    })
+    // 2^64 raw units at 15 decimals.
+    expect(input.opTrustSet?.limitAmount?.value).toBe('18446.744073709551616')
+  })
+
+  it("rejects an unset ('') amount on the raw-JSON memo payment path", () => {
+    const payload = buildPaymentPayload()
+    payload.memo = 'not-a-destination-tag'
+    payload.toAmount = ''
+    expect(() =>
+      getRippleSigningInputs({
+        keysignPayload: payload,
+        walletCore,
+      })
+    ).toThrow(RangeError)
+  })
+
+  it('keeps the raw-JSON memo payment amount unchanged for a valid value', async () => {
+    const payload = buildPaymentPayload()
+    payload.memo = 'not-a-destination-tag'
+    const [input] = await getRippleSigningInputs({
+      keysignPayload: payload,
+      walletCore,
+    })
+    expect(JSON.parse(input.rawJson ?? '{}').Amount).toBe('1000000')
+  })
+})

--- a/packages/core/mpc/keysign/signingInputs/resolvers/ripple.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/ripple.ts
@@ -5,6 +5,7 @@ import {
   toXrplCurrencyCode,
 } from '@vultisig/core-chain/chains/ripple/issuedCurrency'
 import { assertField } from '@vultisig/lib-utils/record/assertField'
+import { toBoundedBigInt } from '@vultisig/lib-utils/bigint/toBoundedBigInt'
 import { toBoundedLong } from '@vultisig/lib-utils/bigint/toBoundedLong'
 import { TW } from '@trustwallet/wallet-core'
 import Long from 'long'
@@ -38,7 +39,10 @@ export const getRippleSigningInputs: SigningInputsResolver<'ripple'> = ({ keysig
         limitAmount: TW.Ripple.Proto.CurrencyAmount.create({
           currency: toXrplCurrencyCode(currency),
           issuer,
-          value: formatIssuedCurrencyValue(BigInt(keysignPayload.toAmount), coin.decimals),
+          value: formatIssuedCurrencyValue(
+            toBoundedBigInt(keysignPayload.toAmount, { bits: 128, signed: false }),
+            coin.decimals
+          ),
         }),
       }),
     }
@@ -65,7 +69,7 @@ export const getRippleSigningInputs: SigningInputsResolver<'ripple'> = ({ keysig
           TransactionType: 'Payment',
           Account: account,
           Destination: keysignPayload.toAddress,
-          Amount: keysignPayload.toAmount,
+          Amount: toBoundedLong(keysignPayload.toAmount, { unsigned: false }).toString(),
           Fee: gas.toString(),
           Sequence: Number(sequence),
           LastLedgerSequence: Number(lastLedgerSequence),

--- a/packages/core/mpc/keysign/signingInputs/resolvers/ripple.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/ripple.ts
@@ -69,7 +69,11 @@ export const getRippleSigningInputs: SigningInputsResolver<'ripple'> = ({ keysig
           TransactionType: 'Payment',
           Account: account,
           Destination: keysignPayload.toAddress,
-          Amount: toBoundedLong(keysignPayload.toAmount, { unsigned: false }).toString(),
+          // Unlike the two Payment PROTO paths (int64 field, so signedness must
+          // match), this is a plain JSON string: XRP drops are non-negative, so
+          // reject a negative amount here instead of building JSON that XRPL
+          // would bounce after the MPC ceremony already ran.
+          Amount: toBoundedLong(keysignPayload.toAmount, { unsigned: true }).toString(),
           Fee: gas.toString(),
           Sequence: Number(sequence),
           LastLedgerSequence: Number(lastLedgerSequence),

--- a/packages/core/mpc/keysign/signingInputs/resolvers/solana/send.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/solana/send.test.ts
@@ -137,3 +137,31 @@ describe('getSolanaSendSigningInput priority fee plumbing', () => {
     expect(input.priorityFeePrice?.price?.toString()).toBe('1000000')
   })
 })
+
+describe('getSolanaSendSigningInput -- amount strict parse (#1147)', () => {
+  let walletCore: WalletCore
+
+  beforeAll(async () => {
+    walletCore = await initWasm()
+  })
+
+  it("rejects an unset ('') amount instead of building a zero-value transfer", () => {
+    const payload = buildPayload({})
+    payload.toAmount = ''
+    // Pre-fix: BigInt('') -> 0n -> Long.fromString('0') silently co-signed.
+    expect(() => getSolanaSendSigningInput({ keysignPayload: payload, walletCore })).toThrow(RangeError)
+  })
+
+  it('rejects an amount at 2^64 instead of silently wrapping the uint64 field', () => {
+    const payload = buildPayload({})
+    payload.toAmount = (2n ** 64n).toString()
+    expect(() => getSolanaSendSigningInput({ keysignPayload: payload, walletCore })).toThrow(RangeError)
+  })
+
+  it('still builds a native transfer at the uint64 max (no false-reject)', () => {
+    const payload = buildPayload({})
+    payload.toAmount = (2n ** 64n - 1n).toString()
+    const input = getSolanaSendSigningInput({ keysignPayload: payload, walletCore })
+    expect(input.transferTransaction?.value?.toString()).toBe('18446744073709551615')
+  })
+})

--- a/packages/core/mpc/keysign/signingInputs/resolvers/solana/send.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/solana/send.ts
@@ -1,5 +1,6 @@
 import { solanaConfig } from '@vultisig/core-chain/chains/solana/solanaConfig'
 import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { toBoundedLong } from '@vultisig/lib-utils/bigint/toBoundedLong'
 import { maxBigInt } from '@vultisig/lib-utils/math/maxBigInt'
 import { TW, WalletCore } from '@trustwallet/wallet-core'
 import Long from 'long'
@@ -31,7 +32,10 @@ export const getSolanaSendSigningInput = ({
   // `setComputeUnitPrice` instruction when the wire value is missing.
   const priorityFeePrice = maxBigInt(priorityFee ? BigInt(priorityFee) : 0n, BigInt(solanaConfig.priorityFeePrice))
 
-  const amount = BigInt(keysignPayload.toAmount)
+  // Lamports / SPL token amounts are proto uint64 fields; the bounded parse
+  // rejects an unset ('' -> 0n) or >64-bit amount instead of silently building
+  // a zero-value or wrapped transfer.
+  const amount = toBoundedLong(keysignPayload.toAmount, { unsigned: true })
   const sender = coin.address
   const recipient = keysignPayload.toAddress
 
@@ -40,7 +44,7 @@ export const getSolanaSendSigningInput = ({
       return {
         transferTransaction: TW.Solana.Proto.Transfer.create({
           recipient,
-          value: Long.fromString(amount.toString()),
+          value: amount,
           memo: keysignPayload.memo,
         }),
       }
@@ -53,7 +57,7 @@ export const getSolanaSendSigningInput = ({
     const tokenTransferSharedFields = {
       tokenMintAddress: coin.id,
       senderTokenAddress: fromTokenAssociatedAddress,
-      amount: Long.fromString(amount.toString()),
+      amount,
       decimals: coin.decimals,
       tokenProgramId,
       memo: keysignPayload.memo,

--- a/packages/core/mpc/keysign/signingInputs/resolvers/tron.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/tron.test.ts
@@ -156,3 +156,55 @@ describe('getTronSigningInputs -- native transfer amount bounds (#1138)', () => 
     ).toThrow(RangeError)
   })
 })
+
+describe('getTronSigningInputs -- TRC20 amount strict parse (#1147)', () => {
+  const USDT_CONTRACT = 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t'
+
+  const buildTrc20Payload = (toAmount: string) =>
+    create(KeysignPayloadSchema, {
+      coin: create(CoinSchema, {
+        chain: Chain.Tron,
+        ticker: 'USDT',
+        address: OWNER,
+        decimals: 6,
+        isNativeToken: false,
+        contractAddress: USDT_CONTRACT,
+      }),
+      toAddress: OWNER,
+      toAmount,
+      blockchainSpecific: {
+        case: 'tronSpecific',
+        value: makeTronSpecific(),
+      },
+    })
+
+  it("rejects an unset ('') TRC20 amount instead of building a zero-value transfer", () => {
+    // Pre-fix: BigInt('') -> 0n -> a 0x00 amount byte silently co-signed.
+    expect(() =>
+      getTronSigningInputs({
+        keysignPayload: buildTrc20Payload(''),
+        walletCore,
+      })
+    ).toThrow(RangeError)
+  })
+
+  it('rejects a negative TRC20 amount', () => {
+    expect(() =>
+      getTronSigningInputs({
+        keysignPayload: buildTrc20Payload('-1'),
+        walletCore,
+      })
+    ).toThrow(RangeError)
+  })
+
+  it('still builds a TRC20 transfer above 64 bits (uint256 calldata must not false-reject)', async () => {
+    // 20 tokens at 18 decimals = 2e19 > 2^64; a 64-bit bound here would
+    // false-reject a perfectly ordinary 18-decimal TRC20 transfer.
+    const [input] = await getTronSigningInputs({
+      keysignPayload: buildTrc20Payload('20000000000000000000'),
+      walletCore,
+    })
+    const amount = input.transaction?.transferTrc20Contract?.amount
+    expect(Buffer.from(amount ?? new Uint8Array()).toString('hex')).toBe('01158e460913d00000')
+  })
+})

--- a/packages/core/mpc/keysign/signingInputs/resolvers/tron.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/tron.ts
@@ -1,6 +1,7 @@
 import { Buffer } from 'buffer'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { bigIntToHex } from '@vultisig/lib-utils/bigint/bigIntToHex'
+import { toBoundedBigInt } from '@vultisig/lib-utils/bigint/toBoundedBigInt'
 import { toBoundedLong } from '@vultisig/lib-utils/bigint/toBoundedLong'
 import { stripHexPrefix } from '@vultisig/lib-utils/hex/stripHexPrefix'
 import { matchDiscriminatedUnion } from '@vultisig/lib-utils/matchDiscriminatedUnion'
@@ -210,7 +211,10 @@ export const getTronSigningInputs: SigningInputsResolver<'tron'> = ({ keysignPay
           return [input]
         }
 
-        const amountHex = Buffer.from(stripHexPrefix(bigIntToHex(BigInt(keysignPayload.toAmount))), 'hex')
+        const amountHex = Buffer.from(
+          stripHexPrefix(bigIntToHex(toBoundedBigInt(keysignPayload.toAmount, { bits: 256, signed: false }))),
+          'hex'
+        )
 
         const contract = TW.Tron.Proto.TransferTRC20Contract.create({
           ownerAddress: shouldBePresent(keysignPayload?.coin?.address),
@@ -275,7 +279,10 @@ export const getTronSigningInputs: SigningInputsResolver<'tron'> = ({ keysignPay
     return [input]
   }
 
-  const amountHex = Buffer.from(stripHexPrefix(bigIntToHex(BigInt(keysignPayload.toAmount))), 'hex')
+  const amountHex = Buffer.from(
+    stripHexPrefix(bigIntToHex(toBoundedBigInt(keysignPayload.toAmount, { bits: 256, signed: false }))),
+    'hex'
+  )
 
   const contract = TW.Tron.Proto.TransferTRC20Contract.create({
     ownerAddress: shouldBePresent(keysignPayload?.coin?.address),

--- a/packages/lib/utils/bigint/toBoundedBigInt.test.ts
+++ b/packages/lib/utils/bigint/toBoundedBigInt.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { toBoundedBigInt } from './toBoundedBigInt'
+
+const U64_MAX = 2n ** 64n - 1n
+const U128_MAX = 2n ** 128n - 1n
+const U256_MAX = 2n ** 256n - 1n
+
+describe('toBoundedBigInt', () => {
+  it('parses in-range values for each supported width', () => {
+    expect(toBoundedBigInt('123456789', { bits: 64, signed: false })).toBe(123456789n)
+    expect(toBoundedBigInt(U64_MAX, { bits: 64, signed: false })).toBe(U64_MAX)
+    expect(toBoundedBigInt(U128_MAX, { bits: 128, signed: false })).toBe(U128_MAX)
+    expect(toBoundedBigInt(U256_MAX, { bits: 256, signed: false })).toBe(U256_MAX)
+  })
+
+  it('rejects values above the requested width', () => {
+    expect(() => toBoundedBigInt(U64_MAX + 1n, { bits: 64, signed: false })).toThrow(RangeError)
+    expect(() => toBoundedBigInt(U128_MAX + 1n, { bits: 128, signed: false })).toThrow(RangeError)
+    expect(() => toBoundedBigInt(U256_MAX + 1n, { bits: 256, signed: false })).toThrow(RangeError)
+  })
+
+  it('respects signedness bounds', () => {
+    expect(toBoundedBigInt(-(2n ** 63n), { bits: 64, signed: true })).toBe(-(2n ** 63n))
+    expect(() => toBoundedBigInt(2n ** 63n, { bits: 64, signed: true })).toThrow(RangeError)
+    expect(() => toBoundedBigInt(-1n, { bits: 64, signed: false })).toThrow(RangeError)
+  })
+
+  it("rejects '' instead of the BigInt('') -> 0n fail-open", () => {
+    expect(BigInt('')).toBe(0n)
+    expect(() => toBoundedBigInt('', { bits: 64, signed: false })).toThrow(RangeError)
+    expect(() => toBoundedBigInt('', { bits: 256, signed: false })).toThrow(RangeError)
+  })
+
+  it('rejects non-decimal-integer strings that bare BigInt() would accept', () => {
+    for (const bad of ['0x10', ' 42', '42 ', '4_2', '1e3', '']) {
+      expect(() => toBoundedBigInt(bad, { bits: 64, signed: false })).toThrow(RangeError)
+    }
+  })
+})

--- a/packages/lib/utils/bigint/toBoundedBigInt.ts
+++ b/packages/lib/utils/bigint/toBoundedBigInt.ts
@@ -1,0 +1,39 @@
+// A plain base-10 integer, optionally signed. Deliberately strict: `BigInt()`
+// alone would also accept `''` (-> 0n), `'0x10'` (-> 16n) and whitespace-padded
+// strings, all of which would WIDEN the accepted input in a guard whose whole
+// job is to tighten it. The `''` case is the dangerous one: proto3 defaults an
+// unset `toAmount` string to `''`, so `BigInt('')` would silently build a
+// zero-amount transfer.
+const INTEGER_STRING = /^-?\d+$/
+
+/**
+ * Strictly parses a decimal integer into a `bigint`, rejecting any value
+ * outside the given bit width for the requested signedness.
+ *
+ * Companion to `toBoundedLong` for amount fields that are NOT proto 64-bit
+ * integers: byte-encoded amounts (Tron TRC20 uint256 calldata, Polkadot u128
+ * balances), SCALE-compact-encoded amounts (Bittensor), and decimal-string
+ * amounts (XRPL issued currencies). Those encoders happily accept `0n` from
+ * `BigInt('')`, so the strict parse is what turns an unset/malformed amount
+ * into a throw instead of a silently co-signed zero-value transfer.
+ */
+export const toBoundedBigInt = (
+  value: bigint | string,
+  { bits, signed }: { bits: 64 | 128 | 256; signed: boolean }
+): bigint => {
+  if (typeof value === 'string' && !INTEGER_STRING.test(value)) {
+    throw new RangeError(`toBoundedBigInt: expected a base-10 integer string, got ${JSON.stringify(value)}`)
+  }
+
+  const asBigInt = typeof value === 'bigint' ? value : BigInt(value)
+
+  const [min, max] = signed ? [-(2n ** BigInt(bits - 1)), 2n ** BigInt(bits - 1) - 1n] : [0n, 2n ** BigInt(bits) - 1n]
+
+  if (asBigInt < min || asBigInt > max) {
+    throw new RangeError(
+      `toBoundedBigInt: value ${asBigInt} out of ${signed ? 'signed' : 'unsigned'} ${bits}-bit range [${min}, ${max}]`
+    )
+  }
+
+  return asBigInt
+}

--- a/packages/lib/utils/bigint/toBoundedLong.ts
+++ b/packages/lib/utils/bigint/toBoundedLong.ts
@@ -1,16 +1,6 @@
 import Long from 'long'
 
-const SIGNED_MIN = -(2n ** 63n)
-const SIGNED_MAX = 2n ** 63n - 1n
-const UNSIGNED_MAX = 2n ** 64n - 1n
-
-// A plain base-10 integer, optionally signed. Deliberately strict: `BigInt()`
-// alone would also accept `''` (-> 0n), `'0x10'` (-> 16n) and whitespace-padded
-// strings, all of which would WIDEN the accepted input in a guard whose whole
-// job is to tighten it. The `''` case is the dangerous one: proto3 defaults an
-// unset `toAmount` string to `''`, so `BigInt('')` would silently build a
-// zero-amount transfer where the old `Long.fromString('')` threw.
-const INTEGER_STRING = /^-?\d+$/
+import { toBoundedBigInt } from './toBoundedBigInt'
 
 /**
  * Parses a decimal integer into a `Long`, rejecting any value outside the
@@ -21,25 +11,19 @@ const INTEGER_STRING = /^-?\d+$/
  * co-signed as a different value than the caller intended. This is the same
  * wraparound class `varintBig` already guards on the cosmos proto path.
  *
+ * String parsing is deliberately strict (see `toBoundedBigInt`): `''`,
+ * hex-prefixed and whitespace-padded strings all throw instead of silently
+ * widening the accepted input. The `''` case is the dangerous one: proto3
+ * defaults an unset `toAmount` string to `''`, so `BigInt('')` would silently
+ * build a zero-amount transfer where the old `Long.fromString('')` threw.
+ *
  * Signedness must match the target proto field: pass `{ unsigned: true }` for a
  * proto `uint64` amount (e.g. Sui / Cardano) so the legitimate `(2^63, 2^64)`
  * range is accepted, and `{ unsigned: false }` for a proto `int64` field
  * (e.g. Tron / Ripple).
  */
 export const toBoundedLong = (value: bigint | string, { unsigned }: { unsigned: boolean }): Long => {
-  if (typeof value === 'string' && !INTEGER_STRING.test(value)) {
-    throw new RangeError(`toBoundedLong: expected a base-10 integer string, got ${JSON.stringify(value)}`)
-  }
+  const bounded = toBoundedBigInt(value, { bits: 64, signed: !unsigned })
 
-  const asBigInt = typeof value === 'bigint' ? value : BigInt(value)
-
-  const [min, max] = unsigned ? [0n, UNSIGNED_MAX] : [SIGNED_MIN, SIGNED_MAX]
-
-  if (asBigInt < min || asBigInt > max) {
-    throw new RangeError(
-      `toBoundedLong: value ${asBigInt} out of ${unsigned ? 'unsigned' : 'signed'} 64-bit range [${min}, ${max}]`
-    )
-  }
-
-  return Long.fromString(asBigInt.toString(), unsigned)
+  return Long.fromString(bounded.toString(), unsigned)
 }

--- a/packages/lib/utils/package.json
+++ b/packages/lib/utils/package.json
@@ -139,6 +139,11 @@
       "import": "./dist/bigint/decimalStringToBigInt.js",
       "default": "./dist/bigint/decimalStringToBigInt.js"
     },
+    "./bigint/toBoundedBigInt": {
+      "types": "./dist/bigint/toBoundedBigInt.d.ts",
+      "import": "./dist/bigint/toBoundedBigInt.js",
+      "default": "./dist/bigint/toBoundedBigInt.js"
+    },
     "./bigint/toBoundedLong": {
       "types": "./dist/bigint/toBoundedLong.d.ts",
       "import": "./dist/bigint/toBoundedLong.js",


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#1147

> Stacked on #1140 (base is `advisor/014-bounded-long-fromstring`, since `toBoundedLong` only exists there - #1147's "now-merged #1140" premise was slightly ahead of reality). GitHub will retarget to `main` once #1140 lands. Only the last 1 commit is this PR.

## what

#1140 closed the `BigInt('') -> 0n` fail-open (proto3 defaults an unset `toAmount` to `''`, so a bare `BigInt()` silently builds a zero-amount transfer that gets co-signed) for the resolvers it touched. This finishes the sweep for the 5 sites it missed - all verified still live before patching:

| site | target field | bound |
|---|---|---|
| `resolvers/tron.ts:213,278` (TRC20) | `transfer(address,uint256)` calldata bytes | u256 |
| `resolvers/polkadot.ts:24` | u128 balance bytes | u128 |
| `resolvers/bittensor.ts:66` | SCALE-compact (subtensor `Balance` = u64) | u64 |
| `resolvers/solana/send.ts:34` | proto `uint64` value/amount | u64 via `toBoundedLong` |
| `resolvers/ripple.ts:41` (issued currency) | decimal-string trust-line limit | u128 |

Plus one more of the exact same class found whilst in the house: ripple's raw-JSON memo payment path inlined `toAmount` unvalidated into the tx JSON - now guarded like its sibling Payment proto path.

## how

New `toBoundedBigInt` (`@vultisig/lib-utils/bigint/toBoundedBigInt`) - the bigint-returning sibling of `toBoundedLong`, which now delegates to it (one source of truth for the strict base-10 regex + bounds). Bit width is per target field on purpose: a blind 64-bit bound on TRC20 would false-reject 20 tokens of an 18-decimal TRC20 (2e19 > 2^64). Signedness read from each encoder, not copied from #1140.

Bonus the sweep surfaced: pre-fix solana silently encoded a u64-max amount as `'-1'` (`Long.fromString` defaults to signed) - the `{ unsigned: true }` routing fixes that too, pinned by test.

## testing

Fail-before (resolver sources reverted to base, new tests kept):

```
Test Files  5 failed (5)
     Tests  12 failed | 51 passed (63)
```

(the 5 pre-passing ones are the no-false-reject happy paths - they're supposed to pass on both sides)

Pass-after:

```
resolvers + bigint utils:  Test Files 15 passed (15) / Tests 129 passed (129)
yarn workspace @vultisig/sdk typecheck: pass
yarn build:all && yarn typecheck (full chain): exit 0, 0 TS errors
yarn lint: pass
yarn format:check: all matched files use Prettier code style
yarn check:shared-exports: up to date
yarn knip: exit 0, zero delta vs base
```

Per-resolver regression tests: empty-string amount throws `RangeError` (not zero-builds), negative throws, plus a large-amount happy path per resolver proving no false-reject (TRC20 > 2^64 builds the exact expected calldata bytes, polkadot 2^64 builds the exact value bytes, bittensor u64-max SCALE-encodes, ripple IOU 2^64 formats, solana u64-max stays `18446744073709551615`).

Changeset included (`@vultisig/sdk` patch).

## risk

Low - pure tightening: every previously-valid amount still builds byte-identical inputs (pinned by the happy-path tests); only `''`/negative/malformed/out-of-field-range amounts now throw instead of being silently co-signed as zero.

🤖 Agent-generated