### PR TITLE
Export Cosmos fee helpers from the React Native SDK entrypoint

### DIFF
--- a/.changeset/rn-cosmos-fee-denom-exports.md
+++ b/.changeset/rn-cosmos-fee-denom-exports.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Export the canonical Cosmos fee-denom helpers from the React Native entrypoint.

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -65,6 +65,10 @@ configureDefaultStorage(() => new ReactNativeStorage())
 
 // Chain enum and types
 export { Chain } from '@vultisig/core-chain/Chain'
+export {
+  getCosmosAllowedFeeDenoms,
+  isCosmosFeeDenomAllowed,
+} from '@vultisig/core-chain/chains/cosmos/cosmosFeeDenomAllowlist'
 
 // WalletCore type compatible with both @trustwallet/wallet-core and @vultisig/walletcore-native
 export type { WalletCoreLike } from '@vultisig/walletcore-native'

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -39,4 +39,12 @@ describe('RN entry wires configureCrypto and configureDefaultStorage', () => {
     expect(storage).toBeDefined()
     expect(typeof storage.get).toBe('function')
   })
+
+  it('exports the canonical Cosmos fee-denom helpers from the RN entry', async () => {
+    const rn = await import('../../../../src/platforms/react-native/index')
+
+    expect(rn.getCosmosAllowedFeeDenoms(rn.Chain.Cosmos)).toContain('uatom')
+    expect(rn.isCosmosFeeDenomAllowed(rn.Chain.Cosmos, 'uatom')).toBe(true)
+    expect(rn.isCosmosFeeDenomAllowed(rn.Chain.Cosmos, 'uusdc')).toBe(false)
+  })
 })


### PR DESCRIPTION
Refs #1199

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cosmos fee-denomination helpers to the React Native SDK exports.
  * Applications can now retrieve allowed Cosmos fee denominations and validate whether a denomination is supported.

* **Bug Fixes**
  * Improved access to the canonical Cosmos fee-denomination validation functionality through the React Native entrypoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->