### PR TITLE
fix(cli): classify permanent non-EVM broadcast errors

### DIFF
--- a/.changeset/calm-wolves-retry.md
+++ b/.changeset/calm-wolves-retry.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/cli': patch
+---
+
+Classify permanent UTXO, Solana, Sui, and Cosmos broadcast validation failures as non-retryable invalid input while leaving ambiguous and transient failures retryable.

--- a/clients/cli/src/core/errors.test.ts
+++ b/clients/cli/src/core/errors.test.ts
@@ -623,11 +623,59 @@ describe('anticipated CLI taxonomy regressions', () => {
       )
     })
 
+    it('keeps a Sui -32002 rejection retryable when the message is not a recognized permanent signal', () => {
+      // -32002 (TransactionExecutionClientError) is a broad bucket covering more than
+      // signature failures — an unrecognized message under that code must not be
+      // blanket-matched to permanent.
+      const rpcError = Object.assign(new Error('Insufficient gas budget for this transaction'), { code: -32002 })
+      expectTransient(
+        new VaultError(
+          VaultErrorCode.BroadcastFailed,
+          `Failed to broadcast transaction on Sui: ${rpcError.message}`,
+          rpcError
+        )
+      )
+    })
+
     it('maps a Cosmos ABCI CheckTx rejection to non-retryable input', () => {
       expectPermanent(
         new VaultError(
           VaultErrorCode.BroadcastFailed,
           'Failed to broadcast transaction on Cosmos: Broadcasting transaction failed with code 2 (codespace: sdk). Log: tx parse error'
+        )
+      )
+    })
+
+    it('maps a Cosmos insufficient-funds rejection to non-retryable input', () => {
+      expectPermanent(
+        new VaultError(
+          VaultErrorCode.BroadcastFailed,
+          'Failed to broadcast transaction on Cosmos: Broadcasting transaction failed with code 5 (codespace: sdk). Log: 100000uatom is smaller than 500000uatom: insufficient funds'
+        )
+      )
+    })
+
+    it('keeps a Cosmos account-sequence-mismatch rejection retryable', () => {
+      // Code 32 ("incorrect account sequence") is not in the permanent allowlist — a
+      // gap in the account's sequence is a transient MPC-race shape that can resolve
+      // once the intervening sequence lands, so the identical signed bytes may still
+      // succeed on a later attempt.
+      expectTransient(
+        new VaultError(
+          VaultErrorCode.BroadcastFailed,
+          'Failed to broadcast transaction on Cosmos: Broadcasting transaction failed with code 32 (codespace: sdk). Log: account sequence mismatch, expected 5, got 4: incorrect account sequence'
+        )
+      )
+    })
+
+    it('keeps a Cosmos rejection from a non-root codespace retryable', () => {
+      // A module-specific codespace (e.g. wasm) can reuse root-codespace-style
+      // numeric codes for unrelated conditions, so the allowlist only applies to
+      // "codespace: sdk".
+      expectTransient(
+        new VaultError(
+          VaultErrorCode.BroadcastFailed,
+          'Failed to broadcast transaction on Cosmos: Broadcasting transaction failed with code 5 (codespace: wasm). Log: execute wasm contract failed'
         )
       )
     })

--- a/clients/cli/src/core/errors.test.ts
+++ b/clients/cli/src/core/errors.test.ts
@@ -516,4 +516,126 @@ describe('anticipated CLI taxonomy regressions', () => {
     expect(result.exitCode).toBe(ExitCode.EXTERNAL_SERVICE)
     expect(result.retryable).toBe(true)
   })
+
+  describe('non-EVM permanent broadcast rejections', () => {
+    const expectPermanent = (err: VaultError) => {
+      const result = classifyError(err)
+      expect(result.code).toBe('INVALID_INPUT')
+      expect(result.exitCode).toBe(ExitCode.INVALID_INPUT)
+      expect(result.retryable).toBe(false)
+      expect(result.suggestions).toBeUndefined()
+    }
+
+    const expectTransient = (err: VaultError) => {
+      const result = classifyError(err)
+      expect(result.code).toBe('EXTERNAL_SERVICE')
+      expect(result.exitCode).toBe(ExitCode.EXTERNAL_SERVICE)
+      expect(result.retryable).toBe(true)
+    }
+
+    it.each([
+      ['-26', 'mandatory-script-verify-flag-failed'],
+      ['-27', 'transaction already in block chain'],
+    ])('maps a UTXO bitcoind %s rejection preserved by Blockchair to non-retryable input', (code, reason) => {
+      expectPermanent(
+        new VaultError(
+          VaultErrorCode.BroadcastFailed,
+          `Failed to broadcast raw transaction on Bitcoin: Failed to broadcast transaction: RPC error ${code}: ${reason}`
+        )
+      )
+    })
+
+    it('maps a UTXO decode rejection preserved by Blockchair to non-retryable input', () => {
+      expectPermanent(
+        new VaultError(
+          VaultErrorCode.BroadcastFailed,
+          'Failed to broadcast raw transaction on Bitcoin: Failed to broadcast transaction: TX decode failed'
+        )
+      )
+    })
+
+    it('keeps a UTXO Blockchair transport failure retryable', () => {
+      expectTransient(
+        new VaultError(
+          VaultErrorCode.BroadcastFailed,
+          'Failed to broadcast raw transaction on Bitcoin: HTTP 503 Service Unavailable'
+        )
+      )
+    })
+
+    it('maps a Solana preflight deserialize rejection to non-retryable input', () => {
+      expectPermanent(
+        new VaultError(
+          VaultErrorCode.BroadcastFailed,
+          'Failed to broadcast transaction on Solana: Simulation failed. Message: failed to deserialize transaction'
+        )
+      )
+    })
+
+    it('maps the Solana raw-broadcast base58 decoder rejection to non-retryable input', () => {
+      expectPermanent(
+        new VaultError(
+          VaultErrorCode.BroadcastFailed,
+          'Failed to broadcast raw transaction on Solana: Non-base58 character'
+        )
+      )
+    })
+
+    it('keeps a Solana blockhash miss retryable after the resolver exhausts its bounded retries', () => {
+      expectTransient(
+        new VaultError(
+          VaultErrorCode.BroadcastFailed,
+          'Failed to broadcast transaction on Solana: Simulation failed. Message: BlockhashNotFound'
+        )
+      )
+    })
+
+    it('maps a Sui transaction-execution client rejection to non-retryable input', () => {
+      const rpcError = Object.assign(new Error('Invalid user signature: cryptographic signature verification failed'), {
+        code: -32002,
+      })
+      expectPermanent(
+        new VaultError(
+          VaultErrorCode.BroadcastFailed,
+          `Failed to broadcast transaction on Sui: ${rpcError.message}`,
+          rpcError
+        )
+      )
+    })
+
+    it('maps the Sui raw-broadcast required-fields guard to non-retryable input', () => {
+      expectPermanent(
+        new VaultError(
+          VaultErrorCode.BroadcastFailed,
+          'Sui broadcast requires JSON with "unsignedTx" and "signature" fields'
+        )
+      )
+    })
+
+    it('keeps a Sui server-busy JSON-RPC failure retryable', () => {
+      const rpcError = Object.assign(new Error('Server busy'), { code: -32604 })
+      expectTransient(
+        new VaultError(
+          VaultErrorCode.BroadcastFailed,
+          `Failed to broadcast transaction on Sui: ${rpcError.message}`,
+          rpcError
+        )
+      )
+    })
+
+    it('maps a Cosmos ABCI CheckTx rejection to non-retryable input', () => {
+      expectPermanent(
+        new VaultError(
+          VaultErrorCode.BroadcastFailed,
+          'Failed to broadcast transaction on Cosmos: Broadcasting transaction failed with code 2 (codespace: sdk). Log: tx parse error'
+        )
+      )
+    })
+
+    it('keeps a Cosmos RPC transport failure retryable', () => {
+      expectTransient(
+        new VaultError(VaultErrorCode.BroadcastFailed, 'Failed to broadcast transaction on Cosmos: request timed out')
+      )
+    })
+  })
 })

--- a/clients/cli/src/core/errors.ts
+++ b/clients/cli/src/core/errors.ts
@@ -1,4 +1,12 @@
-import { VaultError, VaultErrorCode, VaultImportError, VaultImportErrorCode } from '@vultisig/sdk'
+import {
+  Chain,
+  type ChainKind,
+  getChainKind,
+  VaultError,
+  VaultErrorCode,
+  VaultImportError,
+  VaultImportErrorCode,
+} from '@vultisig/sdk'
 
 // Typed exit codes for machine-readable error handling
 // Enables agents to distinguish error types programmatically
@@ -316,11 +324,61 @@ export class DuplicateBroadcastRefusedError extends VsigError {
   }
 }
 
+const EVM_PERMANENT_BROADCAST_INPUT_RE =
+  /failed to decode signed transaction|could not decode (?:signed )?transaction|invalid raw transaction|invalid transaction encoding|invalid (?:transaction )?signature|invalid sender|invalid rlp|rlp:|unsupported transaction type/i
+
+const UTXO_PERMANENT_BROADCAST_INPUT_RE = /\bTX decode failed\b|\b(?:RPC error|code|error code)\s*:?\s*-(?:26|27)\b/i
+
+const SOLANA_PERMANENT_BROADCAST_INPUT_RE =
+  /failed to deserialize(?: transaction)?|failed to sanitize|(?:transaction )?signature verification (?:failed|failure)|non-base58 character|invalid base58/i
+
+const SUI_PERMANENT_BROADCAST_INPUT_RE = /Sui broadcast requires JSON with "unsignedTx" and "signature" fields/i
+
+const COSMOS_PERMANENT_BROADCAST_INPUT_RE =
+  /Broadcasting transaction failed with code (?!0\b)\d+ \(codespace: [^)]*\)\. Log:/i
+
+type PermanentBroadcastInputClassifier = (err: VaultError, details: string) => boolean
+
+const permanentBroadcastInputClassifiers: Partial<Record<ChainKind, PermanentBroadcastInputClassifier>> = {
+  evm: (_err, details) => EVM_PERMANENT_BROADCAST_INPUT_RE.test(details),
+  utxo: (_err, details) => UTXO_PERMANENT_BROADCAST_INPUT_RE.test(details),
+  solana: (_err, details) => SOLANA_PERMANENT_BROADCAST_INPUT_RE.test(details),
+  sui: (err, details) => {
+    const rpcCode = (err.originalError as (Error & { code?: unknown }) | undefined)?.code
+    return rpcCode === -32002 || SUI_PERMANENT_BROADCAST_INPUT_RE.test(details)
+  },
+  cosmos: (_err, details) => COSMOS_PERMANENT_BROADCAST_INPUT_RE.test(details),
+}
+
+function getBroadcastErrorChain(details: string): Chain | undefined {
+  const normalized = details.toLowerCase()
+  const wrappedChain = Object.values(Chain).find(chain => normalized.includes(` on ${chain.toLowerCase()}:`))
+  if (wrappedChain) return wrappedChain
+
+  // RawBroadcastService deliberately rethrows its local required-fields
+  // VaultError without the standard "on <chain>:" wrapper.
+  if (normalized.startsWith('sui broadcast ')) return Chain.Sui
+
+  return undefined
+}
+
 function isPermanentBroadcastInputError(err: VaultError): boolean {
   const details = `${err.message}\n${err.originalError?.message ?? ''}`
-  return /failed to decode signed transaction|could not decode (?:signed )?transaction|invalid raw transaction|invalid transaction encoding|invalid (?:transaction )?signature|invalid sender|invalid rlp|rlp:|unsupported transaction type/i.test(
-    details
-  )
+  const chain = getBroadcastErrorChain(details)
+
+  if (chain) {
+    const classifier = permanentBroadcastInputClassifiers[getChainKind(chain)]
+    if (classifier) return classifier(err, details)
+
+    return false
+  }
+
+  // Preserve the pre-existing EVM classification for older/hand-built errors
+  // that lack the SDK's standard chain wrapper. For every new family predicate,
+  // ambiguity intentionally stays retryable: a false non-retryable result can
+  // strand a user, while a false retryable result is additionally constrained
+  // by broadcast-journal dedupe and the exit 9/13 fund-safety semantics.
+  return EVM_PERMANENT_BROADCAST_INPUT_RE.test(details)
 }
 
 // The SDK words a bad receiver differently depending on which layer rejects it:

--- a/clients/cli/src/core/errors.ts
+++ b/clients/cli/src/core/errors.ts
@@ -332,10 +332,52 @@ const UTXO_PERMANENT_BROADCAST_INPUT_RE = /\bTX decode failed\b|\b(?:RPC error|c
 const SOLANA_PERMANENT_BROADCAST_INPUT_RE =
   /failed to deserialize(?: transaction)?|failed to sanitize|(?:transaction )?signature verification (?:failed|failure)|non-base58 character|invalid base58/i
 
-const SUI_PERMANENT_BROADCAST_INPUT_RE = /Sui broadcast requires JSON with "unsignedTx" and "signature" fields/i
+// The local required-fields guard (RawBroadcastService) is always permanent —
+// it never carries an RPC code, so it's checked independently of the -32002 gate below.
+const SUI_REQUIRED_FIELDS_GUARD_RE = /Sui broadcast requires JSON with "unsignedTx" and "signature" fields/i
 
-const COSMOS_PERMANENT_BROADCAST_INPUT_RE =
-  /Broadcasting transaction failed with code (?!0\b)\d+ \(codespace: [^)]*\)\. Log:/i
+// -32002 ("TransactionExecutionClientError") is a broad Sui JSON-RPC bucket covering
+// many distinct client-caused execution failures, not signature verification alone —
+// pairing the code with a message match keeps a generic/unrecognized -32002 (e.g. an
+// object-version or gas condition we can't positively identify as permanent) retryable
+// instead of a blanket match on the code.
+const SUI_PERMANENT_EXECUTION_MESSAGE_RE =
+  /invalid (?:user )?signature|signature verification (?:failed|failure)|malformed transaction|invalid transaction (?:data|bytes)/i
+
+// Cosmos SDK RootCodespace error codes (codespace "sdk") whose message is a
+// genuinely non-recoverable rejection of THIS signed tx — the identical bytes can
+// never succeed regardless of retries or waiting. See
+// https://github.com/cosmos/cosmos-sdk/blob/main/types/errors/errors.go. Deliberately
+// narrow: any other codespace, any unlisted code (notably 32 "incorrect account
+// sequence" — a transient MPC-race shape that can resolve once the intervening
+// sequence lands), or a code/message mismatch falls through to retryable.
+const COSMOS_PERMANENT_SDK_CODES: Partial<Record<number, RegExp>> = {
+  2: /tx parse error/i,
+  4: /unauthorized|signature verification failed/i,
+  5: /insufficient funds/i,
+  6: /unknown request/i,
+  7: /invalid address/i,
+  8: /invalid pubkey/i,
+  9: /unknown address/i,
+  10: /invalid coins/i,
+  12: /memo too large/i,
+  13: /insufficient fee/i,
+  14: /maximum number of signatures exceeded/i,
+  15: /no signatures supplied/i,
+  18: /invalid request/i,
+  21: /tx too large/i,
+}
+
+const COSMOS_BROADCAST_FAILURE_RE = /broadcasting transaction failed with code (\d+) \(codespace: (\w+)\)\. log: (.+)/i
+
+function isCosmosPermanentBroadcastInput(details: string): boolean {
+  const match = details.match(COSMOS_BROADCAST_FAILURE_RE)
+  if (!match) return false
+  const [, codeText, codespace, log] = match
+  if (codespace.toLowerCase() !== 'sdk') return false
+  const canonicalMessage = COSMOS_PERMANENT_SDK_CODES[Number(codeText)]
+  return canonicalMessage ? canonicalMessage.test(log) : false
+}
 
 type PermanentBroadcastInputClassifier = (err: VaultError, details: string) => boolean
 
@@ -344,10 +386,11 @@ const permanentBroadcastInputClassifiers: Partial<Record<ChainKind, PermanentBro
   utxo: (_err, details) => UTXO_PERMANENT_BROADCAST_INPUT_RE.test(details),
   solana: (_err, details) => SOLANA_PERMANENT_BROADCAST_INPUT_RE.test(details),
   sui: (err, details) => {
+    if (SUI_REQUIRED_FIELDS_GUARD_RE.test(details)) return true
     const rpcCode = (err.originalError as (Error & { code?: unknown }) | undefined)?.code
-    return rpcCode === -32002 || SUI_PERMANENT_BROADCAST_INPUT_RE.test(details)
+    return rpcCode === -32002 && SUI_PERMANENT_EXECUTION_MESSAGE_RE.test(details)
   },
-  cosmos: (_err, details) => COSMOS_PERMANENT_BROADCAST_INPUT_RE.test(details),
+  cosmos: (_err, details) => isCosmosPermanentBroadcastInput(details),
 }
 
 function getBroadcastErrorChain(details: string): Chain | undefined {


### PR DESCRIPTION
## Summary

- dispatch permanent broadcast validation checks by SDK chain kind for UTXO, Solana, Sui, and Cosmos
- preserve the existing EVM classification and leave ambiguous or transient failures retryable
- cover permanent and transient RPC shapes per family and add an `@vultisig/cli` patch changeset

The classifier intentionally fails toward retryable when a message is ambiguous. A false non-retryable result can strand a user, while retries still have the broadcast journal and exit 9/13 safeguards.

## Validation

- `yarn build:all`
- `yarn cli:build && yarn cli:smoke`
- `yarn test:cli` (775 passed)
- `yarn typecheck`
- `yarn lint`
- `yarn test`
- `yarn prettier --config .config/.prettierrc --check clients/cli/src/core/errors.ts clients/cli/src/core/errors.test.ts .changeset/calm-wolves-retry.md`

No live transactions were attempted.