### PR TITLE
fix(sdk): add React Native network timeouts and cancellation

### DIFF
--- a/.changeset/rn-network-timeout-cancellation.md
+++ b/.changeset/rn-network-timeout-cancellation.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Add bounded timeouts and caller cancellation to React Native RPC and Fast Vault network flows.

--- a/packages/sdk/src/platforms/react-native/chains/solana/rpc.ts
+++ b/packages/sdk/src/platforms/react-native/chains/solana/rpc.ts
@@ -8,7 +8,9 @@
  * would pull `rpc-websockets` into the bundle at import time.
  */
 
-import { jsonRpcCall } from '../../rpcFetch'
+import { jsonRpcCall, JsonRpcCallOptions } from '../../rpcFetch'
+
+type RpcRequestOptions = Pick<JsonRpcCallOptions, 'signal' | 'timeoutMs'>
 
 type RpcBlockhash = {
   context: { slot: number }
@@ -25,6 +27,8 @@ type RpcSendTxOpts = {
   skipPreflight?: boolean
   preflightCommitment?: 'processed' | 'confirmed' | 'finalized'
   maxRetries?: number
+  signal?: AbortSignal
+  timeoutMs?: number
 }
 
 /**
@@ -33,9 +37,10 @@ type RpcSendTxOpts = {
  * builders that need a `recentBlockhash` before signing.
  */
 export async function getSolanaRecentBlockhash(
-  rpcUrl: string
+  rpcUrl: string,
+  options: RpcRequestOptions = {}
 ): Promise<{ blockhash: string; lastValidBlockHeight: number }> {
-  const res = await jsonRpcCall<RpcBlockhash>(rpcUrl, 'getLatestBlockhash', [{ commitment: 'confirmed' }])
+  const res = await jsonRpcCall<RpcBlockhash>(rpcUrl, 'getLatestBlockhash', [{ commitment: 'confirmed' }], options)
   return {
     blockhash: res.value.blockhash,
     lastValidBlockHeight: res.value.lastValidBlockHeight,
@@ -47,8 +52,12 @@ export async function getSolanaRecentBlockhash(
  * yet exist (consistent with `Connection.getBalance` on an uninitialized
  * account).
  */
-export async function getSolanaBalance(address: string, rpcUrl: string): Promise<bigint> {
-  const res = await jsonRpcCall<RpcBalance>(rpcUrl, 'getBalance', [address, { commitment: 'confirmed' }])
+export async function getSolanaBalance(
+  address: string,
+  rpcUrl: string,
+  options: RpcRequestOptions = {}
+): Promise<bigint> {
+  const res = await jsonRpcCall<RpcBalance>(rpcUrl, 'getBalance', [address, { commitment: 'confirmed' }], options)
   return BigInt(res.value ?? 0)
 }
 
@@ -65,13 +74,18 @@ export async function broadcastSolanaTx(
   rpcUrl: string,
   opts: Omit<RpcSendTxOpts, 'encoding'> = {}
 ): Promise<string> {
-  return jsonRpcCall<string>(rpcUrl, 'sendTransaction', [
-    rawTxBase64,
-    {
-      encoding: 'base64',
-      skipPreflight: opts.skipPreflight ?? false,
-      preflightCommitment: opts.preflightCommitment ?? 'confirmed',
-      maxRetries: opts.maxRetries ?? 3,
-    },
-  ])
+  return jsonRpcCall<string>(
+    rpcUrl,
+    'sendTransaction',
+    [
+      rawTxBase64,
+      {
+        encoding: 'base64',
+        skipPreflight: opts.skipPreflight ?? false,
+        preflightCommitment: opts.preflightCommitment ?? 'confirmed',
+        maxRetries: opts.maxRetries ?? 3,
+      },
+    ],
+    { signal: opts.signal, timeoutMs: opts.timeoutMs }
+  )
 }

--- a/packages/sdk/src/platforms/react-native/fetchWithTimeout.ts
+++ b/packages/sdk/src/platforms/react-native/fetchWithTimeout.ts
@@ -1,0 +1,79 @@
+export const DEFAULT_RN_FETCH_TIMEOUT_MS = 30_000
+
+export class FetchTimeoutError extends Error {
+  readonly timeoutMs: number
+
+  constructor(timeoutMs: number) {
+    super(`Request timeout after ${timeoutMs}ms`)
+    this.name = 'FetchTimeoutError'
+    this.timeoutMs = timeoutMs
+  }
+}
+
+const assertTimeout = (timeoutMs: number): void => {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new RangeError(`timeoutMs must be a positive finite number, got ${timeoutMs}`)
+  }
+}
+
+const signalReason = (signal: AbortSignal): unknown =>
+  (signal as AbortSignal & { reason?: unknown }).reason ?? new Error('Request aborted')
+
+export const throwIfSignalAborted = (signal?: AbortSignal): void => {
+  if (signal?.aborted) {
+    throw signalReason(signal)
+  }
+}
+
+export async function withFetchTimeout<T>(
+  input: RequestInfo | URL,
+  init: RequestInit,
+  timeoutMs: number,
+  consume: (response: Response) => Promise<T>
+): Promise<T> {
+  assertTimeout(timeoutMs)
+
+  const callerSignal = init.signal ?? undefined
+  throwIfSignalAborted(callerSignal)
+
+  const controller = new AbortController()
+  let abortOperation: (reason: unknown) => void = () => {}
+  const abortPromise = new Promise<never>((_resolve, reject) => {
+    abortOperation = reason => {
+      controller.abort()
+      reject(reason)
+    }
+  })
+  const abortFromCaller = () => abortOperation(callerSignal ? signalReason(callerSignal) : new Error('Request aborted'))
+  callerSignal?.addEventListener('abort', abortFromCaller, { once: true })
+  const timer = setTimeout(() => abortOperation(new FetchTimeoutError(timeoutMs)), timeoutMs)
+
+  try {
+    const operation = fetch(input, { ...init, signal: controller.signal }).then(consume)
+    return await Promise.race([operation, abortPromise])
+  } finally {
+    clearTimeout(timer)
+    callerSignal?.removeEventListener('abort', abortFromCaller)
+  }
+}
+
+export const delayWithSignal = (ms: number, signal?: AbortSignal): Promise<void> => {
+  try {
+    throwIfSignalAborted(signal)
+  } catch (error) {
+    return Promise.reject(error)
+  }
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    const onAbort = () => {
+      clearTimeout(timer)
+      signal?.removeEventListener('abort', onAbort)
+      reject(signal ? signalReason(signal) : new Error('Delay aborted'))
+    }
+    signal?.addEventListener('abort', onAbort, { once: true })
+  })
+}

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -100,7 +100,7 @@ export type { VultisigConfig } from '../../Vultisig'
 export { Vultisig } from '../../Vultisig'
 
 // RN-safe fetch-based RPC helpers (no Node net/tls/http/ws dependency)
-export type { JsonRpcCallOptions, JsonRpcParams, JsonRpcResponse } from './rpcFetch'
+export type { JsonRpcCallOptions, JsonRpcParams, JsonRpcResponse, QueryUrlOptions } from './rpcFetch'
 export { jsonRpcCall, JsonRpcError, queryUrl } from './rpcFetch'
 
 // RN runtime config registry — consumers inject chain RPC URLs and

--- a/packages/sdk/src/platforms/react-native/mpc/fastVaultSign.ts
+++ b/packages/sdk/src/platforms/react-native/mpc/fastVaultSign.ts
@@ -13,6 +13,12 @@
 
 import { keysign } from '@vultisig/core-mpc/keysign'
 
+import {
+  DEFAULT_RN_FETCH_TIMEOUT_MS,
+  delayWithSignal,
+  throwIfSignalAborted,
+  withFetchTimeout,
+} from '../fetchWithTimeout'
 import { getConfiguredRelayUrl, getConfiguredVultiServerUrl } from '../runtime'
 import { joinRelaySession, startRelaySession, waitForParties } from './relay'
 
@@ -27,6 +33,10 @@ export type FastVaultSignOptions = {
   chain?: string
   isEcdsa?: boolean
   maxAttempts?: number
+  /** Cancels VultiServer, relay coordination, retry delays, and pre-keysign work. */
+  signal?: AbortSignal
+  /** Per-request network timeout. Defaults to 30 seconds; relay party wait remains 60 seconds overall. */
+  requestTimeoutMs?: number
   /** Override the VultiServer URL configured via configureRuntime / SDK default. */
   vultiServerUrl?: string
   /** Override the relay URL configured via configureRuntime / SDK default. */
@@ -81,8 +91,6 @@ function randomUUID(): string {
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
 }
 
-const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms))
-
 /**
  * Validate a URL before POSTing the vault password to it. `configureRuntime`
  * already validates values installed via the registry, but `opts.vultiServerUrl`
@@ -108,10 +116,14 @@ export async function fastVaultSign(opts: FastVaultSignOptions): Promise<string>
   const maxAttempts = opts.maxAttempts ?? 2
   let lastErr: Error | undefined
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    throwIfSignalAborted(opts.signal)
     try {
       return await fastVaultSignAttempt(opts)
     } catch (err) {
       lastErr = err instanceof Error ? err : new Error(String(err))
+      if (opts.signal?.aborted) {
+        throwIfSignalAborted(opts.signal)
+      }
       const msg = lastErr.message.toLowerCase()
       // Use word-boundary regex for HTTP 5xx so error strings like
       // "port 5001 closed" or "txid ...5000..." don't accidentally match.
@@ -123,7 +135,7 @@ export async function fastVaultSign(opts: FastVaultSignOptions): Promise<string>
         has5xx ||
         msg.includes('keysign failed')
       if (attempt < maxAttempts && retryable) {
-        await sleep(2000)
+        await delayWithSignal(2000, opts.signal)
         continue
       }
       throw lastErr
@@ -164,23 +176,34 @@ async function fastVaultSignAttempt(opts: FastVaultSignOptions): Promise<string>
     chain,
   }
 
-  const res = await fetch(`${vultiServerUrl}/sign`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(signPayload),
-  })
-  if (!res.ok) {
-    const errBody = await res.text()
-    throw new Error(`VultiServer sign failed: ${res.status} - ${errBody.substring(0, 200)}`)
-  }
-  await res.text()
+  const requestTimeoutMs = opts.requestTimeoutMs ?? DEFAULT_RN_FETCH_TIMEOUT_MS
+  await withFetchTimeout(
+    `${vultiServerUrl}/sign`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(signPayload),
+      signal: opts.signal,
+    },
+    requestTimeoutMs,
+    async res => {
+      if (!res.ok) {
+        const errBody = await res.text()
+        throw new Error(`VultiServer sign failed: ${res.status} - ${errBody.substring(0, 200)}`)
+      }
+      await res.text()
+    }
+  )
 
-  await joinRelaySession(relayUrl, sessionId, localPartyId)
-  const parties = await waitForParties(relayUrl, sessionId, 2, 60_000)
-  await startRelaySession(relayUrl, sessionId, parties)
+  const relayOptions = { signal: opts.signal, requestTimeoutMs }
+  await joinRelaySession(relayUrl, sessionId, localPartyId, relayOptions)
+  const parties = await waitForParties(relayUrl, sessionId, 2, 60_000, opts.signal, requestTimeoutMs)
+  await startRelaySession(relayUrl, sessionId, parties, relayOptions)
 
   const serverPartyId = parties.find(p => p !== localPartyId) ?? parties[0]!
   const mpcChainPath = localDerivePath.replaceAll("'", '')
+
+  throwIfSignalAborted(opts.signal)
 
   const result = await keysign({
     keyShare: keyshareBase64,

--- a/packages/sdk/src/platforms/react-native/mpc/relay.ts
+++ b/packages/sdk/src/platforms/react-native/mpc/relay.ts
@@ -10,6 +10,7 @@
 import {
   DEFAULT_RN_FETCH_TIMEOUT_MS,
   delayWithSignal,
+  FetchTimeoutError,
   throwIfSignalAborted,
   withFetchTimeout,
 } from '../fetchWithTimeout'
@@ -56,12 +57,18 @@ export async function waitForParties(
   while (Date.now() - start < timeoutMs) {
     throwIfSignalAborted(signal)
     const remainingMs = Math.max(1, timeoutMs - (Date.now() - start))
-    const parties = await withFetchTimeout(
-      `${relayUrl}/${sessionId}`,
-      { signal },
-      Math.min(requestTimeoutMs, remainingMs),
-      async res => (res.ok ? ((await res.json()) as string[]) : null)
-    )
+    let parties: string[] | null
+    try {
+      parties = await withFetchTimeout(
+        `${relayUrl}/${sessionId}`,
+        { signal },
+        Math.min(requestTimeoutMs, remainingMs),
+        async res => (res.ok ? ((await res.json()) as string[]) : null)
+      )
+    } catch (error) {
+      if (!(error instanceof FetchTimeoutError)) throw error
+      continue
+    }
     if (parties && parties.length >= expectedCount) return parties
 
     const delayMs = Math.min(1000, Math.max(0, timeoutMs - (Date.now() - start)))

--- a/packages/sdk/src/platforms/react-native/mpc/relay.ts
+++ b/packages/sdk/src/platforms/react-native/mpc/relay.ts
@@ -7,21 +7,41 @@
  * - no other behavior differences.
  */
 
+import {
+  DEFAULT_RN_FETCH_TIMEOUT_MS,
+  delayWithSignal,
+  throwIfSignalAborted,
+  withFetchTimeout,
+} from '../fetchWithTimeout'
+
 export type RelaySessionOptions = {
   relayUrl: string
   sessionId: string
   signal?: AbortSignal
+  requestTimeoutMs?: number
 }
 
-export async function joinRelaySession(relayUrl: string, sessionId: string, localPartyId: string): Promise<void> {
-  const res = await fetch(`${relayUrl}/${sessionId}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify([localPartyId]),
-  })
-  if (!res.ok) {
-    throw new Error(`Join relay failed: ${res.status} ${await res.text()}`)
-  }
+export async function joinRelaySession(
+  relayUrl: string,
+  sessionId: string,
+  localPartyId: string,
+  options: Pick<RelaySessionOptions, 'signal' | 'requestTimeoutMs'> = {}
+): Promise<void> {
+  await withFetchTimeout(
+    `${relayUrl}/${sessionId}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify([localPartyId]),
+      signal: options.signal,
+    },
+    options.requestTimeoutMs ?? DEFAULT_RN_FETCH_TIMEOUT_MS,
+    async res => {
+      if (!res.ok) {
+        throw new Error(`Join relay failed: ${res.status} ${await res.text()}`)
+      }
+    }
+  )
 }
 
 export async function waitForParties(
@@ -29,28 +49,46 @@ export async function waitForParties(
   sessionId: string,
   expectedCount: number,
   timeoutMs = 120_000,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  requestTimeoutMs = DEFAULT_RN_FETCH_TIMEOUT_MS
 ): Promise<string[]> {
   const start = Date.now()
   while (Date.now() - start < timeoutMs) {
-    signal?.throwIfAborted()
-    const res = await fetch(`${relayUrl}/${sessionId}`, { signal })
-    if (res.ok) {
-      const parties: string[] = await res.json()
-      if (parties.length >= expectedCount) return parties
-    }
-    await new Promise(r => setTimeout(r, 1000))
+    throwIfSignalAborted(signal)
+    const remainingMs = Math.max(1, timeoutMs - (Date.now() - start))
+    const parties = await withFetchTimeout(
+      `${relayUrl}/${sessionId}`,
+      { signal },
+      Math.min(requestTimeoutMs, remainingMs),
+      async res => (res.ok ? ((await res.json()) as string[]) : null)
+    )
+    if (parties && parties.length >= expectedCount) return parties
+
+    const delayMs = Math.min(1000, Math.max(0, timeoutMs - (Date.now() - start)))
+    if (delayMs > 0) await delayWithSignal(delayMs, signal)
   }
   throw new Error('Timeout waiting for parties to join relay')
 }
 
-export async function startRelaySession(relayUrl: string, sessionId: string, parties: string[]): Promise<void> {
-  const res = await fetch(`${relayUrl}/start/${sessionId}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(parties),
-  })
-  if (!res.ok) {
-    throw new Error(`Start session failed: ${res.status}`)
-  }
+export async function startRelaySession(
+  relayUrl: string,
+  sessionId: string,
+  parties: string[],
+  options: Pick<RelaySessionOptions, 'signal' | 'requestTimeoutMs'> = {}
+): Promise<void> {
+  await withFetchTimeout(
+    `${relayUrl}/start/${sessionId}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(parties),
+      signal: options.signal,
+    },
+    options.requestTimeoutMs ?? DEFAULT_RN_FETCH_TIMEOUT_MS,
+    async res => {
+      if (!res.ok) {
+        throw new Error(`Start session failed: ${res.status}`)
+      }
+    }
+  )
 }

--- a/packages/sdk/src/platforms/react-native/rpcFetch.ts
+++ b/packages/sdk/src/platforms/react-native/rpcFetch.ts
@@ -6,6 +6,8 @@
  * REST endpoints where the callsite controls the URL and payload shape.
  */
 
+import { DEFAULT_RN_FETCH_TIMEOUT_MS, withFetchTimeout } from './fetchWithTimeout'
+
 export type JsonRpcParams = unknown[] | Record<string, unknown>
 
 export type JsonRpcResponse<T> = {
@@ -18,8 +20,11 @@ export type JsonRpcResponse<T> = {
 export type JsonRpcCallOptions = {
   id?: number | string
   signal?: AbortSignal
+  timeoutMs?: number
   headers?: Record<string, string>
 }
+
+export type QueryUrlOptions = RequestInit & { timeoutMs?: number }
 
 export class JsonRpcError extends Error {
   readonly code: number
@@ -48,23 +53,29 @@ export async function jsonRpcCall<T = unknown>(
     method,
     params,
   })
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...(options.headers ?? {}) },
-    body,
-    signal: options.signal,
-  })
-  if (!res.ok) {
-    throw new Error(`JSON-RPC HTTP ${res.status} ${res.statusText} from ${url}`)
-  }
-  const payload = (await res.json()) as JsonRpcResponse<T>
-  if (payload.error) {
-    throw new JsonRpcError(payload.error.code, payload.error.message, payload.error.data)
-  }
-  if (payload.result === undefined) {
-    throw new Error(`JSON-RPC response missing result: ${JSON.stringify(payload)}`)
-  }
-  return payload.result
+  return withFetchTimeout(
+    url,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(options.headers ?? {}) },
+      body,
+      signal: options.signal,
+    },
+    options.timeoutMs ?? DEFAULT_RN_FETCH_TIMEOUT_MS,
+    async res => {
+      if (!res.ok) {
+        throw new Error(`JSON-RPC HTTP ${res.status} ${res.statusText} from ${url}`)
+      }
+      const payload = (await res.json()) as JsonRpcResponse<T>
+      if (payload.error) {
+        throw new JsonRpcError(payload.error.code, payload.error.message, payload.error.data)
+      }
+      if (payload.result === undefined) {
+        throw new Error(`JSON-RPC response missing result: ${JSON.stringify(payload)}`)
+      }
+      return payload.result
+    }
+  )
 }
 
 /**
@@ -72,11 +83,13 @@ export async function jsonRpcCall<T = unknown>(
  * Useful for REST RPC endpoints (Ripple, Tron, Cosmos LCD, etc.) where the
  * endpoint isn't JSON-RPC but still returns JSON.
  */
-export async function queryUrl<T = unknown>(url: string, init: RequestInit = {}): Promise<T> {
-  const res = await fetch(url, init)
-  if (!res.ok) {
-    const preview = await res.text().catch(() => '')
-    throw new Error(`HTTP ${res.status} ${res.statusText} from ${url}: ${preview.slice(0, 200)}`)
-  }
-  return (await res.json()) as T
+export async function queryUrl<T = unknown>(url: string, init: QueryUrlOptions = {}): Promise<T> {
+  const { timeoutMs = DEFAULT_RN_FETCH_TIMEOUT_MS, ...requestInit } = init
+  return withFetchTimeout(url, requestInit, timeoutMs, async res => {
+    if (!res.ok) {
+      const preview = await res.text().catch(() => '')
+      throw new Error(`HTTP ${res.status} ${res.statusText} from ${url}: ${preview.slice(0, 200)}`)
+    }
+    return (await res.json()) as T
+  })
 }

--- a/packages/sdk/tests/unit/platforms/react-native/fastVaultSign.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/fastVaultSign.test.ts
@@ -81,9 +81,16 @@ describe('fastVaultSign — cancellation', () => {
   it('cancels a VultiServer body that stalls after response headers', async () => {
     const controller = new AbortController()
     const reason = new Error('cancel sign response body')
+    let notifyBodyRead!: () => void
+    const bodyRead = new Promise<void>(resolve => {
+      notifyBodyRead = resolve
+    })
     const fetchMock = vi.fn(async () => ({
       ok: true,
-      text: () => new Promise(() => {}),
+      text: () => {
+        notifyBodyRead()
+        return new Promise<string>(() => {})
+      },
     }))
     vi.stubGlobal('fetch', fetchMock)
     const promise = fastVaultSign({
@@ -93,6 +100,7 @@ describe('fastVaultSign — cancellation', () => {
       requestTimeoutMs: 10_000,
     })
 
+    await bodyRead
     controller.abort(reason)
 
     await expect(promise).rejects.toBe(reason)

--- a/packages/sdk/tests/unit/platforms/react-native/fastVaultSign.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/fastVaultSign.test.ts
@@ -12,6 +12,8 @@ vi.mock('../../../../src/platforms/react-native/mpc/relay', () => ({
 }))
 
 const { keysign } = await import('@vultisig/core-mpc/keysign')
+const { joinRelaySession, startRelaySession, waitForParties } =
+  await import('../../../../src/platforms/react-native/mpc/relay')
 const { fastVaultSign, schnorrSign, INTERNAL_FOR_TESTING } =
   await import('../../../../src/platforms/react-native/mpc/fastVaultSign')
 
@@ -27,6 +29,105 @@ const BASE_OPTS = {
   relayUrl: 'https://api.vultisig.com/router',
   maxAttempts: 1,
 }
+
+describe('fastVaultSign — cancellation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+    vi.mocked(keysign).mockReset()
+    vi.mocked(joinRelaySession).mockClear()
+    vi.mocked(waitForParties).mockClear()
+    vi.mocked(startRelaySession).mockClear()
+  })
+
+  it('cancels a wedged VultiServer sign request without retrying', async () => {
+    const controller = new AbortController()
+    const reason = new Error('sign screen closed')
+    const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal
+        signal?.addEventListener('abort', () => reject(signal.reason), { once: true })
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const promise = fastVaultSign({
+      ...BASE_OPTS,
+      maxAttempts: 2,
+      signal: controller.signal,
+      requestTimeoutMs: 10_000,
+    })
+    controller.abort(reason)
+
+    await expect(promise).rejects.toBe(reason)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(joinRelaySession).not.toHaveBeenCalled()
+    expect(keysign).not.toHaveBeenCalled()
+  })
+
+  it('supports a legacy Hermes AbortSignal without reason or throwIfAborted', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const legacySignal = {
+      aborted: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    } as unknown as AbortSignal
+
+    await expect(fastVaultSign({ ...BASE_OPTS, signal: legacySignal })).rejects.toThrow('Request aborted')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('cancels a VultiServer body that stalls after response headers', async () => {
+    const controller = new AbortController()
+    const reason = new Error('cancel sign response body')
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      text: () => new Promise(() => {}),
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+    const promise = fastVaultSign({
+      ...BASE_OPTS,
+      maxAttempts: 2,
+      signal: controller.signal,
+      requestTimeoutMs: 10_000,
+    })
+
+    controller.abort(reason)
+
+    await expect(promise).rejects.toBe(reason)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(joinRelaySession).not.toHaveBeenCalled()
+  })
+
+  it('threads one caller signal and request timeout through the relay ceremony', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('', { status: 200 }))
+    )
+    vi.mocked(keysign).mockResolvedValueOnce({ r: 'aa'.repeat(32), s: 'bb'.repeat(32), recovery_id: '00' } as never)
+    const controller = new AbortController()
+
+    await fastVaultSign({ ...BASE_OPTS, signal: controller.signal, requestTimeoutMs: 12_345 })
+
+    expect(joinRelaySession).toHaveBeenCalledWith(BASE_OPTS.relayUrl, expect.any(String), BASE_OPTS.localPartyId, {
+      signal: controller.signal,
+      requestTimeoutMs: 12_345,
+    })
+    expect(waitForParties).toHaveBeenCalledWith(
+      BASE_OPTS.relayUrl,
+      expect.any(String),
+      2,
+      60_000,
+      controller.signal,
+      12_345
+    )
+    expect(startRelaySession).toHaveBeenCalledWith(BASE_OPTS.relayUrl, expect.any(String), ['local', 'server'], {
+      signal: controller.signal,
+      requestTimeoutMs: 12_345,
+    })
+  })
+})
 
 describe('fastVaultSign — ECDSA recovery_id handling', () => {
   afterEach(() => {

--- a/packages/sdk/tests/unit/platforms/react-native/relay-timeout.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/relay-timeout.test.ts
@@ -6,12 +6,15 @@ import { joinRelaySession, waitForParties } from '../../../../src/platforms/reac
 const neverRespondingFetch = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
   return new Promise<Response>((_resolve, reject) => {
     const signal = init?.signal
-    signal?.addEventListener('abort', () => reject(signal.reason), { once: true })
+    signal?.addEventListener('abort', () => reject(signal.reason), {
+      once: true,
+    })
   })
 })
 
 describe('React Native relay timeout and cancellation', () => {
   afterEach(() => {
+    vi.useRealTimers()
     vi.unstubAllGlobals()
     vi.clearAllMocks()
   })
@@ -20,7 +23,9 @@ describe('React Native relay timeout and cancellation', () => {
     vi.stubGlobal('fetch', neverRespondingFetch)
 
     await expect(
-      joinRelaySession('http://127.0.0.1:1', 'session', 'local', { requestTimeoutMs: 10 })
+      joinRelaySession('http://127.0.0.1:1', 'session', 'local', {
+        requestTimeoutMs: 10,
+      })
     ).rejects.toBeInstanceOf(FetchTimeoutError)
   })
 
@@ -33,5 +38,17 @@ describe('React Native relay timeout and cancellation', () => {
     controller.abort(reason)
 
     await expect(promise).rejects.toBe(reason)
+  })
+
+  it('keeps polling after a per-request timeout until the overall deadline', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('fetch', neverRespondingFetch)
+
+    const promise = waitForParties('http://127.0.0.1:1', 'session', 2, 100, undefined, 20)
+    const expectation = expect(promise).rejects.toThrow('Timeout waiting for parties to join relay')
+
+    await vi.advanceTimersByTimeAsync(100)
+    await expectation
+    expect(neverRespondingFetch).toHaveBeenCalledTimes(5)
   })
 })

--- a/packages/sdk/tests/unit/platforms/react-native/relay-timeout.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/relay-timeout.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { FetchTimeoutError } from '../../../../src/platforms/react-native/fetchWithTimeout'
+import { joinRelaySession, waitForParties } from '../../../../src/platforms/react-native/mpc/relay'
+
+const neverRespondingFetch = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+  return new Promise<Response>((_resolve, reject) => {
+    const signal = init?.signal
+    signal?.addEventListener('abort', () => reject(signal.reason), { once: true })
+  })
+})
+
+describe('React Native relay timeout and cancellation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('bounds a wedged relay join request', async () => {
+    vi.stubGlobal('fetch', neverRespondingFetch)
+
+    await expect(
+      joinRelaySession('http://127.0.0.1:1', 'session', 'local', { requestTimeoutMs: 10 })
+    ).rejects.toBeInstanceOf(FetchTimeoutError)
+  })
+
+  it('cancels an in-flight relay poll with the caller reason', async () => {
+    vi.stubGlobal('fetch', neverRespondingFetch)
+    const controller = new AbortController()
+    const reason = new Error('sign screen closed')
+    const promise = waitForParties('http://127.0.0.1:1', 'session', 2, 60_000, controller.signal, 10_000)
+
+    controller.abort(reason)
+
+    await expect(promise).rejects.toBe(reason)
+  })
+})

--- a/packages/sdk/tests/unit/platforms/react-native/rpc-fetch-timeout.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/rpc-fetch-timeout.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { getSolanaBalance } from '../../../../src/platforms/react-native/chains/solana/rpc'
+import { FetchTimeoutError } from '../../../../src/platforms/react-native/fetchWithTimeout'
+import { jsonRpcCall, queryUrl } from '../../../../src/platforms/react-native/rpcFetch'
+
+const neverRespondingFetch = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+  return new Promise<Response>((_resolve, reject) => {
+    const signal = init?.signal
+    signal?.addEventListener('abort', () => reject(signal.reason), { once: true })
+  })
+})
+
+describe('React Native fetch timeout and cancellation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('bounds a wedged JSON-RPC request with a typed timeout', async () => {
+    vi.stubGlobal('fetch', neverRespondingFetch)
+
+    const error = await jsonRpcCall('http://127.0.0.1:1', 'eth_chainId', [], { timeoutMs: 10 }).catch(
+      (cause: unknown) => cause
+    )
+
+    expect(error).toBeInstanceOf(FetchTimeoutError)
+    expect(error).toMatchObject({ timeoutMs: 10, message: 'Request timeout after 10ms' })
+    expect(neverRespondingFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the timeout active after headers while the JSON body is stalled', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: () => new Promise(() => {}),
+      }))
+    )
+
+    await expect(jsonRpcCall('http://127.0.0.1:1', 'eth_chainId', [], { timeoutMs: 10 })).rejects.toBeInstanceOf(
+      FetchTimeoutError
+    )
+  })
+
+  it('preserves the caller abort reason for REST queries', async () => {
+    vi.stubGlobal('fetch', neverRespondingFetch)
+    const controller = new AbortController()
+    const reason = new Error('caller cancelled')
+    const promise = queryUrl('http://127.0.0.1:1', { signal: controller.signal, timeoutMs: 10_000 })
+
+    controller.abort(reason)
+
+    await expect(promise).rejects.toBe(reason)
+  })
+
+  it('cancels a REST response whose body stalls after headers', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: () => new Promise(() => {}),
+      }))
+    )
+    const controller = new AbortController()
+    const reason = new Error('cancel stalled body')
+    const promise = queryUrl('http://127.0.0.1:1', { signal: controller.signal, timeoutMs: 10_000 })
+
+    controller.abort(reason)
+
+    await expect(promise).rejects.toBe(reason)
+  })
+
+  it('threads caller cancellation through Solana helpers', async () => {
+    vi.stubGlobal('fetch', neverRespondingFetch)
+    const controller = new AbortController()
+    const reason = new Error('leave send screen')
+    const promise = getSolanaBalance('11111111111111111111111111111111', 'http://127.0.0.1:1', {
+      signal: controller.signal,
+      timeoutMs: 10_000,
+    })
+
+    controller.abort(reason)
+
+    await expect(promise).rejects.toBe(reason)
+  })
+})


### PR DESCRIPTION
Closes #1250
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added React Native request timeouts with abort/cancellation support across JSON-RPC, REST queries, Solana RPC helpers, and fast-vault signing/relay coordination.
  * Introduced `timeoutMs` options (and `signal` where applicable) to control network operations; added query timeout configuration.

* **Bug Fixes**
  * Prevented stalled JSON-RPC and relay polling flows from hanging indefinitely.
  * Preserved caller cancellation reasons through timeout/abort lifecycles, including in-flight response handling.

* **Tests**
  * Added/expanded unit tests covering timeout bounds, cancellation behavior, and correct propagation of timeout/abort options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->