### PR TITLE
fix(core): guard TON amount byte encoding

### DIFF
--- a/.changeset/ton-negative-amount-guard.md
+++ b/.changeset/ton-negative-amount-guard.md
@@ -1,0 +1,7 @@
+---
+'@vultisig/core-mpc': patch
+---
+
+Reject negative TON signing amounts before byte encoding so native, dApp-supplied
+TON messages, and Jetton helper amounts cannot silently truncate a `-`-prefixed
+hex value.

--- a/.changeset/ton-negative-amount-guard.md
+++ b/.changeset/ton-negative-amount-guard.md
@@ -1,5 +1,6 @@
 ---
 '@vultisig/core-mpc': patch
+'@vultisig/sdk': patch
 ---
 
 Reject negative TON signing amounts before byte encoding so native, dApp-supplied

--- a/packages/core/mpc/keysign/signingInputs/resolvers/ton/jetton.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/ton/jetton.ts
@@ -1,14 +1,12 @@
-import { Buffer } from 'buffer'
 import { tonConfig } from '@vultisig/core-chain/chains/ton/config'
 import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
-import { numberToEvenHex } from '@vultisig/lib-utils/hex/numberToHex'
 import { TW } from '@trustwallet/wallet-core'
 import { WalletCore } from '@trustwallet/wallet-core'
 
 import { getKeysignAmount } from '../../../utils/getKeysignAmount'
 import { getKeysignCoin } from '../../../utils/getKeysignCoin'
-import { toSafeComment } from './native'
+import { toSafeComment, tonAmountToBytes } from './native'
 
 type BuildJettonTransferInput = {
   keysignPayload: KeysignPayload
@@ -30,10 +28,10 @@ export const buildJettonTransfer = ({
   const forwardAmount = isActiveDestination ? 1n : 0n
 
   const jettonTransfer = TW.TheOpenNetwork.Proto.JettonTransfer.create({
-    jettonAmount: Buffer.from(numberToEvenHex(shouldBePresent(getKeysignAmount(keysignPayload))), 'hex'),
+    jettonAmount: tonAmountToBytes(shouldBePresent(getKeysignAmount(keysignPayload))),
     toOwner: destinationAddress,
     responseAddress: coin.address,
-    forwardAmount: Buffer.from(numberToEvenHex(forwardAmount), 'hex'),
+    forwardAmount: tonAmountToBytes(forwardAmount),
   })
 
   const mode =
@@ -41,7 +39,7 @@ export const buildJettonTransfer = ({
 
   return TW.TheOpenNetwork.Proto.Transfer.create({
     dest: jettonAddress,
-    amount: Buffer.from(numberToEvenHex(tonConfig.jettonAmount), 'hex'),
+    amount: tonAmountToBytes(tonConfig.jettonAmount),
     bounceable: true,
     comment: toSafeComment(keysignPayload.memo ?? ''),
     mode,

--- a/packages/core/mpc/keysign/signingInputs/resolvers/ton/native.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/ton/native.test.ts
@@ -25,6 +25,10 @@ const buildPayload = (toAmount: string): KeysignPayload =>
 
 describe('TON signing input amount encoding', () => {
   it('encodes non-negative native TON amounts as bytes', () => {
+    // TON testnet transaction ee3d0d792404c489ee46fa335a951f7f9158a1758e6a24c3acfbc14b04441133
+    // records a 1 TON internal-message value. Its 1_000_000_000 nanoton amount
+    // must remain the unsigned big-endian bytes 3b9aca00 at this resolver boundary.
+    // https://testnet.tonviewer.com/transaction/ee3d0d792404c489ee46fa335a951f7f9158a1758e6a24c3acfbc14b04441133
     const transfer = buildNativeTonTransfer({
       keysignPayload: buildPayload('1000000000'),
       bounceable: true,

--- a/packages/core/mpc/keysign/signingInputs/resolvers/ton/native.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/ton/native.test.ts
@@ -24,6 +24,8 @@ const buildPayload = (toAmount: string): KeysignPayload =>
   }) as KeysignPayload
 
 describe('TON signing input amount encoding', () => {
+  const maxTonAmount = (1n << 120n) - 1n
+
   it('encodes non-negative native TON amounts as bytes', () => {
     // TON testnet transaction ee3d0d792404c489ee46fa335a951f7f9158a1758e6a24c3acfbc14b04441133
     // records a 1 TON internal-message value. Its 1_000_000_000 nanoton amount
@@ -60,5 +62,18 @@ describe('TON signing input amount encoding', () => {
 
   it('rejects negative bigint amounts used by Jetton amount helpers', () => {
     expect(() => tonAmountToBytes(-1n)).toThrow('TON amount must be a non-negative integer')
+  })
+
+  it('accepts zero and the VarUInteger 16 maximum', () => {
+    expect(tonAmountToBytes('0').toString('hex')).toBe('00')
+    expect(tonAmountToBytes(maxTonAmount).toString('hex')).toBe('ff'.repeat(15))
+  })
+
+  it('rejects the first value above the VarUInteger 16 maximum', () => {
+    expect(() => tonAmountToBytes(maxTonAmount + 1n)).toThrow('TON amount exceeds the VarUInteger 16 maximum')
+  })
+
+  it('rejects oversized decimal strings before bigint conversion', () => {
+    expect(() => tonAmountToBytes('1'.repeat(10_000))).toThrow('TON amount exceeds the VarUInteger 16 maximum')
   })
 })

--- a/packages/core/mpc/keysign/signingInputs/resolvers/ton/native.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/ton/native.test.ts
@@ -1,0 +1,60 @@
+import { Buffer } from 'buffer'
+
+import { Chain } from '@vultisig/core-chain/Chain'
+import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { describe, expect, it } from 'vitest'
+
+import { buildNativeTonTransfer, buildNativeTonTransferFromMessage, tonAmountToBytes } from './native'
+
+const TON_ADDRESS = 'EQAtiFQ15MZBgpAGwD1jfJm6maz5otBOPefyw9Wc3MVmMgzp'
+
+const buildPayload = (toAmount: string): KeysignPayload =>
+  ({
+    coin: {
+      chain: Chain.Ton,
+      ticker: 'GRAM',
+      address: TON_ADDRESS,
+      decimals: 9,
+      isNativeToken: true,
+      hexPublicKey: '11'.repeat(32),
+    },
+    toAddress: TON_ADDRESS,
+    toAmount,
+    memo: '',
+  }) as KeysignPayload
+
+describe('TON signing input amount encoding', () => {
+  it('encodes non-negative native TON amounts as bytes', () => {
+    const transfer = buildNativeTonTransfer({
+      keysignPayload: buildPayload('1000000000'),
+      bounceable: true,
+      sendMaxAmount: false,
+    })
+
+    expect(Buffer.from(transfer.amount).toString('hex')).toBe('3b9aca00')
+  })
+
+  it('rejects negative native TON amounts before hex encoding', () => {
+    expect(() =>
+      buildNativeTonTransfer({
+        keysignPayload: buildPayload('-1'),
+        bounceable: true,
+        sendMaxAmount: false,
+      })
+    ).toThrow('TON amount must be a non-negative integer')
+  })
+
+  it('rejects negative dApp signTon message amounts before hex encoding', () => {
+    expect(() =>
+      buildNativeTonTransferFromMessage({
+        to: TON_ADDRESS,
+        amount: '-1',
+        bounceable: true,
+      })
+    ).toThrow('TON amount must be a non-negative integer')
+  })
+
+  it('rejects negative bigint amounts used by Jetton amount helpers', () => {
+    expect(() => tonAmountToBytes(-1n)).toThrow('TON amount must be a non-negative integer')
+  })
+})

--- a/packages/core/mpc/keysign/signingInputs/resolvers/ton/native.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/ton/native.ts
@@ -2,7 +2,6 @@ import { Buffer } from 'buffer'
 import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
 import { numberToEvenHex } from '@vultisig/lib-utils/hex/numberToHex'
 import { TW } from '@trustwallet/wallet-core'
-import Long from 'long'
 
 type BuildNativeTonTransferFromMessageInput = {
   to: string
@@ -38,6 +37,21 @@ export const validateTonComment = (memo: string): void => {
   }
 }
 
+const tonUnsignedDecimalRegex = /^\d+$/
+
+export const tonAmountToBytes = (amount: string | bigint): Buffer => {
+  if (typeof amount === 'string' && !tonUnsignedDecimalRegex.test(amount)) {
+    throw new Error('TON amount must be a non-negative integer')
+  }
+
+  const value = typeof amount === 'bigint' ? amount : BigInt(amount)
+  if (value < 0n) {
+    throw new Error('TON amount must be a non-negative integer')
+  }
+
+  return Buffer.from(numberToEvenHex(value), 'hex')
+}
+
 export const buildNativeTonTransfer = ({
   keysignPayload,
   bounceable,
@@ -49,11 +63,11 @@ export const buildNativeTonTransfer = ({
       : TW.TheOpenNetwork.Proto.SendMode.PAY_FEES_SEPARATELY) |
     TW.TheOpenNetwork.Proto.SendMode.IGNORE_ACTION_PHASE_ERRORS
 
-  const amount = sendMaxAmount ? Long.ZERO : Long.fromString(keysignPayload.toAmount)
+  const amount = sendMaxAmount ? 0n : keysignPayload.toAmount
 
   return TW.TheOpenNetwork.Proto.Transfer.create({
     dest: keysignPayload.toAddress,
-    amount: Buffer.from(numberToEvenHex(amount), 'hex'),
+    amount: tonAmountToBytes(amount),
     bounceable,
     comment: toSafeComment(keysignPayload.memo || ''),
     mode,
@@ -72,7 +86,7 @@ export const buildNativeTonTransferFromMessage = ({
 
   return TW.TheOpenNetwork.Proto.Transfer.create({
     dest: to,
-    amount: Buffer.from(numberToEvenHex(Long.fromString(amount)), 'hex'),
+    amount: tonAmountToBytes(amount),
     bounceable,
     comment: '',
     customPayload: payload || undefined,

--- a/packages/core/mpc/keysign/signingInputs/resolvers/ton/native.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/ton/native.ts
@@ -38,15 +38,29 @@ export const validateTonComment = (memo: string): void => {
 }
 
 const tonUnsignedDecimalRegex = /^\d+$/
+const tonMaxAmount = (1n << 120n) - 1n
+const tonMaxAmountDecimal = tonMaxAmount.toString()
 
 export const tonAmountToBytes = (amount: string | bigint): Buffer => {
   if (typeof amount === 'string' && !tonUnsignedDecimalRegex.test(amount)) {
     throw new Error('TON amount must be a non-negative integer')
   }
 
-  const value = typeof amount === 'bigint' ? amount : BigInt(amount)
+  const normalizedAmount = typeof amount === 'string' ? amount.replace(/^0+(?=\d)/, '') : amount
+  if (
+    typeof normalizedAmount === 'string' &&
+    (normalizedAmount.length > tonMaxAmountDecimal.length ||
+      (normalizedAmount.length === tonMaxAmountDecimal.length && normalizedAmount > tonMaxAmountDecimal))
+  ) {
+    throw new Error('TON amount exceeds the VarUInteger 16 maximum')
+  }
+
+  const value = typeof normalizedAmount === 'bigint' ? normalizedAmount : BigInt(normalizedAmount)
   if (value < 0n) {
     throw new Error('TON amount must be a non-negative integer')
+  }
+  if (value > tonMaxAmount) {
+    throw new Error('TON amount exceeds the VarUInteger 16 maximum')
   }
 
   return Buffer.from(numberToEvenHex(value), 'hex')


### PR DESCRIPTION
Closes #1146
Pins the native TON resolver's 1 TON byte encoding to a public testnet transaction and rejects negative amounts before byte serialization across native, dApp, and Jetton paths. Vector: https://testnet.tonviewer.com/transaction/ee3d0d792404c489ee46fa335a951f7f9158a1758e6a24c3acfbc14b04441133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * TON transfers now reject negative amounts before encoding.
  * Added validation for invalid, oversized, and out-of-range TON amounts.
  * Improved amount handling for native TON, Jetton transfers, and dApp-supplied messages.
  * Preserved correct encoding for zero, standard, and maximum supported amounts.

* **Tests**
  * Added coverage for valid TON amount encoding and rejected invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->