### PR TITLE
fix(swap): support THORChain secured-asset swaps

### DIFF
--- a/.changeset/thorchain-secured-asset-swaps.md
+++ b/.changeset/thorchain-secured-asset-swaps.md
@@ -1,0 +1,6 @@
+---
+"@vultisig/core-chain": patch
+"@vultisig/core-mpc": patch
+---
+
+Fix native swaps from THORChain secured assets. Swap quotes now emit secured-asset notation (`CHAIN-ASSET`, e.g. `XRP-XRP`, `ETH-USDC-0x…`) instead of the L1 pool notation (`CHAIN.ASSET`) that THORNode rejects for `thor1`-settling swaps, and the spent secured asset is encoded correctly in the `MsgDeposit` (L1 chain and symbol derived from the denom, `secured` flag set). Applies to all secured assets and swap directions.

--- a/packages/core/chain/swap/native/asset/toNativeSwapAsset.test.ts
+++ b/packages/core/chain/swap/native/asset/toNativeSwapAsset.test.ts
@@ -76,21 +76,21 @@ describe('toNativeSwapAsset', () => {
     ).toBe('thor.ruji')
   })
 
-  it('maps secured-asset hyphen denoms to cross-chain swap ids', () => {
+  it('maps THORChain secured-asset hyphen denoms to secured (dash) notation', () => {
     expect(
       toNativeSwapAsset({
         chain: Chain.THORChain,
         id: 'btc-btc',
         ticker: 'BTC',
       })
-    ).toBe('BTC.BTC')
+    ).toBe('BTC-BTC')
     expect(
       toNativeSwapAsset({
         chain: Chain.THORChain,
         id: 'eth-usdc-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
         ticker: 'USDC',
       })
-    ).toBe('ETH.USDC-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')
+    ).toBe('ETH-USDC-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')
   })
 
   it('derives secured-asset denom prefixes from nativeSwapChainIds', () => {
@@ -101,7 +101,7 @@ describe('toNativeSwapAsset', () => {
           id: `${swapId.toLowerCase()}-asset`,
           ticker: 'ASSET',
         })
-      ).toBe(`${swapId}.ASSET`)
+      ).toBe(`${swapId}-ASSET`)
     }
   })
 

--- a/packages/core/chain/swap/native/asset/toNativeSwapAsset.ts
+++ b/packages/core/chain/swap/native/asset/toNativeSwapAsset.ts
@@ -1,3 +1,4 @@
+import { Chain } from '@vultisig/core-chain/Chain'
 import { CoinKey } from '@vultisig/core-chain/coin/Coin'
 import { isOneOf } from '@vultisig/lib-utils/array/isOneOf'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
@@ -51,7 +52,14 @@ const normalizeNativeSwapChainDenom = ({
     const swapId = getSecuredAssetSwapId(segments[0])
     if (swapId) {
       const rest = segments.slice(1).join('-')
-      return `${swapId}.${formatSecuredAssetRest(rest)}`
+      // THORChain secured assets settle on THORChain (a thor1 destination), so
+      // they must use secured-asset notation `CHAIN-ASSET`, not L1 pool
+      // notation `CHAIN.ASSET`. With the dot form THORNode reads the target as
+      // the L1 asset and rejects the swap ("swap destination address is not the
+      // same chain as the target asset"). MayaChain has no secured assets, so
+      // keep its existing dot notation.
+      const separator = chain === Chain.THORChain ? '-' : '.'
+      return `${swapId}${separator}${formatSecuredAssetRest(rest)}`
     }
   }
 

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos.test.ts
@@ -313,8 +313,7 @@ describe('getCosmosSigningInputs gas limit', () => {
             fromCoin: {
               chain: Chain.THORChain,
               ticker: 'USDC',
-              contractAddress:
-                'eth-usdc-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+              contractAddress: 'eth-usdc-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
               decimals: 8,
             },
             fromAmount: '41391997',

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos.test.ts
@@ -227,4 +227,113 @@ describe('getCosmosSigningInputs gas limit', () => {
     })
     expect(depositCoin?.decimals.toString()).toBe('8')
   })
+
+  it('encodes a secured-asset swap deposit with the L1 secured asset (native)', async () => {
+    const memo = `=:ETH-USDC:${thorSender}`
+    const [input] = await getCosmosSigningInputs({
+      keysignPayload: create(KeysignPayloadSchema, {
+        coin: create(CoinSchema, {
+          chain: Chain.THORChain,
+          ticker: 'RUNE',
+          address: thorSender,
+          decimals: 8,
+          isNativeToken: true,
+          hexPublicKey: publicKeyHex,
+        }),
+        toAddress: '',
+        toAmount: '200000000',
+        memo,
+        blockchainSpecific: {
+          case: 'thorchainSpecific',
+          value: create(THORChainSpecificSchema, {
+            accountNumber: 7n,
+            sequence: 3n,
+            fee: 2_000_000n,
+            isDeposit: true,
+            transactionType: TransactionType.UNSPECIFIED,
+          }),
+        },
+        swapPayload: {
+          case: 'thorchainSwapPayload',
+          value: {
+            fromCoin: {
+              chain: Chain.THORChain,
+              ticker: 'XRP',
+              contractAddress: 'xrp-xrp',
+              decimals: 8,
+            },
+            fromAmount: '200000000',
+            vaultAddress: '',
+            routerAddress: '',
+            expirationTime: 0n,
+          },
+        },
+      }),
+      walletCore,
+    })
+
+    const depositCoin = input.messages[0]?.thorchainDepositMessage?.coins?.[0]
+    expect(depositCoin?.asset).toMatchObject({
+      chain: 'XRP',
+      symbol: 'XRP',
+      ticker: 'XRP',
+      secured: true,
+    })
+    expect(depositCoin?.amount).toBe('200000000')
+    expect(depositCoin?.decimals.toString()).toBe('8')
+  })
+
+  it('encodes a secured-asset swap deposit with the contract symbol (token)', async () => {
+    const [input] = await getCosmosSigningInputs({
+      keysignPayload: create(KeysignPayloadSchema, {
+        coin: create(CoinSchema, {
+          chain: Chain.THORChain,
+          ticker: 'RUNE',
+          address: thorSender,
+          decimals: 8,
+          isNativeToken: true,
+          hexPublicKey: publicKeyHex,
+        }),
+        toAddress: '',
+        toAmount: '41391997',
+        memo: `=:XRP-XRP:${thorSender}`,
+        blockchainSpecific: {
+          case: 'thorchainSpecific',
+          value: create(THORChainSpecificSchema, {
+            accountNumber: 7n,
+            sequence: 3n,
+            fee: 2_000_000n,
+            isDeposit: true,
+            transactionType: TransactionType.UNSPECIFIED,
+          }),
+        },
+        swapPayload: {
+          case: 'thorchainSwapPayload',
+          value: {
+            fromCoin: {
+              chain: Chain.THORChain,
+              ticker: 'USDC',
+              contractAddress:
+                'eth-usdc-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+              decimals: 8,
+            },
+            fromAmount: '41391997',
+            vaultAddress: '',
+            routerAddress: '',
+            expirationTime: 0n,
+          },
+        },
+      }),
+      walletCore,
+    })
+
+    const depositCoin = input.messages[0]?.thorchainDepositMessage?.coins?.[0]
+    expect(depositCoin?.asset).toMatchObject({
+      chain: 'ETH',
+      symbol: 'USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48',
+      ticker: 'USDC',
+      secured: true,
+    })
+    expect(depositCoin?.decimals.toString()).toBe('8')
+  })
 })

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
@@ -65,6 +65,33 @@ const getThorchainDepositAsset = ({
   })
 }
 
+// Mirrors iOS THORChainHelper.isSecuredAsset (thorchain.swift): a THORChain-held
+// token whose denom encodes an L1 chain prefix + '-' (e.g. `xrp-xrp`,
+// `eth-usdc-0x…`). RUNE and `x/…` THORChain-native tokens are not secured assets.
+const isSecuredAssetSwapCoin = (assetCoin: { chain: string; contractAddress?: string }): boolean =>
+  assetCoin.chain === Chain.THORChain &&
+  !!assetCoin.contractAddress &&
+  !assetCoin.contractAddress.startsWith('x/') &&
+  assetCoin.contractAddress.includes('-')
+
+// Builds the MsgDeposit asset for a THORChain secured asset spent in a swap.
+// Mirrors iOS THORChainHelper: the L1 chain and symbol are derived from the
+// secured denom (`eth-usdc-0x…` -> chain `ETH`, symbol `USDC-0X…`) with the
+// `secured` flag set, so THORNode matches the deposited coin against the same
+// secured asset referenced by the server-issued swap memo (`=:ETH-USDC:…`).
+const getSecuredAssetDepositAsset = (assetCoin: { contractAddress: string; ticker: string }) => {
+  const [chainPrefix, ...symbolParts] = assetCoin.contractAddress.split('-')
+  const symbol = symbolParts.join('-')
+
+  return TW.Cosmos.Proto.THORChainAsset.create({
+    chain: chainPrefix.toUpperCase(),
+    symbol: (symbol || assetCoin.ticker).toUpperCase(),
+    ticker: assetCoin.ticker.toUpperCase().replace(/X\//g, ''),
+    synth: false,
+    secured: true,
+  })
+}
+
 export const getCosmosSigningInputs: SigningInputsResolver<'cosmos'> = ({ keysignPayload, walletCore }) => {
   const chain = getKeysignChain<'cosmos'>(keysignPayload)
   const coin = getKeysignCoin<CosmosChain>(keysignPayload)
@@ -374,9 +401,18 @@ export const getCosmosSigningInputs: SigningInputsResolver<'cosmos'> = ({ keysig
 
         const assetCoin = swapPayload?.fromCoin ?? coin
         const isSecuredWithdrawal = isSecuredAssetWithdrawal({ chain, keysignPayload, native: swapPayload })
+        const securedSwapFromCoin =
+          swapPayload?.fromCoin && isSecuredAssetSwapCoin(swapPayload.fromCoin)
+            ? swapPayload.fromCoin
+            : undefined
 
         const depositCoin = TW.Cosmos.Proto.THORChainCoin.create({
-          asset: getThorchainDepositAsset({ assetCoin, chain, secured: isSecuredWithdrawal }),
+          asset: securedSwapFromCoin
+            ? getSecuredAssetDepositAsset({
+                contractAddress: securedSwapFromCoin.contractAddress,
+                ticker: securedSwapFromCoin.ticker,
+              })
+            : getThorchainDepositAsset({ assetCoin, chain, secured: isSecuredWithdrawal }),
           ...(isPositive
             ? {
                 amount: amountStr,

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
@@ -402,9 +402,7 @@ export const getCosmosSigningInputs: SigningInputsResolver<'cosmos'> = ({ keysig
         const assetCoin = swapPayload?.fromCoin ?? coin
         const isSecuredWithdrawal = isSecuredAssetWithdrawal({ chain, keysignPayload, native: swapPayload })
         const securedSwapFromCoin =
-          swapPayload?.fromCoin && isSecuredAssetSwapCoin(swapPayload.fromCoin)
-            ? swapPayload.fromCoin
-            : undefined
+          swapPayload?.fromCoin && isSecuredAssetSwapCoin(swapPayload.fromCoin) ? swapPayload.fromCoin : undefined
 
         const depositCoin = TW.Cosmos.Proto.THORChainCoin.create({
           asset: securedSwapFromCoin


### PR DESCRIPTION
Closes #1325

## Problem
Native (THORChain) swaps involving a THORChain **secured asset** (a bank denom held on a `thor1…` address — `xrp-xrp`, `eth-usdc-0x…`, `btc-btc`, …) were built with **L1 pool notation**, breaking in two places:

1. `toNativeSwapAsset` emitted the dotted L1 form (`xrp-xrp` → `XRP.XRP`, `eth-usdc-0x…` → `ETH.USDC-0x…`). Since a secured asset settles on THORChain (a `thor1` destination), THORNode reads the dotted form as an L1 asset and rejects the swap during simulation: *"swap destination address is not the same chain as the target asset"*.
2. The `MsgDeposit` that spends the secured asset (`getCosmosSigningInputs` → `getThorchainDepositAsset`) didn't build a *secured* `THORChainAsset` for swaps — only `secure-:` withdrawals were handled — so the deposit asset's chain was derived from the holding chain (`THORChain` → `THOR`) with a malformed symbol.

Affects **all** secured assets (BTC, ETH, USDC, ATOM, LTC, XRP, BNB, XRUNE, …).

## Fix
- **Quote** (`toNativeSwapAsset.ts`): THORChain secured assets now emit secured-asset notation `CHAIN-ASSET` (`XRP-XRP`, `ETH-USDC-0x…`). MayaChain keeps its dot notation (it has no secured assets).
- **Deposit** (`cosmos/index.ts`): when a swap spends a THORChain secured asset, the `MsgDeposit` asset is built from the secured denom — L1 `chain` and `symbol` parsed from the denom, plain `ticker`, `secured: true`, coin decimals. Mirrors the iOS secured-asset encoding (`vultisig-ios` `thorchain.swift`).

## Verification
- Verified against THORChain's `/thorchain/quote/swap`: with the dash form, secured→secured, secured→L1, and L1→secured all return valid `thor1`-settling memos (`=:ETH-USDC:thor1…`); the old dot form returns an empty/failed quote.
- Confirmed end-to-end in the Vultisig extension (patched build): a previously-failing secured-asset swap now produces a valid quote.
- New unit tests: `toNativeSwapAsset` (dash notation), and `getCosmosSigningInputs` asserting the generated deposit `THORChainAsset` (`XRP`/`XRP`/secured and `ETH`/`USDC-0X…`/secured, decimals 8).
- `yarn vitest run` across `swap` + `signingInputs` + `swap` suites: **559 passing**; typecheck ✓, lint ✓.

## Test plan
- [ ] Quote + sign + broadcast a real secured-asset swap (secured → secured and secured → L1) and confirm THORNode accepts and settles it.
- [ ] Confirm existing THORChain flows are unchanged: RUNE/token swaps, secured-asset (`secure-:`) withdrawals, LP add/withdraw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed THORChain secured-asset swaps to use the required dash notation in swap quotes.
  * Corrected secured-asset deposit details for native assets and tokens, improving compatibility with THORChain settlement.
  * Ensured swap flows preserve the correct asset chain, symbol, ticker, amount, and decimals.

* **Tests**
  * Added regression coverage for secured native-asset and token swap deposits.
  * Updated formatting tests for THORChain secured-asset notation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->