### PR TITLE
feat(core-chain): register bRUNE / ybRUNE and liquid-bond staking config

### DIFF
--- a/.changeset/brune-ybrune-registry.md
+++ b/.changeset/brune-ybrune-registry.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/core-chain': minor
+'@vultisig/sdk': minor
+---
+
+Register the Rujira liquid-bond THORChain tokens bRUNE (`x/brune`) and ybRUNE (`x/staking-x/brune`), and add the `bruneBondConfig` staking-contract config. bRUNE is auto-discovered as a normal wallet token priced against RUNE (`priceProviderId: 'thorchain'`); the ybRUNE auto-compounding staking receipt is excluded from wallet discovery and carries native-token metadata for backfill.

--- a/packages/core/chain/chains/cosmos/thor/brune-bond/config.ts
+++ b/packages/core/chain/chains/cosmos/thor/brune-bond/config.ts
@@ -1,0 +1,8 @@
+export const bruneBondConfig = {
+  contract: 'thor179fex2rxd45caedmz4hxsnu42sw20lu0djyh4yukyh965sq8muuqptru2g',
+  depositDenom: 'x/brune',
+  depositDecimals: 8,
+  shareDenom: 'x/staking-x/brune',
+  shareTicker: 'ybRUNE',
+  shareDecimals: 8,
+} as const

--- a/packages/core/chain/coin/find/resolvers/cosmos.test.ts
+++ b/packages/core/chain/coin/find/resolvers/cosmos.test.ts
@@ -58,6 +58,26 @@ describe('findCosmosCoins', () => {
     ])
   })
 
+  // ybRUNE (`x/staking-x/brune`) is the auto-compounding staking receipt for
+  // bonded RUNE. Like the sTCY share denom, it must be filtered out of wallet
+  // discovery so it never surfaces as a bogus fallback-ticker coin ("STAKING").
+  it('excludes the ybRUNE staking receipt denom from THORChain discovery', async () => {
+    getAllBalancesMock.mockResolvedValue([
+      { denom: 'rune', amount: '1' },
+      { denom: 'x/staking-x/brune', amount: '9' },
+      { denom: 'tcy', amount: '2' },
+    ])
+    getCosmosTokenMetadataMock.mockRejectedValue(new Error('no metadata'))
+
+    const coins = await findCosmosCoins({
+      address: 'thor1address',
+      chain: Chain.THORChain,
+    })
+
+    expect(coins.some(coin => coin.id === 'x/staking-x/brune')).toBe(false)
+    expect(coins).toEqual([expect.objectContaining({ id: 'tcy', ticker: 'TCY' })])
+  })
+
   // #428: factory/{addr}/{subdenom} shaped denoms must resolve to the
   // subdenom as the ticker, NOT the creator address. The previous
   // [1]?.toUpperCase() picked the second segment (the address), so we'd

--- a/packages/core/chain/coin/find/resolvers/cosmos.ts
+++ b/packages/core/chain/coin/find/resolvers/cosmos.ts
@@ -2,6 +2,7 @@ import { CosmosChain } from '@vultisig/core-chain/Chain'
 import { getAllCosmosBalances } from '@vultisig/core-chain/chains/cosmos/account/getAllCosmosBalances'
 import { getCosmosClient } from '@vultisig/core-chain/chains/cosmos/client'
 import { cosmosFeeCoinDenom } from '@vultisig/core-chain/chains/cosmos/cosmosFeeCoinDenom'
+import { bruneBondConfig } from '@vultisig/core-chain/chains/cosmos/thor/brune-bond/config'
 import { tcyAutoCompounderConfig } from '@vultisig/core-chain/chains/cosmos/thor/tcy-autocompound/config'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { CoinMetadata } from '@vultisig/core-chain/coin/Coin'
@@ -77,7 +78,8 @@ export const findCosmosCoins: FindCoinsResolver<CosmosChain> = async ({ address,
     without(
       balances.map(({ denom }) => denom),
       cosmosFeeCoinDenom[chain],
-      tcyAutoCompounderConfig.shareDenom
+      tcyAutoCompounderConfig.shareDenom,
+      bruneBondConfig.shareDenom
     ).map(denom => getDiscoveredDenom(chain, denom))
   )
 

--- a/packages/core/chain/coin/knownTokens/cosmos.test.ts
+++ b/packages/core/chain/coin/knownTokens/cosmos.test.ts
@@ -89,3 +89,15 @@ describe('knownCosmosTokens[Chain.Osmosis]', () => {
     }
   })
 })
+
+describe('knownCosmosTokens[Chain.THORChain]', () => {
+  const thorchain = knownCosmosTokens[Chain.THORChain]
+
+  it('registers bRUNE (bonded RUNE) priced against RUNE', () => {
+    expect(thorchain['x/brune']).toMatchObject({
+      ticker: 'bRUNE',
+      decimals: 8,
+      priceProviderId: 'thorchain',
+    })
+  })
+})

--- a/packages/core/chain/coin/knownTokens/cosmos.ts
+++ b/packages/core/chain/coin/knownTokens/cosmos.ts
@@ -38,6 +38,12 @@ export const knownCosmosTokens: Record<CosmosChain, Record<string, KnownCoinMeta
       decimals: 8,
       priceProviderId: 'tcy',
     },
+    'x/brune': {
+      ticker: 'bRUNE',
+      logo: 'brune',
+      decimals: 8,
+      priceProviderId: 'thorchain',
+    },
     'x/ruji': {
       ticker: 'RUJI',
       logo: 'ruji',

--- a/packages/core/chain/coin/knownTokens/thorchain.ts
+++ b/packages/core/chain/coin/knownTokens/thorchain.ts
@@ -6,6 +6,11 @@ export const thorchainNativeTokensMetadata: Record<string, CoinMetadata> = {
     logo: 'ruji',
     decimals: 8,
   },
+  'x/staking-x/brune': {
+    ticker: 'ybRUNE',
+    logo: 'ybrune',
+    decimals: 8,
+  },
   'thor.nami': {
     ticker: 'NAMI',
     logo: 'nami.png',

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -390,6 +390,11 @@
       "import": "./dist/chains/cosmos/terraClassicTax.js",
       "default": "./dist/chains/cosmos/terraClassicTax.js"
     },
+    "./chains/cosmos/thor/brune-bond/config": {
+      "types": "./dist/chains/cosmos/thor/brune-bond/config.d.ts",
+      "import": "./dist/chains/cosmos/thor/brune-bond/config.js",
+      "default": "./dist/chains/cosmos/thor/brune-bond/config.js"
+    },
     "./chains/cosmos/thor/getThorchainInboundAddress": {
       "types": "./dist/chains/cosmos/thor/getThorchainInboundAddress.d.ts",
       "import": "./dist/chains/cosmos/thor/getThorchainInboundAddress.js",


### PR DESCRIPTION
## Description

Registers the Rujira liquid-bonding THORChain tokens **bRUNE** (`x/brune`) and **ybRUNE** (`x/staking-x/brune`) in `@vultisig/core-chain`, plus the staking-contract config the deposit/DeFi flows will consume. This is the SDK-side foundation that unblocks the Windows work in vultisig/vultisig-windows#4328.

Before this change, `x/brune` had no registered metadata, so THORChain auto-discovery surfaced it with a derived ticker, a missing logo and **no price ($0.00)**, and the ybRUNE receipt would surface as a bogus `STAKING` wallet coin.

What this PR does:

- **Register bRUNE** in `knownCosmosTokens[THORChain]` (decimals 8, `priceProviderId: 'thorchain'` — bonded RUNE tracks RUNE spot). Auto-discovery now attaches a ticker, logo and USD price.
- **Register the ybRUNE receipt** in `thorchainNativeTokensMetadata` (decimals/logo backfill), mirroring the existing `x/staking-x/ruji` → sRUJI entry.
- **Add `bruneBondConfig`** (`chains/cosmos/thor/brune-bond/config.ts`) — contract + deposit/share denoms, mirroring `tcyAutoCompounderConfig`.
- **Exclude the ybRUNE share denom** from THORChain coin auto-discovery, matching the existing sTCY exclusion, so the receipt never shows as a wallet coin.
- Changeset bumps `@vultisig/core-chain` and `@vultisig/sdk` (minor).

Notes:

- Auto-discovery uppercases tickers, so the wallet list shows `BRUNE`; the canonical `bRUNE` casing lives in the registry for non-discovery paths. This is existing token-detection behaviour and is intentionally left untouched.
- NAV-based valuation of the ybRUNE receipt (`ratio × bRUNE price`) is intentionally **not** wired here — it belongs to the Windows DeFi position work, since the current NAV path treats `nav_per_share` as the price directly.

Fixes #1315

## Which feature is affected?

- [x] New Chain / Chain related feature — token registry + staking config only (no signing/broadcast in this PR)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional context

Local validation: `build:shared`, full `typecheck` (0 errors), `test:core` (added 2 tests), `check:shared-exports`, `changeset:check-sdk-bundle`, `lint`, `format:check`, and `knip` all pass.

Follow-up Windows sub-issues that depend on this: bRUNE display + ybRUNE portfolio exclusion, bRUNE stake / ybRUNE unstake flow, and the ybRUNE DeFi position card with NAV valuation.
