### PR TITLE
fix(swap): align provider registries

### DIFF
--- a/.changeset/swap-registry-hygiene.md
+++ b/.changeset/swap-registry-hygiene.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/core-chain': patch
+---
+
+Keep swap chain support registries aligned with provider-specific coverage.

--- a/.changeset/swap-registry-hygiene.md
+++ b/.changeset/swap-registry-hygiene.md
@@ -1,5 +1,6 @@
 ---
 '@vultisig/core-chain': patch
+'@vultisig/sdk': patch
 ---
 
 Keep swap chain support registries aligned with provider-specific coverage.

--- a/packages/core/chain/swap/general/knownAggregatorRouters.ts
+++ b/packages/core/chain/swap/general/knownAggregatorRouters.ts
@@ -50,14 +50,9 @@ const ONE_INCH_V6_STANDARD_ROUTER = '0x111111125421ca6dc452d289314280a0f8842a65'
 // v6.0 quote request returning this address (NOT the standard one above).
 const ONE_INCH_V6_ZKSYNC_ROUTER = '0x6fd4383cb451173d5f9304f041c7bcbf27d561ff'
 
-// KyberSwap MetaAggregationRouterV2 — same address confirmed live 2026-07-08 on every chain
-// that returned a response through aggregator-api.kyberswap.com's /routes (Ethereum, BSC,
-// Arbitrum, Optimism, Avalanche, Base, Polygon — 7 of 9 kyberSwapEnabledChains chains).
-// zkSync/Blast 404'd on this exact API path during verification — that looks like those two
-// chains aren't actually live through this aggregator endpoint today (a pre-existing,
-// separate question from this fix — kyberSwapEnabledChains may be ahead of what the live API
-// serves), not evidence of a differing router address. No chain-scoping needed unless that
-// changes.
+// KyberSwap MetaAggregationRouterV2 — same address confirmed live 2026-07-08 on every
+// kyberSwapEnabledChains chain through aggregator-api.kyberswap.com's /routes
+// (Ethereum, BSC, Arbitrum, Optimism, Avalanche, Base, Polygon).
 const KYBER_STANDARD_ROUTER = '0x6131b5fae19ea4f9d964eac0408e4408b66337b5'
 
 export type EnforcedRouterProvider = '1inch' | 'kyber'

--- a/packages/core/chain/swap/general/kyber/chains.ts
+++ b/packages/core/chain/swap/general/kyber/chains.ts
@@ -8,8 +8,6 @@ export const kyberSwapEnabledChains = [
   Chain.Optimism,
   Chain.Avalanche,
   Chain.Base,
-  Chain.Zksync,
-  Chain.Blast,
 ] as const
 
 export type KyberSwapEnabledChain = (typeof kyberSwapEnabledChains)[number]

--- a/packages/core/chain/swap/swapEnabledChains.test.ts
+++ b/packages/core/chain/swap/swapEnabledChains.test.ts
@@ -1,0 +1,38 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { cowSwapSupportedChains } from '@vultisig/core-chain/swap/general/cowswap/config'
+import { jupiterSwapEnabledChains } from '@vultisig/core-chain/swap/general/jupiter/JupiterSwapEnabledChains'
+import { kyberSwapEnabledChains } from '@vultisig/core-chain/swap/general/kyber/chains'
+import { lifiSwapEnabledChains } from '@vultisig/core-chain/swap/general/lifi/LifiSwapEnabledChains'
+import { oneInchSwapEnabledChains } from '@vultisig/core-chain/swap/general/oneInch/OneInchSwapEnabledChains'
+import { swapKitEnabledChains } from '@vultisig/core-chain/swap/general/swapkit/SwapKitEnabledChains'
+import { nativeSwapEnabledChains } from '@vultisig/core-chain/swap/native/NativeSwapChain'
+import { describe, expect, it } from 'vitest'
+
+import { swapEnabledChains } from './swapEnabledChains'
+
+const providerChainLists = [
+  nativeSwapEnabledChains,
+  cowSwapSupportedChains,
+  kyberSwapEnabledChains,
+  oneInchSwapEnabledChains,
+  jupiterSwapEnabledChains,
+  lifiSwapEnabledChains,
+  swapKitEnabledChains,
+] as const
+
+describe('swapEnabledChains', () => {
+  it('includes every provider-specific enabled-chain registry', () => {
+    const enabled = new Set(swapEnabledChains)
+
+    for (const providerChains of providerChainLists) {
+      for (const chain of providerChains) {
+        expect(enabled.has(chain)).toBe(true)
+      }
+    }
+  })
+
+  it('does not advertise Kyber chains whose API path is not live', () => {
+    expect(kyberSwapEnabledChains).not.toContain(Chain.Zksync)
+    expect(kyberSwapEnabledChains).not.toContain(Chain.Blast)
+  })
+})

--- a/packages/core/chain/swap/swapEnabledChains.ts
+++ b/packages/core/chain/swap/swapEnabledChains.ts
@@ -1,3 +1,6 @@
+import { cowSwapSupportedChains } from '@vultisig/core-chain/swap/general/cowswap/config'
+import { jupiterSwapEnabledChains } from '@vultisig/core-chain/swap/general/jupiter/JupiterSwapEnabledChains'
+import { kyberSwapEnabledChains } from '@vultisig/core-chain/swap/general/kyber/chains'
 import { lifiSwapEnabledChains } from '@vultisig/core-chain/swap/general/lifi/LifiSwapEnabledChains'
 import { oneInchSwapEnabledChains } from '@vultisig/core-chain/swap/general/oneInch/OneInchSwapEnabledChains'
 import { swapKitEnabledChains } from '@vultisig/core-chain/swap/general/swapkit/SwapKitEnabledChains'
@@ -5,7 +8,10 @@ import { nativeSwapEnabledChains } from '@vultisig/core-chain/swap/native/Native
 
 export const swapEnabledChains = [
   ...nativeSwapEnabledChains,
+  ...cowSwapSupportedChains,
+  ...kyberSwapEnabledChains,
   ...oneInchSwapEnabledChains,
+  ...jupiterSwapEnabledChains,
   ...lifiSwapEnabledChains,
   ...swapKitEnabledChains,
 ] as const


### PR DESCRIPTION
Refs #1151
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded swap availability by incorporating chains supported by additional swap providers (including CowSwap, KyberSwap, and Jupiter).
* **Bug Fixes**
  * Removed zkSync and Blast from KyberSwap-enabled chains to match currently live KyberSwap routing coverage.
* **Documentation**
  * Refreshed KyberSwap router verification details to reflect current live-chain coverage.
* **Tests**
  * Added coverage to ensure all provider-reported enabled chains are included in the overall swap-enabled list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->