### PR TITLE
fix(cli): let agent ask sign with VAULT_PASSWORD, no --password needed

### DIFF
--- a/.changeset/headless-sign-vault-password.md
+++ b/.changeset/headless-sign-vault-password.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/cli': patch
+---
+
+Fix `agent ask` headless signing so a vault unlocked via `VAULT_PASSWORD` (or the OS keyring) can sign without also passing `--password`. The sign-time gate now keys off whether a password is actually needed — an encrypted vault that is still locked with no password in hand — and retries the same non-interactive chain (cache → keyring → `VAULT_PASSWORDS`/`VAULT_PASSWORD`) before prompting, instead of always re-prompting when `--password` was absent. Unencrypted vaults skip the gate entirely. The transaction confirmation gate is unchanged. Also corrects the `VAULT_PASSWORD` help text.

--- a/clients/cli/src/agent/__tests__/sessionSignGate.test.ts
+++ b/clients/cli/src/agent/__tests__/sessionSignGate.test.ts
@@ -1,0 +1,270 @@
+// Regression tests for the sign-time password gate in runPasswordGatedTool
+// (abts-02 / sdkcli2-10 #3): headless `agent ask --yes` with VAULT_PASSWORD (the
+// documented signing env var) must sign without a --password flag.
+//
+// The bug: the gate re-prompted for a password whenever the `--password` flag
+// (config.password) was unset — ignoring that #899 already unlocked the vault
+// (and seeded the executor's password) from the keyring/env chain at init. In
+// ask mode requestPassword throws, so VAULT_PASSWORD-only signing hard-failed
+// with PASSWORD_REQUIRED even though the secret was already in hand.
+//
+// The fix gates on NEED — an encrypted-but-still-locked vault with no executor
+// password — and retries the same non-interactive chain (cache → keyring →
+// VAULT_PASSWORDS/VAULT_PASSWORD) before ever prompting. The #682 confirmation
+// gate is a separate chokepoint and must still fire before every sign; each
+// success case below asserts requestConfirmation ran before body().
+//
+// The method is private; it's exercised via the prototype with a minimal `this`
+// so no real vault / fs / network is touched (mirrors sessionConfirmGate.test).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { clearCachedPassword } from '../../core/password-manager'
+import { AgentErrorCode } from '../agentErrors'
+import { AgentSession } from '../session'
+import type { RecentAction } from '../types'
+
+// The OS-keyring branch of resolvePasswordNonInteractive. Default: no entry, so
+// the chain resolves from env only (or returns null). Keeps the real
+// password-manager chain in play without touching the machine keychain.
+vi.mock('../../core/credential-store', () => ({
+  getServerPassword: vi.fn(async () => null),
+}))
+
+type VaultStub = {
+  isEncrypted: boolean
+  isUnlocked: () => boolean
+  id: string
+  name: string
+}
+
+function makeUi(opts: { approve?: boolean; requestPassword: () => Promise<string> }) {
+  const order: string[] = []
+  const ui = {
+    onToolCall: vi.fn(),
+    onToolResult: vi.fn(),
+    requestConfirmation: vi.fn(async (_msg: string) => {
+      order.push('confirm')
+      return opts.approve ?? true
+    }),
+    requestPassword: vi.fn(opts.requestPassword),
+  }
+  return { ui, order }
+}
+
+// requestPassword that throws exactly as ask-mode's does (ask.ts) — a headless
+// one-shot has no interactive prompt.
+const askModeRequestPassword = async (): Promise<string> => {
+  throw new Error('Password required but not provided. Use --password flag.')
+}
+
+function callGate(opts: {
+  toolName: string
+  ui: ReturnType<typeof makeUi>['ui']
+  order: string[]
+  vault: VaultStub
+  executorHasPassword: boolean
+  config?: Record<string, unknown>
+  pendingSummary?: string | null
+  input?: Record<string, unknown>
+}): {
+  result: Promise<RecentAction>
+  setPassword: ReturnType<typeof vi.fn>
+  body: ReturnType<typeof vi.fn>
+} {
+  const setPassword = vi.fn()
+  const body = vi.fn(async () => {
+    opts.order.push('body')
+    return { tool: opts.toolName, success: true, data: { tx_hash: '0xsigned' } } as RecentAction
+  })
+  const executor = {
+    hasPassword: () => opts.executorHasPassword,
+    setPassword,
+    getPendingSummary: () => opts.pendingSummary ?? null,
+    clearPendingTransaction: vi.fn(),
+  }
+  const fakeThis = {
+    executor,
+    vault: opts.vault,
+    config: opts.config ?? { askMode: true },
+  }
+  const result = (AgentSession.prototype as any).runPasswordGatedTool.call(
+    fakeThis,
+    opts.toolName,
+    'tc-1',
+    opts.ui,
+    body,
+    opts.input
+  )
+  return { result, setPassword, body }
+}
+
+const lockedVault: VaultStub = {
+  isEncrypted: true,
+  isUnlocked: () => false,
+  id: 'vault-id-1',
+  name: 'Vultisig Cluster #1',
+}
+
+let prevVaultPassword: string | undefined
+let prevVaultPasswords: string | undefined
+
+beforeEach(() => {
+  prevVaultPassword = process.env.VAULT_PASSWORD
+  prevVaultPasswords = process.env.VAULT_PASSWORDS
+  delete process.env.VAULT_PASSWORD
+  delete process.env.VAULT_PASSWORDS
+  // The in-memory password cache is module-level state — clear it so a value
+  // resolved in one test can't leak into the next.
+  clearCachedPassword()
+})
+
+afterEach(() => {
+  if (prevVaultPassword === undefined) delete process.env.VAULT_PASSWORD
+  else process.env.VAULT_PASSWORD = prevVaultPassword
+  if (prevVaultPasswords === undefined) delete process.env.VAULT_PASSWORDS
+  else process.env.VAULT_PASSWORDS = prevVaultPasswords
+  clearCachedPassword()
+})
+
+describe('runPasswordGatedTool — sign gate keys off NEED, not --password', () => {
+  // (a) The repro'd HIGH: ask-mode, no --password, executor already unlocked
+  // from the env/keyring chain at init. The gate must NOT prompt (which would
+  // throw) and must NOT fail PASSWORD_REQUIRED — it signs.
+  it('ask-mode + executor already holds the password → no prompt, signs', async () => {
+    const { ui, order } = makeUi({ requestPassword: askModeRequestPassword })
+    // isUnlocked() deliberately false so the ONLY thing keeping the gate from
+    // prompting is executor.hasPassword() — pins that branch specifically.
+    const { result, setPassword, body } = callGate({
+      toolName: 'sign_tx',
+      ui,
+      order,
+      vault: lockedVault,
+      executorHasPassword: true,
+      pendingSummary: 'send 0.05 POL on Polygon to 0xd8dA',
+    })
+    const res = await result
+
+    expect(ui.requestPassword).not.toHaveBeenCalled()
+    expect(res.success).toBe(true)
+    expect(res.data?.code).not.toBe(AgentErrorCode.PASSWORD_REQUIRED)
+    expect(body).toHaveBeenCalledOnce()
+    expect(setPassword).not.toHaveBeenCalled()
+    // #682 confirmation gate still fires, and BEFORE signing.
+    expect(ui.requestConfirmation).toHaveBeenCalledOnce()
+    expect(order).toEqual(['confirm', 'body'])
+  })
+
+  // (b) Executor password was cleared mid-session and the vault re-locked, but
+  // VAULT_PASSWORD is still exported. The gate resolves it silently via the
+  // non-interactive chain — no prompt — and threads it into the executor.
+  it('env-resolvable password + executor cleared → resolves silently, no prompt', async () => {
+    process.env.VAULT_PASSWORD = 'env-secret'
+    const { ui, order } = makeUi({ requestPassword: askModeRequestPassword })
+    const { result, setPassword, body } = callGate({
+      toolName: 'sign_tx',
+      ui,
+      order,
+      vault: lockedVault,
+      executorHasPassword: false,
+      pendingSummary: 'send 0.05 POL on Polygon to 0xd8dA',
+    })
+    const res = await result
+
+    expect(ui.requestPassword).not.toHaveBeenCalled()
+    expect(setPassword).toHaveBeenCalledWith('env-secret')
+    expect(res.success).toBe(true)
+    expect(body).toHaveBeenCalledOnce()
+    expect(order).toEqual(['confirm', 'body'])
+  })
+
+  // (c) Unencrypted vault: there is no password to have, so the gate must be
+  // skipped entirely (isEncrypted false) and signing proceeds.
+  it('unencrypted vault → gate skipped, no prompt, signs', async () => {
+    const { ui, order } = makeUi({ requestPassword: askModeRequestPassword })
+    const { result, setPassword, body } = callGate({
+      toolName: 'sign_tx',
+      ui,
+      order,
+      vault: { isEncrypted: false, isUnlocked: () => true, id: 'vault-id-1', name: 'Unencrypted' },
+      executorHasPassword: false,
+    })
+    const res = await result
+
+    expect(ui.requestPassword).not.toHaveBeenCalled()
+    expect(setPassword).not.toHaveBeenCalled()
+    expect(res.success).toBe(true)
+    expect(body).toHaveBeenCalledOnce()
+    expect(ui.requestConfirmation).toHaveBeenCalledOnce()
+    expect(order).toEqual(['confirm', 'body'])
+  })
+
+  // (d) Locked vault, nothing resolvable, no flag: existing behavior preserved.
+  // Ask mode (requestPassword throws) → PASSWORD_REQUIRED failure, body never
+  // runs; the confirmation gate has already been cleared.
+  it('locked vault + nothing resolvable + ask-mode → PASSWORD_REQUIRED preserved', async () => {
+    const { ui, order } = makeUi({ requestPassword: askModeRequestPassword })
+    const { result, setPassword, body } = callGate({
+      toolName: 'sign_tx',
+      ui,
+      order,
+      vault: lockedVault,
+      executorHasPassword: false,
+      pendingSummary: 'send 1 POL',
+    })
+    const res = await result
+
+    expect(ui.requestPassword).toHaveBeenCalledOnce()
+    expect(res.success).toBe(false)
+    expect(res.data?.code).toBe(AgentErrorCode.PASSWORD_REQUIRED)
+    expect(body).not.toHaveBeenCalled()
+    expect(setPassword).not.toHaveBeenCalled()
+    // Confirmation still ran (and was the only step before the password gate).
+    expect(order).toEqual(['confirm'])
+  })
+
+  // (d, interactive variant) Locked vault, nothing resolvable, but an
+  // interactive UI (TUI) whose requestPassword RESOLVES: the prompt still works
+  // and its value threads into the executor, then signing proceeds.
+  it('locked vault + nothing resolvable + interactive UI → prompts, then signs', async () => {
+    const { ui, order } = makeUi({ requestPassword: async () => 'typed-secret' })
+    const { result, setPassword, body } = callGate({
+      toolName: 'sign_tx',
+      ui,
+      order,
+      vault: lockedVault,
+      executorHasPassword: false,
+      config: { askMode: false },
+      pendingSummary: 'send 1 POL',
+    })
+    const res = await result
+
+    expect(ui.requestPassword).toHaveBeenCalledOnce()
+    expect(setPassword).toHaveBeenCalledWith('typed-secret')
+    expect(res.success).toBe(true)
+    expect(body).toHaveBeenCalledOnce()
+    expect(order).toEqual(['confirm', 'body'])
+  })
+
+  // (e) The --password flag path is unchanged: config.password short-circuits
+  // the whole gate (the executor was seeded at construction), signing proceeds.
+  it('--password (config.password) set → gate short-circuits, signs, no prompt', async () => {
+    const { ui, order } = makeUi({ requestPassword: askModeRequestPassword })
+    const { result, setPassword, body } = callGate({
+      toolName: 'sign_tx',
+      ui,
+      order,
+      vault: lockedVault,
+      executorHasPassword: true,
+      config: { askMode: true, password: 'flag-secret' },
+      pendingSummary: 'send 1 POL',
+    })
+    const res = await result
+
+    expect(ui.requestPassword).not.toHaveBeenCalled()
+    expect(setPassword).not.toHaveBeenCalled()
+    expect(res.success).toBe(true)
+    expect(body).toHaveBeenCalledOnce()
+    expect(ui.requestConfirmation).toHaveBeenCalledOnce()
+    expect(order).toEqual(['confirm', 'body'])
+  })
+})

--- a/clients/cli/src/agent/executor.ts
+++ b/clients/cli/src/agent/executor.ts
@@ -172,6 +172,15 @@ export class AgentExecutor {
     this.password = password
   }
 
+  /**
+   * Whether a password is already held (set at unlock via the keyring/env chain
+   * or `--password`). The sign gate consults this so a session unlocked
+   * non-interactively doesn't get re-prompted for a secret it already has.
+   */
+  hasPassword(): boolean {
+    return this.password != null
+  }
+
   /** Opt out of the persistent broadcast-journal duplicate guard (`--force`). */
   setForceBroadcast(force: boolean): void {
     this.forceBroadcast = force

--- a/clients/cli/src/agent/session.ts
+++ b/clients/cli/src/agent/session.ts
@@ -1109,33 +1109,55 @@ export class AgentSession {
       }
     }
 
+    // Gate signing on whether a password is actually NEEDED, not on the
+    // --password flag. An encrypted vault is unlocked at init from the
+    // keyring/env chain (#899), which also seeds the executor's password, so a
+    // headless session that set VAULT_PASSWORD (or the OS keyring) already has
+    // the secret and must not be re-prompted. Only a still-locked vault with no
+    // executor password requires one — and even then we retry the same
+    // non-interactive chain (cache → keyring → VAULT_PASSWORDS/VAULT_PASSWORD)
+    // before prompting, so #899's "never prompt when the chain resolves"
+    // contract holds at sign time too. Unencrypted vaults are always
+    // "unlocked", so they skip this entirely. `--password` (config.password)
+    // short-circuits the whole block: it was applied to the executor at
+    // construction.
+    //
     // Delay caching the prompted password until after body() succeeds so a
-    // wrong password triggers a re-prompt on the next call rather than
-    // staying silently locked in to a bad value.
+    // wrong password triggers a re-prompt on the next call rather than staying
+    // silently locked in to a bad value.
     let promptedPassword: string | undefined
     if (PASSWORD_REQUIRED_TOOLS.has(toolName) && !this.config.password) {
-      try {
-        promptedPassword = await ui.requestPassword()
-        this.executor.setPassword(promptedPassword)
-      } catch {
-        const failure: RecentAction = {
-          tool: toolName,
-          success: false,
-          data: {
-            error: 'Password not provided',
-            code: AgentErrorCode.PASSWORD_REQUIRED,
-          },
+      const vaultLocked = this.vault.isEncrypted && !this.vault.isUnlocked()
+      const needsPassword = vaultLocked && !this.executor.hasPassword()
+      if (needsPassword) {
+        const resolved = await resolvePasswordNonInteractive(this.vault.id, this.vault.name)
+        if (resolved) {
+          this.executor.setPassword(resolved)
+        } else {
+          try {
+            promptedPassword = await ui.requestPassword()
+            this.executor.setPassword(promptedPassword)
+          } catch {
+            const failure: RecentAction = {
+              tool: toolName,
+              success: false,
+              data: {
+                error: 'Password not provided',
+                code: AgentErrorCode.PASSWORD_REQUIRED,
+              },
+            }
+            ui.onToolCall(toolCallId, toolName, input)
+            ui.onToolResult(
+              toolCallId,
+              toolName,
+              false,
+              failure.data,
+              'Password not provided',
+              AgentErrorCode.PASSWORD_REQUIRED
+            )
+            return failure
+          }
         }
-        ui.onToolCall(toolCallId, toolName, input)
-        ui.onToolResult(
-          toolCallId,
-          toolName,
-          false,
-          failure.data,
-          'Password not provided',
-          AgentErrorCode.PASSWORD_REQUIRED
-        )
-        return failure
       }
     }
 

--- a/clients/cli/src/index.ts
+++ b/clients/cli/src/index.ts
@@ -139,7 +139,7 @@ program
         .map(([k, v]) => `  ${k}  ${v}`)
         .join('\n') +
       '\n\nEnvironment variables:\n' +
-      '  VAULT_PASSWORD          Vault password for signing (bypasses prompt)\n' +
+      '  VAULT_PASSWORD          Vault password — unlocks the vault for reads and signing (no prompt)\n' +
       '  VULTISIG_PASSWORD       Alias for VAULT_PASSWORD\n' +
       '  VAULT_PASSWORDS         Space-separated VaultName:password pairs\n' +
       '  VULTISIG_VAULT          Default vault name or ID\n' +


### PR DESCRIPTION
## Problem

`vultisig agent ask "<send>" --yes` run headlessly with the vault password supplied via `VAULT_PASSWORD` fails at the mid-turn `sign_tx` with `PASSWORD_REQUIRED`, even though that same env var already unlocked the vault for reads and address derivation. Adding `--password <pw>` on argv is the only thing that lets the send sign and broadcast.

This is a self-contradiction in the current contract:

- The CLI help advertises `VAULT_PASSWORD` as the credential "for signing".
- The headless unlock chain added in #899 (cache → OS keyring → `VAULT_PASSWORDS` → `VAULT_PASSWORD`) deliberately de-emphasizes `--password` — it warns that passing the secret on argv leaks it into `ps`/shell history.
- But the sign-time gate still required exactly that `--password` flag: it prompted for a password whenever `config.password` was unset, ignoring that the vault (and the executor) had already been unlocked from the chain at init. In ask mode there is no interactive prompt, so the prompt throws and the whole turn fails.

The net effect: any headless/CI consumer that follows the documented env-var setup silently cannot sign.

## Root cause

The gate keyed off the `--password` flag rather than off whether a password was actually needed. Since `unlockEncryptedVault` already unlocked the vault at init and seeded the executor's password, the executor's re-unlock at sign time is skipped for a standard encrypted-vault session — the password is never needed again after init. The gate was enforcing a requirement the signing path doesn't have.

## Fix

Gate signing on **need**, not on the flag:

- Only prompt when the vault is encrypted, still locked, and the executor holds no password.
- Even then, retry the same non-interactive chain (cache → keyring → `VAULT_PASSWORDS`/`VAULT_PASSWORD`) before falling back to an interactive prompt — so the "never prompt when the chain resolves" behavior holds at sign time too, and a mid-session cleared password is recovered safely.
- Unencrypted vaults skip the gate entirely (there is no password to supply).
- `--password` continues to work unchanged (it is applied to the executor at construction and short-circuits the gate).

The transaction confirmation gate is a separate chokepoint and is untouched — every sign still requires an explicit confirmation first.

Also corrects the `VAULT_PASSWORD` help text to describe the now-consistent contract.

## Verification

- New regression suite (`sessionSignGate.test.ts`) covering: executor-already-unlocked (no prompt, signs), env-resolvable-with-executor-cleared (resolves silently), unencrypted vault (gate skipped), locked-with-nothing-resolvable (ask-mode `PASSWORD_REQUIRED` preserved / interactive prompt still works), and `--password` unchanged. Each signing case also asserts the confirmation gate still fires before signing. Confirmed red on `main` for the three core cases, green with the fix.
- Full CLI suite green (`yarn test:cli`), typecheck, ESLint, and Prettier clean.
- Verified end-to-end against a live agent backend: a headless `agent ask "Send 0.05 POL on Polygon …" --yes` with the password supplied **only** via `VAULT_PASSWORD` (no `--password`) signed and broadcast on the first try — confirmed on-chain (Polygon tx `0x2bcb7ee9…5ee8`, status success, 0.05 POL from the vault address). Before this fix the same invocation failed at `sign_tx` with `PASSWORD_REQUIRED`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Headless signing no longer prompts for `--password` when the vault is already unlocked or credentials are available through supported non-interactive sources.
  * Unencrypted vaults can now be signed without unnecessary password checks.
  * Password prompts remain available when no credentials can be resolved.

* **Documentation**
  * Updated `VAULT_PASSWORD` help text to clarify that it unlocks the vault for reading and signing without prompting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->