### PR TITLE
feat(sdk): expose CosmWasm execute builders

### DIFF
--- a/.changeset/cross-platform-cosmwasm-execute.md
+++ b/.changeset/cross-platform-cosmwasm-execute.md
@@ -1,6 +1,6 @@
 ---
-'@vultisig/sdk': patch
-'@vultisig/cli': patch
+'@vultisig/sdk': minor
+'@vultisig/cli': minor
 ---
 
 Expose generic CosmWasm Amino and protobuf execute builders from the root SDK and reuse the canonical Amino envelope in the CLI.

--- a/.changeset/cross-platform-cosmwasm-execute.md
+++ b/.changeset/cross-platform-cosmwasm-execute.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+Expose generic CosmWasm Amino and protobuf execute builders from the root SDK and reuse the canonical Amino envelope in the CLI.

--- a/clients/cli/src/commands/execute.ts
+++ b/clients/cli/src/commands/execute.ts
@@ -7,7 +7,7 @@
  * Primary use case: Execute FIN swaps on Rujira DEX
  */
 import type { CosmosChain, VaultBase } from '@vultisig/sdk'
-import { Chain, Vultisig } from '@vultisig/sdk'
+import { buildCosmosWasmExecuteMsg, Chain, Vultisig } from '@vultisig/sdk'
 import qrcode from 'qrcode-terminal'
 
 import type { CommandContext, TransactionResult } from '../core'
@@ -97,7 +97,9 @@ export async function executeExecute(ctx: CommandContext, params: ExecuteParams)
   const chainConfig = COSMOS_CHAIN_CONFIG[params.chain]
   if (!chainConfig) {
     throw new Error(
-      `Chain ${params.chain} does not support CosmWasm execute. Supported chains: ${Object.keys(COSMOS_CHAIN_CONFIG).join(', ')}`
+      `Chain ${params.chain} does not support CosmWasm execute. Supported chains: ${Object.keys(
+        COSMOS_CHAIN_CONFIG
+      ).join(', ')}`
     )
   }
 
@@ -257,17 +259,12 @@ async function executeContractTransaction(
       ticker: chainConfig.denom.toUpperCase(),
     }
 
-    // Build MsgExecuteContract in Amino format
-    // The type URL follows standard CosmWasm naming convention
-    const executeContractMsg = {
-      type: 'wasm/MsgExecuteContract',
-      value: JSON.stringify({
-        sender: address,
-        contract: params.contract,
-        msg: msg,
-        funds: funds.map(f => ({ denom: f.denom, amount: f.amount })),
-      }),
-    }
+    const executeContractMsg = buildCosmosWasmExecuteMsg({
+      sender: address,
+      contract: params.contract,
+      msg,
+      funds,
+    })
 
     // Build fee (THORChain has zero fees for CosmWasm)
     const fee = {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -623,6 +623,7 @@ export type {
   UndelegateParams,
   WithdrawRewardsParams,
 } from './tools'
+export type { BuildCosmosWasmExecuteMsgParams, CosmWasmExecuteFund } from './tools'
 export {
   abiDecode,
   abiEncode,
@@ -639,6 +640,7 @@ export {
   buildBuyPt,
   buildCctpBridge,
   buildCctpClaim,
+  buildCosmosWasmExecuteMsg,
   buildCw20TransferMsg,
   buildDelegateMsg,
   buildGlifRedeemSticnt,
@@ -807,6 +809,11 @@ export {
   utxoFeeRate,
   VerifierClient,
 } from './tools'
+
+// The protobuf builder is environment-neutral despite its historical RN path.
+// Export it from the root so Node/CLI consumers share the same wire builder.
+export type { BuildCosmosWasmExecuteOptions, CosmosTxBuilderResult } from './platforms/react-native/chains/cosmos/tx'
+export { buildCosmosWasmExecuteTx } from './platforms/react-native/chains/cosmos/tx'
 
 // Vault-bound gas/fee estimation (chain-specific fee floor for a loaded vault).
 // The pure read-only per-chain gas price lives in `evmGasPrice` above; this

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -205,8 +205,12 @@ export {
   buildWithdrawRewardsMsg,
   cosmosStaking,
 } from '../../tools/prep/cosmosStaking'
-// Pure CW-20 transfer msg builder (only depends on bech32 — no WalletCore /
-// native crypto, safe as a static re-export on the RN graph).
+// Pure CosmWasm Amino message builders (only depend on JSON/bech32 — no
+// WalletCore or native crypto, safe as static re-exports on the RN graph).
+// Keep this list aligned with the root entrypoint: package exports resolve
+// React Native consumers to this hand-curated module.
+export type { BuildCosmosWasmExecuteMsgParams, CosmWasmExecuteFund } from '../../tools/prep/cosmosWasmExecute'
+export { buildCosmosWasmExecuteMsg } from '../../tools/prep/cosmosWasmExecute'
 export { buildCw20TransferMsg } from '../../tools/prep/cw20Transfer'
 // `preparePolkadotAssetSend` is pure-crypto (@polkadot/util + @polkadot/util-crypto,
 // both RN-safe) with no MPC/wasm dependency, so it ships as a static re-export

--- a/packages/sdk/src/tools/index.ts
+++ b/packages/sdk/src/tools/index.ts
@@ -330,6 +330,8 @@ export { isMalformedEvmAddress, isNullAddress, isSelfSend, recipientSanity } fro
 
 // Vault-free prep helpers (KeysignPayload construction without a full vault)
 export {
+  buildCosmosWasmExecuteMsg,
+  type BuildCosmosWasmExecuteMsgParams,
   buildCw20TransferMsg,
   type BuildCw20TransferMsgParams,
   type BuildCw20TransferMsgResult,
@@ -344,6 +346,7 @@ export {
   type ConsolidateUtxo,
   cosmosStaking,
   type CosmosStakingMsgEnvelope,
+  type CosmWasmExecuteFund,
   type DelegateParams,
   getMaxSendAmountFromKeys,
   type GetMaxSendAmountFromKeysParams,

--- a/packages/sdk/src/tools/prep/cosmosWasmExecute.ts
+++ b/packages/sdk/src/tools/prep/cosmosWasmExecute.ts
@@ -1,0 +1,48 @@
+import type { CosmosMsgInput } from '../../types/cosmos'
+import { CosmosMsgType } from '../../types/cosmos-msg'
+
+export type CosmWasmExecuteFund = {
+  denom: string
+  amount: string
+}
+
+export type BuildCosmosWasmExecuteMsgParams = {
+  sender: string
+  contract: string
+  msg: unknown
+  funds?: readonly CosmWasmExecuteFund[]
+}
+
+const requireNonEmpty = (value: string, field: 'sender' | 'contract'): string => {
+  const trimmed = value.trim()
+  if (!trimmed) throw new Error(`invalid CosmWasm execute ${field}: value is required`)
+  return trimmed
+}
+
+/**
+ * Build the canonical generic Amino `MsgExecuteContract` envelope.
+ *
+ * This is pure transaction-shape preparation: callers remain responsible for
+ * chain-specific address validation, account state, fees, signing, and
+ * broadcasting. The `msg` value stays an object in the JSON envelope, matching
+ * the CosmJS/WalletCore Amino convention used by `prepareSignAminoTx`.
+ */
+export const buildCosmosWasmExecuteMsg = ({
+  sender,
+  contract,
+  msg,
+  funds = [],
+}: BuildCosmosWasmExecuteMsgParams): CosmosMsgInput => {
+  if (msg === undefined || typeof msg === 'function' || typeof msg === 'symbol') {
+    throw new Error('invalid CosmWasm execute msg: value must be JSON-serializable')
+  }
+
+  const value = JSON.stringify({
+    sender: requireNonEmpty(sender, 'sender'),
+    contract: requireNonEmpty(contract, 'contract'),
+    msg,
+    funds: funds.map(({ denom, amount }) => ({ denom, amount })),
+  })
+
+  return { type: CosmosMsgType.MsgExecuteContract, value }
+}

--- a/packages/sdk/src/tools/prep/cw20Transfer.ts
+++ b/packages/sdk/src/tools/prep/cw20Transfer.ts
@@ -1,7 +1,7 @@
 import { bech32 } from 'bech32'
 
 import type { CosmosMsgInput } from '../../types/cosmos'
-import { CosmosMsgType } from '../../types/cosmos-msg'
+import { buildCosmosWasmExecuteMsg } from './cosmosWasmExecute'
 
 /**
  * Pure-crypto builder for an UNSIGNED CosmWasm CW-20 token transfer message.
@@ -180,7 +180,7 @@ export const buildCw20TransferMsg = (params: BuildCw20TransferMsgParams): BuildC
 
   // Amino `MsgExecuteContract` value. `msg` here is the CW-20 execute object;
   // `funds: []` (a pure transfer carries no attached coins).
-  const value = JSON.stringify({
+  const msg = buildCosmosWasmExecuteMsg({
     sender,
     contract,
     msg: { transfer: { recipient, amount } },
@@ -188,7 +188,7 @@ export const buildCw20TransferMsg = (params: BuildCw20TransferMsgParams): BuildC
   })
 
   return {
-    msg: { type: CosmosMsgType.MsgExecuteContract, value },
+    msg,
     recipient,
     contract,
     sender,

--- a/packages/sdk/src/tools/prep/index.ts
+++ b/packages/sdk/src/tools/prep/index.ts
@@ -12,6 +12,11 @@ export {
   type UndelegateParams,
   type WithdrawRewardsParams,
 } from './cosmosStaking'
+export {
+  buildCosmosWasmExecuteMsg,
+  type BuildCosmosWasmExecuteMsgParams,
+  type CosmWasmExecuteFund,
+} from './cosmosWasmExecute'
 export { buildCw20TransferMsg, type BuildCw20TransferMsgParams, type BuildCw20TransferMsgResult } from './cw20Transfer'
 export {
   IBC_CHAIN_HRP,

--- a/packages/sdk/tests/unit/platforms/react-native/cosmos-wasm-execute-golden-vectors.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/cosmos-wasm-execute-golden-vectors.test.ts
@@ -1,0 +1,75 @@
+import { sha256 } from '@noble/hashes/sha2.js'
+import { PubKey } from 'cosmjs-types/cosmos/crypto/secp256k1/keys'
+import { AuthInfo, Fee, ModeInfo, SignDoc, SignerInfo, TxBody } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
+import { MsgExecuteContract } from 'cosmjs-types/cosmwasm/wasm/v1/tx'
+import { Any } from 'cosmjs-types/google/protobuf/any'
+import { describe, expect, it } from 'vitest'
+
+import { buildCosmosWasmExecuteTx } from '../../../../src'
+
+const bytesToHex = (bytes: Uint8Array): string => Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('')
+
+describe('root buildCosmosWasmExecuteTx export', () => {
+  it('matches an independent cosmjs-types SignDoc encoding byte for byte', () => {
+    const executeMsgJson = JSON.stringify({ swap: { minimum_output: '123' } })
+    const pubKeyBytes = new Uint8Array(33).fill(0x03)
+    const opts = {
+      chainId: 'thorchain-1',
+      fromAddress: 'thor1sender',
+      contractAddress: 'thor1contract',
+      executeMsgJson,
+      funds: [{ denom: 'rune', amount: '250000000' }],
+      sequence: 12,
+      accountNumber: 777,
+      pubKeyBytes,
+      gasLimit: 500_000,
+      feeDenom: 'rune',
+      feeAmount: '0',
+      memo: 'sdk-1187',
+    }
+
+    const actual = buildCosmosWasmExecuteTx(opts)
+    const execute = MsgExecuteContract.fromPartial({
+      sender: opts.fromAddress,
+      contract: opts.contractAddress,
+      msg: new TextEncoder().encode(executeMsgJson),
+      funds: opts.funds,
+    })
+    const body = TxBody.fromPartial({
+      messages: [
+        Any.fromPartial({
+          typeUrl: '/cosmwasm.wasm.v1.MsgExecuteContract',
+          value: MsgExecuteContract.encode(execute).finish(),
+        }),
+      ],
+      memo: opts.memo,
+    })
+    const authInfo = AuthInfo.fromPartial({
+      signerInfos: [
+        SignerInfo.fromPartial({
+          publicKey: Any.fromPartial({
+            typeUrl: '/cosmos.crypto.secp256k1.PubKey',
+            value: PubKey.encode(PubKey.fromPartial({ key: pubKeyBytes })).finish(),
+          }),
+          modeInfo: ModeInfo.fromPartial({ single: { mode: 1 } }),
+          sequence: BigInt(opts.sequence),
+        }),
+      ],
+      fee: Fee.fromPartial({
+        amount: [{ denom: opts.feeDenom, amount: opts.feeAmount }],
+        gasLimit: BigInt(opts.gasLimit),
+      }),
+    })
+    const expectedSignDoc = SignDoc.encode(
+      SignDoc.fromPartial({
+        bodyBytes: TxBody.encode(body).finish(),
+        authInfoBytes: AuthInfo.encode(authInfo).finish(),
+        chainId: opts.chainId,
+        accountNumber: BigInt(opts.accountNumber),
+      })
+    ).finish()
+
+    expect(bytesToHex(actual.signDocBytes)).toBe(bytesToHex(expectedSignDoc))
+    expect(actual.signingHashHex).toBe(bytesToHex(sha256(expectedSignDoc)))
+  })
+})

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -47,4 +47,20 @@ describe('RN entry wires configureCrypto and configureDefaultStorage', () => {
     expect(rn.isCosmosFeeDenomAllowed(rn.Chain.Cosmos, 'uatom')).toBe(true)
     expect(rn.isCosmosFeeDenomAllowed(rn.Chain.Cosmos, 'uusdc')).toBe(false)
   })
+
+  it('exports the generic CosmWasm execute message builder from the RN root surface', async () => {
+    const sdk = await import('../../../../src/platforms/react-native/index')
+
+    expect(typeof sdk.buildCosmosWasmExecuteMsg).toBe('function')
+    expect(
+      sdk.buildCosmosWasmExecuteMsg({
+        sender: 'thor1sender',
+        contract: 'thor1contract',
+        msg: { swap: { minimum_output: '123' } },
+      })
+    ).toEqual({
+      type: 'wasm/MsgExecuteContract',
+      value: '{"sender":"thor1sender","contract":"thor1contract","msg":{"swap":{"minimum_output":"123"}},"funds":[]}',
+    })
+  })
 })

--- a/packages/sdk/tests/unit/tools/prep/cosmosWasmExecute.test.ts
+++ b/packages/sdk/tests/unit/tools/prep/cosmosWasmExecute.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildCosmosWasmExecuteMsg } from '../../../../src/tools/prep/cosmosWasmExecute'
+
+describe('buildCosmosWasmExecuteMsg', () => {
+  it('builds the exact generic Amino envelope used by CLI execute', () => {
+    const result = buildCosmosWasmExecuteMsg({
+      sender: 'thor1sender',
+      contract: 'thor1contract',
+      msg: { swap: { minimum_output: '123' } },
+      funds: [{ denom: 'rune', amount: '250000000' }],
+    })
+
+    expect(result).toEqual({
+      type: 'wasm/MsgExecuteContract',
+      value:
+        '{"sender":"thor1sender","contract":"thor1contract","msg":{"swap":{"minimum_output":"123"}},"funds":[{"denom":"rune","amount":"250000000"}]}',
+    })
+  })
+
+  it.each(['sender', 'contract'] as const)('rejects an empty %s', field => {
+    expect(() =>
+      buildCosmosWasmExecuteMsg({
+        sender: field === 'sender' ? '  ' : 'thor1sender',
+        contract: field === 'contract' ? '' : 'thor1contract',
+        msg: {},
+      })
+    ).toThrow(`invalid CosmWasm execute ${field}: value is required`)
+  })
+
+  it('copies funds so later caller mutation cannot change the signed envelope', () => {
+    const funds = [{ denom: 'urujira', amount: '7' }]
+    const result = buildCosmosWasmExecuteMsg({
+      sender: 'thor1sender',
+      contract: 'thor1contract',
+      msg: { deposit: {} },
+      funds,
+    })
+
+    funds[0].amount = '999'
+    expect(JSON.parse(result.value).funds).toEqual([{ denom: 'urujira', amount: '7' }])
+  })
+
+  it('rejects an undefined message instead of silently omitting the signed field', () => {
+    expect(() =>
+      buildCosmosWasmExecuteMsg({
+        sender: 'thor1sender',
+        contract: 'thor1contract',
+        msg: undefined,
+      })
+    ).toThrow('invalid CosmWasm execute msg: value must be JSON-serializable')
+  })
+})

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -99,6 +99,11 @@ describe('@vultisig/sdk public exports', () => {
     expect(typeof sdk.isSeedphraseImportSupportedChain).toBe('function')
   })
 
+  it('exports generic CosmWasm amino and protobuf execute builders', () => {
+    expect(typeof sdk.buildCosmosWasmExecuteMsg).toBe('function')
+    expect(typeof sdk.buildCosmosWasmExecuteTx).toBe('function')
+  })
+
   it('VaultBase prototype exposes prep-only primitives used by mcp-ts execute_* tools', () => {
     // prepareSendTx / prepareSwapTx / prepareContractCallTx are public instance
     // methods on VaultBase — they build a KeysignPayload without broadcasting.


### PR DESCRIPTION
Closes #1187
Built SDK package proof confirms the root builders produce the canonical Amino envelope and protobuf SignDoc byte parity; the React Native conditional root now exposes the same generic Amino builder.