### PR TITLE
fix(sdk): preserve isHidden in static discoverTokens

### DIFF
--- a/.changeset/sdk-discover-tokens-ishidden.md
+++ b/.changeset/sdk-discover-tokens-ishidden.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+Preserve `isHidden` metadata in `Vultisig.discoverTokens()` so the static vault-free token discovery surface matches `vault.discoverTokens()`.

--- a/packages/sdk/src/Vultisig.ts
+++ b/packages/sdk/src/Vultisig.ts
@@ -1285,6 +1285,7 @@ export class Vultisig extends UniversalEventEmitter<SdkEvents> {
       ticker: coin.ticker,
       decimals: coin.decimals,
       logo: coin.logo,
+      ...(coin.isHidden === undefined ? {} : { isHidden: coin.isHidden }),
     }))
   }
 

--- a/packages/sdk/tests/unit/Vultisig.static-methods.test.ts
+++ b/packages/sdk/tests/unit/Vultisig.static-methods.test.ts
@@ -226,6 +226,34 @@ describe('Vultisig static methods', () => {
       expect(result[0]?.contractAddress).toBe('')
     })
 
+    it('preserves isHidden when core discovery returns it', async () => {
+      vi.mocked(findCoins).mockResolvedValue([
+        {
+          chain: Chain.Ethereum,
+          id: '0xhidden',
+          ticker: 'HID',
+          decimals: 18,
+          isHidden: true,
+        },
+      ] as never)
+
+      const result = await Vultisig.discoverTokens({
+        chain: Chain.Ethereum,
+        address: '0xhidden-wallet',
+      })
+
+      expect(result).toEqual([
+        {
+          chain: Chain.Ethereum,
+          contractAddress: '0xhidden',
+          ticker: 'HID',
+          decimals: 18,
+          logo: undefined,
+          isHidden: true,
+        },
+      ])
+    })
+
     it('returns [] when the address holds nothing', async () => {
       vi.mocked(findCoins).mockResolvedValue([] as never)
       const result = await Vultisig.discoverTokens({


### PR DESCRIPTION
## Summary
- preserve `isHidden` in `Vultisig.discoverTokens()` so the static vault-free API matches `vault.discoverTokens()`
- add a regression test covering hidden-token metadata passthrough
- add a changeset for `@vultisig/sdk` + `@vultisig/cli`

## Problem
`Vultisig.discoverTokens()` claimed to mirror `TokenDiscoveryService.discoverTokens()` exactly, but it dropped `DiscoveredToken.isHidden` even though the instance/vault surface preserved it.

## Test plan
- [x] `yarn build:shared`
- [x] `yarn workspace @vultisig/sdk vitest run --config tests/unit/vitest.config.ts tests/unit/Vultisig.static-methods.test.ts`
- [x] `yarn build:sdk`
- [x] built-dist runtime proof: `node --input-type=module` import of `packages/sdk/dist/index.node.esm.js` confirmed `Vultisig.discoverTokens.toString()` contains the `isHidden` mapping
- [ ] `yarn cli:build` *(pre-existing mainline blocker: unresolved `@vultisig/core-chain/chains/ripple/address` import from `clients/cli/src/commands/transaction.ts`)*

## Receipts
```text
$ yarn workspace @vultisig/sdk vitest run --config tests/unit/vitest.config.ts tests/unit/Vultisig.static-methods.test.ts
Test Files  1 passed (1)
Tests  21 passed (21)
```

```text
$ node --input-type=module ...
PASS: discoverTokens runtime includes isHidden mapping
```

## Links
- closes #1336
- round-33 report mirror: https://gist.github.com/gomesalexandre/4c9bc77d2f8ce66567ac5767a79a190e
