### PR TITLE
Scope clearVaults to SDK-owned keys

### DIFF
--- a/.changeset/clear-vaults-sdk-keys.md
+++ b/.changeset/clear-vaults-sdk-keys.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Keep `clearVaults` scoped to SDK-owned keys in shared storage adapters.

--- a/docs/SDK-USERS-GUIDE.md
+++ b/docs/SDK-USERS-GUIDE.md
@@ -2315,10 +2315,11 @@ sdk.dispose()
 Custom adapters may share a backing store with application data. The SDK
 reserves `vault:*`, `pending:*`, `cache:*`, `addressBook:*`, `activeVaultId`,
 `pushNotificationRegistrations`, `config:defaultCurrency`, and
-`config:defaultChains`. `sdk.clearVaults()` removes the vault-scoped keys and
-local push registrations but intentionally retains the two SDK preference
-keys. The adapter's `clear()` method remains an explicit adapter-wide operation
-that may also remove unrelated host keys.
+`config:defaultChains`. `sdk.clearVaults()` removes the vault-scoped keys,
+saved and vault address-book entries, and local push registrations but
+intentionally retains the two SDK preference keys. The adapter's `clear()`
+method remains an explicit adapter-wide operation that may also remove
+unrelated host keys.
 
 ---
 

--- a/docs/SDK-USERS-GUIDE.md
+++ b/docs/SDK-USERS-GUIDE.md
@@ -2272,7 +2272,7 @@ import { Vultisig, type VaultStorage } from '@vultisig/sdk'
 import * as fs from 'fs'
 import * as path from 'path'
 
-class CustomStorage implements Storage {
+class CustomStorage implements VaultStorage {
   constructor(private basePath: string) {}
 
   async get(key: string): Promise<string | null> {
@@ -2311,6 +2311,14 @@ await sdk.initialize()
 // ... use the SDK ...
 sdk.dispose()
 ```
+
+Custom adapters may share a backing store with application data. The SDK
+reserves `vault:*`, `pending:*`, `cache:*`, `addressBook:*`, `activeVaultId`,
+`pushNotificationRegistrations`, `config:defaultCurrency`, and
+`config:defaultChains`. `sdk.clearVaults()` removes the vault-scoped keys and
+local push registrations but intentionally retains the two SDK preference
+keys. The adapter's `clear()` method remains an explicit adapter-wide operation
+that may also remove unrelated host keys.
 
 ---
 

--- a/packages/sdk/src/VaultManager.ts
+++ b/packages/sdk/src/VaultManager.ts
@@ -412,7 +412,9 @@ export class VaultManager {
         key === 'pushNotificationRegistrations'
     )
 
-    await Promise.all(vaultKeys.map(key => this.storage.remove(key)))
+    for (const key of vaultKeys) {
+      await this.storage.remove(key)
+    }
 
     // Clear active vault
     await this.storage.remove('activeVaultId')

--- a/packages/sdk/src/VaultManager.ts
+++ b/packages/sdk/src/VaultManager.ts
@@ -402,13 +402,17 @@ export class VaultManager {
    * Clear all stored vaults
    */
   async clearVaults(): Promise<void> {
-    // Remove all vault data
+    // Remove all SDK-owned per-vault and pending-vault data.
     const keys = await this.storage.list()
-    const vaultKeys = keys.filter(k => k.startsWith('vault:'))
+    const vaultKeys = keys.filter(
+      key =>
+        key.startsWith('vault:') ||
+        key.startsWith('pending:') ||
+        key.startsWith('cache:') ||
+        key === 'pushNotificationRegistrations'
+    )
 
-    for (const key of vaultKeys) {
-      await this.storage.remove(key)
-    }
+    await Promise.all(vaultKeys.map(key => this.storage.remove(key)))
 
     // Clear active vault
     await this.storage.remove('activeVaultId')

--- a/packages/sdk/src/Vultisig.ts
+++ b/packages/sdk/src/Vultisig.ts
@@ -1015,13 +1015,14 @@ export class Vultisig extends UniversalEventEmitter<SdkEvents> {
   }
 
   /**
-   * Clear all stored vaults
+   * Clear all SDK-owned vault data while preserving unrelated values in a
+   * shared custom storage adapter.
    */
   async clearVaults(): Promise<void> {
     await this.ensureInitialized()
     await this.vaultManager.clearVaults()
-    await this.storage.clear()
-    this.addressBookManager.clear()
+    this.pendingVaults.clear()
+    await this.addressBookManager.clear()
     this.emit('vaultChanged', { vaultId: '' })
   }
 

--- a/packages/sdk/src/storage/types.ts
+++ b/packages/sdk/src/storage/types.ts
@@ -23,6 +23,12 @@ export type StoredValue<T = unknown> = {
 /**
  * Universal storage interface for vault persistence.
  * All implementations must support async operations and provide atomic writes.
+ * Custom adapters may share their backing store with host application data.
+ * The SDK reserves `vault:*`, `pending:*`, `cache:*`, `addressBook:*`,
+ * `activeVaultId`, `pushNotificationRegistrations`, `config:defaultCurrency`,
+ * and `config:defaultChains`. `clearVaults()` removes the vault-scoped keys and
+ * notification registrations but intentionally retains the two SDK preference
+ * keys. `clear()` remains an explicit adapter-wide operation.
  */
 export type Storage = {
   /**
@@ -48,7 +54,8 @@ export type Storage = {
   list(): Promise<string[]>
 
   /**
-   * Clear all stored data.
+   * Clear all data in the adapter, including non-SDK host keys.
+   * SDK vault APIs do not call this adapter-wide operation.
    * @throws StorageError if operation not permitted
    */
   clear(): Promise<void>

--- a/packages/sdk/src/storage/types.ts
+++ b/packages/sdk/src/storage/types.ts
@@ -26,9 +26,10 @@ export type StoredValue<T = unknown> = {
  * Custom adapters may share their backing store with host application data.
  * The SDK reserves `vault:*`, `pending:*`, `cache:*`, `addressBook:*`,
  * `activeVaultId`, `pushNotificationRegistrations`, `config:defaultCurrency`,
- * and `config:defaultChains`. `clearVaults()` removes the vault-scoped keys and
- * notification registrations but intentionally retains the two SDK preference
- * keys. `clear()` remains an explicit adapter-wide operation.
+ * and `config:defaultChains`. `clearVaults()` removes the vault-scoped keys,
+ * saved and vault address-book entries, and notification registrations but
+ * intentionally retains the two SDK preference keys. `clear()` remains an
+ * explicit adapter-wide operation.
  */
 export type Storage = {
   /**

--- a/packages/sdk/tests/unit/Vultisig.test.ts
+++ b/packages/sdk/tests/unit/Vultisig.test.ts
@@ -381,6 +381,67 @@ describe('Vultisig', () => {
 
       expect(sdkWithCustomStorage).toBeDefined()
     })
+
+    it('clearVaults preserves unrelated data in a shared storage adapter', async () => {
+      const storage = new MemoryStorage()
+      await storage.set('host:preferences', { theme: 'dark' })
+      await storage.set('vault:test-vault', 'encrypted-vault')
+      await storage.set('pending:test-vault', 'pending-vault')
+      await storage.set('cache:test-vault:balances', { Bitcoin: '1' })
+      await storage.set('addressBook:saved', [{ name: 'Recipient' }])
+      await storage.set('addressBook:vaults', [{ name: 'Vault' }])
+      await storage.set('pushNotificationRegistrations', { 'test-vault': { partyName: 'device' } })
+      await storage.set('config:defaultCurrency', 'EUR')
+      await storage.set('config:defaultChains', [Chain.Bitcoin])
+      await storage.set('activeVaultId', 'test-vault')
+
+      const sdkWithSharedStorage = new Vultisig({ storage, autoInit: false })
+      await sdkWithSharedStorage.clearVaults()
+
+      expect(await storage.get('host:preferences')).toEqual({ theme: 'dark' })
+      expect(await storage.get('vault:test-vault')).toBeNull()
+      expect(await storage.get('pending:test-vault')).toBeNull()
+      expect(await storage.get('cache:test-vault:balances')).toBeNull()
+      expect(await storage.get('addressBook:saved')).toBeNull()
+      expect(await storage.get('addressBook:vaults')).toBeNull()
+      expect(await storage.get('pushNotificationRegistrations')).toBeNull()
+      expect(await storage.get('activeVaultId')).toBeNull()
+      expect(await storage.get('config:defaultCurrency')).toBe('EUR')
+      expect(await storage.get('config:defaultChains')).toEqual([Chain.Bitcoin])
+    })
+
+    it('awaits asynchronous SDK-owned cleanup before resolving', async () => {
+      const storage = new MemoryStorage()
+      await storage.set('addressBook:saved', [{ name: 'Recipient' }])
+      const remove = storage.remove.bind(storage)
+      let releaseRemoval!: () => void
+      const removalGate = new Promise<void>(resolve => {
+        releaseRemoval = resolve
+      })
+      vi.spyOn(storage, 'remove').mockImplementation(async key => {
+        if (key === 'addressBook:saved') await removalGate
+        await remove(key)
+      })
+      const sdkWithSharedStorage = new Vultisig({ storage, autoInit: false })
+      let resolved = false
+      const clearing = sdkWithSharedStorage.clearVaults().then(() => {
+        resolved = true
+      })
+
+      await vi.waitFor(() => expect(storage.remove).toHaveBeenCalledWith('addressBook:saved'))
+      expect(resolved).toBe(false)
+      releaseRemoval()
+      await clearing
+      expect(await storage.get('addressBook:saved')).toBeNull()
+    })
+
+    it('propagates custom-adapter cleanup failures', async () => {
+      const storage = new MemoryStorage()
+      vi.spyOn(storage, 'remove').mockRejectedValueOnce(new Error('adapter remove failed'))
+      const sdkWithSharedStorage = new Vultisig({ storage, autoInit: false })
+
+      await expect(sdkWithSharedStorage.clearVaults()).rejects.toThrow('adapter remove failed')
+    })
   })
 
   describe('edge cases', () => {


### PR DESCRIPTION
Closes #1208
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `clearVaults()` to remove the full set of SDK-owned vault-related keys (including pending/cache and push registration keys) when using shared/custom storage, while preserving unrelated data.
  * `clearVaults()` no longer performs adapter-wide clearing and now also clears in-memory pending vault state.
  * Improved async cleanup behavior and surfaced adapter removal failures.
* **Documentation**
  * Updated the SDK Storage guide with clarified scoping, reserved namespaces, and guidance on `clearVaults()` vs adapter `clear()`.
* **Tests**
  * Added unit coverage for shared storage behavior, async completion, and adapter error handling.
* **Chores**
  * Added a patch changeset for the SDK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->