### PR TITLE
fix(tokens): keep non-EVM known-token ids canonical

### DIFF
--- a/.changeset/r29-known-token-case-sensitive-non-evm.md
+++ b/.changeset/r29-known-token-case-sensitive-non-evm.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/sdk': patch
+---
+
+Keep known-token lookup case-insensitive only for EVM contract addresses, and require exact canonical ids for non-EVM assets like Solana mints and XRPL issued-currency token ids.

--- a/packages/core/chain/coin/knownTokens/index.test.ts
+++ b/packages/core/chain/coin/knownTokens/index.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { Chain } from '../../Chain'
+import { rippleTokenId } from '../../chains/ripple/issuedCurrency'
+import { getKnownTokenById, getKnownTokenIndexId, knownTokensIndex } from '.'
+
+describe('knownTokens chain-sensitive lookup', () => {
+  const ethereumUsdc = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+  const solanaUsdc = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+  const rippleRlusd = rippleTokenId({
+    currency: 'RLUSD',
+    issuer: 'rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De',
+  })
+
+  it('normalizes only EVM ids for indexing', () => {
+    expect(getKnownTokenIndexId(Chain.Ethereum, ethereumUsdc)).toBe(ethereumUsdc.toLowerCase())
+    expect(getKnownTokenIndexId(Chain.Solana, solanaUsdc)).toBe(solanaUsdc)
+    expect(getKnownTokenIndexId(Chain.Ripple, rippleRlusd)).toBe(rippleRlusd)
+  })
+
+  it('keeps Ethereum lookups case-insensitive', () => {
+    expect(getKnownTokenById(Chain.Ethereum, ethereumUsdc)?.ticker).toBe('USDC')
+    expect(getKnownTokenById(Chain.Ethereum, ethereumUsdc.toLowerCase())?.ticker).toBe('USDC')
+  })
+
+  it('requires exact canonical ids for Solana and Ripple', () => {
+    expect(knownTokensIndex[Chain.Solana][solanaUsdc]?.ticker).toBe('USDC')
+    expect(knownTokensIndex[Chain.Solana][solanaUsdc.toLowerCase()]).toBeUndefined()
+    expect(getKnownTokenById(Chain.Solana, solanaUsdc)?.ticker).toBe('USDC')
+    expect(getKnownTokenById(Chain.Solana, solanaUsdc.toLowerCase())).toBeUndefined()
+
+    expect(getKnownTokenById(Chain.Ripple, rippleRlusd)?.ticker).toBe('RLUSD')
+    expect(getKnownTokenById(Chain.Ripple, rippleRlusd.toLowerCase())).toBeUndefined()
+  })
+})

--- a/packages/core/chain/coin/knownTokens/index.ts
+++ b/packages/core/chain/coin/knownTokens/index.ts
@@ -1327,9 +1327,11 @@ export const knownTokens = makeRecord(Object.values(Chain), chain => {
 
 type KnownIndex = Record<Chain, Record<string, KnownCoin>>
 
-export const getKnownTokenIndexId = (chain: Chain, id: string): string => (isChainOfKind(chain, 'evm') ? id.toLowerCase() : id)
+export const getKnownTokenIndexId = (chain: Chain, id: string): string =>
+  isChainOfKind(chain, 'evm') ? id.toLowerCase() : id
 
-export const getKnownTokenById = (chain: Chain, id: string): KnownCoin | undefined => knownTokensIndex[chain]?.[getKnownTokenIndexId(chain, id)]
+export const getKnownTokenById = (chain: Chain, id: string): KnownCoin | undefined =>
+  knownTokensIndex[chain]?.[getKnownTokenIndexId(chain, id)]
 
 export const knownTokensIndex: KnownIndex = makeRecord(Object.values(Chain), chain => {
   const byId: Record<string, KnownCoin> = {}

--- a/packages/core/chain/coin/knownTokens/index.ts
+++ b/packages/core/chain/coin/knownTokens/index.ts
@@ -1,4 +1,5 @@
 import { Chain } from '@vultisig/core-chain/Chain'
+import { isChainOfKind } from '@vultisig/core-chain/ChainKind'
 import { rippleKnownIssuedTokens } from '@vultisig/core-chain/chains/ripple/issuedCurrency'
 import { makeRecord } from '@vultisig/lib-utils/record/makeRecord'
 import { omit } from '@vultisig/lib-utils/record/omit'
@@ -1326,11 +1327,15 @@ export const knownTokens = makeRecord(Object.values(Chain), chain => {
 
 type KnownIndex = Record<Chain, Record<string, KnownCoin>>
 
+export const getKnownTokenIndexId = (chain: Chain, id: string): string => (isChainOfKind(chain, 'evm') ? id.toLowerCase() : id)
+
+export const getKnownTokenById = (chain: Chain, id: string): KnownCoin | undefined => knownTokensIndex[chain]?.[getKnownTokenIndexId(chain, id)]
+
 export const knownTokensIndex: KnownIndex = makeRecord(Object.values(Chain), chain => {
   const byId: Record<string, KnownCoin> = {}
   for (const coin of knownTokens[chain] ?? []) {
     if (!coin.id) continue
-    byId[coin.id.toLowerCase()] = coin
+    byId[getKnownTokenIndexId(chain, coin.id)] = coin
   }
   return byId
 })

--- a/packages/core/chain/coin/knownTokens/utils.ts
+++ b/packages/core/chain/coin/knownTokens/utils.ts
@@ -2,10 +2,10 @@ import { Chain } from '@vultisig/core-chain/Chain'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 
 import { CoinKey, KnownCoin, Token } from '../Coin'
-import { knownTokensIndex } from '.'
+import { getKnownTokenById } from '.'
 
 const getKnownToken = <C extends Chain>(key: Token<CoinKey<C>>): (KnownCoin & { chain: C }) | undefined => {
-  return knownTokensIndex[key.chain]?.[key.id.toLowerCase()] as (KnownCoin & { chain: C }) | undefined
+  return getKnownTokenById(key.chain, key.id) as (KnownCoin & { chain: C }) | undefined
 }
 
 export const assertKnownToken = <C extends Chain>(key: Token<CoinKey<C>>): KnownCoin & { chain: C } =>

--- a/packages/core/chain/coin/price/__tests__/resolveTokenPriceId.test.ts
+++ b/packages/core/chain/coin/price/__tests__/resolveTokenPriceId.test.ts
@@ -88,6 +88,12 @@ describe('resolveTokenPriceId', () => {
       expect(resolveTokenPriceId(Chain.Ton, 'EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs')).toBe('tether')
     })
 
+    it('Ripple RLUSD issued-currency id -> ripple-usd', () => {
+      expect(
+        resolveTokenPriceId(Chain.Ripple, '524C555344000000000000000000000000000000.rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De')
+      ).toBe('ripple-usd')
+    })
+
     it('Arbitrum USDC -> usd-coin', () => {
       expect(resolveTokenPriceId(Chain.Arbitrum, '0xaf88d065e77c8cC2239327C5EDb3A432268e5831')).toBe('usd-coin')
     })
@@ -108,6 +114,16 @@ describe('resolveTokenPriceId', () => {
 
     it('unknown Solana mint -> undefined', () => {
       expect(resolveTokenPriceId(Chain.Solana, 'So11111111111111111111111111111111111111112')).toBeUndefined()
+    })
+
+    it('lowercased Solana mint -> undefined', () => {
+      expect(resolveTokenPriceId(Chain.Solana, 'epjfwdd5aufqssqem2qn1xzybapc8g4weggkzwytdt1v')).toBeUndefined()
+    })
+
+    it('lowercased Ripple issued-currency id -> undefined', () => {
+      expect(
+        resolveTokenPriceId(Chain.Ripple, '524c555344000000000000000000000000000000.rmxckbedwqr76quhesumdegf4b9xj8m5de')
+      ).toBeUndefined()
     })
   })
 

--- a/packages/core/chain/coin/price/resolveTokenPriceId.ts
+++ b/packages/core/chain/coin/price/resolveTokenPriceId.ts
@@ -1,8 +1,7 @@
 import type { Chain } from '../../Chain'
-import { getChainKind } from '../../ChainKind'
 import { cosmosFeeCoinDenom } from '../../chains/cosmos/cosmosFeeCoinDenom'
 import { chainFeeCoin } from '../chainFeeCoin'
-import { knownTokens, knownTokensIndex } from '../knownTokens'
+import { getKnownTokenById } from '../knownTokens'
 
 /**
  * Resolve a token's CoinGecko price-provider id from the SDK's curated
@@ -29,10 +28,7 @@ export function resolveTokenPriceId(chain: Chain, denomOrAddress?: string): stri
     return chainFeeCoin[chain]?.priceProviderId || undefined
   }
 
-  const knownPriceProviderId =
-    getChainKind(chain) === 'evm'
-      ? knownTokensIndex[chain]?.[identifier.toLowerCase()]?.priceProviderId
-      : knownTokens[chain]?.find(coin => coin.id === identifier)?.priceProviderId
+  const knownPriceProviderId = getKnownTokenById(chain, identifier)?.priceProviderId
   if (knownPriceProviderId) return knownPriceProviderId
 
   return cosmosFeeCoinDenom[chain as keyof typeof cosmosFeeCoinDenom] === identifier

--- a/packages/core/chain/swap/native/utils/getNativeSwapDecimals.ts
+++ b/packages/core/chain/swap/native/utils/getNativeSwapDecimals.ts
@@ -1,6 +1,6 @@
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { CoinKey } from '@vultisig/core-chain/coin/Coin'
-import { knownTokensIndex } from '@vultisig/core-chain/coin/knownTokens'
+import { getKnownTokenById } from '@vultisig/core-chain/coin/knownTokens'
 import { isFeeCoin } from '@vultisig/core-chain/coin/utils/isFeeCoin'
 
 import { Chain } from '../../../Chain'
@@ -19,7 +19,7 @@ export const getNativeSwapDecimals = (coin: CoinKey) => {
       return chainFeeCoin[coin.chain].decimals
     }
 
-    const known = coin.id ? knownTokensIndex[coin.chain][coin.id.toLowerCase()] : undefined
+    const known = coin.id ? getKnownTokenById(coin.chain, coin.id) : undefined
 
     if (known) {
       return known.decimals

--- a/packages/sdk/src/Vultisig.ts
+++ b/packages/sdk/src/Vultisig.ts
@@ -3,7 +3,7 @@ import { Chain } from '@vultisig/core-chain/Chain'
 import { getThorchainSwapDestinationAssets } from '@vultisig/core-chain/chains/cosmos/thor/securedAssets'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { findCoins as coreFindCoins } from '@vultisig/core-chain/coin/find'
-import { knownTokens, knownTokensIndex } from '@vultisig/core-chain/coin/knownTokens'
+import { getKnownTokenById, knownTokens } from '@vultisig/core-chain/coin/knownTokens'
 import { getCoinPrices as coreCoinPrices } from '@vultisig/core-chain/coin/price/getCoinPrices'
 import { getCoinPricesWithChange as coreCoinPricesWithChange } from '@vultisig/core-chain/coin/price/getCoinPricesWithChange'
 import { scanAddressWithBlockaid } from '@vultisig/core-chain/security/blockaid/address'
@@ -1343,7 +1343,7 @@ export class Vultisig extends UniversalEventEmitter<SdkEvents> {
    * @returns Token metadata or null if not found
    */
   static getKnownToken(chain: Chain, tokenId: string): TokenInfo | null {
-    const coin = knownTokensIndex[chain]?.[tokenId.toLowerCase()]
+    const coin = getKnownTokenById(chain, tokenId)
     if (!coin) return null
     return {
       chain,

--- a/packages/sdk/src/vault/services/TokenDiscoveryService.ts
+++ b/packages/sdk/src/vault/services/TokenDiscoveryService.ts
@@ -1,6 +1,6 @@
 import { Chain } from '@vultisig/core-chain/Chain'
 import { findCoins } from '@vultisig/core-chain/coin/find'
-import { knownTokensIndex } from '@vultisig/core-chain/coin/knownTokens'
+import { getKnownTokenById } from '@vultisig/core-chain/coin/knownTokens'
 import { getTokenMetadata as coreGetTokenMetadata } from '@vultisig/core-chain/coin/token/metadata'
 import { ChainWithTokenMetadataDiscovery } from '@vultisig/core-chain/coin/token/metadata/chains'
 
@@ -38,7 +38,7 @@ export class TokenDiscoveryService {
 
   async resolveToken(chain: Chain, tokenId: string): Promise<TokenInfo> {
     // Check known tokens first (fast, no network)
-    const known = knownTokensIndex[chain]?.[tokenId.toLowerCase()]
+    const known = getKnownTokenById(chain, tokenId)
     if (known) {
       return {
         chain,

--- a/packages/sdk/tests/unit/Vultisig.static-methods.test.ts
+++ b/packages/sdk/tests/unit/Vultisig.static-methods.test.ts
@@ -1,4 +1,5 @@
 import { Chain } from '@vultisig/core-chain/Chain'
+import { rippleTokenId } from '@vultisig/core-chain/chains/ripple/issuedCurrency'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Only mock async/network-dependent core modules
@@ -92,6 +93,11 @@ describe('Vultisig static methods', () => {
   describe('getKnownToken', () => {
     // USDC on Ethereum is a well-known stable token in the registry
     const USDC_ADDRESS = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+    const SOLANA_USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+    const RIPPLE_RLUSD_ID = rippleTokenId({
+      currency: 'RLUSD',
+      issuer: 'rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De',
+    })
 
     it('should return token info for a known contract address', () => {
       const token = Vultisig.getKnownToken(Chain.Ethereum, USDC_ADDRESS)
@@ -128,6 +134,16 @@ describe('Vultisig static methods', () => {
       expect(rlusd?.tokenId).toMatch(/^[A-F0-9]{40}\.r.+$/u)
       expect(rlusd?.contractAddress).toBe(rlusd?.tokenId)
       expect(Vultisig.getKnownToken(Chain.Ripple, rlusd!.tokenId!)).toEqual(rlusd)
+    })
+
+    it('requires exact-case lookup for Solana mints', () => {
+      expect(Vultisig.getKnownToken(Chain.Solana, SOLANA_USDC_MINT)?.ticker).toBe('USDC')
+      expect(Vultisig.getKnownToken(Chain.Solana, SOLANA_USDC_MINT.toLowerCase())).toBeNull()
+    })
+
+    it('requires exact canonical ids for Ripple issued currencies', () => {
+      expect(Vultisig.getKnownToken(Chain.Ripple, RIPPLE_RLUSD_ID)?.ticker).toBe('RLUSD')
+      expect(Vultisig.getKnownToken(Chain.Ripple, RIPPLE_RLUSD_ID.toLowerCase())).toBeNull()
     })
   })
 

--- a/packages/sdk/tests/unit/tools/token/knownTokensSolana.test.ts
+++ b/packages/sdk/tests/unit/tools/token/knownTokensSolana.test.ts
@@ -18,14 +18,14 @@ const SOLANA_USDT_MINT = 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB'
 
 describe('knownTokens — Solana SPL fast-path (Bug J)', () => {
   // knownTokens[chain] is a KnownCoin[] (array). knownTokensIndex[chain]
-  // is the lowercased-key map that consumers use for lookups (see e.g.
-  // packages/core/chain/swap/native/utils/getNativeSwapDecimals.ts:23).
+  // is the chain-aware map that consumers use for lookups (see e.g.
+  // packages/core/chain/swap/native/utils/getNativeSwapDecimals.ts).
   // Both are derived from the same leanTokens source — checking either
   // proves the entries land. Tests below use both to pin the contract.
 
   describe('USDC', () => {
     it('is reachable via knownTokensIndex (the canonical lookup API)', () => {
-      const fromIndex = knownTokensIndex[Chain.Solana][SOLANA_USDC_MINT.toLowerCase()]
+      const fromIndex = knownTokensIndex[Chain.Solana][SOLANA_USDC_MINT]
       expect(fromIndex).toBeDefined()
       expect(fromIndex.ticker).toBe('USDC')
       expect(fromIndex.decimals).toBe(6)
@@ -41,7 +41,7 @@ describe('knownTokens — Solana SPL fast-path (Bug J)', () => {
 
   describe('USDT', () => {
     it('is reachable via knownTokensIndex (the canonical lookup API)', () => {
-      const fromIndex = knownTokensIndex[Chain.Solana][SOLANA_USDT_MINT.toLowerCase()]
+      const fromIndex = knownTokensIndex[Chain.Solana][SOLANA_USDT_MINT]
       expect(fromIndex).toBeDefined()
       expect(fromIndex.ticker).toBe('USDT')
       expect(fromIndex.decimals).toBe(6)
@@ -89,6 +89,16 @@ describe('knownTokens — Solana SPL fast-path (Bug J)', () => {
     it('USDT mint id matches Tether canonical case', () => {
       const usdt = knownTokens[Chain.Solana].find(c => c.id?.toLowerCase() === SOLANA_USDT_MINT.toLowerCase())
       expect(usdt?.id).toBe('Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB')
+    })
+  })
+
+  describe('non-EVM lookup is case-sensitive', () => {
+    it('does not resolve a lowercased Solana USDC mint', () => {
+      expect(knownTokensIndex[Chain.Solana][SOLANA_USDC_MINT.toLowerCase()]).toBeUndefined()
+    })
+
+    it('does not resolve a lowercased Solana USDT mint', () => {
+      expect(knownTokensIndex[Chain.Solana][SOLANA_USDT_MINT.toLowerCase()]).toBeUndefined()
     })
   })
 })

--- a/packages/sdk/tests/unit/vault/services/TokenDiscoveryService.test.ts
+++ b/packages/sdk/tests/unit/vault/services/TokenDiscoveryService.test.ts
@@ -5,19 +5,46 @@ vi.mock('@vultisig/core-chain/coin/find', () => ({
   findCoins: vi.fn(),
 }))
 
-vi.mock('@vultisig/core-chain/coin/knownTokens', () => ({
-  knownTokensIndex: {
-    Ethereum: {
-      '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': {
-        chain: 'Ethereum',
-        id: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-        ticker: 'USDC',
-        decimals: 6,
-        logo: 'usdc.png',
-        priceProviderId: 'usd-coin',
-      },
+const knownTokensByChain: Record<string, Record<string, any>> = {
+  Ethereum: {
+    '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': {
+      chain: 'Ethereum',
+      id: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+      ticker: 'USDC',
+      decimals: 6,
+      logo: 'usdc.png',
+      priceProviderId: 'usd-coin',
     },
   },
+  Solana: {
+    EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v: {
+      chain: 'Solana',
+      id: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+      ticker: 'USDC',
+      decimals: 6,
+      logo: 'usdc.png',
+      priceProviderId: 'usd-coin',
+    },
+  },
+  Ripple: {
+    '524C555344000000000000000000000000000000.rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De': {
+      chain: 'Ripple',
+      id: '524C555344000000000000000000000000000000.rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De',
+      ticker: 'RLUSD',
+      decimals: 15,
+      logo: 'rlusd',
+      priceProviderId: 'rlusd',
+    },
+  },
+}
+
+vi.mock('@vultisig/core-chain/coin/knownTokens', () => ({
+  getKnownTokenById: vi.fn((chain: string, id: string) => {
+    if (chain === 'Ethereum') {
+      return knownTokensByChain[chain]?.[id.toLowerCase()]
+    }
+    return knownTokensByChain[chain]?.[id]
+  }),
 }))
 
 vi.mock('@vultisig/core-chain/coin/token/metadata', () => ({
@@ -129,6 +156,9 @@ describe('TokenDiscoveryService', () => {
   })
 
   describe('resolveToken', () => {
+    const solanaUsdcMint = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+    const rippleRlusdId = '524C555344000000000000000000000000000000.rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De'
+
     it('should return token from known tokens registry (fast path)', async () => {
       const token = await service.resolveToken(Chain.Ethereum, '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48')
 
@@ -151,6 +181,20 @@ describe('TokenDiscoveryService', () => {
 
       expect(token).not.toBeNull()
       expect(token.ticker).toBe('USDC')
+    })
+
+    it('requires exact-case lookup for known Solana mints', async () => {
+      const token = await service.resolveToken(Chain.Solana, solanaUsdcMint)
+
+      expect(token.ticker).toBe('USDC')
+      await expect(service.resolveToken(Chain.Solana, solanaUsdcMint.toLowerCase())).rejects.toThrow(VaultError)
+    })
+
+    it('requires exact canonical ids for known Ripple issued currencies', async () => {
+      const token = await service.resolveToken(Chain.Ripple, rippleRlusdId)
+
+      expect(token.ticker).toBe('RLUSD')
+      await expect(service.resolveToken(Chain.Ripple, rippleRlusdId.toLowerCase())).rejects.toThrow(VaultError)
     })
 
     it('should fall back to chain API for unknown tokens', async () => {


### PR DESCRIPTION
## Summary
- make known-token lookup chain-sensitive instead of globally lowercasing ids
- keep EVM contract-address lookup case-insensitive
- require exact canonical ids for non-EVM assets like Solana mints and XRPL issued-currency ids

Closes #1289

## Why
The known-token registry was lowercasing lookup ids globally, so lowercase non-EVM ids could false-hit as canonical known tokens. That is wrong for case-sensitive ids like Solana mints and XRPL `<currency>.<issuer>` ids.

## What changed
- added shared core helpers for chain-sensitive known-token lookup
- rewired first-party consumers (`resolveTokenPriceId`, `getNativeSwapDecimals`, `Vultisig.getKnownToken`, `TokenDiscoveryService.resolveToken`) through the shared helper
- added regression coverage proving Ethereum stays case-insensitive while Solana/Ripple require canonical ids
- added a changeset for `@vultisig/core-chain` and `@vultisig/sdk`

## Verification
- `yarn test:core packages/core/chain/coin/knownTokens/index.test.ts`
- `yarn test:core packages/core/chain/coin/price/__tests__/resolveTokenPriceId.test.ts`
- `yarn build:shared`
- `yarn workspace @vultisig/sdk vitest run tests/unit/tools/token/knownTokensSolana.test.ts tests/unit/Vultisig.static-methods.test.ts tests/unit/vault/services/TokenDiscoveryService.test.ts`
- `yarn build:sdk`
- built-dist runtime proof:
  ```json
  {
    "ethereumLowercase": "USDC",
    "solanaCanonical": "USDC",
    "solanaLowercase": null,
    "rippleCanonical": "RLUSD",
    "rippleLowercase": null
  }
  ```

## Report
- Round 29 report: https://gist.github.com/gomesalexandre/141ba146713327a032b13d995176b1e3
- Campaign index artifact: https://claude.ai/code/artifact/be2deadf-6195-4dfa-a910-b269b9af7a84

## Risk
- low: behavior-only correctness fix at the registry lookup boundary
- EVM case-insensitive behavior is preserved and covered by tests
- non-EVM change is intentionally fail-closed to canonical ids only
