### PR TITLE
fix(sui): bounded deterministic coin selection + covering gas object

### DIFF
--- a/.changeset/sui-bounded-coin-selection.md
+++ b/.changeset/sui-bounded-coin-selection.md
@@ -1,0 +1,6 @@
+---
+"@vultisig/core-mpc": patch
+"@vultisig/sdk": patch
+---
+
+Sui sends now use bounded deterministic coin selection matching iOS #4734 / Android #3989: the fewest largest objects covering the send (capped at 255, balance desc / objectID asc tie-break), a gas object that actually covers the budget (smallest covering, largest fallback) instead of an arbitrary first object, and a bounded keysign payload (covering subset + top gas candidates) so dusty wallets no longer overflow the relay payload or Sui's transaction size limits. Coin-type matching is normalization-aware (short 0x2 vs long-form package addresses).

--- a/packages/core/mpc/chains/sui/coinSelection.test.ts
+++ b/packages/core/mpc/chains/sui/coinSelection.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Sui bounded coin selection (sdk#1132) — parity with iOS #4734.
+ *
+ * The fixture tests mirror `SuiHelperInputDataTests.swift` from the iOS PR
+ * (same coins, amounts, gas budgets, and expected selections) so the SDK's
+ * `TW.Sui.Proto.SigningInput` references the identical object set iOS
+ * references — the cross-device keysign consensus requirement.
+ */
+
+import { create } from '@bufbuild/protobuf'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { TW } from '@trustwallet/wallet-core'
+import Long from 'long'
+import { describe, expect, it } from 'vitest'
+
+import { SuiCoinSchema, SuiSpecificSchema } from '../../types/vultisig/keysign/v1/blockchain_specific_pb'
+import { CoinSchema } from '../../types/vultisig/keysign/v1/coin_pb'
+import { KeysignPayloadSchema } from '../../types/vultisig/keysign/v1/keysign_message_pb'
+import { getSuiSigningInputs } from '../../keysign/signingInputs/resolvers/sui'
+import {
+  isNativeSuiCoinType,
+  maxSuiInputCoinObjects,
+  normalizeSuiCoinType,
+  selectSuiGasObject,
+  selectSuiInputCoins,
+  selectSuiPayloadCoins,
+  suiCoinTypesMatch,
+  suiGasCandidateObjectCount,
+} from './coinSelection'
+
+// Long-form native type — exactly what `suix_getAllCoins` returns.
+const NATIVE_TYPE = '0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI'
+const TOKEN_TYPE = '0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN'
+const RECIPIENT = '0x51d5b8e2f3d2f0aef0aefdc4e6c0f4f3d2b1a09788c7e6f5d4c3b2a190817263'
+const SENDER = '0x0000000000000000000000000000000000000000000000000000000000000abc'
+
+const coinObject = (id: string, type: string, balance: string, version = '1') =>
+  create(SuiCoinSchema, {
+    coinObjectId: id,
+    version,
+    digest: `digest-${id}`,
+    balance,
+    coinType: type,
+  })
+
+const makePayload = ({
+  isNative,
+  coins,
+  amount,
+  gasBudget,
+}: {
+  isNative: boolean
+  coins: ReturnType<typeof coinObject>[]
+  amount: bigint
+  gasBudget: bigint
+}) =>
+  create(KeysignPayloadSchema, {
+    coin: create(CoinSchema, {
+      chain: Chain.Sui,
+      ticker: isNative ? 'SUI' : 'COIN',
+      address: SENDER,
+      decimals: isNative ? 9 : 8,
+      isNativeToken: isNative,
+      contractAddress: isNative ? '' : TOKEN_TYPE,
+    }),
+    toAddress: RECIPIENT,
+    toAmount: amount.toString(),
+    blockchainSpecific: {
+      case: 'suicheSpecific',
+      value: create(SuiSpecificSchema, {
+        coins,
+        referenceGasPrice: '1000',
+        gasBudget: gasBudget.toString(),
+      }),
+    },
+  })
+
+// The sui resolver is synchronous; narrow the resolver-union return type.
+const resolve = (payload: ReturnType<typeof makePayload>) =>
+  getSuiSigningInputs({ keysignPayload: payload } as Parameters<typeof getSuiSigningInputs>[0]) as TW.Sui.Proto.SigningInput[]
+
+describe('normalizeSuiCoinType / matching', () => {
+  it('matches short and long package-address forms', () => {
+    expect(suiCoinTypesMatch('0x2::sui::SUI', NATIVE_TYPE)).toBe(true)
+    expect(isNativeSuiCoinType(NATIVE_TYPE)).toBe(true)
+    expect(isNativeSuiCoinType('0x2::sui::SUI')).toBe(true)
+  })
+
+  it('is case-insensitive but exact on module/struct — look-alikes never match', () => {
+    expect(isNativeSuiCoinType('0X2::SUI::sui')).toBe(true)
+    expect(isNativeSuiCoinType('0xb45f::xsui::XSUI')).toBe(false)
+    expect(suiCoinTypesMatch(TOKEN_TYPE, TOKEN_TYPE.toUpperCase())).toBe(true)
+  })
+
+  it('normalizes the address segment only', () => {
+    expect(normalizeSuiCoinType('0x0002::sui::SUI')).toBe('0x2::sui::sui')
+    expect(normalizeSuiCoinType('0x0::a::B')).toBe('0x0::a::b')
+  })
+})
+
+describe('selectSuiInputCoins', () => {
+  const coins = [
+    coinObject('0xa', NATIVE_TYPE, '1000000000'),
+    coinObject('0xb', NATIVE_TYPE, '2000000000'),
+    coinObject('0xc', NATIVE_TYPE, '3000000000'),
+  ]
+
+  it('selects the fewest largest objects covering the target', () => {
+    const selected = selectSuiInputCoins(coins, BigInt(4_003_000_000))
+    expect(selected.map(c => c.coinObjectId)).toEqual(['0xc', '0xb'])
+  })
+
+  it('keeps at least one object for a zero-amount target', () => {
+    const selected = selectSuiInputCoins(coins, BigInt(0))
+    expect(selected.map(c => c.coinObjectId)).toEqual(['0xc'])
+  })
+
+  it('tie-breaks equal balances by objectID ascending (deterministic across devices)', () => {
+    const tied = [
+      coinObject('0xbeta', NATIVE_TYPE, '100'),
+      coinObject('0xalpha', NATIVE_TYPE, '100'),
+    ]
+    const selected = selectSuiInputCoins(tied, BigInt(150))
+    expect(selected.map(c => c.coinObjectId)).toEqual(['0xalpha', '0xbeta'])
+  })
+
+  it('caps at maxSuiInputCoinObjects even when the target is not reached', () => {
+    const dust = Array.from({ length: 400 }, (_, i) => coinObject(`0xdust${i}`, NATIVE_TYPE, '1'))
+    const selected = selectSuiInputCoins(dust, BigInt(1_000_000))
+    expect(selected).toHaveLength(maxSuiInputCoinObjects)
+  })
+})
+
+describe('selectSuiGasObject', () => {
+  it('picks the smallest native object covering the budget', () => {
+    const coins = [
+      coinObject('0xsmall', NATIVE_TYPE, '500000'),
+      coinObject('0xcovers', NATIVE_TYPE, '3000000'),
+      coinObject('0xbig', NATIVE_TYPE, '9000000'),
+    ]
+    expect(selectSuiGasObject(coins, BigInt(3_000_000))?.coinObjectId).toBe('0xcovers')
+  })
+
+  it('falls back to the largest object when none covers (best effort, matches iOS #4734)', () => {
+    const coins = [
+      coinObject('0xsmall', NATIVE_TYPE, '1000'),
+      coinObject('0xbigger', NATIVE_TYPE, '2000'),
+    ]
+    expect(selectSuiGasObject(coins, BigInt(3_000_000))?.coinObjectId).toBe('0xbigger')
+  })
+
+  it('returns undefined when the wallet holds no native SUI object', () => {
+    expect(selectSuiGasObject([coinObject('0xt', TOKEN_TYPE, '100')], BigInt(1))).toBeUndefined()
+  })
+})
+
+describe('selectSuiPayloadCoins', () => {
+  it('native: embeds only the covering subset', () => {
+    const coins = [
+      coinObject('0xa', NATIVE_TYPE, '1000000000'),
+      coinObject('0xb', NATIVE_TYPE, '2000000000'),
+      coinObject('0xc', NATIVE_TYPE, '3000000000'),
+      coinObject('0xmeme', '0xdead::meme::MEME', '999999999999'),
+    ]
+    const selected = selectSuiPayloadCoins({
+      coins,
+      contractAddress: '',
+      amount: BigInt(4_000_000_000),
+      gasBudget: BigInt(3_000_000),
+    })
+    expect(selected.map(c => c.coinObjectId)).toEqual(['0xc', '0xb'])
+  })
+
+  it('token: embeds covering token objects + the largest few native gas candidates', () => {
+    const coins = [
+      ...Array.from({ length: 10 }, (_, i) => coinObject(`0xgas${i}`, NATIVE_TYPE, `${(i + 1) * 1_000_000}`)),
+      coinObject('0xt1', TOKEN_TYPE, '100'),
+      coinObject('0xt2', TOKEN_TYPE, '200'),
+      coinObject('0xmeme', '0xdead::meme::MEME', '999'),
+    ]
+    const selected = selectSuiPayloadCoins({
+      coins,
+      contractAddress: TOKEN_TYPE,
+      amount: BigInt(250),
+      gasBudget: BigInt(3_000_000),
+    })
+    const ids = selected.map(c => c.coinObjectId)
+    expect(ids.slice(0, 2)).toEqual(['0xt2', '0xt1'])
+    expect(ids).toHaveLength(2 + suiGasCandidateObjectCount)
+    // Largest five gas objects survive as candidates; memecoin dropped.
+    expect(ids).toContain('0xgas9')
+    expect(ids).not.toContain('0xgas0')
+    expect(ids).not.toContain('0xmeme')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SigningInput fixture parity — mirrors SuiHelperInputDataTests.swift (#4734)
+// ---------------------------------------------------------------------------
+
+describe('getSuiSigningInputs — native send merges the objects it needs (iOS #4734 fixtures)', () => {
+  const nativeCoins = [
+    coinObject('0xa', NATIVE_TYPE, '1000000000'),
+    coinObject('0xb', NATIVE_TYPE, '2000000000'),
+    coinObject('0xc', NATIVE_TYPE, '3000000000'),
+  ]
+
+  it('selects the largest objects covering amount + gas', () => {
+    const [input] = resolve(
+      makePayload({ isNative: true, coins: nativeCoins, amount: BigInt(4_000_000_000), gasBudget: BigInt(3_000_000) })
+    )
+    expect(new Set(input.paySui!.inputCoins!.map(c => c!.objectId))).toEqual(new Set(['0xc', '0xb']))
+    expect(input.paySui!.amounts!.map(a => Long.fromValue(a!).toString())).toEqual(['4000000000'])
+  })
+
+  it('small send selects only the largest object', () => {
+    const [input] = resolve(
+      makePayload({ isNative: true, coins: nativeCoins, amount: BigInt(100_000_000), gasBudget: BigInt(3_000_000) })
+    )
+    expect(input.paySui!.inputCoins!.map(c => c!.objectId)).toEqual(['0xc'])
+  })
+
+  it('near-max send selects all objects', () => {
+    const [input] = resolve(
+      makePayload({ isNative: true, coins: nativeCoins, amount: BigInt(5_900_000_000), gasBudget: BigInt(3_000_000) })
+    )
+    expect(new Set(input.paySui!.inputCoins!.map(c => c!.objectId))).toEqual(new Set(['0xa', '0xb', '0xc']))
+  })
+
+  it('dusty wallet (800 objects) references only what it needs — bounded at 255', () => {
+    const coins = [
+      coinObject('0xbig', NATIVE_TYPE, '10000000000'),
+      ...Array.from({ length: 800 }, (_, i) => coinObject(`0xdust${i}`, NATIVE_TYPE, '1000')),
+    ]
+    const [input] = resolve(
+      makePayload({ isNative: true, coins, amount: BigInt(1_000_000_000), gasBudget: BigInt(3_000_000) })
+    )
+    expect(input.paySui!.inputCoins!.map(c => c!.objectId)).toEqual(['0xbig'])
+    expect(input.paySui!.inputCoins!.length).toBeLessThanOrEqual(maxSuiInputCoinObjects)
+  })
+
+  it('look-alike objects (xSUI LST) are never passed as native inputs', () => {
+    const coins = [
+      coinObject('0xnative', NATIVE_TYPE, '5000000000'),
+      coinObject('0xlst', '0xb45f::xsui::XSUI', '9000000000'),
+    ]
+    const [input] = resolve(
+      makePayload({ isNative: true, coins, amount: BigInt(1_000_000_000), gasBudget: BigInt(3_000_000) })
+    )
+    expect(input.paySui!.inputCoins!.map(c => c!.objectId)).toEqual(['0xnative'])
+  })
+
+  it('long-form native coin types (as returned by suix_getAllCoins) are recognized', () => {
+    // Pre-#1132 the resolver compared coinType with `===` against the short
+    // form only, so a long-form-typed wallet produced EMPTY inputs.
+    const coins = [coinObject('0xlong', NATIVE_TYPE, '5000000000')]
+    const [input] = resolve(
+      makePayload({ isNative: true, coins, amount: BigInt(1_000_000_000), gasBudget: BigInt(3_000_000) })
+    )
+    expect(input.paySui!.inputCoins!.map(c => c!.objectId)).toEqual(['0xlong'])
+  })
+})
+
+describe('getSuiSigningInputs — token send selects a covering gas object (iOS #4734 fixtures)', () => {
+  it('picks the smallest covering gas object, not the first RPC object', () => {
+    const coins = [
+      // First SUI object is too small to pay gas — the old `gasCoins[0]` pick.
+      coinObject('0xgasTooSmall', NATIVE_TYPE, '500000'),
+      coinObject('0xgasCovers', NATIVE_TYPE, '3000000'),
+      coinObject('0xgasBig', NATIVE_TYPE, '9000000'),
+      coinObject('0xtoken1', TOKEN_TYPE, '100'),
+      coinObject('0xtoken2', TOKEN_TYPE, '200'),
+    ]
+    const [input] = resolve(
+      makePayload({ isNative: false, coins, amount: BigInt(250), gasBudget: BigInt(3_000_000) })
+    )
+    expect(new Set(input.pay!.inputCoins!.map(c => c!.objectId))).toEqual(new Set(['0xtoken1', '0xtoken2']))
+    expect(input.pay!.gas!.objectId).toBe('0xgasCovers')
+  })
+
+  it('covering-selects token inputs when the amount needs every object', () => {
+    const coins = [
+      coinObject('0xgas', NATIVE_TYPE, '5000000'),
+      coinObject('0xt1', TOKEN_TYPE, '100'),
+      coinObject('0xt2', TOKEN_TYPE, '200'),
+      coinObject('0xt3', TOKEN_TYPE, '300'),
+    ]
+    const [input] = resolve(makePayload({ isNative: false, coins, amount: BigInt(550), gasBudget: BigInt(3_000_000) }))
+    expect(new Set(input.pay!.inputCoins!.map(c => c!.objectId))).toEqual(new Set(['0xt1', '0xt2', '0xt3']))
+    expect(input.pay!.gas!.objectId).toBe('0xgas')
+  })
+
+  it('small token send references only the largest token object', () => {
+    const coins = [
+      coinObject('0xgas', NATIVE_TYPE, '5000000'),
+      coinObject('0xt1', TOKEN_TYPE, '100'),
+      coinObject('0xt2', TOKEN_TYPE, '200'),
+      coinObject('0xt3', TOKEN_TYPE, '300'),
+    ]
+    const [input] = resolve(makePayload({ isNative: false, coins, amount: BigInt(250), gasBudget: BigInt(3_000_000) }))
+    expect(input.pay!.inputCoins!.map(c => c!.objectId)).toEqual(['0xt3'])
+    expect(input.pay!.gas!.objectId).toBe('0xgas')
+  })
+
+  it('throws when no native SUI object exists to pay gas', () => {
+    const coins = [coinObject('0xt1', TOKEN_TYPE, '100')]
+    expect(() =>
+      resolve(makePayload({ isNative: false, coins, amount: BigInt(50), gasBudget: BigInt(3_000_000) }))
+    ).toThrow(/at least one SUI coin for gas fees/)
+  })
+})

--- a/packages/core/mpc/chains/sui/coinSelection.test.ts
+++ b/packages/core/mpc/chains/sui/coinSelection.test.ts
@@ -77,7 +77,9 @@ const makePayload = ({
 
 // The sui resolver is synchronous; narrow the resolver-union return type.
 const resolve = (payload: ReturnType<typeof makePayload>) =>
-  getSuiSigningInputs({ keysignPayload: payload } as Parameters<typeof getSuiSigningInputs>[0]) as TW.Sui.Proto.SigningInput[]
+  getSuiSigningInputs({ keysignPayload: payload } as Parameters<
+    typeof getSuiSigningInputs
+  >[0]) as TW.Sui.Proto.SigningInput[]
 
 describe('normalizeSuiCoinType / matching', () => {
   it('matches short and long package-address forms', () => {
@@ -116,10 +118,7 @@ describe('selectSuiInputCoins', () => {
   })
 
   it('tie-breaks equal balances by objectID ascending (deterministic across devices)', () => {
-    const tied = [
-      coinObject('0xbeta', NATIVE_TYPE, '100'),
-      coinObject('0xalpha', NATIVE_TYPE, '100'),
-    ]
+    const tied = [coinObject('0xbeta', NATIVE_TYPE, '100'), coinObject('0xalpha', NATIVE_TYPE, '100')]
     const selected = selectSuiInputCoins(tied, BigInt(150))
     expect(selected.map(c => c.coinObjectId)).toEqual(['0xalpha', '0xbeta'])
   })
@@ -142,10 +141,7 @@ describe('selectSuiGasObject', () => {
   })
 
   it('falls back to the largest object when none covers (best effort, matches iOS #4734)', () => {
-    const coins = [
-      coinObject('0xsmall', NATIVE_TYPE, '1000'),
-      coinObject('0xbigger', NATIVE_TYPE, '2000'),
-    ]
+    const coins = [coinObject('0xsmall', NATIVE_TYPE, '1000'), coinObject('0xbigger', NATIVE_TYPE, '2000')]
     expect(selectSuiGasObject(coins, BigInt(3_000_000))?.coinObjectId).toBe('0xbigger')
   })
 
@@ -271,9 +267,7 @@ describe('getSuiSigningInputs — token send selects a covering gas object (iOS 
       coinObject('0xtoken1', TOKEN_TYPE, '100'),
       coinObject('0xtoken2', TOKEN_TYPE, '200'),
     ]
-    const [input] = resolve(
-      makePayload({ isNative: false, coins, amount: BigInt(250), gasBudget: BigInt(3_000_000) })
-    )
+    const [input] = resolve(makePayload({ isNative: false, coins, amount: BigInt(250), gasBudget: BigInt(3_000_000) }))
     expect(new Set(input.pay!.inputCoins!.map(c => c!.objectId))).toEqual(new Set(['0xtoken1', '0xtoken2']))
     expect(input.pay!.gas!.objectId).toBe('0xgasCovers')
   })

--- a/packages/core/mpc/chains/sui/coinSelection.ts
+++ b/packages/core/mpc/chains/sui/coinSelection.ts
@@ -1,0 +1,181 @@
+/**
+ * Deterministic Sui coin-object selection (sdk#1132).
+ *
+ * Port of vultisig-ios#4734 (`SuiConstants.swift` / `SuiCoinType`), Android
+ * sibling vultisig-android#3989. In MPC keysign every co-signing device
+ * independently recomputes the Sui transaction bytes from the shared payload;
+ * the selection here must stay IDENTICAL across iOS / Android / SDK (and
+ * therefore Windows + FastVault's server co-signer) or the sighashes diverge
+ * and the ceremony fails. Do not change sort keys, tie-breaks, caps, or the
+ * gas-pick fallback without coordinating all platforms.
+ */
+
+import { SuiCoin } from '../../types/vultisig/keysign/v1/blockchain_specific_pb'
+
+/** Canonical fully-qualified type of the native SUI coin (short address form). */
+export const suiNativeCoinType = '0x2::sui::SUI'
+
+/**
+ * Upper bound on the coin objects a single send may reference. Sui rejects a
+ * transaction whose serialized size exceeds 128 KiB, and a `PaySui` send uses
+ * its entire input set as the gas payment — which Sui caps at 256 objects.
+ * Staying one under the cap keeps every send safely within both limits.
+ */
+export const maxSuiInputCoinObjects = 255
+
+/**
+ * How many of the largest native SUI objects to embed as gas candidates for a
+ * token send. The signer picks one to pay gas; carrying the largest few keeps
+ * the payload small while guaranteeing a covering object survives a
+ * re-estimated gas budget.
+ */
+export const suiGasCandidateObjectCount = 5
+
+/**
+ * Collapses a package-address segment to `0x` + hex with leading zeros
+ * stripped, so `0x0000…0002` and `0x2` compare equal.
+ */
+const normalizeSuiAddress = (address: string): string => {
+  const hex = address.startsWith('0x') ? address.slice(2) : address
+  const trimmed = hex.replace(/^0+/, '')
+  return `0x${trimmed === '' ? '0' : trimmed}`
+}
+
+/**
+ * Normalizes a fully-qualified `address::module::struct` coin type for exact
+ * comparison: lowercases the whole string and collapses the package-address
+ * segment to canonical form. Ticker-substring matching is wrong here — it
+ * cannot distinguish `0x2::sui::SUI` from `0x…::xsui::XSUI`.
+ */
+export const normalizeSuiCoinType = (coinType: string): string => {
+  const lowered = coinType.toLowerCase()
+  const [addressSegment] = lowered.split(':')
+  if (!addressSegment) return lowered
+  return normalizeSuiAddress(addressSegment) + lowered.slice(addressSegment.length)
+}
+
+/** Whether two fully-qualified coin types refer to the same coin. */
+export const suiCoinTypesMatch = (a: string, b: string): boolean => normalizeSuiCoinType(a) === normalizeSuiCoinType(b)
+
+/** Whether the given coin-object type is the native SUI coin. */
+export const isNativeSuiCoinType = (coinType: string): boolean => suiCoinTypesMatch(coinType, suiNativeCoinType)
+
+/** Parses a coin object's balance (base-unit MIST), unparseable = zero. */
+export const suiCoinBalance = (coin: SuiCoin): bigint => {
+  try {
+    return BigInt(coin.balance || '0')
+  } catch {
+    return BigInt(0)
+  }
+}
+
+/**
+ * Selects the fewest coin objects (largest balance first) that together cover
+ * `target`, bounded by `maxObjects`.
+ *
+ * Selection is deterministic (balance descending, then `coinObjectId`
+ * ascending) so every co-signing device selects the identical set and signs
+ * the identical transaction. If even `maxObjects` largest objects don't reach
+ * `target`, they are still returned (best effort) — the caller decides how to
+ * handle an under-funded selection.
+ */
+export const selectSuiInputCoins = (
+  coins: SuiCoin[],
+  target: bigint,
+  maxObjects: number = maxSuiInputCoinObjects
+): SuiCoin[] => {
+  const sorted = [...coins].sort((lhs, rhs) => {
+    const lhsBalance = suiCoinBalance(lhs)
+    const rhsBalance = suiCoinBalance(rhs)
+    if (lhsBalance !== rhsBalance) return lhsBalance > rhsBalance ? -1 : 1
+    return lhs.coinObjectId < rhs.coinObjectId ? -1 : lhs.coinObjectId > rhs.coinObjectId ? 1 : 0
+  })
+
+  const selected: SuiCoin[] = []
+  let accumulated = BigInt(0)
+  for (const coin of sorted) {
+    // Always keep at least one object so a zero/near-zero-amount send still
+    // has an input; otherwise stop once the target is covered.
+    if (selected.length > 0 && accumulated >= target) break
+    if (selected.length >= maxObjects) break
+    selected.push(coin)
+    accumulated += suiCoinBalance(coin)
+  }
+  return selected
+}
+
+/**
+ * Selects the native SUI coin object that pays gas for a token (non-native)
+ * send. WalletCore's `Sui.Pay` message carries a *single* `gas` object (unlike
+ * `PaySui`, whose whole input set is gas-smashed), so the choice matters:
+ * picking an arbitrary object fails when its balance can't cover the budget,
+ * even though the wallet holds plenty of SUI across other objects.
+ *
+ * Choose the *smallest* native SUI object whose balance already covers
+ * `gasBudget`; when no single object covers it, fall back to the largest
+ * object (best effort — strictly better than an arbitrary pick). Returns
+ * `undefined` only when the wallet holds no native SUI object at all.
+ * Tie-breaks mirror Swift's `min(by:)` (first minimal) / `max(by:)` (last
+ * maximal) over the payload's coin order.
+ */
+export const selectSuiGasObject = (coins: SuiCoin[], gasBudget: bigint): SuiCoin | undefined => {
+  const suiObjects = coins.filter(coin => isNativeSuiCoinType(coin.coinType))
+  if (suiObjects.length === 0) return undefined
+
+  let smallestCovering: SuiCoin | undefined
+  for (const coin of suiObjects) {
+    if (suiCoinBalance(coin) < gasBudget) continue
+    if (!smallestCovering || suiCoinBalance(coin) < suiCoinBalance(smallestCovering)) {
+      smallestCovering = coin
+    }
+  }
+  if (smallestCovering) return smallestCovering
+
+  let largest = suiObjects[0]
+  for (const coin of suiObjects) {
+    if (!(suiCoinBalance(coin) < suiCoinBalance(largest))) largest = coin
+  }
+  return largest
+}
+
+/**
+ * The minimal set of coin objects to embed in the keysign payload for a Sui
+ * send — exactly what the signing-input resolver will consume. Unbounded
+ * embedding on a dusty wallet produces a keysign payload too large to relay
+ * (co-signer poll 404 / "data expired") and, at signing, a transaction over
+ * Sui's size limits.
+ *
+ * Native send: the largest objects covering `amount + gasBudget` (the input
+ * set also pays gas). Token send: the largest token objects covering `amount`,
+ * plus the largest few native SUI objects as gas candidates.
+ */
+export const selectSuiPayloadCoins = ({
+  coins,
+  contractAddress,
+  amount,
+  gasBudget,
+}: {
+  coins: SuiCoin[]
+  /** The token's fully-qualified type; empty for a native SUI send. */
+  contractAddress: string
+  amount: bigint
+  gasBudget: bigint
+}): SuiCoin[] => {
+  const nativeObjects = coins.filter(coin => isNativeSuiCoinType(coin.coinType))
+
+  if (!contractAddress) {
+    return selectSuiInputCoins(nativeObjects, amount + gasBudget)
+  }
+
+  const tokenObjects = coins.filter(coin => suiCoinTypesMatch(coin.coinType, contractAddress))
+  const selectedTokens = selectSuiInputCoins(tokenObjects, amount)
+  const gasCandidates = [...nativeObjects]
+    .sort((lhs, rhs) => {
+      const lhsBalance = suiCoinBalance(lhs)
+      const rhsBalance = suiCoinBalance(rhs)
+      if (lhsBalance !== rhsBalance) return lhsBalance > rhsBalance ? -1 : 1
+      return 0
+    })
+    .slice(0, suiGasCandidateObjectCount)
+  return [...selectedTokens, ...gasCandidates]
+}

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/sui/index.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/sui/index.ts
@@ -56,16 +56,19 @@ export const getSuiChainSpecific: GetChainSpecificResolver<'suicheSpecific'> = a
     }
   } while (cursor)
 
+  const rawCoinObjects = rawCoins.map((coin: CoinStruct) => create(SuiCoinSchema, coin))
+
   // Bound the embedded coin set to what the send actually needs (sdk#1132,
   // iOS #4734 parity): embedding every owned object makes a dusty wallet's
   // keysign payload too large to relay (co-signer poll 404 / "data expired")
-  // and drags unrelated coin types (memecoins/LSTs) into the payload. The
-  // signing-input resolver performs the same deterministic selection on this
-  // set, so the bounded output is exactly the inputs the signer consumes —
-  // plus, for a token send, the largest few native objects as gas candidates
-  // so a covering gas object survives the refine step's re-estimated budget.
+  // and drags unrelated coin types (memecoins/LSTs) into the payload. This
+  // baseline selection (sized against the static `suiGasBudget` default) only
+  // needs to be good enough to build a valid dry-run tx below — refine
+  // re-selects from the full `rawCoinObjects` set against the REAL gas
+  // budget once it's known, so the payload coins that actually ship lock in
+  // exactly once, after the real cost is known (sdk#1216 follow-up).
   const coins = selectSuiPayloadCoins({
-    coins: rawCoins.map((coin: CoinStruct) => create(SuiCoinSchema, coin)),
+    coins: rawCoinObjects,
     contractAddress: coin.id ?? '',
     amount: BigInt(keysignPayload.toAmount || '0'),
     gasBudget: suiGasBudget,
@@ -84,6 +87,7 @@ export const getSuiChainSpecific: GetChainSpecificResolver<'suicheSpecific'> = a
       refineSuiChainSpecific({
         keysignPayload,
         chainSpecific,
+        rawCoins: rawCoinObjects,
         walletCore,
       })
     ),

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/sui/index.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/sui/index.ts
@@ -82,6 +82,9 @@ export const getSuiChainSpecific: GetChainSpecificResolver<'suicheSpecific'> = a
     gasBudget: suiGasBudget.toString(),
   })
 
+  // On dry-run/RPC failure, refine never runs — fall back to the static-budget
+  // baseline `chainSpecific` above as-is. Pre-existing best-effort behavior,
+  // unchanged by the refine re-selection/re-pricing this resolver now does.
   return withFallback(
     attempt(
       refineSuiChainSpecific({

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/sui/index.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/sui/index.ts
@@ -5,6 +5,7 @@ import { SuiCoinSchema, SuiSpecificSchema } from '@vultisig/core-mpc/types/vulti
 import { attempt, withFallback } from '@vultisig/lib-utils/attempt'
 import type { CoinStruct } from '@mysten/sui/jsonRpc'
 
+import { selectSuiPayloadCoins } from '../../../../chains/sui/coinSelection'
 import { getKeysignCoin } from '../../../utils/getKeysignCoin'
 import { GetChainSpecificResolver } from '../../resolver'
 import { refineSuiChainSpecific } from './refine'
@@ -55,7 +56,20 @@ export const getSuiChainSpecific: GetChainSpecificResolver<'suicheSpecific'> = a
     }
   } while (cursor)
 
-  const coins = rawCoins.map((coin: CoinStruct) => create(SuiCoinSchema, coin))
+  // Bound the embedded coin set to what the send actually needs (sdk#1132,
+  // iOS #4734 parity): embedding every owned object makes a dusty wallet's
+  // keysign payload too large to relay (co-signer poll 404 / "data expired")
+  // and drags unrelated coin types (memecoins/LSTs) into the payload. The
+  // signing-input resolver performs the same deterministic selection on this
+  // set, so the bounded output is exactly the inputs the signer consumes —
+  // plus, for a token send, the largest few native objects as gas candidates
+  // so a covering gas object survives the refine step's re-estimated budget.
+  const coins = selectSuiPayloadCoins({
+    coins: rawCoins.map((coin: CoinStruct) => create(SuiCoinSchema, coin)),
+    contractAddress: coin.id ?? '',
+    amount: BigInt(keysignPayload.toAmount || '0'),
+    gasBudget: suiGasBudget,
+  })
 
   const referenceGasPrice = await client.getReferenceGasPrice()
 

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/sui/refine.test.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/sui/refine.test.ts
@@ -71,7 +71,11 @@ const dryRunResponse = {
 describe('getSuiChainSpecific -> refine -> getSuiSigningInputs (full pipeline, refine NOT stubbed)', () => {
   it('re-selects payload coins against the REFINED budget so the final signing input covers the budget it declares', async () => {
     mockGetAllCoins.mockReset().mockResolvedValueOnce({ data: wallet, hasNextPage: false, nextCursor: null })
-    mockDryRunTransactionBlock.mockReset().mockResolvedValueOnce(dryRunResponse)
+    // Selection grows 140 -> 149 (see below), so refine's converge loop fires
+    // ONE re-price round. The re-price reports the SAME cost as the first dry
+    // run, so it converges immediately without growing further — the "typical
+    // path converges in one round" case the loop bound's comment describes.
+    mockDryRunTransactionBlock.mockReset().mockResolvedValueOnce(dryRunResponse).mockResolvedValueOnce(dryRunResponse)
 
     const amount = 4_000_000n
     const keysignPayload = buildPayload(amount)
@@ -80,6 +84,7 @@ describe('getSuiChainSpecific -> refine -> getSuiSigningInputs (full pipeline, r
 
     // Refine actually landed (not the attempt/withFallback error path).
     expect(chainSpecific.gasBudget).toBe('3450000')
+    expect(mockDryRunTransactionBlock).toHaveBeenCalledTimes(2)
 
     const target = amount + BigInt(chainSpecific.gasBudget)
     const payloadTotal = chainSpecific.coins.reduce((sum, c) => sum + BigInt(c.balance), 0n)
@@ -108,11 +113,53 @@ describe('getSuiChainSpecific -> refine -> getSuiSigningInputs (full pipeline, r
     expect(inputTotal).toBeGreaterThanOrEqual(target)
     expect(inputCoins.length).toBeLessThanOrEqual(maxSuiInputCoinObjects)
 
-    // Deterministic: an identical wallet + dry-run response selects the
+    // Deterministic: an identical wallet + dry-run responses select the
     // identical object set on a second run.
     mockGetAllCoins.mockReset().mockResolvedValueOnce({ data: wallet, hasNextPage: false, nextCursor: null })
-    mockDryRunTransactionBlock.mockReset().mockResolvedValueOnce(dryRunResponse)
+    mockDryRunTransactionBlock.mockReset().mockResolvedValueOnce(dryRunResponse).mockResolvedValueOnce(dryRunResponse)
     const again = await getSuiChainSpecific({ keysignPayload: buildPayload(amount), walletCore })
     expect(again.coins.map(c => c.coinObjectId)).toEqual(chainSpecific.coins.map(c => c.coinObjectId))
+  })
+
+  it('bounds the converge loop at 2 re-price rounds even when the dry-run cost keeps climbing', async () => {
+    // Each round's re-price reports a HIGHER cost than the last, so the
+    // selection keeps growing (140 -> 149 -> 154 -> 159) and would keep
+    // triggering further rounds forever if unbounded. The loop must stop
+    // after exactly 2 extra rounds (3 dry runs total) and accept the last
+    // computed budget/selection rather than looping indefinitely.
+    mockGetAllCoins.mockReset().mockResolvedValueOnce({ data: wallet, hasNextPage: false, nextCursor: null })
+    mockDryRunTransactionBlock
+      .mockReset()
+      // Round 0 (baseline, 140 objects): 3_000_000 -> budget 3_450_000, grows to 149.
+      .mockResolvedValueOnce({
+        effects: { gasUsed: { computationCost: '2000000', storageCost: '1000000', storageRebate: '0' } },
+      })
+      // Round 1 (re-price on 149 objects): 3_200_000 -> budget 3_680_000, grows to 154.
+      .mockResolvedValueOnce({
+        effects: { gasUsed: { computationCost: '2100000', storageCost: '1100000', storageRebate: '0' } },
+      })
+      // Round 2 (re-price on 154 objects): 3_400_000 -> budget 3_910_000, grows to 159.
+      .mockResolvedValueOnce({
+        effects: { gasUsed: { computationCost: '2200000', storageCost: '1200000', storageRebate: '0' } },
+      })
+
+    const amount = 4_000_000n
+    const keysignPayload = buildPayload(amount)
+
+    const chainSpecific = await getSuiChainSpecific({ keysignPayload, walletCore })
+
+    // Exactly 1 (baseline) + 2 (the bound) dry runs — never a 4th, even though
+    // the round-2 selection (159 objects) still grew past round-1's (154).
+    expect(mockDryRunTransactionBlock).toHaveBeenCalledTimes(3)
+    expect(chainSpecific.gasBudget).toBe('3910000')
+    expect(chainSpecific.coins).toHaveLength(159)
+
+    // The selection accepted at the bound still covers the budget it itself
+    // declares, even though a hypothetical round 3 might have priced higher
+    // still — the documented fail-safe tradeoff of the bound.
+    const target = amount + BigInt(chainSpecific.gasBudget)
+    const payloadTotal = chainSpecific.coins.reduce((sum, c) => sum + BigInt(c.balance), 0n)
+    expect(payloadTotal).toBeGreaterThanOrEqual(target)
+    expect(chainSpecific.coins.length).toBeLessThanOrEqual(maxSuiInputCoinObjects)
   })
 })

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/sui/refine.test.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/sui/refine.test.ts
@@ -1,0 +1,118 @@
+import { create } from '@bufbuild/protobuf'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { initWasm, TW, WalletCore } from '@trustwallet/wallet-core'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+const { mockGetAllCoins, mockGetReferenceGasPrice, mockDryRunTransactionBlock } = vi.hoisted(() => ({
+  mockGetAllCoins: vi.fn(),
+  mockGetReferenceGasPrice: vi.fn(async () => 1000n),
+  mockDryRunTransactionBlock: vi.fn(),
+}))
+
+vi.mock('@vultisig/core-chain/chains/sui/client', () => ({
+  getSuiClient: () => ({
+    getAllCoins: mockGetAllCoins,
+    getReferenceGasPrice: mockGetReferenceGasPrice,
+    dryRunTransactionBlock: mockDryRunTransactionBlock,
+  }),
+}))
+
+import { maxSuiInputCoinObjects } from '../../../../chains/sui/coinSelection'
+import { CoinSchema } from '../../../../types/vultisig/keysign/v1/coin_pb'
+import { KeysignPayloadSchema } from '../../../../types/vultisig/keysign/v1/keysign_message_pb'
+import { getSuiSigningInputs } from '../../../signingInputs/resolvers/sui'
+import { getSuiChainSpecific } from './index'
+
+const NATIVE_TYPE = '0x2::sui::SUI'
+const SENDER = '0x0000000000000000000000000000000000000000000000000000000000000abc'
+const RECIPIENT = '0x51d5b8e2f3d2f0aef0aefdc4e6c0f4f3d2b1a09788c7e6f5d4c3b2a190817263'
+
+const makeRpcCoin = (i: number, balance: string) => ({
+  coinType: NATIVE_TYPE,
+  coinObjectId: `0x${(1000 + i).toString(16).padStart(64, '0')}`,
+  version: `${i + 1}`,
+  digest: '5PLj4rE6ZP1AXwT9CkyzX1zNvfSFVAKUB7T5uf5RCXvY',
+  balance,
+  previousTransaction: `0x${(2000 + i).toString(16).padStart(64, '0')}`,
+})
+
+let walletCore: WalletCore
+
+beforeAll(async () => {
+  walletCore = await initWasm()
+})
+
+const buildPayload = (amount: bigint) =>
+  create(KeysignPayloadSchema, {
+    coin: create(CoinSchema, {
+      chain: Chain.Sui,
+      ticker: 'SUI',
+      address: SENDER,
+      decimals: 9,
+      isNativeToken: true,
+    }),
+    toAddress: RECIPIENT,
+    toAmount: amount.toString(),
+  })
+
+// Fixture mirrors the deep-wave repro for sdk#1216's follow-up gap: 300
+// equal-sized native objects, well under the 255-object cap (isolates the
+// refine-budget-escalation invariant from the cap invariant), sized so the
+// baseline (pre-refine) payload selection has ZERO slack against the static
+// `suiGasBudget` default.
+const wallet = Array.from({ length: 300 }, (_, i) => makeRpcCoin(i, '50000'))
+// computationCost + storageCost = 3_000_000 -> gasBudgetMultiplier (*1.15) =
+// 3_450_000, above the 3_000_000 static baseline used to size the initial
+// (dry-run) payload selection.
+const dryRunResponse = {
+  effects: { gasUsed: { computationCost: '2000000', storageCost: '1000000', storageRebate: '0' } },
+}
+
+describe('getSuiChainSpecific -> refine -> getSuiSigningInputs (full pipeline, refine NOT stubbed)', () => {
+  it('re-selects payload coins against the REFINED budget so the final signing input covers the budget it declares', async () => {
+    mockGetAllCoins.mockReset().mockResolvedValueOnce({ data: wallet, hasNextPage: false, nextCursor: null })
+    mockDryRunTransactionBlock.mockReset().mockResolvedValueOnce(dryRunResponse)
+
+    const amount = 4_000_000n
+    const keysignPayload = buildPayload(amount)
+
+    const chainSpecific = await getSuiChainSpecific({ keysignPayload, walletCore })
+
+    // Refine actually landed (not the attempt/withFallback error path).
+    expect(chainSpecific.gasBudget).toBe('3450000')
+
+    const target = amount + BigInt(chainSpecific.gasBudget)
+    const payloadTotal = chainSpecific.coins.reduce((sum, c) => sum + BigInt(c.balance), 0n)
+    // The bug this test pins: pre-fix, the payload was narrowed against the
+    // BASELINE budget (3_000_000) before refine ran, so it fell short of the
+    // refined target (3_450_000) even though the wallet held far more.
+    expect(payloadTotal).toBeGreaterThanOrEqual(target)
+    expect(chainSpecific.coins.length).toBeLessThanOrEqual(maxSuiInputCoinObjects)
+
+    // Feed the refined chainSpecific into the FINAL signing-input build (the
+    // same shared payload every co-signer independently recomputes from) and
+    // assert the actual TW.Sui.Proto.SigningInput references enough balance
+    // to cover the budget it itself declares.
+    const finalPayload = create(KeysignPayloadSchema, {
+      ...keysignPayload,
+      blockchainSpecific: { case: 'suicheSpecific', value: chainSpecific },
+    })
+    const [signingInput] = getSuiSigningInputs({
+      keysignPayload: finalPayload,
+      walletCore,
+    }) as unknown as TW.Sui.Proto.SigningInput[]
+
+    const byObjectId = new Map(chainSpecific.coins.map(c => [c.coinObjectId, c]))
+    const inputCoins = signingInput.paySui!.inputCoins!
+    const inputTotal = inputCoins.reduce((sum, ref) => sum + BigInt(byObjectId.get(ref!.objectId!)!.balance), 0n)
+    expect(inputTotal).toBeGreaterThanOrEqual(target)
+    expect(inputCoins.length).toBeLessThanOrEqual(maxSuiInputCoinObjects)
+
+    // Deterministic: an identical wallet + dry-run response selects the
+    // identical object set on a second run.
+    mockGetAllCoins.mockReset().mockResolvedValueOnce({ data: wallet, hasNextPage: false, nextCursor: null })
+    mockDryRunTransactionBlock.mockReset().mockResolvedValueOnce(dryRunResponse)
+    const again = await getSuiChainSpecific({ keysignPayload: buildPayload(amount), walletCore })
+    expect(again.coins.map(c => c.coinObjectId)).toEqual(chainSpecific.coins.map(c => c.coinObjectId))
+  })
+})

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/sui/refine.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/sui/refine.ts
@@ -3,11 +3,13 @@ import { create } from '@bufbuild/protobuf'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { getSuiClient } from '@vultisig/core-chain/chains/sui/client'
 import { suiMinGasBudget } from '@vultisig/core-chain/chains/sui/config'
-import { SuiSpecific } from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
+import { SuiCoin, SuiSpecific } from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
 import { KeysignPayload, KeysignPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
 import { maxBigInt } from '@vultisig/lib-utils/math/maxBigInt'
 import { WalletCore } from '@trustwallet/wallet-core'
 
+import { selectSuiPayloadCoins } from '../../../../chains/sui/coinSelection'
+import { getKeysignCoin } from '../../../utils/getKeysignCoin'
 import { getPreSigningOutput } from '../../../preSigningOutput'
 import { getEncodedSigningInputs } from '../../../signingInputs'
 
@@ -16,16 +18,22 @@ const gasBudgetMultiplier = (value: bigint) => (value * 115n) / 100n
 type RefineSuiChainSpecificInput = {
   keysignPayload: KeysignPayload
   chainSpecific: SuiSpecific
+  /** The full owned-coin set (unbounded), for the post-refine re-selection below. */
+  rawCoins: SuiCoin[]
   walletCore: WalletCore
 }
 
 export const refineSuiChainSpecific = async ({
   keysignPayload,
   chainSpecific,
+  rawCoins,
   walletCore,
 }: RefineSuiChainSpecificInput): Promise<SuiSpecific> => {
   const client = getSuiClient()
 
+  // `chainSpecific.coins` here is the baseline selection (sdk#1132), sized
+  // against the static `suiGasBudget` default — good enough to build a valid
+  // dry-run tx, but not yet the real cost.
   const [txInputData] = await getEncodedSigningInputs({
     keysignPayload: create(KeysignPayloadSchema, {
       ...keysignPayload,
@@ -53,10 +61,27 @@ export const refineSuiChainSpecific = async ({
     transactionBlock: txBytes,
   })
 
-  const gasBudget = BigInt(computationCost) + BigInt(storageCost)
+  const gasBudget = maxBigInt(gasBudgetMultiplier(BigInt(computationCost) + BigInt(storageCost)), suiMinGasBudget)
+
+  // Re-select the payload coins from the FULL owned set against the REAL
+  // (refined) budget (sdk#1216 follow-up). Locking the baseline-sized
+  // selection in as the final payload left native sends with near-zero
+  // selection slack under-covered once the actual dry-run cost exceeded the
+  // static estimate — the payload was already narrowed at that point, so the
+  // wallet's remaining objects were unreachable at final signing time even
+  // though the wallet held plenty of balance in aggregate. The payload coins
+  // now lock exactly once, AFTER the real budget is known.
+  const coin = getKeysignCoin(keysignPayload)
+  const coins = selectSuiPayloadCoins({
+    coins: rawCoins,
+    contractAddress: coin.id ?? '',
+    amount: BigInt(keysignPayload.toAmount || '0'),
+    gasBudget,
+  })
 
   return {
     ...chainSpecific,
-    gasBudget: maxBigInt(gasBudgetMultiplier(gasBudget), suiMinGasBudget).toString(),
+    coins,
+    gasBudget: gasBudget.toString(),
   }
 }

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/sui/refine.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/sui/refine.ts
@@ -23,23 +23,27 @@ type RefineSuiChainSpecificInput = {
   walletCore: WalletCore
 }
 
-export const refineSuiChainSpecific = async ({
+/**
+ * Dry-runs `priced` (its `coins`/`gasBudget` baked into a real PaySui/Pay tx)
+ * and returns the real, multiplied-up gas budget the dry run reports.
+ */
+const priceGasBudget = async ({
   keysignPayload,
-  chainSpecific,
-  rawCoins,
+  priced,
   walletCore,
-}: RefineSuiChainSpecificInput): Promise<SuiSpecific> => {
+}: {
+  keysignPayload: KeysignPayload
+  priced: SuiSpecific
+  walletCore: WalletCore
+}): Promise<bigint> => {
   const client = getSuiClient()
 
-  // `chainSpecific.coins` here is the baseline selection (sdk#1132), sized
-  // against the static `suiGasBudget` default — good enough to build a valid
-  // dry-run tx, but not yet the real cost.
   const [txInputData] = await getEncodedSigningInputs({
     keysignPayload: create(KeysignPayloadSchema, {
       ...keysignPayload,
       blockchainSpecific: {
         case: 'suicheSpecific',
-        value: chainSpecific,
+        value: priced,
       },
     }),
     walletCore,
@@ -61,7 +65,32 @@ export const refineSuiChainSpecific = async ({
     transactionBlock: txBytes,
   })
 
-  const gasBudget = maxBigInt(gasBudgetMultiplier(BigInt(computationCost) + BigInt(storageCost)), suiMinGasBudget)
+  return maxBigInt(gasBudgetMultiplier(BigInt(computationCost) + BigInt(storageCost)), suiMinGasBudget)
+}
+
+// Bounds the re-pricing convergence loop below (a fail-safe, not the
+// expected path — see the comment at the loop). Two rounds is generous: each
+// round only adds objects to cover the PREVIOUS round's budget increase, and
+// that increase itself shrinks round over round (a larger selection is
+// closer to exhausting the wallet's largest objects, so there's proportionally
+// less balance left for the next round to add), so this converges in
+// practice within one round.
+const maxGasBudgetConvergeIterations = 2
+
+export const refineSuiChainSpecific = async ({
+  keysignPayload,
+  chainSpecific,
+  rawCoins,
+  walletCore,
+}: RefineSuiChainSpecificInput): Promise<SuiSpecific> => {
+  const coin = getKeysignCoin(keysignPayload)
+  const contractAddress = coin.id ?? ''
+  const amount = BigInt(keysignPayload.toAmount || '0')
+
+  // `chainSpecific.coins` here is the baseline selection (sdk#1132), sized
+  // against the static `suiGasBudget` default — good enough to build a valid
+  // dry-run tx, but not yet the real cost.
+  let gasBudget = await priceGasBudget({ keysignPayload, priced: chainSpecific, walletCore })
 
   // Re-select the payload coins from the FULL owned set against the REAL
   // (refined) budget (sdk#1216 follow-up). Locking the baseline-sized
@@ -71,13 +100,29 @@ export const refineSuiChainSpecific = async ({
   // wallet's remaining objects were unreachable at final signing time even
   // though the wallet held plenty of balance in aggregate. The payload coins
   // now lock exactly once, AFTER the real budget is known.
-  const coin = getKeysignCoin(keysignPayload)
-  const coins = selectSuiPayloadCoins({
-    coins: rawCoins,
-    contractAddress: coin.id ?? '',
-    amount: BigInt(keysignPayload.toAmount || '0'),
-    gasBudget,
-  })
+  let coins = selectSuiPayloadCoins({ coins: rawCoins, contractAddress, amount, gasBudget })
+
+  // PaySui gas-smashes its entire input set, so a native send's real cost
+  // scales with object count. If the re-selection above needed MORE objects
+  // than the baseline dry run above priced, that dry run under-priced the
+  // ACTUAL (bigger) tx — a stale-budget InsufficientGas failure in the
+  // dusty-wallet corner, never a fund-safety issue, but worth pricing
+  // correctly rather than leaving a known-stale estimate. Re-price against
+  // the grown selection and re-select once more; see the iteration bound above.
+  let priorCoinCount = chainSpecific.coins.length
+  for (let iteration = 0; iteration < maxGasBudgetConvergeIterations && coins.length > priorCoinCount; iteration++) {
+    const reprice = await priceGasBudget({
+      keysignPayload,
+      priced: { ...chainSpecific, coins, gasBudget: gasBudget.toString() },
+      walletCore,
+    })
+    const nextGasBudget = maxBigInt(reprice, gasBudget)
+    if (nextGasBudget === gasBudget) break // re-pricing didn't increase further — converged
+
+    priorCoinCount = coins.length
+    gasBudget = nextGasBudget
+    coins = selectSuiPayloadCoins({ coins: rawCoins, contractAddress, amount, gasBudget })
+  }
 
   return {
     ...chainSpecific,

--- a/packages/core/mpc/keysign/signingInputs/resolvers/sui.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/sui.ts
@@ -3,11 +3,15 @@ import { SuiCoin } from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain
 import { TW } from '@trustwallet/wallet-core'
 import Long from 'long'
 
+import {
+  isNativeSuiCoinType,
+  selectSuiGasObject,
+  selectSuiInputCoins,
+  suiCoinTypesMatch,
+} from '../../../chains/sui/coinSelection'
 import { getBlockchainSpecificValue } from '../../chainSpecific/KeysignChainSpecific'
 import { getKeysignCoin } from '../../utils/getKeysignCoin'
 import { SigningInputsResolver } from '../resolver'
-
-const suiContractAddress = '0x2::sui::SUI'
 
 export const getSuiSigningInputs: SigningInputsResolver<'sui'> = ({ keysignPayload }) => {
   const coin = getKeysignCoin(keysignPayload)
@@ -40,8 +44,6 @@ export const getSuiSigningInputs: SigningInputsResolver<'sui'> = ({ keysignPaylo
     'suicheSpecific'
   )
 
-  const coinType = coin.id || suiContractAddress
-
   const createObjectRef = (coin: SuiCoin) =>
     TW.Sui.Proto.ObjectRef.create({
       objectDigest: coin.digest,
@@ -49,23 +51,42 @@ export const getSuiSigningInputs: SigningInputsResolver<'sui'> = ({ keysignPaylo
       version: Long.fromString(coin.version),
     })
 
-  const gasCoins = coins.filter(c => c.coinType === suiContractAddress).map(createObjectRef)
+  const budget = gasBudget ? BigInt(gasBudget) : suiGasBudget
 
   const baseInput = {
     referenceGasPrice: Long.fromString(referenceGasPrice),
     signer: coin.address,
-    gasBudget: gasBudget ? Long.fromString(gasBudget) : Long.fromBigInt(suiGasBudget),
+    gasBudget: Long.fromString(budget.toString()),
   }
 
-  const inputCoins = coins.filter(c => c.coinType === coinType).map(createObjectRef)
+  const amount = BigInt(keysignPayload.toAmount)
+
+  // Coin selection is deterministic and MUST match iOS (#4734) / Android
+  // (#3989) exactly — every co-signing device recomputes these inputs from the
+  // shared payload, and any divergence in the selected set diverges the
+  // sighash and fails the ceremony. See chains/sui/coinSelection.ts.
 
   if (coin.id) {
+    // Token send (Pay): covering-select the token objects; a SINGLE native SUI
+    // object pays gas (Pay's gas field is not gas-smashed like PaySui), so pick
+    // one that actually covers the budget instead of whatever the RPC returned
+    // first — the old `gasCoins[0]` failed with plenty of SUI in other objects.
+    const tokenType = coin.id
+    const tokenCoins = coins.filter(c => suiCoinTypesMatch(c.coinType, tokenType))
+    if (tokenCoins.length === 0) {
+      throw new Error('Non-native token transaction requires the token to be present')
+    }
+    const gasObject = selectSuiGasObject(coins, budget)
+    if (!gasObject) {
+      throw new Error('Non-native token transaction requires at least one SUI coin for gas fees')
+    }
+
     return [
       TW.Sui.Proto.SigningInput.create({
         ...baseInput,
         pay: TW.Sui.Proto.Pay.create({
-          gas: gasCoins[0],
-          inputCoins: inputCoins,
+          gas: createObjectRef(gasObject),
+          inputCoins: selectSuiInputCoins(tokenCoins, amount).map(createObjectRef),
           recipients: [keysignPayload.toAddress],
           amounts: [Long.fromString(keysignPayload.toAmount)],
         }),
@@ -73,11 +94,21 @@ export const getSuiSigningInputs: SigningInputsResolver<'sui'> = ({ keysignPaylo
     ]
   }
 
+  // Native send (PaySui): reference only the largest objects covering
+  // amount + gas. PaySui's whole input set is the gas payment, which Sui
+  // gas-smashes into one coin — a scattered balance is still merged, but the
+  // transaction stays within Sui's 128 KiB size / 256-gas-object limits
+  // instead of referencing every object and failing at broadcast.
+  const nativeCoins = coins.filter(c => isNativeSuiCoinType(c.coinType))
+  if (nativeCoins.length === 0) {
+    throw new Error('Native token transaction requires at least one SUI coin')
+  }
+
   return [
     TW.Sui.Proto.SigningInput.create({
       ...baseInput,
       paySui: TW.Sui.Proto.PaySui.create({
-        inputCoins: inputCoins,
+        inputCoins: selectSuiInputCoins(nativeCoins, amount + budget).map(createObjectRef),
         recipients: [keysignPayload.toAddress],
         amounts: [Long.fromString(keysignPayload.toAmount)],
       }),

--- a/packages/core/mpc/package.json
+++ b/packages/core/mpc/package.json
@@ -29,6 +29,11 @@
       "import": "./dist/chains/cosmos/qbtc/QBTCTx.js",
       "default": "./dist/chains/cosmos/qbtc/QBTCTx.js"
     },
+    "./chains/sui/coinSelection": {
+      "types": "./dist/chains/sui/coinSelection.d.ts",
+      "import": "./dist/chains/sui/coinSelection.js",
+      "default": "./dist/chains/sui/coinSelection.js"
+    },
     "./compression/getSevenZip": {
       "types": "./dist/compression/getSevenZip.d.ts",
       "browser": "./dist/compression/getSevenZip.browser.js",


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#1132

## what

Port of iOS #4734 (`SuiConstants`/`SuiCoinType`), Android sibling #3989. Three gaps in the SDK's Sui send path, all keysign-consensus-relevant (every co-signing device recomputes the tx bytes from the shared payload - selection MUST be identical across iOS / Android / SDK / Windows / FastVault or the sighash diverges and the ceremony fails):

1. **unbounded inputs** - `inputCoins` referenced every matching object; a dusty wallet blew past Sui's 128 KiB tx-size / 256-gas-object caps ('serialized transaction size exceeded maximum')
2. **arbitrary gas object** - `gas: gasCoins[0]`; a token send failed when the RPC's first object couldn't cover the budget despite plenty of SUI elsewhere
3. **unbounded payload** - the keysign payload embedded every owned coin incl. unrelated memecoins, oversizing the relay payload (co-signer poll 404 / 'data expired')

## how

New `packages/core/mpc/chains/sui/coinSelection.ts`, exact iOS #4734 semantics:

- `selectSuiInputCoins`: fewest largest objects covering the target (native `PaySui`: amount+gas; token `Pay`: amount), sorted balance desc then objectID asc, capped at 255, keep-at-least-one, best-effort when under-funded
- `selectSuiGasObject`: smallest native object covering the budget; largest-object fallback when none covers (the iOS #4734 choice, per the issue's 'pick one and make all platforms match'); undefined only with zero native objects (resolver throws)
- `selectSuiPayloadCoins`: covering subset (native) / covering tokens + top-5 native gas candidates (token) embedded in the chainSpecific payload
- normalization-aware type matching (short `0x2` vs the 64-hex long form `suix_getAllCoins` returns) - the old exact-`===` filter missed long-form native objects entirely and can't tell `sui::SUI` from `xsui::XSUI` classes by construction

Wired into `resolvers/sui.ts` (selection) and `chainSpecific/resolvers/sui/index.ts` (payload bounding). `signSui` dApp PTB path untouched.

## testing

Fixture tests mirror `SuiHelperInputDataTests.swift` from iOS #4734 verbatim (same coins/amounts/budgets/expected object sets): native scattered/small/near-max/800-object-dusty/look-alike-LST, token covering-gas/covering-tokens/small-send, plus unit tests for sort/tie-break/cap/fallback/normalization.

fail-before (fix reverted): `10 failed | 12 passed` (every fixture-parity test - old code refs all objects and picks gasCoins[0])
pass-after: `22 passed (22)`; full core suite `1723 passed`; root tsc clean; eslint clean

## coordination

Per the issue: iOS #4734 is still OPEN - the platforms must land this together (or gate) since the new selection intentionally diverges from the old all-objects behavior. This PR makes the SDK ready.

## risk

Sui send construction only. Selection is deterministic and best-effort on under-funded sets (same as iOS); dApp-supplied PTBs and swap paths untouched.

🤖 Agent-generated