### PR TITLE
fix(core-chain): preserve Cosmos hash after indexing timeout

### DIFF
--- a/.changeset/cosmos-broadcast-timeout-pending.md
+++ b/.changeset/cosmos-broadcast-timeout-pending.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/core-chain': patch
+---
+
+Return the Cosmos transaction hash when CosmJS accepts a broadcast but times out waiting for indexing, leaving confirmation to status polling instead of reporting broadcast failure.

--- a/.changeset/cosmos-broadcast-timeout-pending.md
+++ b/.changeset/cosmos-broadcast-timeout-pending.md
@@ -1,5 +1,6 @@
 ---
 '@vultisig/core-chain': patch
+'@vultisig/sdk': patch
 ---
 
 Return the Cosmos transaction hash when CosmJS accepts a broadcast but times out waiting for indexing, leaving confirmation to status polling instead of reporting broadcast failure.

--- a/packages/core/chain/tx/broadcast/resolvers/cosmos.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/cosmos.test.ts
@@ -1,0 +1,79 @@
+import { TimeoutError } from '@cosmjs/stargate'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getCosmosClient: vi.fn(),
+  verifyBroadcastByHash: vi.fn(),
+}))
+
+vi.mock('@vultisig/core-chain/chains/cosmos/client', () => ({
+  getCosmosClient: mocks.getCosmosClient,
+}))
+
+vi.mock('../verifyBroadcastByHash', () => ({
+  verifyBroadcastByHash: mocks.verifyBroadcastByHash,
+}))
+
+import { CosmosChain } from '../../../Chain'
+import { broadcastCosmosTx, getCosmosBroadcastTimeoutTxId } from './cosmos'
+
+const txBytes = Buffer.from([0x0a, 0x01, 0x02])
+const tx = {
+  serialized: JSON.stringify({
+    tx_bytes: txBytes.toString('base64'),
+  }),
+} as any
+
+describe('broadcastCosmosTx', () => {
+  const chain = CosmosChain.Cosmos
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns the tx id when CosmJS accepted the tx but timed out waiting for indexing', async () => {
+    const timeout = new TimeoutError(
+      'Transaction with ID ABC123 was submitted but was not yet found on the chain.',
+      'ABC123'
+    )
+    mocks.getCosmosClient.mockResolvedValue({
+      broadcastTx: vi.fn().mockRejectedValue(timeout),
+    })
+
+    await expect(broadcastCosmosTx({ chain, tx })).resolves.toBe('ABC123')
+
+    expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
+  })
+
+  it('keeps duplicate cache errors idempotent', async () => {
+    mocks.getCosmosClient.mockResolvedValue({
+      broadcastTx: vi.fn().mockRejectedValue(new Error('tx already exists in cache')),
+    })
+
+    await expect(broadcastCosmosTx({ chain, tx })).resolves.toBeUndefined()
+
+    expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
+  })
+
+  it('routes non-timeout errors through hash verification', async () => {
+    const error = new Error('account sequence mismatch')
+    mocks.getCosmosClient.mockResolvedValue({
+      broadcastTx: vi.fn().mockRejectedValue(error),
+    })
+    mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+
+    await expect(broadcastCosmosTx({ chain, tx })).resolves.toBeUndefined()
+
+    expect(mocks.verifyBroadcastByHash).toHaveBeenCalledWith({
+      chain,
+      tx,
+      error,
+    })
+  })
+
+  it('extracts only non-empty tx ids from CosmJS timeout errors', () => {
+    expect(getCosmosBroadcastTimeoutTxId(new TimeoutError('pending', 'ABC123'))).toBe('ABC123')
+    expect(getCosmosBroadcastTimeoutTxId(new TimeoutError('pending', '   '))).toBeUndefined()
+    expect(getCosmosBroadcastTimeoutTxId(new Error('pending'))).toBeUndefined()
+  })
+})

--- a/packages/core/chain/tx/broadcast/resolvers/cosmos.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/cosmos.ts
@@ -1,3 +1,4 @@
+import { TimeoutError } from '@cosmjs/stargate'
 import { CosmosChain } from '@vultisig/core-chain/Chain'
 import { getCosmosClient } from '@vultisig/core-chain/chains/cosmos/client'
 import { attempt } from '@vultisig/lib-utils/attempt'
@@ -5,6 +6,14 @@ import { isInError } from '@vultisig/lib-utils/error/isInError'
 
 import { BroadcastTxResolver } from '../resolver'
 import { verifyBroadcastByHash } from '../verifyBroadcastByHash'
+
+export const getCosmosBroadcastTimeoutTxId = (error: unknown): string | undefined => {
+  if (!(error instanceof TimeoutError)) return undefined
+
+  const { txId } = error
+
+  return txId.trim() || undefined
+}
 
 export const broadcastCosmosTx: BroadcastTxResolver<CosmosChain> = async ({ chain, tx }) => {
   const { serialized } = tx
@@ -20,6 +29,11 @@ export const broadcastCosmosTx: BroadcastTxResolver<CosmosChain> = async ({ chai
 
   if (isInError(error, 'tx already exists in cache')) {
     return
+  }
+
+  const timeoutTxId = getCosmosBroadcastTimeoutTxId(error)
+  if (timeoutTxId) {
+    return timeoutTxId
   }
 
   await verifyBroadcastByHash({ chain, tx, error })


### PR DESCRIPTION
Closes #1125
CosmJS emits this timeout only after sync broadcast accepts the transaction. Runtime proof: the timeout helper returns the submitted ID, and the focused resolver regression covers timeout, duplicate, and fallback paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cosmos transactions that time out during broadcast now return their transaction hash when available.
  * Transaction status polling can continue to determine final confirmation instead of treating indexing delays as broadcast failures.
  * Existing handling for duplicate transactions and other broadcast errors remains unchanged.

* **Tests**
  * Added coverage for timeout, duplicate transaction, verification, and invalid transaction ID scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->