### PR TITLE
fix(chain): point Hyperliquid explorer links at hypurrscan /evm section

### DIFF
--- a/.changeset/hyperliquid-explorer-evm-path.md
+++ b/.changeset/hyperliquid-explorer-evm-path.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/core-chain': patch
+---
+
+Fix broken Hyperliquid block-explorer links by pointing them at hypurrscan's `/evm/` section (`https://hypurrscan.io/evm/tx/<hash>` and `/evm/address/<addr>`). The bare `/tx/` path returned a hypurrscan server error.

--- a/packages/core/chain/chains/evm/chainInfo.ts
+++ b/packages/core/chain/chains/evm/chainInfo.ts
@@ -22,7 +22,9 @@ import {
 } from 'viem/chains'
 
 const hyperliquidRpcUrl = `${rootApiUrl}/hyperevm/`
-export const hyperliquidBlockExplorerUrl = 'https://hypurrscan.io'
+// HyperEVM transactions and addresses live under hypurrscan's `/evm/` section.
+// The bare `https://hypurrscan.io/tx/<hash>` path returns a server error.
+export const hyperliquidBlockExplorerUrl = 'https://hypurrscan.io/evm'
 const hyperliquidNativeCoin = chainFeeCoin[EvmChain.Hyperliquid]
 
 export const hyperliquid = defineChain({

--- a/packages/core/chain/utils/getBlockExplorerUrl/index.test.ts
+++ b/packages/core/chain/utils/getBlockExplorerUrl/index.test.ts
@@ -41,8 +41,7 @@ describe('getBlockExplorerUrl', () => {
   })
 
   it('builds a Hyperliquid transaction URL under hypurrscan /evm', () => {
-    const txHash =
-      '0x00b1b8e2c63d7eb2e2928f297d3898f932cb43ad601f06f0b5da0b31b38d53b6'
+    const txHash = '0x00b1b8e2c63d7eb2e2928f297d3898f932cb43ad601f06f0b5da0b31b38d53b6'
 
     expect(
       getBlockExplorerUrl({

--- a/packages/core/chain/utils/getBlockExplorerUrl/index.test.ts
+++ b/packages/core/chain/utils/getBlockExplorerUrl/index.test.ts
@@ -39,4 +39,29 @@ describe('getBlockExplorerUrl', () => {
       })
     ).toBe(`https://etherscan.io/address/${address}`)
   })
+
+  it('builds a Hyperliquid transaction URL under hypurrscan /evm', () => {
+    const txHash =
+      '0x00b1b8e2c63d7eb2e2928f297d3898f932cb43ad601f06f0b5da0b31b38d53b6'
+
+    expect(
+      getBlockExplorerUrl({
+        chain: Chain.Hyperliquid,
+        entity: 'tx',
+        value: txHash,
+      })
+    ).toBe(`https://hypurrscan.io/evm/tx/${txHash}`)
+  })
+
+  it('builds a Hyperliquid address URL under hypurrscan /evm', () => {
+    const address = '0x1234'
+
+    expect(
+      getBlockExplorerUrl({
+        chain: Chain.Hyperliquid,
+        entity: 'address',
+        value: address,
+      })
+    ).toBe(`https://hypurrscan.io/evm/address/${address}`)
+  })
 })


### PR DESCRIPTION
## Problem

Hyperliquid (HyperEVM) block-explorer links were broken. `getBlockExplorerUrl` built:

```
https://hypurrscan.io/tx/<hash>
```

which returns a hypurrscan **Server Error** ("Unexpected error code=358") — HyperEVM transactions are not served from the bare `/tx/` path.

Reported in vultisig/vultisig-windows#4379 (same bug tracked on Android in vultisig/vultisig-android#5305).

## Fix

HyperEVM transactions and addresses live under hypurrscan's `/evm/` section. Point the base URL at `https://hypurrscan.io/evm`, so both entities resolve:

| Entity | Before (broken) | After |
|--------|-----------------|-------|
| tx | `https://hypurrscan.io/tx/<hash>` ❌ | `https://hypurrscan.io/evm/tx/<hash>` ✅ |
| address | `https://hypurrscan.io/address/<addr>` | `https://hypurrscan.io/evm/address/<addr>` ✅ |

The base constant also feeds the viem `blockExplorers.default.url`, so that is corrected in the same change.

## Changes

- `chains/evm/chainInfo.ts` — `hyperliquidBlockExplorerUrl` → `https://hypurrscan.io/evm` (with an explanatory comment).
- `utils/getBlockExplorerUrl/index.test.ts` — added tests for the Hyperliquid tx and address URLs.
- Changeset: `@vultisig/core-chain` patch.

## Verification

- `vitest run` for `getBlockExplorerUrl` — 5/5 pass (3 existing + 2 new).
- `tsc --noEmit` and eslint clean on the changed files.
- Confirmed working link: `https://hypurrscan.io/evm/tx/0x00b1b8e2c63d7eb2e2928f297d3898f932cb43ad601f06f0b5da0b31b38d53b6`

## Follow-up

After this is published, bump `@vultisig/core-chain` in `vultisig-windows` to pick up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Hyperliquid block-explorer links for transactions and addresses by using the correct HyperEVM URL path (`/evm/`).
  * Prevented broken explorer pages and server errors caused by the previous URL format.

* **Tests**
  * Added/updated test coverage to verify generated transaction and address URLs include `/evm/` for Hyperliquid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->