### PR TITLE
fix(core-chain): preserve unknown transaction status

### DIFF
--- a/.changeset/status-resolver-isknown-contract.md
+++ b/.changeset/status-resolver-isknown-contract.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/core-chain': patch
+---
+
+Mark Sui, Ton, Tron, Bittensor, and QBTC status lookup misses as `isKnown:false` so broadcast verification rethrows rejected sends instead of reporting false success.

--- a/packages/core/chain/tx/status/resolvers/bittensor.ts
+++ b/packages/core/chain/tx/status/resolvers/bittensor.ts
@@ -28,7 +28,7 @@ export const getBittensorTxStatus: TxStatusResolver<OtherChain.Bittensor> = asyn
   )
 
   if (error || !response?.data?.length) {
-    return { status: 'pending' }
+    return { status: 'pending', isKnown: false }
   }
 
   const extrinsic = response.data[0]

--- a/packages/core/chain/tx/status/resolvers/isknown-contract.test.ts
+++ b/packages/core/chain/tx/status/resolvers/isknown-contract.test.ts
@@ -1,3 +1,4 @@
+import { Chain, OtherChain } from '@vultisig/core-chain/Chain'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
@@ -14,7 +15,6 @@ vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
   queryUrl: mocks.queryUrl,
 }))
 
-import { Chain, OtherChain } from '@vultisig/core-chain/Chain'
 import { getBittensorTxStatus } from './bittensor'
 import { getQbtcTxStatus } from './qbtc'
 import { getSuiTxStatus } from './sui'

--- a/packages/core/chain/tx/status/resolvers/isknown-contract.test.ts
+++ b/packages/core/chain/tx/status/resolvers/isknown-contract.test.ts
@@ -14,7 +14,7 @@ vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
   queryUrl: mocks.queryUrl,
 }))
 
-import { Chain, OtherChain } from '../../../Chain'
+import { Chain, OtherChain } from '@vultisig/core-chain/Chain'
 import { getBittensorTxStatus } from './bittensor'
 import { getQbtcTxStatus } from './qbtc'
 import { getSuiTxStatus } from './sui'

--- a/packages/core/chain/tx/status/resolvers/isknown-contract.test.ts
+++ b/packages/core/chain/tx/status/resolvers/isknown-contract.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getSuiClient: vi.fn(),
+  getTransactionBlock: vi.fn(),
+  queryUrl: vi.fn(),
+}))
+
+vi.mock('@vultisig/core-chain/chains/sui/client', () => ({
+  getSuiClient: mocks.getSuiClient,
+}))
+
+vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
+  queryUrl: mocks.queryUrl,
+}))
+
+import { Chain, OtherChain } from '../../../Chain'
+import { getBittensorTxStatus } from './bittensor'
+import { getQbtcTxStatus } from './qbtc'
+import { getSuiTxStatus } from './sui'
+import { getTonTxStatus } from './ton'
+import { getTronTxStatus } from './tron'
+
+describe('status resolver isKnown contract', () => {
+  const hash = '0x' + 'a'.repeat(64)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllGlobals()
+    mocks.getSuiClient.mockReturnValue({
+      getTransactionBlock: mocks.getTransactionBlock,
+    })
+  })
+
+  it('marks Sui lookup failures and unknown hashes as not known', async () => {
+    mocks.getTransactionBlock.mockRejectedValueOnce(new Error('not found'))
+    await expect(getSuiTxStatus({ chain: OtherChain.Sui, hash })).resolves.toEqual({
+      status: 'pending',
+      isKnown: false,
+    })
+
+    mocks.getTransactionBlock.mockResolvedValueOnce(null)
+    await expect(getSuiTxStatus({ chain: OtherChain.Sui, hash })).resolves.toEqual({
+      status: 'pending',
+      isKnown: false,
+    })
+  })
+
+  it('marks non-terminal Sui responses as known pending', async () => {
+    mocks.getTransactionBlock.mockResolvedValueOnce({ effects: { status: { status: 'pending' } } })
+
+    await expect(getSuiTxStatus({ chain: OtherChain.Sui, hash })).resolves.toEqual({
+      status: 'pending',
+      isKnown: true,
+    })
+  })
+
+  it('marks Ton lookup failures and empty transaction lists as not known', async () => {
+    mocks.queryUrl.mockRejectedValueOnce(new Error('api down'))
+    await expect(getTonTxStatus({ chain: OtherChain.Ton, hash })).resolves.toEqual({
+      status: 'pending',
+      isKnown: false,
+    })
+
+    mocks.queryUrl.mockResolvedValueOnce({ transactions: [] })
+    await expect(getTonTxStatus({ chain: OtherChain.Ton, hash })).resolves.toEqual({
+      status: 'pending',
+      isKnown: false,
+    })
+  })
+
+  it('marks Tron lookup failures and unknown hashes as not known', async () => {
+    mocks.queryUrl.mockRejectedValueOnce(new Error('api down'))
+    await expect(getTronTxStatus({ chain: OtherChain.Tron, hash })).resolves.toEqual({
+      status: 'pending',
+      isKnown: false,
+    })
+
+    mocks.queryUrl.mockResolvedValueOnce({})
+    await expect(getTronTxStatus({ chain: OtherChain.Tron, hash })).resolves.toEqual({
+      status: 'not_found',
+      isKnown: false,
+    })
+  })
+
+  it('marks indexed Tron responses without a terminal receipt as known pending', async () => {
+    mocks.queryUrl.mockResolvedValueOnce({ id: hash, blockNumber: 0 })
+    await expect(getTronTxStatus({ chain: OtherChain.Tron, hash })).resolves.toEqual({
+      status: 'pending',
+      isKnown: true,
+    })
+
+    mocks.queryUrl.mockResolvedValueOnce({ id: hash, blockNumber: 123 })
+    await expect(getTronTxStatus({ chain: OtherChain.Tron, hash })).resolves.toEqual({
+      status: 'pending',
+      isKnown: true,
+    })
+  })
+
+  it('marks Bittensor lookup failures and empty indexer results as not known', async () => {
+    mocks.queryUrl.mockRejectedValueOnce(new Error('api down'))
+    await expect(getBittensorTxStatus({ chain: OtherChain.Bittensor, hash })).resolves.toEqual({
+      status: 'pending',
+      isKnown: false,
+    })
+
+    mocks.queryUrl.mockResolvedValueOnce({ pagination: { page: 1, limit: 1, total: 0 }, data: [] })
+    await expect(getBittensorTxStatus({ chain: OtherChain.Bittensor, hash })).resolves.toEqual({
+      status: 'pending',
+      isKnown: false,
+    })
+  })
+
+  it('marks QBTC lookup failures and missing tx responses as not known', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(new Error('api down')))
+    await expect(getQbtcTxStatus({ chain: Chain.QBTC, hash })).resolves.toEqual({
+      status: 'pending',
+      isKnown: false,
+    })
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValueOnce({}),
+      })
+    )
+    await expect(getQbtcTxStatus({ chain: Chain.QBTC, hash })).resolves.toEqual({
+      status: 'pending',
+      isKnown: false,
+    })
+  })
+})

--- a/packages/core/chain/tx/status/resolvers/qbtc.ts
+++ b/packages/core/chain/tx/status/resolvers/qbtc.ts
@@ -30,7 +30,7 @@ export const getQbtcTxStatus: TxStatusResolver<typeof Chain.QBTC> = async ({ has
   })
 
   if (error || !data?.tx_response) {
-    return { status: 'pending' }
+    return { status: 'pending', isKnown: false }
   }
 
   const txResp = data.tx_response

--- a/packages/core/chain/tx/status/resolvers/sui.ts
+++ b/packages/core/chain/tx/status/resolvers/sui.ts
@@ -16,7 +16,7 @@ export const getSuiTxStatus: TxStatusResolver<OtherChain.Sui> = async ({ hash })
   )
 
   if (error || !data) {
-    return { status: 'pending' }
+    return { status: 'pending', isKnown: false }
   }
 
   const effectsStatus = data.effects?.status?.status
@@ -47,5 +47,5 @@ export const getSuiTxStatus: TxStatusResolver<OtherChain.Sui> = async ({ hash })
     return { status: 'error' }
   }
 
-  return { status: 'pending' }
+  return { status: 'pending', isKnown: true }
 }

--- a/packages/core/chain/tx/status/resolvers/ton.ts
+++ b/packages/core/chain/tx/status/resolvers/ton.ts
@@ -27,7 +27,7 @@ export const getTonTxStatus: TxStatusResolver<OtherChain.Ton> = async ({ hash })
   const { data: response, error } = await attempt(queryUrl<TonTransactionsResponse>(url))
 
   if (error || !response || response.transactions.length === 0) {
-    return { status: 'pending' }
+    return { status: 'pending', isKnown: false }
   }
 
   const tx = response.transactions[0]

--- a/packages/core/chain/tx/status/resolvers/tron.test.ts
+++ b/packages/core/chain/tx/status/resolvers/tron.test.ts
@@ -22,21 +22,21 @@ describe('getTronTxStatus', () => {
     mocks.queryUrl.mockResolvedValue({ id: hash })
 
     const result = await getTronTxStatus({ chain: OtherChain.Tron, hash })
-    expect(result).toEqual({ status: 'pending' })
+    expect(result).toEqual({ status: 'pending', isKnown: true })
   })
 
   it('returns pending when blockNumber is 0', async () => {
     mocks.queryUrl.mockResolvedValue({ id: hash, blockNumber: 0 })
 
     const result = await getTronTxStatus({ chain: OtherChain.Tron, hash })
-    expect(result).toEqual({ status: 'pending' })
+    expect(result).toEqual({ status: 'pending', isKnown: true })
   })
 
   it('returns pending when receipt is absent (mined but receipt object missing)', async () => {
     mocks.queryUrl.mockResolvedValue({ id: hash, blockNumber: 12345 })
 
     const result = await getTronTxStatus({ chain: OtherChain.Tron, hash })
-    expect(result).toEqual({ status: 'pending' })
+    expect(result).toEqual({ status: 'pending', isKnown: true })
   })
 
   it('returns success when receipt is present but result is absent', async () => {
@@ -121,13 +121,20 @@ describe('getTronTxStatus', () => {
     mocks.queryUrl.mockResolvedValue({ id: hash, blockNumber: 12345, result: 'SUCCESS' })
 
     const result = await getTronTxStatus({ chain: OtherChain.Tron, hash })
-    expect(result.status).toBe('pending') // no receipt → pending, not success
+    expect(result).toEqual({ status: 'pending', isKnown: true }) // no receipt → pending, not success
   })
 
-  it('returns pending on network error', async () => {
+  it('returns isKnown:false on network error', async () => {
     mocks.queryUrl.mockRejectedValue(new Error('network failure'))
 
     const result = await getTronTxStatus({ chain: OtherChain.Tron, hash })
-    expect(result).toEqual({ status: 'pending' })
+    expect(result).toEqual({ status: 'pending', isKnown: false })
+  })
+
+  it('returns not_found when Tron RPC returns an empty unknown-hash payload', async () => {
+    mocks.queryUrl.mockResolvedValue({})
+
+    const result = await getTronTxStatus({ chain: OtherChain.Tron, hash })
+    expect(result).toEqual({ status: 'not_found', isKnown: false })
   })
 })

--- a/packages/core/chain/tx/status/resolvers/tron.ts
+++ b/packages/core/chain/tx/status/resolvers/tron.ts
@@ -45,8 +45,16 @@ export const getTronTxStatus: TxStatusResolver<OtherChain.Tron> = async ({ hash 
     })
   )
 
-  if (error || !tx || tx.blockNumber === undefined || tx.blockNumber === 0) {
-    return { status: 'pending' }
+  if (error || !tx) {
+    return { status: 'pending', isKnown: false }
+  }
+
+  if (!tx.id) {
+    return { status: 'not_found', isKnown: false }
+  }
+
+  if (tx.blockNumber === undefined || tx.blockNumber === 0) {
+    return { status: 'pending', isKnown: true }
   }
 
   // 1. top-level result === "FAILED" → error
@@ -59,7 +67,7 @@ export const getTronTxStatus: TxStatusResolver<OtherChain.Tron> = async ({ hash 
 
   // 2. receipt absent → pending (native TRX transfers or tx still processing)
   if (!tx.receipt) {
-    return { status: 'pending' }
+    return { status: 'pending', isKnown: true }
   }
 
   // 3. receipt.result in terminal failure set → error


### PR DESCRIPTION
Closes #1119
Live resolver API probes with fresh unknown hashes confirmed Sui, TON, Tron, Bittensor, and QBTC return isKnown:false, so broadcast verification rethrows rejected sends instead of reporting success.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction status handling across Sui, TON, Tron, Bittensor, and QBTC.
  * Unknown or unavailable transactions are now clearly distinguished from recognized transactions that are still pending.
  * Prevented failed status lookups from being incorrectly treated as successful broadcasts.
  * Added clearer handling for missing or unrecognized Tron transactions.

* **Tests**
  * Added coverage validating pending, unknown, and not-found outcomes across supported networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->