### PR TITLE
Share chain reference resolution across SDK, CLI, and MCP

### DIFF
--- a/.changeset/shared-chain-reference-resolver.md
+++ b/.changeset/shared-chain-reference-resolver.md
@@ -1,0 +1,7 @@
+---
+'@vultisig/sdk': minor
+'@vultisig/cli': patch
+'@vultisig/mcp': patch
+---
+
+Expose one SDK chain-reference resolver and use it for CLI and MCP chain names, aliases, and IDs.

--- a/clients/cli/src/agent/__tests__/chainReferenceResolver.test.ts
+++ b/clients/cli/src/agent/__tests__/chainReferenceResolver.test.ts
@@ -1,0 +1,28 @@
+import { Chain } from '@vultisig/sdk'
+import { describe, expect, it } from 'vitest'
+
+import { resolveChain, resolveChainId } from '../executor'
+
+describe('CLI chain reference resolution', () => {
+  it.each([
+    ['Terra Classic', Chain.TerraClassic],
+    ['Bitcoin Cash', Chain.BitcoinCash],
+    ['columbus-5', Chain.TerraClassic],
+  ])('resolves name reference %s through the SDK', (input, expected) => {
+    expect(resolveChain(input)).toBe(expected)
+  })
+
+  it.each([
+    [8453, Chain.Base],
+    ['999', Chain.Hyperliquid],
+    ['5000', Chain.Mantle],
+    ['1329', Chain.Sei],
+  ])('resolves ID reference %s through the SDK', (input, expected) => {
+    expect(resolveChainId(input)).toBe(expected)
+  })
+
+  it('preserves null for unresolved names and IDs', () => {
+    expect(resolveChain('not-a-chain')).toBeNull()
+    expect(resolveChainId('not-an-id')).toBeNull()
+  })
+})

--- a/clients/cli/src/agent/executor.ts
+++ b/clients/cli/src/agent/executor.ts
@@ -7,7 +7,15 @@
  * to be flushed into the next outbound `context.recent_actions`.
  */
 import type { VaultBase, Vultisig } from '@vultisig/sdk'
-import { Chain, chainFeeCoin, getChainKind, VaultError, VaultErrorCode, Vultisig as VultisigSdk } from '@vultisig/sdk'
+import {
+  Chain,
+  chainFeeCoin,
+  getChainKind,
+  resolveChainReference,
+  VaultError,
+  VaultErrorCode,
+  Vultisig as VultisigSdk,
+} from '@vultisig/sdk'
 import { formatUnits, hashTypedData, recoverAddress } from 'viem'
 
 import { VaultStateStore } from '../core/VaultStateStore'
@@ -1907,49 +1915,7 @@ export class AgentExecutor {
 // ============================================================================
 
 export function resolveChain(name: string): Chain | null {
-  if (!name) return null
-
-  // Direct enum match
-  if (Object.values(Chain).includes(name as Chain)) {
-    return name as Chain
-  }
-
-  // Case-insensitive search
-  const lower = name.toLowerCase()
-  for (const [, value] of Object.entries(Chain)) {
-    if (typeof value === 'string' && value.toLowerCase() === lower) {
-      return value as Chain
-    }
-  }
-
-  // Common aliases
-  const aliases: Record<string, string> = {
-    eth: 'Ethereum',
-    btc: 'Bitcoin',
-    sol: 'Solana',
-    bnb: 'BSC',
-    avax: 'Avalanche',
-    matic: 'Polygon',
-    arb: 'Arbitrum',
-    op: 'Optimism',
-    ltc: 'Litecoin',
-    doge: 'Dogecoin',
-    dot: 'Polkadot',
-    atom: 'Cosmos',
-    rune: 'THORChain',
-    thor: 'THORChain',
-    sui: 'Sui',
-    ton: 'Ton',
-    trx: 'Tron',
-    xrp: 'Ripple',
-  }
-
-  const aliased = aliases[lower]
-  if (aliased && Object.values(Chain).includes(aliased as Chain)) {
-    return aliased as Chain
-  }
-
-  return null
+  return resolveChainReference(name) ?? null
 }
 
 /**
@@ -2207,22 +2173,7 @@ export function parseThorSwapMemo(memo: string): ParsedThorSwapMemo {
  * Resolve a Chain from a numeric EVM chain ID.
  */
 export function resolveChainId(chainId: string | number): Chain | null {
-  const id = typeof chainId === 'string' ? parseInt(chainId, 10) : chainId
-  if (isNaN(id)) return null
-
-  const chainIdMap: Record<number, Chain> = {
-    1: Chain.Ethereum,
-    56: Chain.BSC,
-    137: Chain.Polygon,
-    43114: Chain.Avalanche,
-    42161: Chain.Arbitrum,
-    10: Chain.Optimism,
-    8453: Chain.Base,
-    81457: Chain.Blast,
-    324: Chain.Zksync,
-    25: Chain.CronosChain,
-  }
-  return chainIdMap[id] || null
+  return resolveChainReference(chainId) ?? null
 }
 
 // ============================================================================

--- a/clients/cli/src/agent/executor.ts
+++ b/clients/cli/src/agent/executor.ts
@@ -1914,6 +1914,7 @@ export class AgentExecutor {
 // Helpers
 // ============================================================================
 
+/** Resolve a CLI chain name or ID through the SDK's canonical resolver. */
 export function resolveChain(name: string): Chain | null {
   return resolveChainReference(name) ?? null
 }

--- a/clients/mcp/src/tools.ts
+++ b/clients/mcp/src/tools.ts
@@ -1,4 +1,5 @@
 import { descriptions } from '@vultisig/client-shared'
+import { resolveChainReference } from '@vultisig/sdk'
 import * as z from 'zod/v4'
 
 import type { Vault } from './types.js'
@@ -31,7 +32,7 @@ async function wrapHandler<T>(fn: () => Promise<T>): Promise<ToolResult> {
 }
 
 export function resolveChain(name: string, knownChains: readonly string[]): string {
-  const match = knownChains.find(c => c.toLowerCase() === name.toLowerCase())
+  const match = resolveChainReference(name, knownChains)
   if (!match) throw new Error(`Unknown chain "${name}". Use supported_chains or vault_info to see available chains.`)
   return match
 }

--- a/clients/mcp/src/tools.ts
+++ b/clients/mcp/src/tools.ts
@@ -31,6 +31,7 @@ async function wrapHandler<T>(fn: () => Promise<T>): Promise<ToolResult> {
   }
 }
 
+/** Resolve a chain reference within the vault's currently known chain set. */
 export function resolveChain(name: string, knownChains: readonly string[]): string {
   const match = resolveChainReference(name, knownChains)
   if (!match) throw new Error(`Unknown chain "${name}". Use supported_chains or vault_info to see available chains.`)

--- a/clients/mcp/tests/__mocks__/sdk.ts
+++ b/clients/mcp/tests/__mocks__/sdk.ts
@@ -14,3 +14,5 @@ export const Chain = {
 export class Vultisig {}
 export class MemoryStorage {}
 export type VaultBase = any
+
+export { resolveChainReference } from '../../../../packages/sdk/src/utils/resolveChainReference'

--- a/clients/mcp/tests/tools.test.ts
+++ b/clients/mcp/tests/tools.test.ts
@@ -132,7 +132,7 @@ describe('tool handlers', () => {
   })
 })
 
-const CHAINS = ['Ethereum', 'Bitcoin', 'Solana', 'THORChain'] as const
+const CHAINS = ['Ethereum', 'Bitcoin', 'Bitcoin-Cash', 'Solana', 'THORChain', 'TerraClassic', 'Base'] as const
 
 describe('resolveChain', () => {
   it('matches exact chain name', () => {
@@ -143,6 +143,16 @@ describe('resolveChain', () => {
     expect(resolveChain('ethereum', CHAINS)).toBe('Ethereum')
     expect(resolveChain('BITCOIN', CHAINS)).toBe('Bitcoin')
     expect(resolveChain('thorchain', CHAINS)).toBe('THORChain')
+  })
+
+  it('accepts SDK aliases and IDs within the vault chain set', () => {
+    expect(resolveChain('Bitcoin Cash', CHAINS)).toBe('Bitcoin-Cash')
+    expect(resolveChain('columbus-5', CHAINS)).toBe('TerraClassic')
+    expect(resolveChain('8453', CHAINS)).toBe('Base')
+  })
+
+  it('rejects a known SDK chain outside the vault chain set', () => {
+    expect(() => resolveChain('999', CHAINS)).toThrow()
   })
 
   it('throws on unknown chain', () => {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -56,6 +56,7 @@ export {
 export type { FiatToAmountParams } from './utils/fiatToAmount'
 export { fiatToAmount, FiatToAmountError } from './utils/fiatToAmount'
 export { normalizeChain, UnknownChainError } from './utils/normalizeChain'
+export { resolveChainReference } from './utils/resolveChainReference'
 
 // Public-boundary argument validation (AUDIT-R3 TASK-020).
 // Zod schemas + safe-parse helpers for chain and ticker strings.

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -580,6 +580,7 @@ export async function fiatToAmount(...args: unknown[]) {
   return mod.fiatToAmount(...(args as Parameters<typeof mod.fiatToAmount>))
 }
 export { normalizeChain, UnknownChainError } from '../../utils/normalizeChain'
+export { resolveChainReference } from '../../utils/resolveChainReference'
 export async function parseKeygenQR(...args: unknown[]) {
   const mod = await import('../../utils/parseKeygenQR')
   return mod.parseKeygenQR(...(args as Parameters<typeof mod.parseKeygenQR>))

--- a/packages/sdk/src/tools/swap/skip/chainMapping.ts
+++ b/packages/sdk/src/tools/swap/skip/chainMapping.ts
@@ -17,9 +17,8 @@
  * `numberToHex`.
  */
 import type { Chain } from '@vultisig/core-chain/Chain'
-import { getCosmosChainByChainId } from '@vultisig/core-chain/chains/cosmos/chainInfo'
-import { getEvmChainByChainId } from '@vultisig/core-chain/chains/evm/chainInfo'
-import { numberToHex } from '@vultisig/lib-utils/hex/numberToHex'
+
+import { resolveChainIdReference } from '../../../utils/resolveChainReference'
 
 /**
  * Skip chain_id → Vultisig Chain. Returns `undefined` for chains the SDK has no
@@ -29,11 +28,5 @@ import { numberToHex } from '@vultisig/lib-utils/hex/numberToHex'
  * "osmosis-1", "columbus-5", …).
  */
 export function skipChainIdToChainName(skipChainId: string): Chain | undefined {
-  // EVM ids arrive as decimal strings; the SDK keys EVM chains by 0x-hex.
-  if (/^[1-9][0-9]*$/.test(skipChainId)) {
-    const hex = numberToHex(Number(skipChainId))
-    const evm = getEvmChainByChainId(hex)
-    if (evm) return evm as Chain
-  }
-  return getCosmosChainByChainId(skipChainId) as Chain | undefined
+  return resolveChainIdReference(skipChainId)
 }

--- a/packages/sdk/src/utils/resolveChainReference.ts
+++ b/packages/sdk/src/utils/resolveChainReference.ts
@@ -1,0 +1,54 @@
+import type { Chain } from '@vultisig/core-chain/Chain'
+import { getCosmosChainByChainId } from '@vultisig/core-chain/chains/cosmos/chainInfo'
+import { getEvmChainByChainId } from '@vultisig/core-chain/chains/evm/chainInfo'
+import { numberToHex } from '@vultisig/lib-utils/hex/numberToHex'
+
+import { normalizeChain, UnknownChainError } from './normalizeChain'
+
+/**
+ * Resolve an exact Cosmos chain ID or decimal EVM chain ID.
+ *
+ * Kept separate from name normalization so Skip's custody-chain guard can
+ * retain its ID-only contract while sharing the same canonical lookup.
+ */
+export function resolveChainIdReference(chainId: string): Chain | undefined {
+  if (/^[1-9][0-9]*$/.test(chainId)) {
+    const numericId = Number(chainId)
+    if (Number.isSafeInteger(numericId)) {
+      const evm = getEvmChainByChainId(numberToHex(numericId))
+      if (evm) return evm as Chain
+    }
+  }
+
+  return getCosmosChainByChainId(chainId) as Chain | undefined
+}
+
+/**
+ * Resolve a canonical name, alias, Cosmos chain ID, or decimal EVM chain ID
+ * to the SDK's canonical Chain value.
+ *
+ * Unlike `normalizeChain`, this boundary is intentionally non-throwing so
+ * clients can preserve their own unknown-input error or fallback behavior.
+ * When `allowedChains` is provided, a valid reference outside that canonical
+ * set is treated as unresolved.
+ */
+export function resolveChainReference(
+  input: string | number | null | undefined,
+  allowedChains?: readonly string[]
+): Chain | undefined {
+  const reference = typeof input === 'number' ? String(input) : (input?.trim() ?? '')
+  if (!reference) return undefined
+
+  let resolved = resolveChainIdReference(reference)
+  if (!resolved) {
+    try {
+      resolved = normalizeChain(reference)
+    } catch (error) {
+      if (error instanceof UnknownChainError) return undefined
+      throw error
+    }
+  }
+
+  if (allowedChains && !allowedChains.includes(resolved)) return undefined
+  return resolved
+}

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -46,6 +46,7 @@ describe('RN entry wires configureCrypto and configureDefaultStorage', () => {
     expect(rn.getCosmosAllowedFeeDenoms(rn.Chain.Cosmos)).toContain('uatom')
     expect(rn.isCosmosFeeDenomAllowed(rn.Chain.Cosmos, 'uatom')).toBe(true)
     expect(rn.isCosmosFeeDenomAllowed(rn.Chain.Cosmos, 'uusdc')).toBe(false)
+    expect(rn.resolveChainReference('8453')).toBe(rn.Chain.Base)
   })
 
   it('exports the generic CosmWasm execute message builder from the RN root surface', async () => {

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -3,9 +3,10 @@ import { describe, expect, it } from 'vitest'
 import * as sdk from '../../../src/index'
 
 describe('@vultisig/sdk public exports', () => {
-  it('exports fiatToAmount and normalizeChain utilities', () => {
+  it('exports fiatToAmount and chain-reference normalization utilities', () => {
     expect(typeof sdk.fiatToAmount).toBe('function')
     expect(typeof sdk.normalizeChain).toBe('function')
+    expect(typeof sdk.resolveChainReference).toBe('function')
     expect(typeof sdk.FiatToAmountError).toBe('function')
     expect(typeof sdk.UnknownChainError).toBe('function')
   })

--- a/packages/sdk/tests/unit/utils/resolveChainReference.test.ts
+++ b/packages/sdk/tests/unit/utils/resolveChainReference.test.ts
@@ -1,0 +1,27 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { describe, expect, it } from 'vitest'
+
+import { resolveChainReference } from '../../../src/utils/resolveChainReference'
+
+describe('resolveChainReference', () => {
+  it.each([
+    ['Terra Classic', Chain.TerraClassic],
+    ['Bitcoin Cash', Chain.BitcoinCash],
+    ['columbus-5', Chain.TerraClassic],
+    [8453, Chain.Base],
+    ['999', Chain.Hyperliquid],
+    ['5000', Chain.Mantle],
+    ['1329', Chain.Sei],
+  ])('resolves %s to its canonical chain', (input, expected) => {
+    expect(resolveChainReference(input)).toBe(expected)
+  })
+
+  it('narrows resolved values to the caller-provided canonical set', () => {
+    expect(resolveChainReference('btc', [Chain.Bitcoin, Chain.Ethereum])).toBe(Chain.Bitcoin)
+    expect(resolveChainReference('8453', [Chain.Bitcoin, Chain.Ethereum])).toBeUndefined()
+  })
+
+  it.each(['', 'unknown-chain', '0', 1.5, null, undefined])('returns undefined for unresolved input %s', input => {
+    expect(resolveChainReference(input)).toBeUndefined()
+  })
+})

--- a/packages/sdk/tests/unit/utils/resolveChainReference.test.ts
+++ b/packages/sdk/tests/unit/utils/resolveChainReference.test.ts
@@ -7,6 +7,7 @@ describe('resolveChainReference', () => {
   it.each([
     ['Terra Classic', Chain.TerraClassic],
     ['Bitcoin Cash', Chain.BitcoinCash],
+    ['THOR Chain', Chain.THORChain],
     ['columbus-5', Chain.TerraClassic],
     [8453, Chain.Base],
     ['999', Chain.Hyperliquid],


### PR DESCRIPTION
Closes #1253
Adds one public SDK resolver for canonical names, aliases, Cosmos chain IDs, and decimal EVM chain IDs, then makes the CLI and MCP delegate to it while preserving their unknown-chain contracts. Runtime proof on the exact head exercised the built SDK public package plus the first-party CLI and MCP consumers, including allowed-set narrowing and fail-closed unknown input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a shared `resolveChainReference` / `resolveChainIdReference` helper to the SDK for resolving chain names, aliases, and numeric IDs, with optional allowlist filtering.
  - Exposed the resolver via standard and React Native SDK exports, and updated CLI/MCP and swap tooling to use it for consistent behavior.

- **Bug Fixes**
  - Improved resolution behavior for unknown, invalid, and unsupported chain inputs by returning `undefined`/`null` instead of throwing.

- **Tests**
  - Added/expanded unit and CLI/MCP tests covering aliases, IDs, filtering, and invalid inputs.

- **Chores**
  - Updated changesets for SDK/CLI/MCP version bumps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->