### PR TITLE
fix(cli): bound a hung backend and handle outcome-bearing SSE frames

### DIFF
--- a/.changeset/lucky-pandas-repeat.md
+++ b/.changeset/lucky-pandas-repeat.md
@@ -1,0 +1,16 @@
+---
+'@vultisig/cli': patch
+---
+
+Make the agent SSE idle deadline bound a hung backend, and handle the frame types that carry turn-outcome semantics.
+
+Follow-up to the agent-channel hardening in #1305; both are behavior changes worth reading.
+
+**The idle deadline now measures progress, not traffic.** Keep-alive comments no longer extend it. Both backends emit those from a timer that runs independently of whether the turn is advancing, so a deadline they reset bounded only a dead connection — a backend wedged in a model or tool call kept pinging and `agent ask` hung forever, which is the exact failure the deadline was added to stop. The default rises 60s → 180s to match what it now measures: real backend silence, which a healthy turn is documented to produce for up to ~150s (a model call is bounded at 90s, the swap builder at 90s + 60s MCP). A slow-but-progressing turn still resets the clock on every real frame. `VULTISIG_SSE_IDLE_TIMEOUT_MS` is unchanged, and the timeout still throws a typed `TIMEOUT` → exit 3.
+
+**`tool-output-error` and `text-replace` are now handled.** Both were counted as unknown frames and dropped, and both carry semantics the turn result depends on:
+
+- `tool-output-error` is the backend's tool-failure terminal. Ignored, the call never closed, so a FAILED tool was reported as a running one and the turn recorded no failure. It now surfaces as a failed tool result. It can never produce a signable transaction.
+- `text-replace` retracts prose the backend has decided is wrong and supplies a correction. Ignored, the retracted claim stayed as the turn's answer — a turn could answer "I sent your 5 ETH." after the backend had withdrawn exactly that sentence. The correction is now applied, or declined outright if it cannot be applied cleanly, never half-applied.
+
+**`PROTOCOL_DRIFT` warnings are now `--verbose`-only,** and unknown `data-*` card kinds no longer produce them at all. The backend's V1 wire treats unknown data kinds as forward-compatible and emits some from a dynamic call site no static client list can track, so warning by default fired on healthy turns against a newer backend. Automation that read `warnings` for drift will no longer receive it unless `--verbose` is set; the field was already documented as omitted-when-empty. Frames whose absence is a real defect are handled explicitly instead of enumerated.

--- a/clients/cli/README.md
+++ b/clients/cli/README.md
@@ -769,7 +769,7 @@ explorer:https://etherscan.io/tx/0x9f8e7d6c...
 }
 ```
 
-`warnings` is omitted when empty. `PROTOCOL_DRIFT` means the backend emitted an SSE frame type this CLI version does not understand; the turn continues, but automation should retain the warning because a newer CLI may be required to handle that frame.
+`warnings` is omitted when empty, and is **`--verbose`-only**: `PROTOCOL_DRIFT` is a debugging aid, not a machine contract. The backend's V1 wire evolves forward-compatibly — unknown `data-*` card kinds are expected against a newer backend and are tolerated silently — so a warning emitted by default would fire on healthy turns. Run with `--verbose` to see which frame types a turn carried that this CLI does not route.
 
 Failures use the same v1 envelope with `success:false` and a stable `error.code`. This includes
 failed/declined signing and typed blocked/refusal/error turn endings; their partial turn data remains under `data`.
@@ -831,7 +831,7 @@ Orchestrators should branch on `code`. The message in `error` / `message` stays 
 | `ACK_FAILED`                | Transaction broadcast, but its immediate acknowledgement/report failed; hash is valid and must be inspected before retrying                                                   |
 | `BROADCAST_COMMITTED`       | At least one transaction broadcast, but the overall agent request may be incomplete; do not blindly retry                                                                     |
 | `AGENT_TURN_BLOCKED`        | A fund-safety guardrail blocked the requested action (exit 10)                                                                                                                |
-| `AGENT_TURN_REFUSAL`        | The model refused or requested clarification without completing the action (exit 11)                                                                                         |
+| `AGENT_TURN_REFUSAL`        | The model refused or requested clarification without completing the action (exit 11)                                                                                          |
 | `AGENT_TURN_ERROR`          | The typed turn ending reported a failure without a more specific stream error                                                                                                 |
 | `IDEMPOTENT_TURN_DUPLICATE` | The backend already accepted the same keyed turn; inspect the conversation for the original persisted result                                                                  |
 | `IDEMPOTENCY_KEY_REUSED`    | The idempotency key was already used for a _different_ request body. This request did NOT run and nothing was persisted for it — retry with a fresh key (exit code 4, not 14) |
@@ -900,7 +900,7 @@ The pipe interface uses NDJSON (one JSON object per line) on stdin/stdout. Desig
 | `tx_status`   | `tx_hash, chain, status, explorer_url?`         | Transaction broadcast/confirmed/failed                                                                   |
 | `assistant`   | `content`                                       | Full assistant response                                                                                  |
 | `suggestions` | `suggestions[]`                                 | Suggested follow-up actions                                                                              |
-| `warning`     | `warning: { code, message, count, eventTypes }` | Non-fatal protocol drift; an unknown SSE frame was ignored                                               |
+| `warning`     | `warning: { code, message, count, eventTypes }` | Non-fatal protocol drift; an unrecognized SSE frame was ignored (`--verbose` only)                       |
 | `error`       | `message, code`                                 | Error or control signal (`PASSWORD_REQUIRED`, `CONFIRMATION_REQUIRED: …`; always includes stable `code`) |
 | `done`        | `{}`                                            | Response cycle complete                                                                                  |
 
@@ -961,8 +961,14 @@ VULTISIG_SILENT=1
 # Bound agent-backend connection/unary requests (default: 30000ms)
 VULTISIG_HTTP_TIMEOUT_MS=30000
 
-# Bound an established SSE stream with no complete frame (default: 60000ms)
-VULTISIG_SSE_IDLE_TIMEOUT_MS=60000
+# Bound an established SSE stream that stops making PROGRESS (default: 180000ms).
+# Measures time since the last real data frame. Keep-alive comments do NOT extend
+# it — both backends heartbeat on a timer that runs regardless of whether the turn
+# is advancing, so a clock they reset would bound only a dead connection, never a
+# wedged backend. Sized above the backend's worst-case silent stretch (a model call
+# is bounded at 90s; the swap builder is documented at 90s + 60s MCP), so a slow but
+# healthy turn is never killed.
+VULTISIG_SSE_IDLE_TIMEOUT_MS=180000
 ```
 
 ### Settings

--- a/clients/cli/src/agent/__tests__/client.test.ts
+++ b/clients/cli/src/agent/__tests__/client.test.ts
@@ -253,51 +253,25 @@ describe('AgentClient.sendMessageStream', () => {
     expect(onMessage).toHaveBeenCalledTimes(1)
   })
 
-  it('reports unknown V1 frame types as protocol drift while keeping known telemetry quiet', async () => {
+  // H2 (review of #1305): unknown `data-*` kinds are FORWARD-COMPATIBLE by the
+  // backend's own V1 contract (`v1_wire_schema_test.go`) and some are emitted
+  // from a dynamic site — `V1Data(streamSurface, …)` over the mutable
+  // `genericCardSurfaces` map — that no static client list can track. Three
+  // enumeration passes each found types the last had missed. So a `data-*` card
+  // this CLI has no surface for is not drift: it is tolerated, quietly.
+  //
+  // The frames below are every UI-only card the two backends emit today (Go
+  // agent.go quick_actions/vault_required/diagnostics + the streamSurface cards;
+  // Go api/message.go checkout-wall; Mastra uiStream.ts agentStep) PLUS an
+  // invented surface no CLI list has ever heard of. The invented one is the
+  // point: under the old enumerate-everything design it stamped PROTOCOL_DRIFT
+  // on a successful turn, and no test could have caught it, because the whole
+  // failure mode is a surface that does not exist yet.
+  it('tolerates unknown data-* cards quietly, including surfaces no list knows about', async () => {
     const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
     globalThis.fetch = mockFetchSSE([
       'data: {"type":"start","messageId":"m-1"}\n\n',
       'data: {"type":"data-usage","data":{"total_tokens":10}}\n\n',
-      'data: {"type":"data-confirmation","data":{"required":true}}\n\n',
-      'data: {"type":"data-future-critical","data":{"value":1}}\n\n',
-      'data: {"type":"data-future-critical","data":{"value":2}}\n\n',
-      'data: {"type":"finish"}\n\n',
-    ])
-
-    const client = new AgentClient('http://example.com')
-    client.verbose = true
-    const result = await client.sendMessageStream('c1', { public_key: 'pk', content: 'hi' }, {})
-
-    expect(result.protocolWarnings).toEqual([
-      {
-        code: 'PROTOCOL_DRIFT',
-        message: 'Ignored 3 unknown SSE frames: data-confirmation, data-future-critical',
-        count: 3,
-        eventTypes: ['data-confirmation', 'data-future-critical'],
-      },
-    ])
-    expect(stderr).toHaveBeenCalledWith(expect.stringContaining('[SSE] unknown frame type: data-confirmation'))
-    expect(stderr).toHaveBeenCalledWith(expect.stringContaining('[SSE] unknown frame type: data-future-critical'))
-    expect(stderr).not.toHaveBeenCalledWith(expect.stringContaining('data-usage'))
-  })
-
-  // Frames a live backend emits on an ordinary turn. If any drops out of the
-  // 'ignore' list, `vsig agent ask --output json` stamps a PROTOCOL_DRIFT
-  // warning onto a SUCCESSFUL turn and machine consumers learn to filter the
-  // field away. Sources, all non-test emit sites:
-  //   Go  internal/service/agent/agent.go — quick_actions, vault_required,
-  //       diagnostics; plus V1Data(streamSurface, …) over genericCardSurfaces
-  //       (response_validator.go) — polymarket_markets, yield_opportunities,
-  //       yield_position
-  //   Go  internal/api/message.go — checkout-wall (credit exhaustion)
-  //   TS  agent-backend-ts/src/mastra/uiStream.ts — agentStep, one per tool step
-  // This list is only as good as that enumeration: the streamSurface site is
-  // dynamic, so a new backend card surface will NOT be caught by this test —
-  // it has to be added here and in mapV1EventType by hand.
-  it('keeps UI-only backend frames quiet instead of reporting them as protocol drift', async () => {
-    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
-    globalThis.fetch = mockFetchSSE([
-      'data: {"type":"start","messageId":"m-1"}\n\n',
       'data: {"type":"data-quick_actions","data":{"quick_actions":[]}}\n\n',
       'data: {"type":"data-vault_required","data":{"required":true}}\n\n',
       'data: {"type":"data-diagnostics","data":{"trace":"x"}}\n\n',
@@ -306,6 +280,10 @@ describe('AgentClient.sendMessageStream', () => {
       'data: {"type":"data-polymarket_markets","data":{"surface":"polymarket_markets"}}\n\n',
       'data: {"type":"data-yield_opportunities","data":{"surface":"yield_opportunities"}}\n\n',
       'data: {"type":"data-yield_position","data":{"surface":"yield_position"}}\n\n',
+      'data: {"type":"data-confirmation","data":{"required":true}}\n\n',
+      // A surface invented for this test — stands in for whatever the backend
+      // registers next. The CLI must not editorialise about it to machines.
+      'data: {"type":"data-surface_from_the_future","data":{"value":1}}\n\n',
       'data: {"type":"finish"}\n\n',
     ])
 
@@ -313,21 +291,62 @@ describe('AgentClient.sendMessageStream', () => {
     client.verbose = true
     const result = await client.sendMessageStream('c1', { public_key: 'pk', content: 'hi' }, {})
 
+    expect(result.finished).toBe(true)
     expect(result.protocolWarnings).toEqual([])
-    expect(stderr).not.toHaveBeenCalledWith(expect.stringContaining('unknown frame type'))
+    // Tolerated ≠ hidden: a developer running --verbose still sees them.
+    expect(stderr).toHaveBeenCalledWith(
+      expect.stringContaining('[SSE] tolerated unknown data frame: data-surface_from_the_future')
+    )
+    // ...but a frame we route (data-usage → 'ignore') is not even that.
+    expect(stderr).not.toHaveBeenCalledWith(expect.stringContaining('tolerated unknown data frame: data-usage'))
+  })
+
+  // A genuinely unexpected PROTOCOL-level frame (not a `data-*` card, so not
+  // covered by the forward-compat contract) is still recorded — but only under
+  // --verbose. PROTOCOL_DRIFT is a debug aid, not a machine contract: warning by
+  // default fires on healthy turns against a newer backend, and a detector that
+  // fires on ~every healthy turn is one automation learns to filter out.
+  it('records unknown non-data frames as drift only under verbose', async () => {
+    const frames = [
+      'data: {"type":"start","messageId":"m-1"}\n\n',
+      'data: {"type":"reasoning-delta","delta":"hmm"}\n\n',
+      'data: {"type":"reasoning-delta","delta":"hmm2"}\n\n',
+      'data: {"type":"finish"}\n\n',
+    ]
+
+    globalThis.fetch = mockFetchSSE([...frames])
+    const quiet = new AgentClient('http://example.com')
+    const quietResult = await quiet.sendMessageStream('c1', { public_key: 'pk', content: 'hi' }, {})
+    expect(quietResult.protocolWarnings).toEqual([])
+
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    globalThis.fetch = mockFetchSSE([...frames])
+    const loud = new AgentClient('http://example.com')
+    loud.verbose = true
+    const loudResult = await loud.sendMessageStream('c1', { public_key: 'pk', content: 'hi' }, {})
+    expect(loudResult.protocolWarnings).toEqual([
+      {
+        code: 'PROTOCOL_DRIFT',
+        message: 'Ignored 2 unknown SSE frames: reasoning-delta',
+        count: 2,
+        eventTypes: ['reasoning-delta'],
+      },
+    ])
   })
 
   // Frame `type` is backend-controlled and lands in the ask JSON envelope, so
   // both the number of distinct types and each type's length stay bounded.
   it('caps the distinct frame types recorded in a drift warning while keeping the count exact', async () => {
-    const frames = Array.from({ length: 25 }, (_, i) => `data: {"type":"data-junk-${i}","data":{}}\n\n`)
+    const frames = Array.from({ length: 25 }, (_, i) => `data: {"type":"junk-${i}"}\n\n`)
     globalThis.fetch = mockFetchSSE([
       'data: {"type":"start","messageId":"m-1"}\n\n',
       ...frames,
       'data: {"type":"finish"}\n\n',
     ])
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
 
     const client = new AgentClient('http://example.com')
+    client.verbose = true
     const result = await client.sendMessageStream('c1', { public_key: 'pk', content: 'hi' }, {})
 
     const [warning] = result.protocolWarnings
@@ -338,17 +357,150 @@ describe('AgentClient.sendMessageStream', () => {
   it('truncates an oversized frame type instead of echoing it whole', async () => {
     globalThis.fetch = mockFetchSSE([
       'data: {"type":"start","messageId":"m-1"}\n\n',
-      `data: {"type":"data-${'x'.repeat(500)}","data":{}}\n\n`,
+      `data: {"type":"${'x'.repeat(500)}"}\n\n`,
       'data: {"type":"finish"}\n\n',
     ])
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
 
     const client = new AgentClient('http://example.com')
+    client.verbose = true
     const result = await client.sendMessageStream('c1', { public_key: 'pk', content: 'hi' }, {})
 
     const [warning] = result.protocolWarnings
     expect(warning?.eventTypes).toHaveLength(1)
     expect(warning?.eventTypes[0]).toHaveLength(65)
     expect(warning?.eventTypes[0]).toMatch(/…$/)
+  })
+
+  // H2, the dangerous half. `tool-output-error` is the backend's explicit tool
+  // FAILURE terminal (`V1ToolOutputError`, protocol_v1.go). Ignoring it is not a
+  // display gap: the call gets no terminal frame at all, so the tool never
+  // reports done, the turn records no failure, and — in the backend's own words
+  // — that "lets the LLM's same-turn prose claim success even though no action
+  // ever ran". It must land as a done/ok:false tool result, the same typed
+  // failure shape `tool-output-available` with an error payload produces.
+  it('surfaces tool-output-error as a failed tool result, not silence', async () => {
+    const onToolProgress = vi.fn()
+    globalThis.fetch = mockFetchSSE([
+      'data: {"type":"tool-input-available","toolCallId":"call-1","toolName":"execute_swap","input":{}}\n\n',
+      'data: {"type":"tool-output-error","toolCallId":"call-1","errorText":"swap builder timed out"}\n\n',
+      'data: {"type":"finish"}\n\n',
+    ])
+
+    const client = new AgentClient('http://example.com')
+    const result = await client.sendMessageStream('c1', { public_key: 'pk', content: 'hi' }, { onToolProgress })
+
+    // toolName is resolved from the toolCallId cache — the frame carries only
+    // toolCallId + errorText, never a name.
+    expect(onToolProgress).toHaveBeenCalledWith('execute_swap', 'done', undefined, false)
+    // Not drift — it is a frame we now handle.
+    expect(result.protocolWarnings).toEqual([])
+  })
+
+  // Fund-safety: the error terminal reports status 'done', which is the same
+  // status that gates the tool-output→sign bridge. A FAILED tool must never
+  // produce a signable candidate.
+  it('never derives a signable candidate from a tool-output-error', async () => {
+    const onToolOutputTx = vi.fn()
+    globalThis.fetch = mockFetchSSE([
+      'data: {"type":"tool-input-available","toolCallId":"call-1","toolName":"execute_swap","input":{}}\n\n',
+      'data: {"type":"tool-output-error","toolCallId":"call-1","errorText":"boom"}\n\n',
+      'data: {"type":"finish"}\n\n',
+    ])
+
+    const client = new AgentClient('http://example.com')
+    await client.sendMessageStream('c1', { public_key: 'pk', content: 'hi' }, { onToolOutputTx })
+
+    expect(onToolOutputTx).not.toHaveBeenCalled()
+  })
+
+  // H2, the other dangerous half — and the sharpest one. The backend emits
+  // `text-replace` precisely when it has decided the prose it already streamed
+  // is WRONG and must be discarded (protocol_v1.go: a client "MUST locate the
+  // existing part with id==replaces and overwrite its text"). Ignoring it means
+  // `fullText` — which session.ts turns into `responseText`, the `response`
+  // field of `agent ask --output json` — keeps the RETRACTED claim. On current
+  // main this test's stream answers "I sent your 5 ETH." after the backend
+  // retracted exactly that sentence.
+  it('applies text-replace so the turn answers with the corrected text, not the retracted one', async () => {
+    globalThis.fetch = mockFetchSSE([
+      'data: {"type":"text-start","id":"t1"}\n\n',
+      'data: {"type":"text-delta","id":"t1","delta":"I sent your 5 ETH."}\n\n',
+      'data: {"type":"text-end","id":"t1"}\n\n',
+      'data: {"type":"text-replace","replaces":"t1","text":"I could not send your ETH."}\n\n',
+      'data: {"type":"finish"}\n\n',
+    ])
+
+    const client = new AgentClient('http://example.com')
+    const result = await client.sendMessageStream('c1', { public_key: 'pk', content: 'hi' }, {})
+
+    expect(result.fullText).toBe('I could not send your ETH.')
+    expect(result.protocolWarnings).toEqual([])
+  })
+
+  it('replaces only the retracted part, preserving surrounding parts and their order', async () => {
+    globalThis.fetch = mockFetchSSE([
+      'data: {"type":"text-delta","id":"t1","delta":"First. "}\n\n',
+      'data: {"type":"text-delta","id":"t2","delta":"WRONG."}\n\n',
+      'data: {"type":"text-delta","id":"t3","delta":" Last."}\n\n',
+      'data: {"type":"text-replace","replaces":"t2","text":"Right."}\n\n',
+      'data: {"type":"finish"}\n\n',
+    ])
+
+    const client = new AgentClient('http://example.com')
+    const result = await client.sendMessageStream('c1', { public_key: 'pk', content: 'hi' }, {})
+
+    expect(result.fullText).toBe('First. Right. Last.')
+  })
+
+  // Degrade safely, never half-apply. A stream whose deltas carried no `id`
+  // cannot be recomposed from parts without DROPPING that prose, so the
+  // replacement is declined and the text stands as streamed — something the
+  // backend actually said — rather than being partially rebuilt.
+  it('declines a text-replace it cannot apply rather than corrupting the text', async () => {
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    globalThis.fetch = mockFetchSSE([
+      // Legacy/id-less delta: not attributable to a part.
+      'data: {"type":"text-delta","delta":"streamed prose"}\n\n',
+      'data: {"type":"text-replace","replaces":"t1","text":"correction"}\n\n',
+      'data: {"type":"finish"}\n\n',
+    ])
+
+    const client = new AgentClient('http://example.com')
+    client.verbose = true
+    const result = await client.sendMessageStream('c1', { public_key: 'pk', content: 'hi' }, {})
+
+    expect(result.fullText).toBe('streamed prose')
+    expect(stderr).toHaveBeenCalledWith(expect.stringContaining('[SSE] text-replace not applied'))
+  })
+
+  it('declines a text-replace targeting a part it never saw', async () => {
+    globalThis.fetch = mockFetchSSE([
+      'data: {"type":"text-delta","id":"t1","delta":"hello"}\n\n',
+      'data: {"type":"text-replace","replaces":"nonexistent","text":"correction"}\n\n',
+      'data: {"type":"finish"}\n\n',
+    ])
+
+    const client = new AgentClient('http://example.com')
+    const result = await client.sendMessageStream('c1', { public_key: 'pk', content: 'hi' }, {})
+
+    expect(result.fullText).toBe('hello')
+  })
+
+  it('keeps start-step quiet instead of reporting it as drift', async () => {
+    globalThis.fetch = mockFetchSSE([
+      'data: {"type":"start","messageId":"m-1"}\n\n',
+      'data: {"type":"start-step"}\n\n',
+      'data: {"type":"text-delta","id":"t1","delta":"hi"}\n\n',
+      'data: {"type":"finish-step"}\n\n',
+      'data: {"type":"finish"}\n\n',
+    ])
+
+    const client = new AgentClient('http://example.com')
+    const result = await client.sendMessageStream('c1', { public_key: 'pk', content: 'hi' }, {})
+
+    expect(result.protocolWarnings).toEqual([])
+    expect(result.fullText).toBe('hi')
   })
 
   it('derives tool_progress status from v1 frame type and resolves toolName via toolCallId cache', async () => {
@@ -968,7 +1120,7 @@ describe('AgentClient — request timeouts (headless-hang guard)', () => {
     expect(error).toBeInstanceOf(AgentStreamIdleTimeoutError)
     expect(normalizeAgentError(error)).toEqual({
       code: AgentErrorCode.TIMEOUT,
-      message: 'SSE stream idle timeout after 50ms without a frame',
+      message: 'SSE stream idle timeout after 50ms without progress',
     })
     expect(agentErrorCodeToExitCode(AgentErrorCode.TIMEOUT)).toBe(ExitCode.NETWORK)
     vi.useRealTimers()
@@ -997,28 +1149,83 @@ describe('AgentClient — request timeouts (headless-hang guard)', () => {
     vi.useRealTimers()
   })
 
-  it('resets the SSE idle deadline on keep-alive frames', async () => {
+  // H1 (review of #1305): the deadline exists to bound a HUNG BACKEND. Both
+  // backends heartbeat from a ticker that runs independently of turn progress
+  // (Go `internal/api/message.go` writes `": ping"` every 15s from a safego
+  // goroutine; Mastra `withSseHeartbeat(resp, 15_000)`), so a clock that
+  // keep-alives reset bounds only a dead transport — the wedged backend pings
+  // forever and `agent ask` hangs exactly as it did pre-#1305. This test
+  // replaces one that asserted the opposite (keep-alives DO reset), which
+  // encoded the defect as the contract.
+  it('bounds a heartbeating-but-wedged backend: keep-alives do not defer the deadline', async () => {
     vi.useFakeTimers()
     const encoder = new TextEncoder()
     let controller!: ReadableStreamDefaultController<Uint8Array>
     const stream = new ReadableStream<Uint8Array>({
       start(c) {
         controller = c
-        c.enqueue(encoder.encode(': keep-alive\n\n'))
+        // The turn starts and produces real output, then the agent loop wedges
+        // and only the heartbeat goroutine keeps writing.
+        c.enqueue(encoder.encode('data: {"type":"text-delta","id":"t1","delta":"thinking"}\n\n'))
       },
     })
     globalThis.fetch = vi.fn(async () => new Response(stream, { status: 200 })) as typeof fetch
 
     const client = new AgentClient('http://example.com', 60_000, 50)
     const pending = client.sendMessageStream('c1', { public_key: 'pk', content: 'hi' }, {})
-    await vi.advanceTimersByTimeAsync(40)
-    controller.enqueue(encoder.encode(': keep-alive\n\n'))
-    await Promise.resolve()
-    await vi.advanceTimersByTimeAsync(40)
+    const caught = pending.catch((error: unknown) => error)
+
+    // Pings at 40ms against a 50ms deadline — the real 15s/180s ratio is far
+    // wider, so this is a conservative stand-in for "heartbeating forever".
+    for (let i = 0; i < 3; i++) {
+      await vi.advanceTimersByTimeAsync(40)
+      // Once the deadline fires the reader is cancelled and the stream closes;
+      // stop pinging then, exactly as the real backend's heartbeat exits on a
+      // write error to a dead socket.
+      try {
+        controller.enqueue(encoder.encode(': ping\n\n'))
+      } catch {
+        break
+      }
+      await Promise.resolve()
+    }
+
+    await expect(caught).resolves.toBeInstanceOf(AgentStreamIdleTimeoutError)
+    vi.useRealTimers()
+  })
+
+  // The no-false-positive property the review verified must survive the change:
+  // a turn that is SLOW but genuinely progressing still resets the clock, since
+  // real data frames — unlike comments — prove the agent loop advanced.
+  it('does not time out a slow-but-progressing turn', async () => {
+    vi.useFakeTimers()
+    const encoder = new TextEncoder()
+    let controller!: ReadableStreamDefaultController<Uint8Array>
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) {
+        controller = c
+      },
+    })
+    globalThis.fetch = vi.fn(async () => new Response(stream, { status: 200 })) as typeof fetch
+
+    const client = new AgentClient('http://example.com', 60_000, 50)
+    const pending = client.sendMessageStream('c1', { public_key: 'pk', content: 'hi' }, {})
+
+    // 4 × 40ms = 160ms of wall clock, 3× the 50ms deadline — survived only
+    // because each frame is real progress.
+    for (let i = 0; i < 4; i++) {
+      await vi.advanceTimersByTimeAsync(40)
+      controller.enqueue(encoder.encode(`data: {"type":"text-delta","id":"t1","delta":"tick"}\n\n`))
+      await Promise.resolve()
+    }
     controller.enqueue(encoder.encode('data: {"type":"finish"}\n\n'))
     controller.close()
 
-    await expect(pending).resolves.toMatchObject({ finished: true, disconnected: false })
+    await expect(pending).resolves.toMatchObject({
+      finished: true,
+      disconnected: false,
+      fullText: 'ticktickticktick',
+    })
     vi.useRealTimers()
   })
 })
@@ -1055,15 +1262,19 @@ describe('resolveSseIdleTimeoutMs (VULTISIG_SSE_IDLE_TIMEOUT_MS parsing)', () =>
     else process.env.VULTISIG_SSE_IDLE_TIMEOUT_MS = original
   })
 
-  it('defaults to 60000ms, safely above the backend keep-alive cadence', () => {
+  // 180s, not the previous 60s: now that keep-alives no longer defer the
+  // deadline it measures real backend SILENCE, and a healthy turn is documented
+  // to be silent for up to ~150s (claudeRequestTimeout 90s + 60s MCP). It stays
+  // below the backend's own 5min agentTurnMaxDuration so a wedge is still bounded.
+  it('defaults to 180000ms, above the backend worst-case silent stretch', () => {
     delete process.env.VULTISIG_SSE_IDLE_TIMEOUT_MS
-    expect(resolveSseIdleTimeoutMs()).toBe(60_000)
+    expect(resolveSseIdleTimeoutMs()).toBe(180_000)
   })
 
   it('honors a valid positive override and rejects disabling typos', () => {
     process.env.VULTISIG_SSE_IDLE_TIMEOUT_MS = '90000'
     expect(resolveSseIdleTimeoutMs()).toBe(90_000)
     process.env.VULTISIG_SSE_IDLE_TIMEOUT_MS = '0'
-    expect(resolveSseIdleTimeoutMs()).toBe(60_000)
+    expect(resolveSseIdleTimeoutMs()).toBe(180_000)
   })
 })

--- a/clients/cli/src/agent/client.ts
+++ b/clients/cli/src/agent/client.ts
@@ -47,7 +47,7 @@ export function createTurnIdempotencyKey(): string {
 /** Default per-request timeout (ms) for agent-backend HTTP calls. Bounds a
  *  stalled TCP connection so a headless `vsig agent` run can't hang forever. */
 const DEFAULT_HTTP_TIMEOUT_MS = 30_000
-const DEFAULT_SSE_IDLE_TIMEOUT_MS = 60_000
+const DEFAULT_SSE_IDLE_TIMEOUT_MS = 180_000
 /** Bounds on the backend-controlled frame types recorded in a PROTOCOL_DRIFT warning. */
 const MAX_DRIFT_EVENT_TYPES = 10
 const MAX_DRIFT_TYPE_LENGTH = 64
@@ -62,9 +62,23 @@ export function resolveHttpTimeoutMs(): number {
   return Number.isFinite(n) && n > 0 ? n : DEFAULT_HTTP_TIMEOUT_MS
 }
 
-/** Maximum time between complete SSE frames. The backend emits keep-alive
- * comments every 15s, so 60s tolerates several delayed heartbeats while still
- * bounding a dead established stream. */
+/** Maximum time an established SSE stream may go without PROGRESS — a completed
+ * data frame. Keep-alive comments do NOT extend it: both backends emit those
+ * from a ticker that runs independently of turn progress (Go
+ * `internal/api/message.go`, a `safego.Go` heartbeat writing `": ping"` every
+ * 15s; Mastra `uiStream.ts` `withSseHeartbeat(resp, 15_000)`), so a backend
+ * wedged in a model/MCP call heartbeats forever. A comment-reset clock therefore
+ * bounds only a DEAD TRANSPORT, never the hung backend this deadline exists to
+ * catch.
+ *
+ * The default is sized against the backend's own worst-case SILENT stretch, not
+ * its heartbeat cadence: a single model call is bounded by `claudeRequestTimeout`
+ * (90s, `agent.go`) and the swap builder is documented at "90s + 60s MCP timeout"
+ * (`message.go`) — ~150s during which a healthy turn emits no frame at all. 180s
+ * clears that with margin while still sitting below the backend's own
+ * `agentTurnMaxDuration` (5min, `detach.go`), so a wedged turn is bounded here
+ * rather than never. Raising this from the previous 60s is required by the
+ * semantic change: 60s of no-frames was safe only because comments reset it. */
 export function resolveSseIdleTimeoutMs(): number {
   const raw = process.env.VULTISIG_SSE_IDLE_TIMEOUT_MS
   if (raw === undefined || raw.trim() === '') return DEFAULT_SSE_IDLE_TIMEOUT_MS
@@ -76,7 +90,7 @@ export class AgentStreamIdleTimeoutError extends Error {
   readonly code = AgentErrorCode.TIMEOUT
 
   constructor(readonly timeoutMs: number) {
-    super(`SSE stream idle timeout after ${timeoutMs}ms without a frame`)
+    super(`SSE stream idle timeout after ${timeoutMs}ms without progress`)
     this.name = 'AgentStreamIdleTimeoutError'
   }
 }
@@ -133,7 +147,13 @@ function v1StatusFromType(type: string | null): 'running' | 'done' | undefined {
     case 'tool-input-available':
     case 'tool-input-delta':
       return 'running'
+    // Both terminal frames close the tool call. `tool-output-error` is the
+    // backend's explicit failure terminal (`V1ToolOutputError`): without it the
+    // call has no terminal frame at all, so the tool card stays 'running'
+    // forever and the turn reports no failure — "which lets the LLM's same-turn
+    // prose claim success even though no action ever ran" (protocol_v1.go).
     case 'tool-output-available':
+    case 'tool-output-error':
       return 'done'
     default:
       return undefined
@@ -149,15 +169,25 @@ function isErrorPayloadObject(o: Record<string, unknown>): boolean {
 }
 
 /**
- * Derive real tool success from the terminal-frame output payload
- * (fund-safety bug #B). Returns false when the payload signals an error
- * ({"status":"error"} / {"error":...} / stringified), true on a clean
- * result, and undefined when there's nothing to judge (not the 'done'
- * frame, or no output — older backends) so the consumer keeps its prior
- * optimistic default. Extracted from handleSSEEvent to keep that
+ * Derive real tool success from the terminal frame (fund-safety bug #B).
+ * Returns false for an explicit `tool-output-error` frame or an output payload
+ * that signals an error ({"status":"error"} / {"error":...} / stringified),
+ * true on a clean result, and undefined when there's nothing to judge (not a
+ * terminal frame, or no output — older backends) so the consumer keeps its
+ * prior optimistic default. Extracted from handleSSEEvent to keep that
  * function under the cognitive-complexity budget.
  */
-function deriveToolDoneOk(status: 'running' | 'done' | undefined, output: unknown): boolean | undefined {
+function deriveToolDoneOk(
+  status: 'running' | 'done' | undefined,
+  output: unknown,
+  v1Type: string | null
+): boolean | undefined {
+  // A `tool-output-error` frame IS the failure signal. It carries `errorText`
+  // and never `output`, so the payload heuristics below have nothing to judge
+  // and would return undefined — which the consumer reads as the optimistic
+  // `ok ?? true` default, i.e. it would report a FAILED tool as successful.
+  // Decide from the frame type itself, before any payload inspection.
+  if (v1Type === 'tool-output-error') return false
   if (status !== 'done' || output == null) return undefined
   if (typeof output === 'object') {
     return !isErrorPayloadObject(output as Record<string, unknown>)
@@ -178,6 +208,37 @@ function deriveToolDoneOk(status: 'running' | 'done' | undefined, output: unknow
     return !(/"status"\s*:\s*"error"/i.test(s) || /"error"\s*:/i.test(s))
   }
   return true
+}
+
+/**
+ * Per-stream text-part accumulator. The V1 text protocol streams prose as
+ * ordered parts — `text-start` / `text-delta` / `text-end`, each carrying an
+ * `id` (`protocol_v1.go` V1TextStart/V1TextDelta) — and `text-replace` RETRACTS
+ * one of those parts, supplying corrected text. Its contract is explicit: a
+ * client "MUST locate the existing part with id==replaces and overwrite its
+ * text, discarding the rejected text". Tracking parts by id is what lets that
+ * overwrite land in place, mirroring the backend's own composition
+ * (`unified_loop.go`), instead of appending a second contradictory bubble — or,
+ * as before this fix, silently keeping the retracted text as the turn's answer.
+ */
+type TextParts = {
+  byId: Map<string, string>
+  order: string[]
+  /** False once any `text-delta` arrived without an `id`. Such a stream cannot
+   *  be recomposed from parts without dropping the un-keyed prose, so a
+   *  `text-replace` against it is DEGRADED (logged, not applied) rather than
+   *  half-applied. */
+  allIdentified: boolean
+}
+
+function newTextParts(): TextParts {
+  return { byId: new Map(), order: [], allIdentified: true }
+}
+
+function recomposeText(parts: TextParts): string {
+  let out = ''
+  for (const id of parts.order) out += parts.byId.get(id) ?? ''
+  return out
 }
 
 function sseErrorToMessage(value: unknown): string {
@@ -493,6 +554,9 @@ export class AgentClient {
     // terminal 'done' callback still carries the tool name.
     const toolNameByCallId = new Map<string, string>()
 
+    // Ordered text parts, so a `text-replace` can overwrite what it retracts.
+    const textParts = newTextParts()
+
     const reader = res.body.getReader()
     const decoder = new TextDecoder()
     let buffer = ''
@@ -503,6 +567,15 @@ export class AgentClient {
     /** Strip optional single leading space from an SSE field value per spec. */
     const stripLeadingSpace = (v: string): string => (v.length > 0 && v[0] === ' ' ? v.slice(1) : v)
 
+    /**
+     * Returns true only when the line completed a real data frame — i.e. the
+     * backend made PROGRESS. That is the sole signal allowed to defer the idle
+     * deadline. Keep-alive comments and blank separators return false: they
+     * prove the TRANSPORT is alive (and are still consumed normally, so the
+     * connection is never torn down for carrying them), but they say nothing
+     * about whether the agent loop is advancing, because both backends emit
+     * them from progress-independent tickers.
+     */
     const processLine = (raw: string): boolean => {
       const line = raw.endsWith('\r') ? raw.slice(0, -1) : raw
       if (line.startsWith('event:')) {
@@ -514,16 +587,14 @@ export class AgentClient {
         const completedFrame = currentData.length > 0
         if (currentData) {
           // SSE spec: default event type is "message" when no event: field is present
-          this.handleSSEEvent(currentEvent || 'message', currentData, result, callbacks, toolNameByCallId)
+          this.handleSSEEvent(currentEvent || 'message', currentData, result, callbacks, toolNameByCallId, textParts)
         }
         currentEvent = ''
         currentData = ''
         return completedFrame
-      } else if (line[0] === ':') {
-        // SSE comment (keep-alive ping) - ignore
-        return true
       }
-      // Unknown fields (id:, retry:, etc.) silently ignored - no reconnection support.
+      // SSE comments (`:` keep-alive pings), unknown fields (id:, retry:, etc.)
+      // and blank separators are consumed but are NOT progress.
       // Bare \r line endings are unsupported (only \n and \r\n).
       return false
     }
@@ -550,7 +621,7 @@ export class AgentClient {
           if (trailing && processLine(trailing)) lastFrameAt = Date.now()
           // Flush any pending event (stream ended without final blank line)
           if (currentData) {
-            this.handleSSEEvent(currentEvent || 'message', currentData, result, callbacks, toolNameByCallId)
+            this.handleSSEEvent(currentEvent || 'message', currentData, result, callbacks, toolNameByCallId, textParts)
           }
           break
         }
@@ -604,7 +675,8 @@ export class AgentClient {
     data: string,
     result: SSEStreamResult,
     callbacks: StreamCallbacks,
-    toolNameByCallId: Map<string, string>
+    toolNameByCallId: Map<string, string>,
+    textParts: TextParts
   ): void {
     try {
       const parsed = JSON.parse(data)
@@ -621,7 +693,10 @@ export class AgentClient {
 
       switch (routingEvent) {
         case 'text_delta':
-          this.handleTextDelta(parsed, result, callbacks)
+          this.handleTextDelta(parsed, result, callbacks, textParts)
+          break
+        case 'text_replace':
+          this.handleTextReplace(parsed, result, textParts)
           break
         case 'tool_progress':
           this.handleToolProgress(parsed, data, callbacks, toolNameByCallId, v1Type)
@@ -668,6 +743,13 @@ export class AgentClient {
           break
         case 'ignore':
           break
+        case 'tolerated':
+          // An unknown `data-*` card. The backend evolves these forward-compatibly
+          // and emits some from a dynamic site, so this is expected traffic
+          // against a newer backend, not a defect: visible to a developer under
+          // --verbose, invisible to machine callers.
+          if (this.verbose) process.stderr.write(`[SSE] tolerated unknown data frame: ${v1Type}\n`)
+          break
         default:
           this.recordProtocolDrift(v1Type ?? event, result)
       }
@@ -680,12 +762,23 @@ export class AgentClient {
     }
   }
 
-  // `type` is backend-controlled wire content that lands in the ask JSON, so it
-  // is bounded on both axes: a malformed backend emitting many long, distinct
-  // types would otherwise grow `eventTypes` without limit and re-join it on
-  // every frame. `count` stays exact — only the type list is capped.
+  // PROTOCOL_DRIFT is a DEBUG signal, not a machine-consumer contract, so it
+  // rides the result envelope only under --verbose. The backend deliberately
+  // evolves the wire forward-compatibly; warning by default therefore fires on
+  // healthy turns against a newer backend, and a drift detector that fires on
+  // ~every healthy turn is one machine consumers learn to filter out — worse
+  // than not shipping it. Unknown `data-*` cards never reach here at all (they
+  // route to 'tolerated'); this is now only for genuinely unexpected
+  // protocol-level frames.
+  //
+  // `type` is backend-controlled wire content, so it stays bounded on both axes:
+  // a malformed backend emitting many long, distinct types would otherwise grow
+  // `eventTypes` without limit and re-join it on every frame. `count` stays
+  // exact — only the type list is capped.
   private recordProtocolDrift(rawType: string, result: SSEStreamResult): void {
+    if (!this.verbose) return
     const type = rawType.length > MAX_DRIFT_TYPE_LENGTH ? `${rawType.slice(0, MAX_DRIFT_TYPE_LENGTH)}…` : rawType
+    process.stderr.write(`[SSE] unknown frame type: ${type}\n`)
     let warning = result.protocolWarnings[0]
     if (!warning) {
       warning = { code: 'PROTOCOL_DRIFT', message: '', count: 0, eventTypes: [] }
@@ -697,13 +790,60 @@ export class AgentClient {
     }
     const noun = warning.count === 1 ? 'frame' : 'frames'
     warning.message = `Ignored ${warning.count} unknown SSE ${noun}: ${warning.eventTypes.join(', ')}`
-    if (this.verbose) process.stderr.write(`[SSE] unknown frame type: ${type}\n`)
   }
 
-  private handleTextDelta(parsed: SSEPayload, result: SSEStreamResult, callbacks: StreamCallbacks): void {
+  private handleTextDelta(
+    parsed: SSEPayload,
+    result: SSEStreamResult,
+    callbacks: StreamCallbacks,
+    textParts: TextParts
+  ): void {
     if (typeof parsed.delta !== 'string') return
+    // Live append is unchanged — the TTY streams as it arrives. The part map is
+    // kept in parallel purely so a later `text-replace` can rewrite `fullText`
+    // (the turn's authoritative answer, see session.ts `responseText`).
     result.fullText += parsed.delta
     callbacks.onTextDelta?.(parsed.delta)
+
+    const id = typeof parsed.id === 'string' && parsed.id.length > 0 ? parsed.id : null
+    if (!id) {
+      textParts.allIdentified = false
+      return
+    }
+    if (!textParts.byId.has(id)) textParts.order.push(id)
+    textParts.byId.set(id, (textParts.byId.get(id) ?? '') + parsed.delta)
+  }
+
+  /**
+   * Apply a `text-replace`: overwrite the retracted part in place and recompose
+   * `fullText` from the ordered parts. This is the truthful-outcome case — the
+   * backend emits this frame precisely when it has decided the streamed prose is
+   * WRONG, so keeping the retracted text means `agent ask` answers with the
+   * claim the backend just withdrew.
+   *
+   * The live TTY has already printed the retracted text and cannot unprint it,
+   * but the corrected `fullText` still lands: session.ts renders the final
+   * assistant message from it after the stream, and it is the `response` field
+   * of `agent ask --output json`.
+   */
+  private handleTextReplace(parsed: SSEPayload, result: SSEStreamResult, textParts: TextParts): void {
+    const replaces = typeof parsed.replaces === 'string' ? parsed.replaces : ''
+    const text = typeof parsed.text === 'string' ? parsed.text : null
+    // Degrade safely rather than half-apply. Recomposing a stream that carried
+    // un-keyed deltas would DROP that prose, and replacing a part we never saw
+    // would invent ordering — both are worse than leaving the text as streamed,
+    // which is at least something the backend actually said.
+    if (text === null || !replaces || !textParts.allIdentified || !textParts.byId.has(replaces)) {
+      if (this.verbose) {
+        process.stderr.write(
+          `[SSE] text-replace not applied (replaces=${replaces || '<missing>'}); text left as streamed\n`
+        )
+      }
+      return
+    }
+    textParts.byId.set(replaces, text)
+    result.fullText = recomposeText(textParts)
+    if (this.verbose) process.stderr.write(`[SSE] text-replace applied to part ${replaces}\n`)
   }
 
   private handleToolProgress(
@@ -725,9 +865,9 @@ export class AgentClient {
     const label = typeof parsed.label === 'string' ? parsed.label : undefined
     this.maybeEmitClientSideToolCall(parsed, callbacks, v1Type, callId, toolName)
 
-    const ok = deriveToolDoneOk(status, parsed.output)
+    const ok = deriveToolDoneOk(status, parsed.output, v1Type)
     if (status && toolName) callbacks.onToolProgress?.(toolName, status, label, ok)
-    this.maybeSignToolOutput(status, toolName, parsed.output, callbacks)
+    this.maybeSignToolOutput(status, toolName, parsed.output, callbacks, v1Type)
     if (status === 'done' && callId) toolNameByCallId.delete(callId)
   }
 
@@ -744,8 +884,15 @@ export class AgentClient {
     status: 'running' | 'done' | undefined,
     toolName: string | undefined,
     output: unknown,
-    callbacks: StreamCallbacks
+    callbacks: StreamCallbacks,
+    v1Type: string | null
   ): void {
+    // `tool-output-error` is a terminal ('done') frame, so it reaches here — but
+    // it reports a tool that FAILED and carries no output. deriveToolOutputCandidate
+    // would return null for its absent payload anyway; this guard is explicit so
+    // the fail-closed property is stated at the signing boundary rather than
+    // resting on a null-check three calls away.
+    if (v1Type === 'tool-output-error') return
     if (status !== 'done' || !toolName || !callbacks.onToolOutputTx) return
     if (!CLI_SIGNABLE_FLAT_TOOLS.has(toolName) && !CLI_SIGNABLE_PREP_TOOLS.has(toolName)) return
     const candidate = deriveToolOutputCandidate(toolName, output)
@@ -791,36 +938,39 @@ export class AgentClient {
     callbacks.onError?.(msg, codeFromBackend)
   }
 
-  // Maps a V1 `type` field to the legacy event bucket used by handleSSEEvent's
-  // switch. Frame-level types (start, text-start, text-end, finish-step) and
-  // known frame-level lifecycle and non-critical telemetry route to 'ignore'.
-  // `data-tx_ready` also routes to 'ignore':
-  // #927 Phase 2 signs purely from `tool-output-available`, and production emits
-  // `data-tx_ready` only as a hollow `{typed_confirm}` marker the CLI doesn't use.
+  // Maps a V1 `type` field to the event bucket used by handleSSEEvent's switch.
   //
-  // The 'ignore' list must cover EVERY frame both backends actually emit, or a
-  // healthy turn reports PROTOCOL_DRIFT. UI-only frames the CLI has no surface
-  // for: `data-quick_actions` / `data-vault_required` / `data-diagnostics`
-  // (Go, agent.go), `data-checkout-wall` (Go, api/message.go, on credit
-  // exhaustion) and `data-agentStep` (Mastra, uiStream.ts — one per tool step).
-  // `data-confirmation` is deliberately NOT here: it appears only in backend
-  // tests, so a real one is genuine drift and must stay loud.
+  // This enumerates what the CLI HANDLES, not what the backends can emit — the
+  // inverse of the original design. Enumerating the latter is unwinnable by
+  // construction: the frames are produced by two independently-evolving backends
+  // including a DYNAMIC site, `V1Data(streamSurface, …)` (agent.go) over the
+  // mutable `genericCardSurfaces` map (response_validator.go), and three
+  // successive enumeration passes each found types the last had missed. The
+  // backend's V1 contract also treats unknown data kinds as forward-compatible
+  // by design (`v1_wire_schema_test.go`), so a `data-*` kind this CLI has no
+  // surface for is simply a card it does not render — not drift. Those fall to
+  // `default` → 'tolerated' and stay quiet; no list here pretends to be complete.
   //
-  // The generic-card surfaces below are emitted from a DYNAMIC call site —
-  // `V1Data(streamSurface, …)` (agent.go) over the backend's
-  // `genericCardSurfaces` map (response_validator.go). A static list cannot
-  // track that map, so a new backend surface will drift here until it is added
-  // on both sides; the backend's own comment already says new surfaces must be
-  // registered in two places, and this is now a third. See the review's open
-  // question on whether unknown `data-*` should be tolerated by contract.
+  // What must be explicit instead is the small set of KNOWN-DANGEROUS frames —
+  // the ones whose omission is not a display gap but a false turn result:
+  //   • `tool-output-error` — the tool-failure terminal. Ignored, a failed tool
+  //     never closes and the turn reports success.
+  //   • `text-replace` — retracts prose the backend has decided is wrong.
+  //     Ignored, the RETRACTED text stays as the turn's answer.
+  // `data-tx_ready` routes to 'ignore' deliberately: #927 Phase 2 signs purely
+  // from `tool-output-available`, and production emits `data-tx_ready` only as a
+  // hollow `{typed_confirm}` marker the CLI doesn't use.
   private mapV1EventType(type: string): string {
     switch (type) {
       case 'text-delta':
         return 'text_delta'
+      case 'text-replace':
+        return 'text_replace'
       case 'tool-input-start':
       case 'tool-input-available':
       case 'tool-input-delta':
       case 'tool-output-available':
+      case 'tool-output-error':
         return 'tool_progress'
       case 'data-title':
         return 'title'
@@ -836,24 +986,30 @@ export class AgentClient {
         return 'error'
       case 'finish':
         return 'done'
+      // Frame-level lifecycle the CLI has no surface for. These are NOT data
+      // cards, so they can't ride the forward-compatible `data-*` tolerance —
+      // they must be named to stay quiet.
       case 'start':
+      case 'start-step':
       case 'text-start':
       case 'text-end':
       case 'finish-step':
+        return 'ignore'
+      // Known per-turn telemetry cards. These WOULD be tolerated by the
+      // `data-*` rule below, so naming them is not load-bearing — unlike the old
+      // design, forgetting one costs a --verbose log line, not a PROTOCOL_DRIFT
+      // stamped on a healthy turn. They are named only because they arrive on
+      // essentially every turn and calling them "unknown" in the verbose log
+      // would be both noisy and untrue.
       case 'data-tokens':
       case 'data-usage':
       case 'data-tx_ready':
-      case 'data-quick_actions':
-      case 'data-vault_required':
-      case 'data-diagnostics':
-      case 'data-checkout-wall':
-      case 'data-agentStep':
-      case 'data-polymarket_markets':
-      case 'data-yield_opportunities':
-      case 'data-yield_position':
         return 'ignore'
       default:
-        return 'unknown'
+        // Unknown `data-*` card → tolerated by the backend's forward-compat
+        // contract. Anything else is a protocol-level frame we genuinely did not
+        // expect → drift (verbose only; see recordProtocolDrift).
+        return type.startsWith('data-') ? 'tolerated' : 'unknown'
     }
   }
 


### PR DESCRIPTION
Follow-up to #1305. That PR added an SSE idle deadline and unknown-frame reporting to the agent channel; review found the deadline couldn't detect the failure it was added for, and that the frame handling was missing three types — two of which carry semantics the turn result depends on. Both are still reproducible on current `main` (#1305 is merged; 2c1c6568 fixed the blank-line path only).

## H1 — the idle deadline didn't bound a hung backend

The deadline exists because "a hung backend wedges `agent ask` forever". But keep-alive comments reset it, and both backends emit those from a ticker that runs independently of turn progress — `internal/api/message.go` writes `": ping"` every 15s from a heartbeat goroutine (its comment says it's there to survive a 90s swap build), and Mastra does the same via `withSseHeartbeat(resp, 15_000)`. So a backend wedged in a model or MCP call keeps pinging, the clock keeps resetting, and the CLI hangs exactly as it did before. Only a dead transport was ever bounded.

Verified before changing anything: one data frame, then comment-only pings at 40ms against a 50ms deadline — unsettled after 400ms (8x the deadline). The existing test suite missed this because both it and the e2e lane used a **no-frames** stream, which is the transport-death case.

Now only real data frames defer the deadline. Comments are still consumed normally — they prove the transport is alive; they just don't prove the agent loop is.

**The default rises 60s → 180s**, and this is the part worth a second opinion. The deadline now measures a different thing: real backend silence rather than absence of traffic. A healthy turn is documented to be silent for up to ~150s (`claudeRequestTimeout` = 90s; the swap builder at "90s + 60s MCP timeout"), so leaving it at 60s would start killing healthy turns — 60s was only ever safe *because* comments reset it. 180s clears the documented worst case and stays below the backend's own `agentTurnMaxDuration` (5min), so a wedge is still bounded. `VULTISIG_SSE_IDLE_TIMEOUT_MS` and the typed `TIMEOUT` → exit 3 are unchanged.

## H2 — invert the enumeration

The old design enumerated every frame the backends emit and warned on anything else. That can't be maintained: one emit site is dynamic (`V1Data(streamSurface, …)` over the mutable `genericCardSurfaces` map), there are two independently-evolving backends, and three review passes each found types the last had missed. The backend's V1 contract also treats unknown data kinds as forward-compatible (`v1_wire_schema_test.go`), which inverts the warn-by-default premise outright.

So this enumerates what the CLI **handles**, and tolerates unknown `data-*` cards quietly — a card we don't render isn't drift. What's explicit instead is the small set of frames whose omission is a false turn result rather than a display gap:

- **`tool-output-error`** — the tool-failure terminal. Ignored, the call got no terminal frame at all: a failed tool stayed "running" and the turn recorded no failure. In the backend's own words, that "lets the LLM's same-turn prose claim success even though no action ever ran." Now a `done`/`ok:false` result, reusing the existing typed shape. It can never produce a signable candidate — guarded explicitly at the signing boundary rather than relying on the null-check downstream.
- **`text-replace`** — retracts prose the backend has decided is wrong and supplies a correction. This one is sharper than the review characterised it: `fullText` is the `response` field of `agent ask --output json`, so ignoring the frame means answering with the retracted claim. The fixture on current `main` answers **"I sent your 5 ETH."** after the backend retracted exactly that sentence. Text parts are now tracked by id so the correction lands in place, mirroring the backend's own composition in `unified_loop.go`. A replacement that can't be applied cleanly (un-keyed deltas, unknown target) is **declined** and the text stands as streamed — degraded, never half-applied.
- **`start-step`** — lifecycle; quiet.

**`PROTOCOL_DRIFT` moves to `--verbose`-only.** It's a debug aid, not a machine contract: against a forward-compatible wire it fires on healthy turns whenever the backend ships a new card, and a drift detector that fires on ~every healthy turn is one automation learns to filter out. README updated. Note this narrows F11 as merged, and it means `data-confirmation` is now tolerated rather than loud — deliberate, since singling it out would rebuild the same unmaintainable list.

## Verification

- Both findings validated by fixture replay against current `main` **before** any fix code was written.
- Red-then-green: every new test fails on reverting `client.ts`. The wedged-backend test hangs to the vitest timeout on old code (a true never-settling stream, not a throw-path stand-in).
- `yarn test:cli` 53 files / **771 tests** pass (763 → +8). CLI typecheck clean; `yarn lint` clean; changed-file Prettier clean. Changeset: `@vultisig/cli` patch.
- One test — "never derives a signable candidate from a tool-output-error" — does *not* fail on revert, and shouldn't: on old code the frame was ignored so nothing signed either way. It guards the new path.
- No live backend turn: no vault credential in this shell. Verified against deterministic fixtures and backend source. No signing, broadcasts, or fund movement.

## Worth a reviewer's judgment

- **The 180s default.** A generous bound that never kills a healthy turn seemed clearly right over a tight one that does, but the number is mine, not the backend's — it's derived from `claudeRequestTimeout` + the MCP budget. If prod has legitimate turns silent past 180s, this is the knob that would bite.
- **Changeset is `patch`.** It's arguably `minor`: this changes a default timeout and removes `PROTOCOL_DRIFT` from the default `warnings` channel. `warnings` was already documented as omitted-when-empty so consumers must tolerate its absence, but the previous review bumped #1305 to `minor` on similar reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSE timeout handling so keep-alive signals no longer hide an unresponsive backend.
  * Increased the default idle timeout to 180 seconds for healthy, slow responses.
  * Correctly records failed tool results and prevents them from producing signable transactions.
  * Applies streamed text replacements to keep final responses consistent.

* **Improvements**
  * Unknown forward-compatible data frames are tolerated without warnings.
  * Protocol drift warnings now appear only in verbose mode.
  * Updated documentation for timeout and warning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->