### PR TITLE
fix(sdk): price known non-EVM tokens

### DIFF
--- a/.changeset/non-evm-fiat-token-pricing.md
+++ b/.changeset/non-evm-fiat-token-pricing.md
@@ -1,5 +1,6 @@
 ---
-"@vultisig/sdk": patch
+'@vultisig/core-chain': patch
+'@vultisig/sdk': patch
 ---
 
 Fix fiat pricing for known non-EVM token identifiers.

--- a/.changeset/non-evm-fiat-token-pricing.md
+++ b/.changeset/non-evm-fiat-token-pricing.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/sdk": patch
+---
+
+Fix fiat pricing for known non-EVM token identifiers.

--- a/packages/core/chain/coin/price/__tests__/resolveTokenPriceId.test.ts
+++ b/packages/core/chain/coin/price/__tests__/resolveTokenPriceId.test.ts
@@ -99,9 +99,8 @@ describe('resolveTokenPriceId', () => {
       expect(resolveTokenPriceId(Chain.TerraClassic, 'krtc')).toBeUndefined()
     })
 
-    it('uluna on TerraClassic -> undefined (only in chainFeeCoin, not knownTokensIndex)', () => {
-      // uluna is the native denom but it is not registered as a separate knownToken entry
-      expect(resolveTokenPriceId(Chain.TerraClassic, 'uluna')).toBeUndefined()
+    it('unknown native-looking denom on TerraClassic -> undefined', () => {
+      expect(resolveTokenPriceId(Chain.TerraClassic, 'ufoo')).toBeUndefined()
     })
 
     it('unknown Solana mint -> undefined', () => {
@@ -110,6 +109,10 @@ describe('resolveTokenPriceId', () => {
   })
 
   describe('whitespace tolerance (upstream string sources may carry padding)', () => {
+    it('whitespace-padded Cosmos native fee denom resolves to the native coin', () => {
+      expect(resolveTokenPriceId(Chain.TerraClassic, ' uluna ')).toBe('terra-luna')
+    })
+
     it('whitespace-padded EVM contract still resolves', () => {
       expect(resolveTokenPriceId(Chain.Ethereum, '  0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48  ')).toBe('usd-coin')
     })

--- a/packages/core/chain/coin/price/__tests__/resolveTokenPriceId.test.ts
+++ b/packages/core/chain/coin/price/__tests__/resolveTokenPriceId.test.ts
@@ -67,9 +67,12 @@ describe('resolveTokenPriceId', () => {
       expect(resolveTokenPriceId(Chain.Ethereum, '0xdac17f958d2ee523a2206206994597c13d831ec7')).toBe('tether')
     })
 
-    it('Solana USDC mint -> usd-coin (case-insensitive lookup into lowercased index)', () => {
-      // The index stores keys lowercased; passing the canonical mixed-case mint works fine
+    it('Solana USDC canonical mint -> usd-coin', () => {
       expect(resolveTokenPriceId(Chain.Solana, 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v')).toBe('usd-coin')
+    })
+
+    it('does not case-fold a distinct Solana mint into the canonical USDC mint', () => {
+      expect(resolveTokenPriceId(Chain.Solana, 'EpjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v')).toBeUndefined()
     })
 
     it('Solana USDT mint -> tether', () => {

--- a/packages/core/chain/coin/price/resolveTokenPriceId.ts
+++ b/packages/core/chain/coin/price/resolveTokenPriceId.ts
@@ -1,4 +1,5 @@
 import type { Chain } from '../../Chain'
+import { cosmosFeeCoinDenom } from '../../chains/cosmos/cosmosFeeCoinDenom'
 import { chainFeeCoin } from '../chainFeeCoin'
 import { knownTokensIndex } from '../knownTokens'
 
@@ -26,6 +27,9 @@ import { knownTokensIndex } from '../knownTokens'
 export function resolveTokenPriceId(chain: Chain, denomOrAddress?: string): string | undefined {
   const normalized = denomOrAddress?.trim().toLowerCase()
   if (!normalized) {
+    return chainFeeCoin[chain]?.priceProviderId || undefined
+  }
+  if (cosmosFeeCoinDenom[chain as keyof typeof cosmosFeeCoinDenom] === normalized) {
     return chainFeeCoin[chain]?.priceProviderId || undefined
   }
   return knownTokensIndex[chain]?.[normalized]?.priceProviderId || undefined

--- a/packages/core/chain/coin/price/resolveTokenPriceId.ts
+++ b/packages/core/chain/coin/price/resolveTokenPriceId.ts
@@ -1,7 +1,8 @@
 import type { Chain } from '../../Chain'
+import { getChainKind } from '../../ChainKind'
 import { cosmosFeeCoinDenom } from '../../chains/cosmos/cosmosFeeCoinDenom'
 import { chainFeeCoin } from '../chainFeeCoin'
-import { knownTokensIndex } from '../knownTokens'
+import { knownTokens, knownTokensIndex } from '../knownTokens'
 
 /**
  * Resolve a token's CoinGecko price-provider id from the SDK's curated
@@ -10,13 +11,10 @@ import { knownTokensIndex } from '../knownTokens'
  * - When `denomOrAddress` is omitted, empty, or whitespace-only, returns the
  *   native chain coin's priceProviderId from chainFeeCoin (e.g.
  *   resolveTokenPriceId('Ethereum') -> 'ethereum').
- * - When `denomOrAddress` is provided, it is trimmed and lowercased, then
- *   looked up in knownTokensIndex[chain]. The lookup is case-insensitive (the
- *   index stores all keys lowercased) and tolerant of incidental surrounding
- *   whitespace from upstream string sources. Note: lowercasing is locale-
- *   independent (String.prototype.toLowerCase, not toLocaleLowerCase) and the
- *   index keys are built with the same call, so the build/lookup casing is
- *   always symmetric.
+ * - When `denomOrAddress` is provided, incidental surrounding whitespace is
+ *   trimmed. EVM contract addresses are matched case-insensitively; identifiers
+ *   for every other chain are matched exactly because Solana mints, Cosmos
+ *   denoms, TON jettons, and other non-EVM identifiers may be case-sensitive.
  *
  * The native Cosmos fee denom is also resolved to its chain fee coin's
  * priceProviderId. Other unknown identifiers return `undefined` — the caller
@@ -26,14 +24,18 @@ import { knownTokensIndex } from '../knownTokens'
  * Referenced by vultisig/mcp-ts#255 — registry-driven price resolution.
  */
 export function resolveTokenPriceId(chain: Chain, denomOrAddress?: string): string | undefined {
-  const normalized = denomOrAddress?.trim().toLowerCase()
-  if (!normalized) {
+  const identifier = denomOrAddress?.trim()
+  if (!identifier) {
     return chainFeeCoin[chain]?.priceProviderId || undefined
   }
-  const knownPriceProviderId = knownTokensIndex[chain]?.[normalized]?.priceProviderId
+
+  const knownPriceProviderId =
+    getChainKind(chain) === 'evm'
+      ? knownTokensIndex[chain]?.[identifier.toLowerCase()]?.priceProviderId
+      : knownTokens[chain]?.find(coin => coin.id === identifier)?.priceProviderId
   if (knownPriceProviderId) return knownPriceProviderId
 
-  return cosmosFeeCoinDenom[chain as keyof typeof cosmosFeeCoinDenom] === normalized
+  return cosmosFeeCoinDenom[chain as keyof typeof cosmosFeeCoinDenom] === identifier
     ? chainFeeCoin[chain]?.priceProviderId || undefined
     : undefined
 }

--- a/packages/core/chain/coin/price/resolveTokenPriceId.ts
+++ b/packages/core/chain/coin/price/resolveTokenPriceId.ts
@@ -18,9 +18,10 @@ import { knownTokensIndex } from '../knownTokens'
  *   index keys are built with the same call, so the build/lookup casing is
  *   always symmetric.
  *
- * Returns `undefined` if no registry entry exists — never guesses or
- * fabricates an id. The caller decides whether to fall back to CoinGecko
- * search, DeFiLlama, or surface a `price_unavailable` to the user.
+ * The native Cosmos fee denom is also resolved to its chain fee coin's
+ * priceProviderId. Other unknown identifiers return `undefined` — the caller
+ * decides whether to fall back to CoinGecko search, DeFiLlama, or surface a
+ * `price_unavailable` to the user.
  *
  * Referenced by vultisig/mcp-ts#255 — registry-driven price resolution.
  */
@@ -29,8 +30,10 @@ export function resolveTokenPriceId(chain: Chain, denomOrAddress?: string): stri
   if (!normalized) {
     return chainFeeCoin[chain]?.priceProviderId || undefined
   }
-  if (cosmosFeeCoinDenom[chain as keyof typeof cosmosFeeCoinDenom] === normalized) {
-    return chainFeeCoin[chain]?.priceProviderId || undefined
-  }
-  return knownTokensIndex[chain]?.[normalized]?.priceProviderId || undefined
+  const knownPriceProviderId = knownTokensIndex[chain]?.[normalized]?.priceProviderId
+  if (knownPriceProviderId) return knownPriceProviderId
+
+  return cosmosFeeCoinDenom[chain as keyof typeof cosmosFeeCoinDenom] === normalized
+    ? chainFeeCoin[chain]?.priceProviderId || undefined
+    : undefined
 }

--- a/packages/sdk/src/services/FiatValueService.ts
+++ b/packages/sdk/src/services/FiatValueService.ts
@@ -1,5 +1,4 @@
-import type { Chain } from '@vultisig/core-chain/Chain'
-import type { EvmChain } from '@vultisig/core-chain/Chain'
+import { type Chain, EvmChain } from '@vultisig/core-chain/Chain'
 import { cosmosFeeCoinDenom } from '@vultisig/core-chain/chains/cosmos/cosmosFeeCoinDenom'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { getErc20Prices } from '@vultisig/core-chain/coin/price/evm/getErc20Prices'
@@ -467,15 +466,19 @@ export class FiatValueService {
    */
   private async fetchTokenPrice(chain: Chain, tokenAddress: string, currency: FiatCurrency): Promise<number> {
     if (!this.isEvmChain(chain)) {
+      const normalizedTokenAddress = tokenAddress.trim()
       const nativeCosmosDenom = cosmosFeeCoinDenom[chain as keyof typeof cosmosFeeCoinDenom]
       const priceProviderId =
-        resolveTokenPriceId(chain, tokenAddress) ??
-        (nativeCosmosDenom && tokenAddress.toLowerCase() === nativeCosmosDenom
+        resolveTokenPriceId(chain, normalizedTokenAddress) ??
+        (nativeCosmosDenom && normalizedTokenAddress.toLowerCase() === nativeCosmosDenom
           ? chainFeeCoin[chain]?.priceProviderId
           : undefined)
       if (!priceProviderId) return 0
 
-      const prices = await getCoinPrices({ ids: [priceProviderId], fiatCurrency: currency })
+      const prices = await getCoinPrices({
+        ids: [priceProviderId],
+        fiatCurrency: currency,
+      })
       const price = prices[priceProviderId.toLowerCase()]
       if (price === undefined || price === 0) {
         throw new Error(`Price not found for token ${tokenAddress} on ${chain}`)
@@ -484,10 +487,10 @@ export class FiatValueService {
     }
 
     const prices = await getErc20Prices({
-          ids: [tokenAddress],
-          chain: chain as EvmChain,
-          fiatCurrency: currency,
-        })
+      ids: [tokenAddress],
+      chain: chain as EvmChain,
+      fiatCurrency: currency,
+    })
     const price = prices[tokenAddress.toLowerCase()]
     if (price === undefined || price === 0) {
       throw new Error(`Price not found for token ${tokenAddress} on ${chain}`)
@@ -514,20 +517,6 @@ export class FiatValueService {
    * @private
    */
   private isEvmChain(chain: Chain): boolean {
-    const evmChains = [
-      'Ethereum',
-      'Polygon',
-      'BNBChain',
-      'Avalanche',
-      'Arbitrum',
-      'Optimism',
-      'Base',
-      'Blast',
-      'CronosChain',
-      'ZkSync',
-      'Mantle',
-      'Sei',
-    ]
-    return evmChains.includes(chain)
+    return Object.values(EvmChain).includes(chain as EvmChain)
   }
 }

--- a/packages/sdk/src/services/FiatValueService.ts
+++ b/packages/sdk/src/services/FiatValueService.ts
@@ -1,8 +1,10 @@
 import type { Chain } from '@vultisig/core-chain/Chain'
 import type { EvmChain } from '@vultisig/core-chain/Chain'
+import { cosmosFeeCoinDenom } from '@vultisig/core-chain/chains/cosmos/cosmosFeeCoinDenom'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { getErc20Prices } from '@vultisig/core-chain/coin/price/evm/getErc20Prices'
 import { getCoinPrices } from '@vultisig/core-chain/coin/price/getCoinPrices'
+import { resolveTokenPriceId } from '@vultisig/core-chain/coin/price/resolveTokenPriceId'
 import { getCoinValue } from '@vultisig/core-chain/coin/utils/getCoinValue'
 import type { FiatCurrency } from '@vultisig/core-config/FiatCurrency'
 
@@ -460,22 +462,32 @@ export class FiatValueService {
   }
 
   /**
-   * Fetch token price by contract address
-   * Currently supports EVM chains (Ethereum, Polygon, BSC, etc.)
+   * Fetch a token price using the chain's canonical token identifier.
    * @private
    */
   private async fetchTokenPrice(chain: Chain, tokenAddress: string, currency: FiatCurrency): Promise<number> {
     if (!this.isEvmChain(chain)) {
-      return 0
+      const nativeCosmosDenom = cosmosFeeCoinDenom[chain as keyof typeof cosmosFeeCoinDenom]
+      const priceProviderId =
+        resolveTokenPriceId(chain, tokenAddress) ??
+        (nativeCosmosDenom && tokenAddress.toLowerCase() === nativeCosmosDenom
+          ? chainFeeCoin[chain]?.priceProviderId
+          : undefined)
+      if (!priceProviderId) return 0
+
+      const prices = await getCoinPrices({ ids: [priceProviderId], fiatCurrency: currency })
+      const price = prices[priceProviderId.toLowerCase()]
+      if (price === undefined || price === 0) {
+        throw new Error(`Price not found for token ${tokenAddress} on ${chain}`)
+      }
+      return price
     }
 
-    // Fetch ERC-20 token price
     const prices = await getErc20Prices({
-      ids: [tokenAddress],
-      chain: chain as EvmChain,
-      fiatCurrency: currency,
-    })
-
+          ids: [tokenAddress],
+          chain: chain as EvmChain,
+          fiatCurrency: currency,
+        })
     const price = prices[tokenAddress.toLowerCase()]
     if (price === undefined || price === 0) {
       throw new Error(`Price not found for token ${tokenAddress} on ${chain}`)

--- a/packages/sdk/src/services/FiatValueService.ts
+++ b/packages/sdk/src/services/FiatValueService.ts
@@ -1,5 +1,4 @@
 import { type Chain, EvmChain } from '@vultisig/core-chain/Chain'
-import { cosmosFeeCoinDenom } from '@vultisig/core-chain/chains/cosmos/cosmosFeeCoinDenom'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { getErc20Prices } from '@vultisig/core-chain/coin/price/evm/getErc20Prices'
 import { getCoinPrices } from '@vultisig/core-chain/coin/price/getCoinPrices'
@@ -466,13 +465,7 @@ export class FiatValueService {
    */
   private async fetchTokenPrice(chain: Chain, tokenAddress: string, currency: FiatCurrency): Promise<number> {
     if (!this.isEvmChain(chain)) {
-      const normalizedTokenAddress = tokenAddress.trim()
-      const nativeCosmosDenom = cosmosFeeCoinDenom[chain as keyof typeof cosmosFeeCoinDenom]
-      const priceProviderId =
-        resolveTokenPriceId(chain, normalizedTokenAddress) ??
-        (nativeCosmosDenom && normalizedTokenAddress.toLowerCase() === nativeCosmosDenom
-          ? chainFeeCoin[chain]?.priceProviderId
-          : undefined)
+      const priceProviderId = resolveTokenPriceId(chain, tokenAddress)
       if (!priceProviderId) return 0
 
       const prices = await getCoinPrices({

--- a/packages/sdk/src/utils/fiatToAmount.ts
+++ b/packages/sdk/src/utils/fiatToAmount.ts
@@ -1,6 +1,5 @@
 import { Chain } from '@vultisig/core-chain/Chain'
 import { isChainOfKind } from '@vultisig/core-chain/ChainKind'
-import { cosmosFeeCoinDenom } from '@vultisig/core-chain/chains/cosmos/cosmosFeeCoinDenom'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { getErc20Prices } from '@vultisig/core-chain/coin/price/evm/getErc20Prices'
 import { getCoinPrices } from '@vultisig/core-chain/coin/price/getCoinPrices'
@@ -95,14 +94,7 @@ export const fiatToAmount = async (params: FiatToAmountParams): Promise<string> 
         // Non-EVM chains (Cosmos, Solana, TON, Polkadot, etc.) identify tokens by
         // denom / mint / asset-id, not a contract address. Resolve via the curated
         // knownTokens registry which already maps these to CoinGecko ids.
-        // For Cosmos chains, also accept the native fee-coin denom (e.g. "uluna" on
-        // TerraClassic, "uatom" on Cosmos) which identifies the native coin by its
-        // on-chain denomination rather than the absence of a tokenId.
-        const nativeCosmosDenom = cosmosFeeCoinDenom[chain as keyof typeof cosmosFeeCoinDenom]
-        const isNativeCosmosDenom = nativeCosmosDenom != null && tokenId.toLowerCase() === nativeCosmosDenom
-        const priceId =
-          resolveTokenPriceId(chain, tokenId) ??
-          (isNativeCosmosDenom ? chainFeeCoin[chain]?.priceProviderId : undefined)
+        const priceId = resolveTokenPriceId(chain, tokenId)
         if (!priceId) {
           throw new FiatToAmountError(
             `Could not resolve a price provider id for token "${tokenId}" on chain "${chain}". ` +

--- a/packages/sdk/tests/unit/services/FiatValueService.test.ts
+++ b/packages/sdk/tests/unit/services/FiatValueService.test.ts
@@ -4,6 +4,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 // IMPORTANT: Mocks must be defined BEFORE imports
 vi.mock('@vultisig/core-chain/coin/price/getCoinPrices')
 vi.mock('@vultisig/core-chain/coin/price/evm/getErc20Prices')
+vi.mock('@vultisig/core-chain/coin/price/resolveTokenPriceId', () => ({
+  resolveTokenPriceId: vi.fn(),
+}))
+vi.mock('@vultisig/core-chain/chains/cosmos/cosmosFeeCoinDenom', () => ({
+  cosmosFeeCoinDenom: { TerraClassic: 'uluna' },
+}))
 vi.mock('@vultisig/core-chain/coin/utils/getCoinValue')
 vi.mock('@vultisig/core-chain/coin/chainFeeCoin', () => ({
   chainFeeCoin: {
@@ -26,6 +32,11 @@ vi.mock('@vultisig/core-chain/coin/chainFeeCoin', () => ({
       ticker: 'MATIC',
       decimals: 18,
       priceProviderId: 'matic-network',
+    },
+    TerraClassic: {
+      ticker: 'LUNC',
+      decimals: 6,
+      priceProviderId: 'terra-luna',
     },
   },
 }))
@@ -428,10 +439,33 @@ describe('FiatValueService', () => {
       await expect(service.getPrice(Chain.Ethereum, '0xInvalidToken')).rejects.toThrow('Price not found for token')
     })
 
-    it('should return 0 for token pricing on non-EVM chains', async () => {
-      // Bitcoin is not an EVM chain — returns 0 instead of throwing
-      const price = await service.getPrice(Chain.Bitcoin, '0xSomeToken')
-      expect(price).toBe(0)
+    it('should fetch known non-EVM token prices through the canonical registry id', async () => {
+      const { getCoinPrices } = await import('@vultisig/core-chain/coin/price/getCoinPrices')
+      const { resolveTokenPriceId } = await import('@vultisig/core-chain/coin/price/resolveTokenPriceId')
+      const solanaUsdc = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+      vi.mocked(resolveTokenPriceId).mockReturnValue('usd-coin')
+      vi.mocked(getCoinPrices).mockResolvedValue({ 'usd-coin': 1 })
+
+      const price = await service.getPrice(Chain.Solana, solanaUsdc)
+
+      expect(price).toBe(1)
+      expect(getCoinPrices).toHaveBeenCalledWith({ ids: ['usd-coin'], fiatCurrency: 'usd' })
+    })
+
+    it('should price a Cosmos native fee denom passed as a token identifier', async () => {
+      const { getCoinPrices } = await import('@vultisig/core-chain/coin/price/getCoinPrices')
+      const { resolveTokenPriceId } = await import('@vultisig/core-chain/coin/price/resolveTokenPriceId')
+      vi.mocked(resolveTokenPriceId).mockReturnValue(undefined)
+      vi.mocked(getCoinPrices).mockResolvedValue({ 'terra-luna': 0.000062 })
+
+      await expect(service.getPrice(Chain.TerraClassic, 'uluna')).resolves.toBe(0.000062)
+      expect(getCoinPrices).toHaveBeenCalledWith({ ids: ['terra-luna'], fiatCurrency: 'usd' })
+    })
+
+    it('should preserve zero pricing for unknown non-EVM token identifiers', async () => {
+      const { resolveTokenPriceId } = await import('@vultisig/core-chain/coin/price/resolveTokenPriceId')
+      vi.mocked(resolveTokenPriceId).mockReturnValue(undefined)
+      await expect(service.getPrice(Chain.Bitcoin, 'not-a-known-token')).resolves.toBe(0)
     })
   })
 

--- a/packages/sdk/tests/unit/services/FiatValueService.test.ts
+++ b/packages/sdk/tests/unit/services/FiatValueService.test.ts
@@ -472,7 +472,7 @@ describe('FiatValueService', () => {
     it('should price a Cosmos native fee denom passed as a token identifier', async () => {
       const { getCoinPrices } = await import('@vultisig/core-chain/coin/price/getCoinPrices')
       const { resolveTokenPriceId } = await import('@vultisig/core-chain/coin/price/resolveTokenPriceId')
-      vi.mocked(resolveTokenPriceId).mockReturnValue(undefined)
+      vi.mocked(resolveTokenPriceId).mockReturnValue('terra-luna')
       vi.mocked(getCoinPrices).mockResolvedValue({ 'terra-luna': 0.000062 })
 
       await expect(service.getPrice(Chain.TerraClassic, ' uluna ')).resolves.toBe(0.000062)

--- a/packages/sdk/tests/unit/services/FiatValueService.test.ts
+++ b/packages/sdk/tests/unit/services/FiatValueService.test.ts
@@ -131,6 +131,23 @@ describe('FiatValueService', () => {
       })
     })
 
+    for (const chain of [Chain.BSC, Chain.Zksync, Chain.Hyperliquid]) {
+      it(`should route ${chain} tokens through the EVM price API`, async () => {
+        const { getErc20Prices } = await import('@vultisig/core-chain/coin/price/evm/getErc20Prices')
+        const tokenAddress = '0xA0b86991c6218b36c1d19d4a2e9Eb0cE3606eB48'
+        vi.mocked(getErc20Prices).mockResolvedValue({
+          [tokenAddress.toLowerCase()]: 1,
+        })
+
+        await expect(service.getPrice(chain, tokenAddress)).resolves.toBe(1)
+        expect(getErc20Prices).toHaveBeenCalledWith({
+          ids: [tokenAddress],
+          chain,
+          fiatCurrency: 'usd',
+        })
+      })
+    }
+
     it('should support different fiat currencies', async () => {
       const { getCoinPrices } = await import('@vultisig/core-chain/coin/price/getCoinPrices')
       vi.mocked(getCoinPrices).mockResolvedValue({
@@ -458,7 +475,7 @@ describe('FiatValueService', () => {
       vi.mocked(resolveTokenPriceId).mockReturnValue(undefined)
       vi.mocked(getCoinPrices).mockResolvedValue({ 'terra-luna': 0.000062 })
 
-      await expect(service.getPrice(Chain.TerraClassic, 'uluna')).resolves.toBe(0.000062)
+      await expect(service.getPrice(Chain.TerraClassic, ' uluna ')).resolves.toBe(0.000062)
       expect(getCoinPrices).toHaveBeenCalledWith({ ids: ['terra-luna'], fiatCurrency: 'usd' })
     })
 

--- a/packages/sdk/tests/unit/utils/fiatToAmount.test.ts
+++ b/packages/sdk/tests/unit/utils/fiatToAmount.test.ts
@@ -213,6 +213,21 @@ describe('fiatToAmount', () => {
     expect(result).toBe('5')
   })
 
+  it('rejects a case-variant Solana mint instead of using the canonical token price', async () => {
+    const { getCoinPrices } = await import('@vultisig/core-chain/coin/price/getCoinPrices')
+
+    await expect(
+      fiatToAmount({
+        fiatValue: 25,
+        chain: Chain.Solana,
+        tokenId: 'EpjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        decimals: 6,
+      })
+    ).rejects.toThrow(/could not resolve a price provider id/i)
+
+    expect(getCoinPrices).not.toHaveBeenCalled()
+  })
+
   it('resolves EVM USDC on Ethereum via getErc20Prices — no regression', async () => {
     const { getErc20Prices } = await import('@vultisig/core-chain/coin/price/evm/getErc20Prices')
     const usdcAddress = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'


### PR DESCRIPTION
Closes #1167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed fiat pricing for supported non-EVM tokens so prices are fetched from the canonical provider when available (instead of returning zero).
  * Updated token identifier resolution to use trimmed inputs with chain-specific matching rules (EVM case-insensitive, non-EVM exact), including improved Cosmos denom handling and whitespace tolerance.
  * Kept EVM ERC-20 pricing routing behavior consistent while expanding coverage for additional EVM networks.
* **Tests**
  * Expanded unit tests for non-EVM pricing resolution, EVM routing args, and stricter rejection of unsupported/case-variant token identifiers.
* **Release Management**
  * Added a patch release changeset for both `@vultisig/core-chain` and `@vultisig/sdk`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->