### PR TITLE
fix(cli): batch of small CLI polish fixes

### DIFF
--- a/.changeset/low-cluster-cli-polish.md
+++ b/.changeset/low-cluster-cli-polish.md
@@ -1,0 +1,23 @@
+---
+'@vultisig/cli': patch
+'@vultisig/sdk': patch
+---
+
+Batch of small CLI polish and truthfulness fixes:
+
+- Write exported `.vult` files owner-only (0600) instead of with the default umask.
+- Validate the chain argument for `tokens` and `swap-quote`, which previously reported
+  `success: true` with an empty list / a raw TypeError for an unknown chain.
+- Stop `rename` rejecting vault names the ecosystem itself creates (e.g. the `#` in
+  "Vultisig Cluster #1"), which made rename a one-way door.
+- Add `NO_ACTIVE_VAULT` (15) and `CORRUPT_STATE` (16) exit codes with recovery hints,
+  replacing a generic `UNKNOWN_ERROR`/7 for both states.
+- Emit exactly one JSON envelope from a failed `verify` (it previously wrote two
+  documents, breaking `JSON.parse`), and list vaults pending verification in `vaults`.
+- Emit a result envelope from every successful mutation in `-o json`
+  (switch/rename/currency/address-book/import/export previously exited 0 with no output).
+- Generate shell completion from the Commander and SDK chain registries instead of a
+  stale hardcoded list.
+- Silence the `bigint: Failed to load bindings` warning printed to stderr on every
+  invocation.
+- Report `fee` and `total` from `send --dry-run` in JSON.

--- a/.yarn/patches/bigint-buffer-npm-1.1.5-785f4ccd92.patch
+++ b/.yarn/patches/bigint-buffer-npm-1.1.5-785f4ccd92.patch
@@ -1,0 +1,18 @@
+diff --git a/dist/node.js b/dist/node.js
+index 513168c89e387668a79b6beb109587b3eb41a7d0..73d35813858e8fda34541200d0ecff0977a8683c 100644
+--- a/dist/node.js
++++ b/dist/node.js
+@@ -7,7 +7,12 @@ let converter;
+         converter = require('bindings')('bigint_buffer');
+     }
+     catch (e) {
+-        console.warn('bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)');
++        // Patched by vultisig-sdk: the native binding has no darwin-arm64 (and most
++        // other) prebuild, so this fires on EVERY process start and printed
++        // "bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)"
++        // to stderr on every CLI invocation, including --version. The pure-JS fallback
++        // below is fully functional, "npm run rebuild" is meaningless advice for a
++        // globally installed CLI, and the noise made a working CLI look broken.
+     }
+ }
+ /**

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,6 +6,9 @@ npmAuditIgnoreAdvisories:
   # GHSA-3gc7-fjrx-p6mg: bigint-buffer has no patched npm release yet.
   # Owner: SDK maintainers. Revisit when @solana/spl-token removes bigint-buffer
   # or bigint-buffer publishes a fixed version.
-  - "1103747"
+  # NOTE: package.json also pins bigint-buffer to a `patch:` resolution (to silence a
+  # module-load console.warn). That pin holds it at 1.1.5, so a published fix would NOT
+  # be picked up by `yarn up` — drop the patch resolution as well when revisiting this.
+  - '1103747'
 
 yarnPath: .yarn/releases/yarn-4.16.0.cjs

--- a/clients/cli/README.md
+++ b/clients/cli/README.md
@@ -1262,6 +1262,8 @@ Configuration is stored in `~/.vultisig/`:
 | 12   | Interactive confirmation/input required but the session is non-interactive — pass --yes/--confirm or the required flag |
 | 13   | agent ask: transaction broadcast but the overall request may be incomplete — inspect the hash, do NOT blindly retry    |
 | 14   | agent ask: duplicate keyed turn rejected — inspect the conversation for the original result                            |
+| 15   | No active vault selected — create, import, or switch to one                                                            |
+| 16   | Stored state is unreadable — repair it or re-import the vault from a .vult backup                                      |
 
 > These are generated from the `ExitCode` enum in `src/core/errors.ts` (the single source of
 > truth) and are covered by a doc-lint test that fails if this table drifts from the code. Run

--- a/clients/cli/src/commands/__tests__/chainArgCallSites.test.ts
+++ b/clients/cli/src/commands/__tests__/chainArgCallSites.test.ts
@@ -1,0 +1,72 @@
+// The `tokens` / `swap-quote` CALL SITES validate their chain argument
+// (vultisig-sdk sdkcli2-13 P2-6 / P2-10).
+//
+// core/chain-resolver.test.ts covers the helper in isolation — but the reported bug
+// lived at the call sites (`findChainByName(x) || (x as Chain)`), so that file stays
+// green even if the call sites regress. This drives the real CLI end-to-end instead:
+//   tokens bogus-chain      -> was exit 0 + {"success":true,"data":{"tokens":[]}}
+//   swap-quote bogus-chain  -> was exit 7 + a raw "reading 'ticker'" TypeError
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import { ExitCode } from '../../core/errors'
+
+const CLI_ENTRY = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'index.ts')
+
+function run(args: string[]) {
+  const env: NodeJS.ProcessEnv = { ...process.env, NO_COLOR: '1' }
+  delete env.COMP_LINE
+  delete env.COMP_POINT
+  delete env.COMP_CWORD
+  const r = spawnSync(process.execPath, ['--import', 'tsx', CLI_ENTRY, ...args], {
+    input: '',
+    encoding: 'utf8',
+    timeout: 120_000,
+    env,
+  })
+  return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' }
+}
+
+describe('tokens <chain> validation', () => {
+  it('rejects an unknown chain with INVALID_CHAIN / exit 4 instead of an empty success', () => {
+    const { status, stdout } = run(['tokens', 'bogus-chain', '-o', 'json'])
+
+    expect(status).toBe(ExitCode.INVALID_INPUT)
+    const parsed = JSON.parse(stdout)
+    expect(parsed.success).toBe(false)
+    expect(parsed.error.code).toBe('INVALID_CHAIN')
+  })
+
+  it('never reports success:true with an empty token list for a chain that does not exist', () => {
+    const { stdout } = run(['tokens', 'bogus-chain', '-o', 'json'])
+
+    expect(stdout).not.toMatch(/"success":\s*true/)
+  })
+})
+
+describe('swap-quote <fromChain> <toChain> validation', () => {
+  it('rejects an unknown source chain with INVALID_CHAIN / exit 4, not a raw TypeError', () => {
+    const { status, stdout } = run(['swap-quote', 'bogus-chain', 'Bitcoin', '1', '-o', 'json'])
+
+    expect(status).toBe(ExitCode.INVALID_INPUT)
+    const parsed = JSON.parse(stdout)
+    expect(parsed.error.code).toBe('INVALID_CHAIN')
+    expect(parsed.error.message).not.toMatch(/Cannot read properties of undefined/)
+  })
+
+  it('rejects an unknown destination chain too, and says which side was wrong', () => {
+    const { status, stdout } = run(['swap-quote', 'Ethereum', 'bogus-chain', '1', '-o', 'json'])
+
+    expect(status).toBe(ExitCode.INVALID_INPUT)
+    expect(JSON.parse(stdout).error.message).toMatch(/destination chain/)
+  })
+
+  it('emits exactly one parseable JSON document', () => {
+    const { stdout } = run(['swap-quote', 'bogus-chain', 'Bitcoin', '1', '-o', 'json'])
+
+    expect(() => JSON.parse(stdout)).not.toThrow()
+  })
+})

--- a/clients/cli/src/commands/__tests__/exportVaultMode.test.ts
+++ b/clients/cli/src/commands/__tests__/exportVaultMode.test.ts
@@ -1,0 +1,67 @@
+// `export` writes the keyshare file owner-only (vultisig-sdk sdkcli2-13 P1-7 / P4-4).
+//
+// Regression guard: the export used to be written with the default umask (0644 —
+// world-readable) into the cwd, including $HOME, even though the SDK's own vault
+// store is 0600. `auth setup` then auto-discovers that file as a credential anchor.
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resetOutput } from '../../lib/output'
+import { executeExport } from '../vault-management'
+
+function makeCtx() {
+  const vault = {
+    export: vi.fn(async () => ({ data: 'VULT-KEYSHARE-BYTES', filename: 'test-vault.vult' })),
+  }
+  return { ensureActiveVault: vi.fn(async () => vault) } as never
+}
+
+async function modeOf(file: string): Promise<string> {
+  const stat = await fs.stat(file)
+  return (stat.mode & 0o777).toString(8)
+}
+
+describe('export file permissions', () => {
+  let tmpDir: string
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vsig-export-mode-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+    vi.restoreAllMocks()
+    resetOutput()
+  })
+
+  it('creates a new export 0600, not world-readable', async () => {
+    const outputPath = path.join(tmpDir, 'fresh.vult')
+
+    await executeExport(makeCtx(), { outputPath, exportPassword: 'pw' })
+
+    expect(await modeOf(outputPath)).toBe('600')
+  })
+
+  it('tightens the mode when overwriting a pre-existing world-readable file', async () => {
+    // `mode` in writeFile only applies at creation, so an existing 0644 file would
+    // keep its mode and silently leak the new keyshare.
+    const outputPath = path.join(tmpDir, 'stale.vult')
+    await fs.writeFile(outputPath, 'old', { mode: 0o644 })
+    expect(await modeOf(outputPath)).toBe('644')
+
+    await executeExport(makeCtx(), { outputPath, exportPassword: 'pw' })
+
+    expect(await modeOf(outputPath)).toBe('600')
+  })
+
+  it('still writes the keyshare content it was given', async () => {
+    const outputPath = path.join(tmpDir, 'content.vult')
+
+    await executeExport(makeCtx(), { outputPath, exportPassword: 'pw' })
+
+    expect(await fs.readFile(outputPath, 'utf-8')).toBe('VULT-KEYSHARE-BYTES')
+  })
+})

--- a/clients/cli/src/commands/__tests__/exportVaultMode.test.ts
+++ b/clients/cli/src/commands/__tests__/exportVaultMode.test.ts
@@ -26,18 +26,24 @@ async function modeOf(file: string): Promise<string> {
 
 describe('export file permissions', () => {
   let tmpDir: string
+  let originalUmask: number
 
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vsig-export-mode-'))
+    // Force a permissive umask for the duration. Otherwise a developer/CI umask of
+    // 0077 would mask the bug: a plain writeFile would land 0600 by accident and the
+    // fresh-file assertion below would pass even with the fix reverted.
+    originalUmask = process.umask(0o022)
   })
 
   afterEach(async () => {
+    process.umask(originalUmask)
     await fs.rm(tmpDir, { recursive: true, force: true })
     vi.restoreAllMocks()
     resetOutput()
   })
 
-  it('creates a new export 0600, not world-readable', async () => {
+  it('creates a new export 0600, not world-readable, even under a permissive umask', async () => {
     const outputPath = path.join(tmpDir, 'fresh.vult')
 
     await executeExport(makeCtx(), { outputPath, exportPassword: 'pw' })
@@ -45,9 +51,11 @@ describe('export file permissions', () => {
     expect(await modeOf(outputPath)).toBe('600')
   })
 
-  it('tightens the mode when overwriting a pre-existing world-readable file', async () => {
-    // `mode` in writeFile only applies at creation, so an existing 0644 file would
-    // keep its mode and silently leak the new keyshare.
+  it('replaces a pre-existing world-readable file with an owner-only one', async () => {
+    // The keyshare must never land in the pre-existing 0644 file: writeFile's `mode`
+    // only applies when it CREATES the file, so writing in place would put shares in a
+    // world-readable file and only tighten it afterwards. The export writes a fresh
+    // 0600 temp file and renames over the target instead.
     const outputPath = path.join(tmpDir, 'stale.vult')
     await fs.writeFile(outputPath, 'old', { mode: 0o644 })
     expect(await modeOf(outputPath)).toBe('644')
@@ -55,6 +63,28 @@ describe('export file permissions', () => {
     await executeExport(makeCtx(), { outputPath, exportPassword: 'pw' })
 
     expect(await modeOf(outputPath)).toBe('600')
+    expect(await fs.readFile(outputPath, 'utf-8')).toBe('VULT-KEYSHARE-BYTES')
+  })
+
+  it('never writes the keyshare into the pre-existing world-readable inode', async () => {
+    // Directly pins the TOCTOU the temp+rename closes: if the shares were written in
+    // place and chmod'd after, the ORIGINAL inode would hold them at 0644 for a window.
+    // After a rename the target is a different inode, and the old one never saw them.
+    const outputPath = path.join(tmpDir, 'watched.vult')
+    await fs.writeFile(outputPath, 'old', { mode: 0o644 })
+    const inodeBefore = (await fs.stat(outputPath)).ino
+
+    await executeExport(makeCtx(), { outputPath, exportPassword: 'pw' })
+
+    expect((await fs.stat(outputPath)).ino).not.toBe(inodeBefore)
+  })
+
+  it('leaves no temp file behind', async () => {
+    const outputPath = path.join(tmpDir, 'clean.vult')
+
+    await executeExport(makeCtx(), { outputPath, exportPassword: 'pw' })
+
+    expect(await fs.readdir(tmpDir)).toEqual(['clean.vult'])
   })
 
   it('still writes the keyshare content it was given', async () => {

--- a/clients/cli/src/commands/__tests__/mutationEnvelopes.test.ts
+++ b/clients/cli/src/commands/__tests__/mutationEnvelopes.test.ts
@@ -1,0 +1,149 @@
+// Mutations always emit an envelope in JSON mode (vultisig-sdk sdkcli2-13 P1-5 / P2-11).
+//
+// Regression guard: switch/rename/currency/address-book-add/address-book-remove/
+// import/export all ended in success(), which JSON mode suppresses — so each exited 0
+// with ZERO bytes on stdout, while delete/chains-add DID emit envelopes. A machine
+// caller got an empty string back from a successful mutation and could not tell it
+// from a no-op.
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { CommandContext } from '../../core'
+import { configureOutput, resetOutput } from '../../lib/output'
+import { executeAddressBook, executeCurrency } from '../settings'
+import { executeExport, executeRename, executeSwitch } from '../vault-management'
+
+let stdout: string[]
+let writeSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  stdout = []
+  writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(chunk => {
+    stdout.push(String(chunk))
+    return true
+  })
+  configureOutput({ format: 'json' })
+})
+
+afterEach(() => {
+  writeSpy.mockRestore()
+  vi.restoreAllMocks()
+  resetOutput()
+})
+
+/** Parse the single envelope a mutation is expected to write. */
+function envelope(): { success: boolean; v: number; data: Record<string, unknown> } {
+  const raw = stdout.join('')
+  expect(raw, 'mutation wrote nothing to stdout').not.toBe('')
+  return JSON.parse(raw)
+}
+
+const vaultStub = {
+  id: 'vault-1',
+  name: 'Vultisig Cluster #1',
+  type: 'fast',
+  chains: ['Ethereum', 'Bitcoin'],
+}
+
+describe('currency set', () => {
+  function makeCtx() {
+    return {
+      ensureActiveVault: async () => ({ currency: 'usd', setCurrency: vi.fn(async () => {}) }),
+    } as unknown as CommandContext
+  }
+
+  it('emits a versioned envelope naming the new currency', async () => {
+    await executeCurrency(makeCtx(), 'eur')
+
+    const env = envelope()
+    expect(env.success).toBe(true)
+    expect(env.v).toBe(1)
+    expect(env.data).toMatchObject({ currency: 'eur', updated: true })
+  })
+})
+
+describe('address book mutations', () => {
+  function makeCtx() {
+    return {
+      sdk: {
+        addAddressBookEntry: vi.fn(async () => {}),
+        removeAddressBookEntry: vi.fn(async () => {}),
+      },
+    } as unknown as CommandContext
+  }
+
+  it('--add emits an envelope describing the stored entry', async () => {
+    await executeAddressBook(makeCtx(), {
+      add: true,
+      chain: 'Ethereum' as never,
+      address: '0xabc',
+      name: 'treasury',
+    })
+
+    expect(envelope().data.added).toMatchObject({ chain: 'Ethereum', address: '0xabc', name: 'treasury' })
+  })
+
+  it('--remove emits an envelope naming what was removed', async () => {
+    await executeAddressBook(makeCtx(), { remove: '0xabc', chain: 'Ethereum' as never })
+
+    expect(envelope().data.removed).toMatchObject({ address: '0xabc', chain: 'Ethereum' })
+  })
+})
+
+describe('switch', () => {
+  it('emits an envelope identifying the now-active vault', async () => {
+    // setupVaultEvents() subscribes to the vault's emitter.
+    const vault = { ...vaultStub, on: vi.fn() }
+    const ctx = {
+      sdk: { getVaultById: vi.fn(async () => vault), listVaults: vi.fn(async () => [vault]) },
+      setActiveVault: vi.fn(async () => {}),
+    } as unknown as CommandContext
+
+    await executeSwitch(ctx, 'vault-1')
+
+    const env = envelope()
+    expect(env.data).toMatchObject({ switched: true, isActive: true })
+    expect(env.data.vault).toMatchObject({ id: 'vault-1', name: 'Vultisig Cluster #1' })
+  })
+})
+
+describe('rename', () => {
+  it('emits an envelope carrying both the new and previous name', async () => {
+    const vault = { ...vaultStub, rename: vi.fn(async () => {}) }
+    const ctx = { ensureActiveVault: async () => vault } as unknown as CommandContext
+
+    await executeRename(ctx, 'Renamed Vault')
+
+    expect(envelope().data).toMatchObject({
+      renamed: true,
+      previousName: 'Vultisig Cluster #1',
+      vault: { id: 'vault-1', name: 'Renamed Vault' },
+    })
+  })
+})
+
+describe('export', () => {
+  let tmpDir: string
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vsig-export-envelope-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('emits an envelope naming the written path', async () => {
+    const outputPath = path.join(tmpDir, 'out.vult')
+    const ctx = {
+      ensureActiveVault: async () => ({ export: vi.fn(async () => ({ data: 'BYTES', filename: 'v.vult' })) }),
+    } as unknown as CommandContext
+
+    await executeExport(ctx, { outputPath, exportPassword: 'pw' })
+
+    expect(envelope().data).toMatchObject({ exported: true, path: outputPath, encrypted: true })
+  })
+})

--- a/clients/cli/src/commands/__tests__/mutationEnvelopes.test.ts
+++ b/clients/cli/src/commands/__tests__/mutationEnvelopes.test.ts
@@ -9,12 +9,19 @@ import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
+import { FastVault } from '@vultisig/sdk'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { CommandContext } from '../../core'
 import { configureOutput, resetOutput } from '../../lib/output'
 import { executeAddressBook, executeCurrency } from '../settings'
-import { executeExport, executeRename, executeSwitch } from '../vault-management'
+import {
+  executeAddPostQuantumKeys,
+  executeExport,
+  executeImport,
+  executeRename,
+  executeSwitch,
+} from '../vault-management'
 
 let stdout: string[]
 let writeSpy: ReturnType<typeof vi.spyOn>
@@ -122,6 +129,45 @@ describe('rename', () => {
       previousName: 'Vultisig Cluster #1',
       vault: { id: 'vault-1', name: 'Renamed Vault' },
     })
+  })
+})
+
+describe('import', () => {
+  it('emits an envelope identifying the imported vault', async () => {
+    const vault = { ...vaultStub, on: vi.fn() }
+    const ctx = {
+      sdk: { importVault: vi.fn(async () => vault) },
+      setActiveVault: vi.fn(async () => {}),
+    } as unknown as CommandContext
+
+    const file = path.join(await fs.mkdtemp(path.join(os.tmpdir(), 'vsig-import-')), 'v.vult')
+    await fs.writeFile(file, 'VULT-BYTES')
+
+    await executeImport(ctx, file, 'pw')
+
+    const env = envelope()
+    expect(env.data).toMatchObject({ imported: true, isActive: true })
+    expect(env.data.vault).toMatchObject({ id: 'vault-1', name: 'Vultisig Cluster #1' })
+  })
+})
+
+describe('add-mldsa', () => {
+  it('emits an envelope after mutating the vault file', async () => {
+    // FastVault instance check: executeAddPostQuantumKeys refuses anything else.
+    // id/name are prototype getters, so define them rather than assigning.
+    const vault = Object.create(FastVault.prototype, {
+      id: { value: vaultStub.id },
+      name: { value: vaultStub.name },
+    })
+    const ctx = {
+      ensureActiveVault: async () => vault,
+      getPassword: vi.fn(async () => 'pw'),
+      sdk: { addPostQuantumKeysToFastVault: vi.fn(async () => {}) },
+    } as unknown as CommandContext
+
+    await executeAddPostQuantumKeys(ctx, { email: 'e@x.io', password: 'pw' })
+
+    expect(envelope().data).toMatchObject({ added: true, backupRecommended: true })
   })
 })
 

--- a/clients/cli/src/commands/__tests__/sendDryRunFee.test.ts
+++ b/clients/cli/src/commands/__tests__/sendDryRunFee.test.ts
@@ -1,0 +1,104 @@
+// `send --dry-run` reports what the build actually cost (vultisig-sdk sdkcli2-13 P3-1).
+//
+// Regression guard: the SDK's dry-run returns { fee, total, keysignPayload }, and the
+// human preview printed the fee — but the JSON result dropped fee and total entirely,
+// so `--dry-run -o json` returned only amount/balance/chain/dryRun/symbol/to. It read
+// as a bare balance check with no cost information, even though `total` is the very
+// number the insufficient-balance warning compares against.
+import { Chain } from '@vultisig/sdk'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SendDryRunResult } from '../../core'
+import { configureOutput, resetOutput } from '../../lib/output'
+import { sendTransaction } from '../transaction'
+
+let stdout: string[]
+let writeSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  stdout = []
+  writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(chunk => {
+    stdout.push(String(chunk))
+    return true
+  })
+})
+
+afterEach(() => {
+  writeSpy.mockRestore()
+  vi.restoreAllMocks()
+  resetOutput()
+})
+
+function makeVault(opts: { fee: string; total: string; balance: string }) {
+  return {
+    send: vi.fn(async () => ({
+      dryRun: true,
+      fee: opts.fee,
+      total: opts.total,
+      keysignPayload: { some: 'payload' },
+    })),
+    balance: vi.fn(async () => ({
+      formattedAmount: opts.balance,
+      symbol: 'ETH',
+      amount: '0',
+      decimals: 18,
+      chainId: 'ethereum',
+    })),
+    gas: vi.fn(async () => ({})),
+    address: vi.fn(async () => '0xfrom'),
+  } as never
+}
+
+const params = {
+  chain: Chain.Ethereum,
+  to: '0xdead',
+  amount: '1.0',
+  dryRun: true,
+} as never
+
+describe('send --dry-run preview', () => {
+  it('returns the fee and total the build produced', async () => {
+    const result = (await sendTransaction(
+      makeVault({ fee: '0.0021', total: '1.0021', balance: '5.0' }),
+      params
+    )) as SendDryRunResult
+
+    expect(result.fee).toBe('0.0021')
+    expect(result.total).toBe('1.0021')
+  })
+
+  it('carries fee and total into the JSON envelope, not just the human preview', async () => {
+    configureOutput({ format: 'json' })
+
+    await sendTransaction(makeVault({ fee: '0.0021', total: '1.0021', balance: '5.0' }), params)
+
+    const data = JSON.parse(stdout.join('')).data
+    expect(data).toMatchObject({
+      dryRun: true,
+      chain: Chain.Ethereum,
+      fee: '0.0021',
+      total: '1.0021',
+      balance: '5.0',
+    })
+  })
+
+  it('still warns when the total exceeds the balance, and reports the numbers behind it', async () => {
+    configureOutput({ format: 'json' })
+
+    await sendTransaction(makeVault({ fee: '0.5', total: '10.5', balance: '1.0' }), params)
+
+    const data = JSON.parse(stdout.join('')).data
+    expect(data.warning).toMatch(/Insufficient balance/)
+    // The warning is only checkable by a caller if the numbers behind it are present.
+    expect(data.total).toBe('10.5')
+    expect(data.balance).toBe('1.0')
+  })
+
+  it('does not warn when the balance covers the total', async () => {
+    configureOutput({ format: 'json' })
+
+    await sendTransaction(makeVault({ fee: '0.0021', total: '1.0021', balance: '5.0' }), params)
+
+    expect(JSON.parse(stdout.join('')).data.warning).toBeUndefined()
+  })
+})

--- a/clients/cli/src/commands/__tests__/verifySingleEnvelope.test.ts
+++ b/clients/cli/src/commands/__tests__/verifySingleEnvelope.test.ts
@@ -8,10 +8,11 @@
 //  - The failure message parroted SDK jargon ("...with createFastVault()").
 //  - Two-step vaults awaiting verification appeared nowhere in `vaults`: only the
 //    create-time output named the id, so an agent that lost it could not resume.
+import { VaultError, VaultErrorCode } from '@vultisig/sdk'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { CommandContext } from '../../core'
-import { VaultNotFoundError } from '../../core/errors'
+import { type AuthRequiredError, type ExternalServiceError, VaultNotFoundError } from '../../core/errors'
 import { configureOutput, resetOutput } from '../../lib/output'
 import { executeVaults, executeVerify } from '../vault-management'
 
@@ -87,6 +88,65 @@ describe('verify failure output', () => {
       },
       (err: unknown) => {
         expect((err as VaultNotFoundError).suggestions).toEqual(expect.arrayContaining(['vultisig verify v1 --resend']))
+      }
+    )
+  })
+})
+
+describe('verify --resend failure', () => {
+  // A resend that failed must not look like one that succeeded. When executeVerify
+  // stopped signalling failure via `return false`, this path kept returning false —
+  // and the caller no longer converts that into an error, so a rate-limited or
+  // bad-password resend reported exit 0 with empty stdout in JSON mode.
+  function makeCtx(err: Error): CommandContext {
+    return {
+      sdk: { resendVaultVerification: vi.fn().mockRejectedValue(err) },
+      dispose: () => {},
+    } as unknown as CommandContext
+  }
+
+  const resendOpts = { resend: true, email: 'e@x.io', password: 'password123' }
+
+  it('throws rather than resolving, so a failed resend is not reported as success', async () => {
+    const outcome = await executeVerify(makeCtx(new Error('rate limited')), 'v1', resendOpts).then(
+      r => `resolved:${r}`,
+      () => 'threw'
+    )
+
+    expect(outcome).toBe('threw')
+  })
+
+  it('writes no success envelope for an email that was never sent', async () => {
+    configureOutput({ format: 'json' })
+
+    await expect(executeVerify(makeCtx(new Error('rate limited')), 'v1', resendOpts)).rejects.toThrow()
+
+    expect(jsonOut()).toBe('')
+  })
+
+  it('classifies an unrecognised resend failure as retryable, hinting at rate limiting', async () => {
+    await executeVerify(makeCtx(new Error('rate limited')), 'v1', resendOpts).then(
+      () => {
+        throw new Error('expected executeVerify to throw')
+      },
+      (err: unknown) => {
+        const e = err as ExternalServiceError
+        expect(e.code).toBe('EXTERNAL_SERVICE')
+        expect(e.retryable).toBe(true)
+        expect(e.hint).toMatch(/rate-limit/i)
+      }
+    )
+  })
+
+  it('keeps the SDK classification when it is already precise (bad password -> auth)', async () => {
+    const authErr = new VaultError(VaultErrorCode.InvalidConfig, 'Failed to unlock vault: invalid password')
+
+    await executeVerify(makeCtx(authErr), 'v1', resendOpts).then(
+      () => {
+        throw new Error('expected executeVerify to throw')
+      },
+      (err: unknown) => {
+        expect((err as AuthRequiredError).code).toBe('AUTH_REQUIRED')
       }
     )
   })

--- a/clients/cli/src/commands/__tests__/verifySingleEnvelope.test.ts
+++ b/clients/cli/src/commands/__tests__/verifySingleEnvelope.test.ts
@@ -1,0 +1,141 @@
+// `verify` emits one JSON envelope, and `vaults` surfaces pending vaults
+// (vultisig-sdk sdkcli2-13 P2-7).
+//
+// Regression guards:
+//  - A failed `verify ... -o json` wrote a success-shaped {verified:false} envelope
+//    AND THEN threw, so the caller emitted a second {success:false} envelope. stdout
+//    carried two JSON documents and JSON.parse(output) threw.
+//  - The failure message parroted SDK jargon ("...with createFastVault()").
+//  - Two-step vaults awaiting verification appeared nowhere in `vaults`: only the
+//    create-time output named the id, so an agent that lost it could not resume.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { CommandContext } from '../../core'
+import { VaultNotFoundError } from '../../core/errors'
+import { configureOutput, resetOutput } from '../../lib/output'
+import { executeVaults, executeVerify } from '../vault-management'
+
+let stdout: string[]
+let writeSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  stdout = []
+  writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(chunk => {
+    stdout.push(String(chunk))
+    return true
+  })
+})
+
+afterEach(() => {
+  writeSpy.mockRestore()
+  vi.restoreAllMocks()
+  resetOutput()
+})
+
+const jsonOut = () => stdout.join('')
+
+describe('verify failure output', () => {
+  function makeCtx(err: Error): CommandContext {
+    return {
+      sdk: { verifyVault: vi.fn().mockRejectedValue(err) },
+      setActiveVault: vi.fn(async () => {}),
+      dispose: () => {},
+    } as unknown as CommandContext
+  }
+
+  it('writes NO envelope of its own on failure — the caller emits exactly one', async () => {
+    configureOutput({ format: 'json' })
+
+    await expect(executeVerify(makeCtx(new Error('Invalid code')), 'v1', { code: '000000' })).rejects.toThrow()
+
+    // Previously this wrote a success-shaped {"success":true,...,"verified":false}.
+    expect(jsonOut()).toBe('')
+  })
+
+  it('throws instead of returning false, so stdout can never carry two documents', async () => {
+    configureOutput({ format: 'json' })
+
+    const result = await executeVerify(makeCtx(new Error('Invalid code')), 'v1', { code: '000000' }).then(
+      () => 'resolved',
+      () => 'threw'
+    )
+
+    expect(result).toBe('threw')
+  })
+
+  it('does not leak SDK jargon for a missing pending vault, and points at CLI commands', async () => {
+    const sdkErr = new Error('No pending vault found for this ID. Create a vault first with createFastVault().')
+
+    await executeVerify(makeCtx(sdkErr), 'v-missing', { code: '000000' }).then(
+      () => {
+        throw new Error('expected executeVerify to throw')
+      },
+      (err: unknown) => {
+        expect(err).toBeInstanceOf(VaultNotFoundError)
+        const e = err as VaultNotFoundError
+        expect(e.message).not.toMatch(/createFastVault/)
+        expect(e.message).toContain('v-missing')
+        expect(e.suggestions).toEqual(expect.arrayContaining(['vultisig vaults']))
+      }
+    )
+  })
+
+  it('suggests --resend for a wrong or expired code', async () => {
+    await executeVerify(makeCtx(new Error('Invalid code')), 'v1', { code: '000000' }).then(
+      () => {
+        throw new Error('expected executeVerify to throw')
+      },
+      (err: unknown) => {
+        expect((err as VaultNotFoundError).suggestions).toEqual(expect.arrayContaining(['vultisig verify v1 --resend']))
+      }
+    )
+  })
+})
+
+describe('vaults pending visibility', () => {
+  function makeCtx(pending: string[], vaults: unknown[] = []) {
+    return {
+      sdk: {
+        listVaults: vi.fn(async () => vaults),
+        listPendingVaults: vi.fn(async () => pending),
+      },
+      getActiveVault: () => null,
+      dispose: () => {},
+    } as unknown as CommandContext
+  }
+
+  it('reports pending vault ids and status in the JSON envelope', async () => {
+    configureOutput({ format: 'json' })
+
+    await executeVaults(makeCtx(['pending-abc']))
+
+    const parsed = JSON.parse(jsonOut())
+    expect(parsed.success).toBe(true)
+    expect(parsed.data.pending).toEqual([{ id: 'pending-abc', status: 'pending_verification' }])
+  })
+
+  it('emits exactly one parseable JSON document', async () => {
+    configureOutput({ format: 'json' })
+
+    await executeVaults(makeCtx(['pending-abc']))
+
+    expect(() => JSON.parse(jsonOut())).not.toThrow()
+  })
+
+  it('reports an empty pending list when there are none', async () => {
+    configureOutput({ format: 'json' })
+
+    await executeVaults(makeCtx([]))
+
+    expect(JSON.parse(jsonOut()).data.pending).toEqual([])
+  })
+
+  it('does not let a pending-store read failure take down vaults', async () => {
+    configureOutput({ format: 'json' })
+    const ctx = makeCtx([])
+    ;(ctx.sdk.listPendingVaults as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('storage exploded'))
+
+    await expect(executeVaults(ctx)).resolves.toBeDefined()
+    expect(JSON.parse(jsonOut()).data.pending).toEqual([])
+  })
+})

--- a/clients/cli/src/commands/settings.ts
+++ b/clients/cli/src/commands/settings.ts
@@ -47,6 +47,11 @@ export async function executeCurrency(ctx: CommandContext, newCurrency?: string)
   spinner.succeed('Currency updated')
 
   const currencyName = fiatCurrencyNameRecord[currency]
+  if (isJsonOutput()) {
+    outputJson({ currency, name: currencyName, updated: true })
+    return currency
+  }
+
   success(`\n+ Currency preference set to ${currency.toUpperCase()} (${currencyName})`)
 
   return currency
@@ -154,16 +159,20 @@ export async function executeAddressBook(
     }
 
     const spinner = createSpinner('Adding address to address book...')
-    await ctx.sdk.addAddressBookEntry([
-      {
-        chain: chain!,
-        address: address!,
-        name: name!,
-        source: 'saved' as const,
-        dateAdded: Date.now(),
-      },
-    ])
+    const entry = {
+      chain: chain!,
+      address: address!,
+      name: name!,
+      source: 'saved' as const,
+      dateAdded: Date.now(),
+    }
+    await ctx.sdk.addAddressBookEntry([entry])
     spinner.succeed('Address added')
+
+    if (isJsonOutput()) {
+      outputJson({ added: entry })
+      return []
+    }
 
     success(`\n+ Added ${name} (${chain}: ${address})`)
     return []
@@ -173,6 +182,11 @@ export async function executeAddressBook(
     const spinner = createSpinner('Removing address from address book...')
     await ctx.sdk.removeAddressBookEntry([{ address: options.remove, chain: options.chain }])
     spinner.succeed('Address removed')
+
+    if (isJsonOutput()) {
+      outputJson({ removed: { address: options.remove, chain: options.chain } })
+      return []
+    }
 
     success(`\n+ Removed ${options.remove}`)
     return []

--- a/clients/cli/src/commands/transaction.ts
+++ b/clients/cli/src/commands/transaction.ts
@@ -84,12 +84,18 @@ export async function sendTransaction(
   if (params.dryRun) {
     const balance = await vault.balance(params.chain, params.tokenId)
     const hasInsufficientBalance = parseFloat(dryResult.total) > parseFloat(balance.formattedAmount)
+    // fee/total come straight from the build the SDK just did. They were previously
+    // dropped from the JSON result even though the human preview below prints the fee
+    // and `total` is what the insufficient-balance check compares against — so
+    // `--dry-run -o json` looked like a bare balance check with no cost information.
     const result: SendDryRunResult = {
       dryRun: true,
       chain: params.chain,
       to,
       amount: params.amount,
       symbol: balance.symbol,
+      fee: dryResult.fee,
+      total: dryResult.total,
       balance: balance.formattedAmount,
       destinationTag,
     }
@@ -104,7 +110,8 @@ export async function sendTransaction(
       info(`  To:      ${result.to}`)
       info(`  Amount:  ${result.amount} ${result.symbol}`)
       if (result.destinationTag !== undefined) info(`  Destination tag: ${result.destinationTag}`)
-      info(`  Fee:     ${dryResult.fee} ${result.symbol}`)
+      info(`  Fee:     ${result.fee} ${result.symbol}`)
+      info(`  Total:   ${result.total} ${result.symbol}`)
       info(`  Balance: ${result.balance} ${result.symbol}`)
       if (result.warning) warn(`  Warning: ${result.warning}`)
     }

--- a/clients/cli/src/commands/vault-management.ts
+++ b/clients/cli/src/commands/vault-management.ts
@@ -308,6 +308,15 @@ export async function executeImport(ctx: CommandContext, file: string, flagPassw
   await ctx.setActiveVault(vault)
   spinner.succeed(`Vault imported: ${vault.name}`)
 
+  if (isJsonOutput()) {
+    outputJson({
+      imported: true,
+      vault: { id: vault.id, name: vault.name, type: vault.type, chains: vault.chains.length },
+      isActive: true,
+    })
+    return vault
+  }
+
   success('\n+ Vault imported successfully!')
   info('\nRun "vultisig balance" to view balances')
 
@@ -567,6 +576,11 @@ export async function executeExport(ctx: CommandContext, options: ExportVaultOpt
 
   spinner.succeed(`Vault exported: ${outputPath}`)
 
+  if (isJsonOutput()) {
+    outputJson({ exported: true, path: outputPath, encrypted: exportPassword !== undefined })
+    return outputPath
+  }
+
   success('\n+ Vault exported successfully!')
   info(`File: ${outputPath}`)
 
@@ -672,6 +686,15 @@ export async function executeSwitch(ctx: CommandContext, vaultId: string): Promi
   setupVaultEvents(vault)
   spinner.succeed('Vault switched')
 
+  if (isJsonOutput()) {
+    outputJson({
+      switched: true,
+      vault: { id: vault.id, name: vault.name, type: vault.type, chains: vault.chains.length },
+      isActive: true,
+    })
+    return vault
+  }
+
   success(`\n+ Switched to vault: ${vault.name}`)
   info(`  Type: ${vault.type}`)
   info(`  Chains: ${vault.chains.length}`)
@@ -690,6 +713,11 @@ export async function executeRename(ctx: CommandContext, newName: string): Promi
   const spinner = createSpinner('Renaming vault...')
   await vault.rename(newName)
   spinner.succeed('Vault renamed')
+
+  if (isJsonOutput()) {
+    outputJson({ renamed: true, vault: { id: vault.id, name: newName }, previousName: oldName })
+    return
+  }
 
   success(`\n+ Vault renamed from "${oldName}" to "${newName}"`)
 }

--- a/clients/cli/src/commands/vault-management.ts
+++ b/clients/cli/src/commands/vault-management.ts
@@ -546,8 +546,11 @@ export async function executeExport(ctx: CommandContext, options: ExportVaultOpt
   const parentDir = path.dirname(outputPath)
   await fs.mkdir(parentDir, { recursive: true })
 
-  // Write the vault file
-  await fs.writeFile(outputPath, vultContent, 'utf-8')
+  // Write the vault file. An export carries key shares, so it gets the same
+  // owner-only mode as the SDK's vault store — `mode` only applies when the file
+  // is created, so chmod an existing path we may have just overwritten.
+  await fs.writeFile(outputPath, vultContent, { encoding: 'utf-8', mode: 0o600 })
+  await fs.chmod(outputPath, 0o600)
 
   spinner.succeed(`Vault exported: ${outputPath}`)
 

--- a/clients/cli/src/commands/vault-management.ts
+++ b/clients/cli/src/commands/vault-management.ts
@@ -9,6 +9,7 @@ import path from 'path'
 import qrcode from 'qrcode-terminal'
 
 import type { CommandContext } from '../core'
+import { InvalidInputError, VaultNotFoundError, type VsigError } from '../core/errors'
 import {
   createSpinner,
   error,
@@ -422,20 +423,32 @@ export async function executeVerify(
     return true
   } catch (err: any) {
     spinner.fail('Verification failed')
-
-    if (isJsonOutput()) {
-      outputJson({
-        verified: false,
-        error: err.message || 'Verification failed. Please check the code and try again.',
-      })
-      return false
-    }
-
-    error(`\n✗ ${err.message || 'Verification failed. Please check the code and try again.'}`)
-    warn('\nTip: Use --resend to get a new verification code:')
-    info(`  vultisig verify ${vaultId} --resend`)
-    return false
+    // Throw a single typed error rather than pre-writing a result and returning
+    // false: the caller used to turn that false into a second throw, so `-o json`
+    // emitted TWO documents — a success-shaped {verified:false} envelope followed
+    // by an error envelope — and JSON.parse on the output failed. withExit renders
+    // message/hint/suggestions, so the human path keeps the same guidance.
+    throw verificationFailureError(err as Error, vaultId)
   }
+}
+
+/** The SDK words this case for library callers ("...with createFastVault()"), which
+ *  is meaningless in a shell. The CLI owns its own copy. */
+const PENDING_VAULT_MISSING_RE = /no pending vault found/i
+
+function verificationFailureError(err: Error, vaultId: string): VsigError {
+  if (PENDING_VAULT_MISSING_RE.test(err.message ?? '')) {
+    return new VaultNotFoundError(
+      `No pending vault found for ID "${vaultId}".`,
+      'It may already be verified, or the ID may be wrong',
+      ['vultisig vaults', 'vultisig create --two-step']
+    )
+  }
+  return new InvalidInputError(
+    err.message || 'Verification failed. Please check the code and try again.',
+    'The code may be incorrect or expired',
+    [`vultisig verify ${vaultId} --resend`]
+  )
 }
 
 export type AddPostQuantumKeysOptions = {
@@ -566,6 +579,11 @@ export async function executeExport(ctx: CommandContext, options: ExportVaultOpt
 export async function executeVaults(ctx: CommandContext): Promise<VaultBase[]> {
   const spinner = createSpinner('Loading vaults...')
   const vaults = await ctx.sdk.listVaults()
+  // A two-step vault awaiting verification is only named in the create-time output.
+  // An agent that lost that output had no way to rediscover the id and finish
+  // verifying, so list pending vaults here too. Best-effort: a pending-store read
+  // failure must not take down `vaults`, the command used to diagnose vault state.
+  const pending = await listPendingVaultsSafely(ctx)
   spinner.succeed('Vaults loaded')
 
   if (isJsonOutput()) {
@@ -580,21 +598,42 @@ export async function executeVaults(ctx: CommandContext): Promise<VaultBase[]> {
         createdAt: v.createdAt,
         isActive: activeVault?.id === v.id,
       })),
+      pending: pending.map(id => ({ id, status: 'pending_verification' })),
     })
     return vaults
   }
 
-  if (vaults.length === 0) {
+  if (vaults.length === 0 && pending.length === 0) {
     warn('\nNo vaults found. Create or import a vault first.')
     return []
   }
 
   const activeVault = ctx.getActiveVault()
-  displayVaultsList(vaults, activeVault)
+  if (vaults.length > 0) {
+    displayVaultsList(vaults, activeVault)
+  }
 
-  info(chalk.gray('\nUse "vultisig switch <id>" to switch active vault'))
+  if (pending.length > 0) {
+    warn(`\nPending verification (${pending.length}):`)
+    for (const id of pending) {
+      info(`  ${id}`)
+    }
+    info(chalk.gray('Finish with "vultisig verify <id> --code <OTP>"'))
+  }
+
+  if (vaults.length > 0) {
+    info(chalk.gray('\nUse "vultisig switch <id>" to switch active vault'))
+  }
 
   return vaults
+}
+
+async function listPendingVaultsSafely(ctx: CommandContext): Promise<string[]> {
+  try {
+    return await ctx.sdk.listPendingVaults()
+  } catch {
+    return []
+  }
 }
 
 /**

--- a/clients/cli/src/commands/vault-management.ts
+++ b/clients/cli/src/commands/vault-management.ts
@@ -9,7 +9,14 @@ import path from 'path'
 import qrcode from 'qrcode-terminal'
 
 import type { CommandContext } from '../core'
-import { InvalidInputError, VaultNotFoundError, type VsigError } from '../core/errors'
+import {
+  classifyError,
+  ExternalServiceError,
+  InvalidInputError,
+  UnknownError,
+  VaultNotFoundError,
+  type VsigError,
+} from '../core/errors'
 import {
   createSpinner,
   error,
@@ -377,8 +384,11 @@ export async function executeVerify(
       info('Check your inbox for the new verification code.')
     } catch (resendErr: any) {
       spinner.fail('Failed to resend verification email')
-      error(resendErr.message || 'Could not resend email. You may need to wait a few minutes.')
-      return false
+      // Throw rather than `return false`: the caller no longer converts a false
+      // return into an error, so returning here would report the resend as a
+      // success (exit 0, and empty stdout in JSON mode) for an email that was
+      // never sent.
+      throw resendFailureError(resendErr as Error, vaultId)
     }
 
     // Non-interactive sessions can't fall through to the OTP prompt below — resend
@@ -441,6 +451,22 @@ export async function executeVerify(
   }
 }
 
+/**
+ * A resend that failed must not look like one that succeeded. Keep the SDK's own
+ * classification when it produced a precise one (a bad password is AUTH_REQUIRED,
+ * a dropped connection is NETWORK); only an otherwise-unclassifiable failure gets
+ * the resend-specific wording, since rate-limiting is the common cause.
+ */
+function resendFailureError(err: Error, vaultId: string): VsigError {
+  const classified = classifyError(err)
+  if (!(classified instanceof UnknownError)) return classified
+  return new ExternalServiceError(
+    err.message || 'Could not resend the verification email.',
+    'The server may be rate-limiting resends — you may need to wait a few minutes',
+    [`vultisig verify ${vaultId} --resend`]
+  )
+}
+
 /** The SDK words this case for library callers ("...with createFastVault()"), which
  *  is meaningless in a shell. The CLI owns its own copy. */
 const PENDING_VAULT_MISSING_RE = /no pending vault found/i
@@ -497,6 +523,12 @@ export async function executeAddPostQuantumKeys(
       },
     })
     spinner.succeed('ML-DSA keys added. Vault file updated — export a backup if needed.')
+
+    if (isJsonOutput()) {
+      outputJson({ added: true, vault: { id: vault.id, name: vault.name }, backupRecommended: true })
+      return
+    }
+
     success('Post-quantum signing is now available for this vault (where supported).')
   } catch (e) {
     spinner.fail('Failed to add ML-DSA keys')
@@ -568,11 +600,20 @@ export async function executeExport(ctx: CommandContext, options: ExportVaultOpt
   const parentDir = path.dirname(outputPath)
   await fs.mkdir(parentDir, { recursive: true })
 
-  // Write the vault file. An export carries key shares, so it gets the same
-  // owner-only mode as the SDK's vault store — `mode` only applies when the file
-  // is created, so chmod an existing path we may have just overwritten.
-  await fs.writeFile(outputPath, vultContent, { encoding: 'utf-8', mode: 0o600 })
-  await fs.chmod(outputPath, 0o600)
+  // An export carries key shares, so it gets the same owner-only mode as the SDK's
+  // vault store. Write to a fresh temp path and rename over the target, mirroring
+  // storage.ts: `mode` only applies when writeFile CREATES the file, so writing
+  // straight to an existing (or attacker-pre-created) path would put the shares in a
+  // world-readable file and only tighten it afterwards. Creating a new file first
+  // means the shares are never on disk at anything but 0600, and the rename is atomic.
+  const tempPath = `${outputPath}.${process.pid}.${Date.now()}.tmp`
+  try {
+    await fs.writeFile(tempPath, vultContent, { encoding: 'utf-8', mode: 0o600 })
+    await fs.rename(tempPath, outputPath)
+  } catch (err) {
+    await fs.rm(tempPath, { force: true }).catch(() => {})
+    throw err
+  }
 
   spinner.succeed(`Vault exported: ${outputPath}`)
 

--- a/clients/cli/src/core/chain-resolver.test.ts
+++ b/clients/cli/src/core/chain-resolver.test.ts
@@ -1,0 +1,55 @@
+// Chain-argument validation (vultisig-sdk sdkcli2-13 P2-6 / P2-10).
+//
+// Regression guards:
+//  - `tokens <bogus-chain>` exited 0 with `{"success":true,"data":{"tokens":[]}}` — a
+//    machine caller could not distinguish "chain has no tokens" from "no such chain".
+//  - `swap-quote <bogus-chain> ...` exited 7/UNKNOWN_ERROR with a raw
+//    "Cannot read properties of undefined (reading 'ticker')" TypeError.
+// Both call sites cast an unresolved name straight to `Chain`
+// (`findChainByName(x) || (x as Chain)`); resolving up front turns both into
+// INVALID_CHAIN / exit 4.
+import { Chain } from '@vultisig/sdk'
+import { describe, expect, it } from 'vitest'
+
+import { resolveChainOrThrow } from './chain-resolver'
+import { ExitCode, InvalidChainError } from './errors'
+
+describe('resolveChainOrThrow', () => {
+  it('resolves a known chain name case-insensitively', () => {
+    expect(resolveChainOrThrow('Ethereum')).toBe(Chain.Ethereum)
+    expect(resolveChainOrThrow('ethereum')).toBe(Chain.Ethereum)
+    expect(resolveChainOrThrow('ETHEREUM')).toBe(Chain.Ethereum)
+  })
+
+  it('throws INVALID_CHAIN / exit 4 for an unknown chain instead of casting it through', () => {
+    try {
+      resolveChainOrThrow('bogus-chain')
+      throw new Error('expected resolveChainOrThrow to throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(InvalidChainError)
+      const chainErr = err as InvalidChainError
+      expect(chainErr.code).toBe('INVALID_CHAIN')
+      expect(chainErr.exitCode).toBe(ExitCode.INVALID_INPUT)
+      expect(chainErr.retryable).toBe(false)
+    }
+  })
+
+  it('carries the offending name in the error context and message', () => {
+    try {
+      resolveChainOrThrow('bogus-chain')
+      throw new Error('expected resolveChainOrThrow to throw')
+    } catch (err) {
+      expect((err as InvalidChainError).context).toMatchObject({ chain: 'bogus-chain' })
+      expect((err as InvalidChainError).message).toContain('bogus-chain')
+    }
+  })
+
+  it('names which side of a two-chain command was wrong', () => {
+    expect(() => resolveChainOrThrow('nope', 'source chain')).toThrow(/Unsupported source chain: "nope"/)
+    expect(() => resolveChainOrThrow('nope', 'destination chain')).toThrow(/Unsupported destination chain: "nope"/)
+  })
+
+  it('does not accept the empty string as a chain', () => {
+    expect(() => resolveChainOrThrow('')).toThrow(InvalidChainError)
+  })
+})

--- a/clients/cli/src/core/chain-resolver.ts
+++ b/clients/cli/src/core/chain-resolver.ts
@@ -1,6 +1,9 @@
 import type { Chain } from '@vultisig/sdk'
 
-import { findChainByName } from '../interactive'
+// Imported from the leaf module rather than the '../interactive' barrel: the barrel
+// pulls in the shell session, which imports '../core' back, and that cycle would make
+// core transitively load the whole shell + command tree.
+import { findChainByName } from '../interactive/completer'
 import { InvalidChainError } from './errors'
 
 /**

--- a/clients/cli/src/core/chain-resolver.ts
+++ b/clients/cli/src/core/chain-resolver.ts
@@ -1,0 +1,29 @@
+import type { Chain } from '@vultisig/sdk'
+
+import { findChainByName } from '../interactive'
+import { InvalidChainError } from './errors'
+
+/**
+ * Resolve a user-supplied chain name, or throw INVALID_CHAIN.
+ *
+ * Call sites historically wrote `findChainByName(input) || (input as Chain)`, which
+ * launders an unknown name into a `Chain` and defers the failure to whatever the
+ * command does next — `tokens bogus-chain` reported `success: true` with an empty
+ * list, and `swap-quote bogus-chain ...` surfaced a raw TypeError. Resolving up
+ * front turns both into the same typed, non-retryable INVALID_CHAIN.
+ *
+ * `label` names the argument in the message, so a two-chain command can say which
+ * side was wrong.
+ */
+export function resolveChainOrThrow(input: string, label = 'chain'): Chain {
+  const chain = findChainByName(input)
+  if (!chain) {
+    throw new InvalidChainError(
+      `Unsupported ${label}: "${input}"`,
+      'Run "vultisig chains" to see the supported chains, or check the spelling.',
+      undefined,
+      { chain: input }
+    )
+  }
+  return chain
+}

--- a/clients/cli/src/core/command-context.ts
+++ b/clients/cli/src/core/command-context.ts
@@ -9,6 +9,8 @@
  */
 import type { VaultBase, Vultisig } from '@vultisig/sdk'
 
+import { NoActiveVaultError } from './errors'
+
 /**
  * Password cache entry with expiration
  */
@@ -87,7 +89,7 @@ export abstract class BaseCommandContext implements CommandContext {
     }
 
     if (!this._activeVault) {
-      throw new Error('No active vault. Create or import a vault first.')
+      throw new NoActiveVaultError()
     }
 
     return this._activeVault

--- a/clients/cli/src/core/errors.ts
+++ b/clients/cli/src/core/errors.ts
@@ -2,6 +2,7 @@ import {
   Chain,
   type ChainKind,
   getChainKind,
+  StorageError,
   VaultError,
   VaultErrorCode,
   VaultImportError,
@@ -55,6 +56,16 @@ export enum ExitCode {
   // request did not execute or consume credits; inspect the conversation for
   // the first attempt's persisted result before starting a fresh attempt.
   IDEMPOTENT_TURN_DUPLICATE = 14,
+  // The command needs an active vault and there isn't one selected. This is an
+  // expected, actionable state (create/import/switch), NOT a failure — distinct
+  // from UNKNOWN (7) so a headless caller can tell "you have no vault yet" from
+  // "something broke". Vaults may well exist; none is selected.
+  NO_ACTIVE_VAULT = 15,
+  // On-disk CLI/vault state is present but unparseable (truncated or hand-edited
+  // JSON). Retrying cannot help and no amount of waiting fixes it — the state must
+  // be repaired or re-imported from a .vult backup. Distinct from UNKNOWN (7) so a
+  // headless caller can stop retrying and surface a recovery path.
+  CORRUPT_STATE = 16,
 }
 
 export const EXIT_CODE_DESCRIPTIONS: Record<ExitCode, string> = {
@@ -76,6 +87,8 @@ export const EXIT_CODE_DESCRIPTIONS: Record<ExitCode, string> = {
     'agent ask: transaction broadcast but the overall request may be incomplete — inspect the hash, do NOT blindly retry',
   [ExitCode.IDEMPOTENT_TURN_DUPLICATE]:
     'agent ask: duplicate keyed turn rejected — inspect the conversation for the original result',
+  [ExitCode.NO_ACTIVE_VAULT]: 'No active vault selected — create, import, or switch to one',
+  [ExitCode.CORRUPT_STATE]: 'Stored state is unreadable — repair it or re-import the vault from a .vult backup',
 }
 
 export abstract class VsigError extends Error {
@@ -295,6 +308,37 @@ function keyedTurnContext(conversationId?: string, firstRequestAt?: string): Rec
   return Object.keys(context).length > 0 ? context : undefined
 }
 
+/** A command needs an active vault and none is selected. Expected and actionable —
+ *  vaults may exist, none is current. */
+export class NoActiveVaultError extends VsigError {
+  readonly exitCode = ExitCode.NO_ACTIVE_VAULT
+  readonly code = 'NO_ACTIVE_VAULT'
+
+  constructor(message?: string) {
+    super(
+      message ?? 'No active vault. Create or import a vault first.',
+      'Select an existing vault with "vultisig switch <id>", or create/import one',
+      ['vultisig vaults', 'vultisig switch <id>', 'vultisig create', 'vultisig import <file.vult>']
+    )
+  }
+}
+
+/** Stored state exists but is unparseable. Not retryable: the bytes on disk are
+ *  broken, so the caller needs a repair/re-import path rather than another attempt. */
+export class CorruptStateError extends VsigError {
+  readonly exitCode = ExitCode.CORRUPT_STATE
+  readonly code = 'CORRUPT_STATE'
+
+  constructor(message: string, context?: Record<string, string>) {
+    super(
+      message,
+      'The stored file is present but unreadable — it was likely truncated or hand-edited',
+      ['Re-import the vault from its .vult backup: vultisig import <file.vult>', 'vultisig vaults'],
+      context
+    )
+  }
+}
+
 export class UnknownError extends VsigError {
   readonly exitCode = ExitCode.UNKNOWN
   readonly code = 'UNKNOWN_ERROR'
@@ -504,8 +548,28 @@ function classifyVaultError(err: VaultError): VsigError {
   }
 }
 
+/**
+ * A StorageError means "the read/write itself failed", which covers both broken
+ * bytes and ordinary IO trouble. Only the former is CORRUPT_STATE: retrying an
+ * unparseable file is futile, whereas a permission/IO error may well clear. The
+ * node/RN/extension backends all wrap the underlying failure as `cause`, so a
+ * JSON.parse SyntaxError there is the positive signal that the stored value is
+ * genuinely malformed. Anything else deliberately falls through to the existing
+ * classification rather than being mislabelled unrecoverable.
+ */
+function corruptStateErrorFrom(err: StorageError): CorruptStateError | undefined {
+  if (!(err.cause instanceof SyntaxError)) return undefined
+  const keyMatch = err.message.match(/key "([^"]+)"/)
+  return new CorruptStateError(err.message, keyMatch ? { key: keyMatch[1] } : undefined)
+}
+
 export function classifyError(err: Error): VsigError {
   if (err instanceof VsigError) return err
+
+  if (err instanceof StorageError) {
+    const corrupt = corruptStateErrorFrom(err)
+    if (corrupt) return corrupt
+  }
 
   // The journal's duplicate/concurrent refusals aren't VaultErrors — they carry
   // a stable `code === 'DUPLICATE_BROADCAST'`. Map them to exit 9 before the

--- a/clients/cli/src/core/index.ts
+++ b/clients/cli/src/core/index.ts
@@ -3,6 +3,7 @@
  */
 export * from './active-vault'
 export * from './broadcastGuard'
+export * from './chain-resolver'
 export * from './command-context'
 export * from './config-store'
 export * from './credential-store'

--- a/clients/cli/src/core/state-errors.test.ts
+++ b/clients/cli/src/core/state-errors.test.ts
@@ -1,0 +1,87 @@
+// Typed state errors (vultisig-sdk sdkcli2-13 P1-6 / P7a-2).
+//
+// Regression guards:
+//  - "No active vault" threw a plain Error, so `balance -o json` on an empty store
+//    exited 7/UNKNOWN_ERROR with no hint — indistinguishable from a real crash.
+//  - A readable pointer naming a vault whose data file is corrupt propagated the raw
+//    storage failure ("Failed to read value for key X") as UNKNOWN_ERROR/7, with no
+//    remediation path.
+// Both now carry stable codes and recovery hints. Corruption is detected positively
+// (a JSON.parse SyntaxError cause) so transient IO/permission failures are NOT
+// mislabelled unrecoverable.
+import { StorageError, StorageErrorCode } from '@vultisig/sdk'
+import { describe, expect, it } from 'vitest'
+
+import { classifyError, CorruptStateError, ExitCode, NoActiveVaultError, toErrorJson, UnknownError } from './errors'
+
+describe('NoActiveVaultError', () => {
+  it('is NO_ACTIVE_VAULT / exit 15, not UNKNOWN / 7', () => {
+    const err = new NoActiveVaultError()
+    expect(err.code).toBe('NO_ACTIVE_VAULT')
+    expect(err.exitCode).toBe(ExitCode.NO_ACTIVE_VAULT)
+    expect(err.exitCode).not.toBe(ExitCode.UNKNOWN)
+  })
+
+  it('is not retryable and carries an actionable recovery path', () => {
+    const err = new NoActiveVaultError()
+    expect(err.retryable).toBe(false)
+    expect(err.hint).toBeTruthy()
+    expect(err.suggestions).toEqual(expect.arrayContaining(['vultisig switch <id>', 'vultisig create']))
+  })
+
+  it('survives classifyError unchanged and serialises the hint into the JSON envelope', () => {
+    const json = toErrorJson(classifyError(new NoActiveVaultError()))
+    expect(json.success).toBe(false)
+    expect(json.error.code).toBe('NO_ACTIVE_VAULT')
+    expect(json.error.exitCode).toBe(15)
+    expect(json.error.retryable).toBe(false)
+    expect(json.error.hint).toBeTruthy()
+    expect(json.error.suggestions?.length).toBeGreaterThan(0)
+  })
+})
+
+describe('CorruptStateError classification', () => {
+  // What the node storage backend actually throws for an unparseable file.
+  function storageParseFailure(key = 'activeVaultId') {
+    return new StorageError(
+      StorageErrorCode.Unknown,
+      `Failed to read value for key "${key}"`,
+      new SyntaxError('Unexpected end of JSON input')
+    )
+  }
+
+  it('maps an unparseable stored value to CORRUPT_STATE / exit 16', () => {
+    const classified = classifyError(storageParseFailure())
+    expect(classified).toBeInstanceOf(CorruptStateError)
+    expect(classified.code).toBe('CORRUPT_STATE')
+    expect(classified.exitCode).toBe(ExitCode.CORRUPT_STATE)
+  })
+
+  it('offers a re-import recovery path instead of a bare storage message', () => {
+    const classified = classifyError(storageParseFailure())
+    expect(classified.hint).toBeTruthy()
+    expect(classified.suggestions?.some(s => s.includes('import'))).toBe(true)
+    expect(classified.retryable).toBe(false)
+  })
+
+  it('names the offending storage key in the error context', () => {
+    const classified = classifyError(storageParseFailure('vault-abc123'))
+    expect(classified.context).toMatchObject({ key: 'vault-abc123' })
+  })
+
+  it('does NOT label a permission/IO storage failure as corrupt — retrying those can work', () => {
+    const ioFailure = new StorageError(
+      StorageErrorCode.Unknown,
+      'Failed to read value for key "activeVaultId"',
+      Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' })
+    )
+    expect(classifyError(ioFailure)).not.toBeInstanceOf(CorruptStateError)
+  })
+
+  it('does NOT label a StorageError with no cause as corrupt', () => {
+    const bare = new StorageError(StorageErrorCode.Unknown, 'Failed to read value for key "activeVaultId"')
+    const classified = classifyError(bare)
+    expect(classified).not.toBeInstanceOf(CorruptStateError)
+    expect(classified).toBeInstanceOf(UnknownError)
+  })
+})

--- a/clients/cli/src/core/state-errors.test.ts
+++ b/clients/cli/src/core/state-errors.test.ts
@@ -10,9 +10,50 @@
 // (a JSON.parse SyntaxError cause) so transient IO/permission failures are NOT
 // mislabelled unrecoverable.
 import { StorageError, StorageErrorCode } from '@vultisig/sdk'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
+import { BaseCommandContext } from './command-context'
 import { classifyError, CorruptStateError, ExitCode, NoActiveVaultError, toErrorJson, UnknownError } from './errors'
+
+describe('ensureActiveVault throw site', () => {
+  // The tests below construct NoActiveVaultError directly, which would stay green if
+  // the throw site regressed to a plain Error. Drive the real code path too.
+  class TestContext extends BaseCommandContext {
+    get isInteractive() {
+      return false
+    }
+    async getPassword() {
+      return ''
+    }
+  }
+
+  function makeCtx(activeVault: unknown) {
+    return new TestContext({
+      getActiveVault: vi.fn(async () => activeVault),
+      dispose: vi.fn(),
+    } as never)
+  }
+
+  it('throws NoActiveVaultError — not a plain Error — when no vault is active', async () => {
+    await expect(makeCtx(null).ensureActiveVault()).rejects.toBeInstanceOf(NoActiveVaultError)
+  })
+
+  it('gives that throw exit 15 with a hint, rather than UNKNOWN_ERROR/7', async () => {
+    const err = await makeCtx(null)
+      .ensureActiveVault()
+      .catch((e: unknown) => e)
+
+    const classified = classifyError(err as Error)
+    expect(classified.code).toBe('NO_ACTIVE_VAULT')
+    expect(classified.exitCode).toBe(ExitCode.NO_ACTIVE_VAULT)
+    expect(classified.hint).toBeTruthy()
+  })
+
+  it('still returns the vault when one is active', async () => {
+    const vault = { id: 'v1', name: 'Vault' }
+    await expect(makeCtx(vault).ensureActiveVault()).resolves.toBe(vault)
+  })
+})
 
 describe('NoActiveVaultError', () => {
   it('is NO_ACTIVE_VAULT / exit 15, not UNKNOWN / 7', () => {

--- a/clients/cli/src/core/types.ts
+++ b/clients/cli/src/core/types.ts
@@ -29,6 +29,10 @@ export type SendDryRunResult = {
   to: string
   amount: string
   symbol: string
+  /** Network fee the build estimated for this transaction. */
+  fee: string
+  /** amount + fee — what the send actually costs, and what `balance` is checked against. */
+  total: string
   balance: string
   destinationTag?: number
   warning?: string

--- a/clients/cli/src/index.ts
+++ b/clients/cli/src/index.ts
@@ -57,7 +57,7 @@ import {
   executeVerify,
   resolveTxStatusParams,
 } from './commands'
-import { cachePassword, createPasswordCallback, loadActiveVaultSafely } from './core'
+import { cachePassword, createPasswordCallback, loadActiveVaultSafely, resolveChainOrThrow } from './core'
 import { EXIT_CODE_DESCRIPTIONS, ExitCode, InvalidInputError } from './core/errors'
 import { parseServerEndpointOverridesFromArgv, resolveServerEndpoints } from './core/server-endpoints'
 import { findChainByName } from './interactive'
@@ -1077,9 +1077,10 @@ Examples:
           decimals?: string
         }
       ) => {
+        const chain = resolveChainOrThrow(chainStr)
         const context = await init(program.opts().vault)
         await executeTokens(context, {
-          chain: findChainByName(chainStr) || (chainStr as Chain),
+          chain,
           add: options.add,
           remove: options.remove,
           discover: options.discover,
@@ -1130,10 +1131,12 @@ Examples:
       ) => {
         if (!amountStr && !options.max) throw new Error('Provide an amount or use --max')
         if (amountStr && options.max) throw new Error('Cannot specify both amount and --max')
+        const fromChain = resolveChainOrThrow(fromChainStr, 'source chain')
+        const toChain = resolveChainOrThrow(toChainStr, 'destination chain')
         const context = await init(program.opts().vault)
         await executeSwapQuote(context, {
-          fromChain: findChainByName(fromChainStr) || (fromChainStr as Chain),
-          toChain: findChainByName(toChainStr) || (toChainStr as Chain),
+          fromChain,
+          toChain,
           amount: options.max ? 'max' : parseFloat(amountStr!),
           fromToken: options.fromToken,
           toToken: options.toToken,

--- a/clients/cli/src/index.ts
+++ b/clients/cli/src/index.ts
@@ -593,12 +593,10 @@ program
     withExit(
       async (vaultId: string, options: { resend?: boolean; code?: string; email?: string; password?: string }) => {
         const context = await init(program.opts().vault)
-        const verified = await executeVerify(context, vaultId, options)
-        if (!verified) {
-          const err: any = new Error('Verification failed')
-          err.exitCode = 1
-          throw err
-        }
+        // executeVerify throws a typed error on failure; it no longer signals
+        // failure via a `false` return that this had to re-throw (which produced a
+        // second JSON document on stdout).
+        await executeVerify(context, vaultId, options)
       }
     )
   )

--- a/clients/cli/src/lib/completion.ts
+++ b/clients/cli/src/lib/completion.ts
@@ -3,7 +3,8 @@
  *
  * Provides tab completion for bash, zsh, and fish shells using tabtab
  */
-import type { Command } from 'commander'
+import { SUPPORTED_CHAINS } from '@vultisig/sdk'
+import { type Command, program } from 'commander'
 import { existsSync, readdirSync, readFileSync } from 'fs'
 import { homedir } from 'os'
 import { join } from 'path'
@@ -30,60 +31,25 @@ async function getTabtab() {
 }
 
 /**
- * All available commands for completion
+ * Command names for completion, read from Commander itself.
+ *
+ * These lists used to be hand-maintained and had drifted badly: the command array
+ * was missing sign/broadcast/tx-status/execute/discount/agent/auth/delete/join/
+ * rujira/add-mldsa, and the chain list was a hand-picked subset. Reading the real
+ * registries means completion cannot go stale again when a command or chain is added.
+ *
+ * Resolved lazily rather than at module load: `program` is Commander's singleton and
+ * the CLI registers its commands as its module body runs, so the list is only complete
+ * once that has happened — every caller here runs after it.
  */
-const COMMANDS = [
-  'create',
-  'import',
-  'verify',
-  'balance',
-  'send',
-  'portfolio',
-  'currency',
-  'server',
-  'export',
-  'addresses',
-  'address-book',
-  'chains',
-  'vaults',
-  'switch',
-  'rename',
-  'info',
-  'tokens',
-  'swap-chains',
-  'swap-quote',
-  'swap',
-  'completion',
-  'version',
-  'update',
-]
+function getCommands(): string[] {
+  return program.commands.map(cmd => cmd.name()).sort()
+}
 
-/**
- * Common chains for completion
- */
-const CHAINS = [
-  'Ethereum',
-  'Bitcoin',
-  'Solana',
-  'Polygon',
-  'Arbitrum',
-  'Optimism',
-  'Avalanche',
-  'BSC',
-  'Base',
-  'Cosmos',
-  'THORChain',
-  'Maya',
-  'Dydx',
-  'Kujira',
-  'Sui',
-  'Polkadot',
-  'Ripple',
-  'Dogecoin',
-  'Litecoin',
-  'Dash',
-  'Zcash',
-]
+/** Chain names for completion, from the SDK's chain registry. */
+function getChains(): string[] {
+  return [...SUPPORTED_CHAINS]
+}
 
 /**
  * Get stored vault names for completion
@@ -136,7 +102,7 @@ export async function handleCompletion(): Promise<boolean> {
 
   if (!cmd || parts.length === 1 || (parts.length === 2 && lastPartial)) {
     // Complete command names
-    completions = COMMANDS.filter(c => c.startsWith(lastPartial || ''))
+    completions = getCommands().filter(c => c.startsWith(lastPartial || ''))
   } else {
     // Command-specific completions
     switch (cmd) {
@@ -145,7 +111,7 @@ export async function handleCompletion(): Promise<boolean> {
       case 'send':
         // Complete chain names
         if (parts.length === 2 || (parts.length === 3 && lastPartial)) {
-          completions = CHAINS.filter(c => c.toLowerCase().startsWith((lastPartial || '').toLowerCase()))
+          completions = getChains().filter(c => c.toLowerCase().startsWith((lastPartial || '').toLowerCase()))
         }
         break
 
@@ -167,7 +133,7 @@ export async function handleCompletion(): Promise<boolean> {
         if (lastPartial?.startsWith('-')) {
           completions = ['--add', '--remove'].filter(o => o.startsWith(lastPartial))
         } else if (parts.includes('--add') || parts.includes('--remove')) {
-          completions = CHAINS.filter(c => c.toLowerCase().startsWith((lastPartial || '').toLowerCase()))
+          completions = getChains().filter(c => c.toLowerCase().startsWith((lastPartial || '').toLowerCase()))
         }
         break
 
@@ -175,7 +141,7 @@ export async function handleCompletion(): Promise<boolean> {
       case 'swap-quote':
         // Complete chain names for from/to
         if (parts.length <= 3 || (parts.length === 4 && lastPartial)) {
-          completions = CHAINS.filter(c => c.toLowerCase().startsWith((lastPartial || '').toLowerCase()))
+          completions = getChains().filter(c => c.toLowerCase().startsWith((lastPartial || '').toLowerCase()))
         }
         break
 
@@ -318,19 +284,19 @@ _vultisig_completions() {
   local cmd="\${COMP_WORDS[1]}"
 
   if [ "\${COMP_CWORD}" -eq 1 ]; then
-    COMPREPLY=($(compgen -W "${COMMANDS.join(' ')}" -- "\${cur}"))
+    COMPREPLY=($(compgen -W "${getCommands().join(' ')}" -- "\${cur}"))
     return
   fi
 
   case "\${cmd}" in
     balance|tokens|send)
-      COMPREPLY=($(compgen -W "${CHAINS.join(' ')}" -- "\${cur}"))
+      COMPREPLY=($(compgen -W "${getChains().join(' ')}" -- "\${cur}"))
       ;;
     chains)
-      COMPREPLY=($(compgen -W "--add --remove ${CHAINS.join(' ')}" -- "\${cur}"))
+      COMPREPLY=($(compgen -W "--add --remove ${getChains().join(' ')}" -- "\${cur}"))
       ;;
     swap|swap-quote)
-      COMPREPLY=($(compgen -W "${CHAINS.join(' ')}" -- "\${cur}"))
+      COMPREPLY=($(compgen -W "${getChains().join(' ')}" -- "\${cur}"))
       ;;
     completion)
       COMPREPLY=($(compgen -W "install uninstall bash zsh fish" -- "\${cur}"))
@@ -358,8 +324,10 @@ function getZshCompletionScript(): string {
 
 _vultisig() {
   local -a commands chains
-  commands=(${COMMANDS.map(c => `'${c}:${c} command'`).join(' ')})
-  chains=(${CHAINS.join(' ')})
+  commands=(${getCommands()
+    .map(c => `'${c}:${c} command'`)
+    .join(' ')})
+  chains=(${getChains().join(' ')})
 
   _arguments -C \\
     '1: :->command' \\
@@ -396,11 +364,11 @@ function getFishCompletionScript(): string {
   // Generate completions for both vultisig and vsig
   const commands = ['vultisig', 'vsig']
   const commandCompletions = commands
-    .flatMap(cmd => COMMANDS.map(c => `complete -c ${cmd} -n "__fish_use_subcommand" -a "${c}"`))
+    .flatMap(cmd => getCommands().map(c => `complete -c ${cmd} -n "__fish_use_subcommand" -a "${c}"`))
     .join('\n')
   const chainCompletions = commands
     .flatMap(cmd =>
-      CHAINS.map(
+      getChains().map(
         c => `complete -c ${cmd} -n "__fish_seen_subcommand_from balance tokens send swap swap-quote" -a "${c}"`
       )
     )

--- a/clients/cli/src/lib/completionRegistry.test.ts
+++ b/clients/cli/src/lib/completionRegistry.test.ts
@@ -1,0 +1,78 @@
+// Shell completion is generated from the real registries (vultisig-sdk sdkcli2-13 P2-13).
+//
+// Regression guard: completion.ts hand-maintained COMMANDS and CHAINS arrays that had
+// drifted. The shipped zsh/bash/fish scripts offered a command list missing
+// sign/broadcast/tx-status/execute/discount/agent/auth/delete/join/rujira/add-mldsa,
+// and a hand-picked subset of chains. Commands now come from Commander and chains from
+// the SDK registry, so the scripts cannot silently go stale again.
+import { SUPPORTED_CHAINS } from '@vultisig/sdk'
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const CLI_ENTRY = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'index.ts')
+
+/** Commands that exist in the CLI but were absent from the old hardcoded array. */
+const PREVIOUSLY_MISSING = [
+  'sign',
+  'broadcast',
+  'tx-status',
+  'execute',
+  'discount',
+  'agent',
+  'auth',
+  'delete',
+  'join',
+  'rujira',
+  'add-mldsa',
+]
+
+function completionScript(shell: string): string {
+  const env: NodeJS.ProcessEnv = { ...process.env, NO_COLOR: '1' }
+  // Strip ambient completion env so the run isn't diverted into handleCompletion().
+  delete env.COMP_LINE
+  delete env.COMP_POINT
+  delete env.COMP_CWORD
+
+  const result = spawnSync(process.execPath, ['--import', 'tsx', CLI_ENTRY, 'completion', shell], {
+    input: '',
+    encoding: 'utf8',
+    timeout: 120_000,
+    env,
+  })
+  return result.stdout ?? ''
+}
+
+describe('generated completion scripts', () => {
+  const shells = ['zsh', 'bash', 'fish'] as const
+
+  for (const shell of shells) {
+    describe(shell, () => {
+      const script = completionScript(shell)
+
+      it('is non-empty', () => {
+        expect(script.trim().length).toBeGreaterThan(0)
+      })
+
+      it('offers the commands the hardcoded list had drifted away from', () => {
+        for (const cmd of PREVIOUSLY_MISSING) {
+          expect(script, `${shell} completion is missing "${cmd}"`).toContain(cmd)
+        }
+      })
+
+      it('offers chains from the SDK registry, not a hand-picked subset', () => {
+        // Cardano and Tron are in the registry but were absent from the old CHAINS array.
+        expect(script).toContain('Cardano')
+        expect(script).toContain('Tron')
+      })
+
+      it('offers every chain the SDK supports', () => {
+        for (const chain of SUPPORTED_CHAINS) {
+          expect(script, `${shell} completion is missing chain "${chain}"`).toContain(chain)
+        }
+      })
+    })
+  }
+})

--- a/clients/cli/src/lib/completionRegistry.test.ts
+++ b/clients/cli/src/lib/completionRegistry.test.ts
@@ -42,7 +42,45 @@ function completionScript(shell: string): string {
     timeout: 120_000,
     env,
   })
+  // Fail loudly rather than returning '' and letting a "missing X" assertion report
+  // the wrong cause.
+  if (result.status !== 0) {
+    throw new Error(`completion ${shell} exited ${result.status}: ${result.stderr ?? ''}`)
+  }
   return result.stdout ?? ''
+}
+
+function escapeRe(word: string): string {
+  return word.replace(/[.*+?^${}()|[\]\\-]/g, '\\$&')
+}
+
+/**
+ * Whether the script offers `cmd` as its own command token, rather than merely
+ * containing it somewhere. A bare substring check would match 'sign' inside a
+ * description or inside a longer word, and pass even if the token were absent.
+ *
+ * Each shell spells its command list differently: zsh emits 'name:description'
+ * pairs, bash a space-separated `compgen -W` list, fish `-a "name"`.
+ */
+function offersCommand(script: string, shell: string, cmd: string): boolean {
+  const c = escapeRe(cmd)
+  const patterns: Record<string, RegExp> = {
+    zsh: new RegExp(`'${c}:`),
+    bash: new RegExp(`(^|[\\s"])${c}([\\s"]|$)`, 'm'),
+    fish: new RegExp(`__fish_use_subcommand" -a "${c}"`),
+  }
+  return patterns[shell].test(script)
+}
+
+/** Same idea for chains, which every shell emits as a bare space-separated token. */
+function offersChain(script: string, shell: string, chain: string): boolean {
+  const c = escapeRe(chain)
+  const patterns: Record<string, RegExp> = {
+    zsh: new RegExp(`(^|[\\s(])${c}([\\s)]|$)`, 'm'),
+    bash: new RegExp(`(^|[\\s"])${c}([\\s"]|$)`, 'm'),
+    fish: new RegExp(`swap-quote" -a "${c}"`),
+  }
+  return patterns[shell].test(script)
 }
 
 describe('generated completion scripts', () => {
@@ -58,19 +96,19 @@ describe('generated completion scripts', () => {
 
       it('offers the commands the hardcoded list had drifted away from', () => {
         for (const cmd of PREVIOUSLY_MISSING) {
-          expect(script, `${shell} completion is missing "${cmd}"`).toContain(cmd)
+          expect(offersCommand(script, shell, cmd), `${shell} completion does not offer "${cmd}"`).toBe(true)
         }
       })
 
       it('offers chains from the SDK registry, not a hand-picked subset', () => {
         // Cardano and Tron are in the registry but were absent from the old CHAINS array.
-        expect(script).toContain('Cardano')
-        expect(script).toContain('Tron')
+        expect(offersChain(script, shell, 'Cardano')).toBe(true)
+        expect(offersChain(script, shell, 'Tron')).toBe(true)
       })
 
       it('offers every chain the SDK supports', () => {
         for (const chain of SUPPORTED_CHAINS) {
-          expect(script, `${shell} completion is missing chain "${chain}"`).toContain(chain)
+          expect(offersChain(script, shell, chain), `${shell} completion does not offer chain "${chain}"`).toBe(true)
         }
       })
     })

--- a/clients/cli/src/lib/completionRegistry.test.ts
+++ b/clients/cli/src/lib/completionRegistry.test.ts
@@ -5,11 +5,11 @@
 // sign/broadcast/tx-status/execute/discount/agent/auth/delete/join/rujira/add-mldsa,
 // and a hand-picked subset of chains. Commands now come from Commander and chains from
 // the SDK registry, so the scripts cannot silently go stale again.
-import { SUPPORTED_CHAINS } from '@vultisig/sdk'
 import { spawnSync } from 'node:child_process'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { SUPPORTED_CHAINS } from '@vultisig/sdk'
 import { describe, expect, it } from 'vitest'
 
 const CLI_ENTRY = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'index.ts')

--- a/clients/cli/src/lib/stderrCleanliness.test.ts
+++ b/clients/cli/src/lib/stderrCleanliness.test.ts
@@ -1,0 +1,53 @@
+// The CLI does not print dependency noise to stderr (vultisig-sdk sdkcli2-13 P1-3).
+//
+// Regression guard: bigint-buffer console.warn()s at module load when its native
+// binding is absent — which it always is, since the package ships no darwin-arm64 (or
+// most other) prebuild. Every single invocation, `--version` included, emitted
+//   bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)
+// to stderr. The pure-JS fallback works fine and "npm run rebuild" is meaningless for
+// a globally installed CLI, so this was pure noise that made a working CLI look broken.
+// Silenced via a yarn patch (.yarn/patches/bigint-buffer-*.patch), which the SDK's node
+// bundle then inlines.
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const CLI_ENTRY = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'index.ts')
+
+function run(args: string[]) {
+  const env: NodeJS.ProcessEnv = { ...process.env, NO_COLOR: '1' }
+  delete env.COMP_LINE
+  delete env.COMP_POINT
+  delete env.COMP_CWORD
+  return spawnSync(process.execPath, ['--import', 'tsx', CLI_ENTRY, ...args], {
+    input: '',
+    encoding: 'utf8',
+    timeout: 120_000,
+    env,
+  })
+}
+
+describe('stderr cleanliness', () => {
+  it('does not warn about bigint bindings on --version', () => {
+    const { stderr } = run(['--version'])
+    expect(stderr).not.toMatch(/Failed to load bindings/)
+  })
+
+  it('leaves stderr completely empty on a successful --version', () => {
+    const { stdout, stderr, status } = run(['--version'])
+    expect(status).toBe(0)
+    expect(stdout).toMatch(/vultisig\//)
+    expect(stderr).toBe('')
+  })
+
+  it('does not warn about bigint bindings on --help', () => {
+    expect(run(['--help']).stderr).not.toMatch(/Failed to load bindings/)
+  })
+
+  it('never advises "npm run rebuild", which cannot help a global install', () => {
+    const { stdout, stderr } = run(['--version'])
+    expect(stdout + stderr).not.toMatch(/npm run rebuild/)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -213,6 +213,7 @@
     "form-data@npm:^4.0.5": "^4.0.6",
     "hono@npm:^4.11.4": "4.12.25",
     "undici": "^7.28.0",
-    "linkify-it": "5.0.1"
+    "linkify-it": "5.0.1",
+    "bigint-buffer@npm:^1.1.5": "patch:bigint-buffer@npm%3A1.1.5#~/.yarn/patches/bigint-buffer-npm-1.1.5-785f4ccd92.patch"
   }
 }

--- a/packages/sdk/src/vault/VaultBase.ts
+++ b/packages/sdk/src/vault/VaultBase.ts
@@ -463,8 +463,18 @@ export abstract class VaultBase extends UniversalEventEmitter<VaultEvents> {
       errors.push(`Vault name cannot exceed ${vaultConfig.maxNameLength} characters`)
     }
 
-    if (!/^[a-zA-Z0-9\s\-_]+$/.test(name)) {
-      errors.push('Vault name can only contain letters, numbers, spaces, hyphens, and underscores')
+    // Only reject what is actually unsafe. The name is interpolated into the export
+    // filename (see export()), so path separators and control characters are out —
+    // but the previous alphanumeric allowlist also rejected the `#` in ecosystem-created
+    // names like "Vultisig Cluster #1", which creation and import both accept. That made
+    // rename a one-way door: rename away from such a name, and you could never rename back.
+    if (/[/\\]/.test(name)) {
+      errors.push('Vault name cannot contain path separators')
+    }
+
+    // eslint-disable-next-line no-control-regex
+    if (/[\u0000-\u001f\u007f]/.test(name)) {
+      errors.push('Vault name cannot contain control characters')
     }
 
     return {

--- a/packages/sdk/tests/unit/vaultNamePolicy.test.ts
+++ b/packages/sdk/tests/unit/vaultNamePolicy.test.ts
@@ -1,0 +1,56 @@
+// Vault-name policy on rename (vultisig-sdk sdkcli2-13 P2-12).
+//
+// Regression guard: rename enforced an alphanumeric allowlist
+// (/^[a-zA-Z0-9\s\-_]+$/) that rejected the `#` in ecosystem-created names like
+// "Vultisig Cluster #1" — names creation and import both accept. That made rename a
+// one-way door: rename away from such a name and you could never rename back.
+// The policy now rejects only what is genuinely unsafe for the export filename the
+// name is interpolated into: path separators and control characters.
+import { describe, expect, it } from 'vitest'
+
+import { VaultBase } from '../../src/vault/VaultBase'
+
+// validateVaultName is private; exercise it through the class the way rename() does.
+function validate(name: string): { isValid: boolean; errors?: string[] } {
+  return (
+    VaultBase.prototype as unknown as {
+      validateVaultName(name: string): { isValid: boolean; errors?: string[] }
+    }
+  ).validateVaultName(name)
+}
+
+describe('vault name policy', () => {
+  it('accepts the ecosystem-created "#" name that rename used to reject', () => {
+    expect(validate('Vultisig Cluster #1').isValid).toBe(true)
+  })
+
+  it('still accepts plain alphanumeric names', () => {
+    for (const name of ['My Vault', 'vault-1', 'vault_2', 'Vault 3']) {
+      expect(validate(name).isValid).toBe(true)
+    }
+  })
+
+  it('accepts other printable punctuation the ecosystem may produce', () => {
+    for (const name of ['Vault (main)', "Avran's Vault", 'Vault #2 — primary', 'Fund 100%']) {
+      expect(validate(name).isValid).toBe(true)
+    }
+  })
+
+  it('rejects path separators, which would escape the export filename', () => {
+    expect(validate('../etc/passwd').isValid).toBe(false)
+    expect(validate('a/b').errors).toContain('Vault name cannot contain path separators')
+    expect(validate('a\\b').errors).toContain('Vault name cannot contain path separators')
+  })
+
+  it('rejects control characters', () => {
+    expect(validate('bad\u0000name').errors).toContain('Vault name cannot contain control characters')
+    expect(validate('bad\nname').errors).toContain('Vault name cannot contain control characters')
+    expect(validate('bad\u007fname').errors).toContain('Vault name cannot contain control characters')
+  })
+
+  it('keeps the pre-existing length and emptiness rules', () => {
+    expect(validate('').isValid).toBe(false)
+    expect(validate('a').isValid).toBe(false)
+    expect(validate('x'.repeat(500)).isValid).toBe(false)
+  })
+})

--- a/packages/sdk/tests/unit/vaultNamePolicy.test.ts
+++ b/packages/sdk/tests/unit/vaultNamePolicy.test.ts
@@ -6,7 +6,7 @@
 // one-way door: rename away from such a name and you could never rename back.
 // The policy now rejects only what is genuinely unsafe for the export filename the
 // name is interpolated into: path separators and control characters.
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { VaultBase } from '../../src/vault/VaultBase'
 
@@ -52,5 +52,41 @@ describe('vault name policy', () => {
     expect(validate('').isValid).toBe(false)
     expect(validate('a').isValid).toBe(false)
     expect(validate('x'.repeat(500)).isValid).toBe(false)
+  })
+})
+
+// The suite above reaches the private validator directly. Drive rename() itself too,
+// so the policy can't pass here while the real one-way door stays shut.
+describe('rename() end-to-end', () => {
+  // rename() reads vaultData.name, writes vaultData/coreVault, then persists via
+  // save(). Stub only persistence so the real validator + real rename() body run.
+  function makeVault(initialName: string) {
+    const vault = Object.create(VaultBase.prototype) as VaultBase
+    Object.assign(vault, {
+      vaultData: { name: initialName },
+      coreVault: { name: initialName },
+      save: vi.fn(async () => {}),
+      emit: vi.fn(),
+    })
+    return vault
+  }
+
+  it('accepts the ecosystem-created "#" name it used to reject', async () => {
+    const vault = makeVault('Old Name')
+
+    await expect(vault.rename('Vultisig Cluster #1')).resolves.not.toThrow()
+  })
+
+  it('lets a vault renamed away from a "#" name be renamed back — the one-way door', async () => {
+    const vault = makeVault('Vultisig Cluster #1')
+
+    await vault.rename('Temporary Name')
+    await expect(vault.rename('Vultisig Cluster #1')).resolves.not.toThrow()
+  })
+
+  it('still rejects a name carrying a path separator', async () => {
+    const vault = makeVault('Old Name')
+
+    await expect(vault.rename('../evil')).rejects.toThrow(/path separators/)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -8330,13 +8330,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bigint-buffer@npm:^1.1.5":
+"bigint-buffer@npm:1.1.5":
   version: 1.1.5
   resolution: "bigint-buffer@npm:1.1.5"
   dependencies:
     bindings: "npm:^1.3.0"
     node-gyp: "npm:latest"
   checksum: 10c0/aa41e53d38242a2f05f85b08eaf592635f92e5328822784cda518232b1644efdbf29ab3664951b174cc645848add4605488e25c9439bcc749660c885b4ff6118
+  languageName: node
+  linkType: hard
+
+"bigint-buffer@patch:bigint-buffer@npm%3A1.1.5#~/.yarn/patches/bigint-buffer-npm-1.1.5-785f4ccd92.patch":
+  version: 1.1.5
+  resolution: "bigint-buffer@patch:bigint-buffer@npm%3A1.1.5#~/.yarn/patches/bigint-buffer-npm-1.1.5-785f4ccd92.patch::version=1.1.5&hash=3d0962"
+  dependencies:
+    bindings: "npm:^1.3.0"
+    node-gyp: "npm:latest"
+  checksum: 10c0/5efb16aacaaf49a110f3803bdb83bd34fb457bcee2fab9488fb6c24bbf425773d0a3c2fed0d3221da6d37e9a80ddf5af9633bc62edda7cac02c5226c18b3a80a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Batch of small, independent CLI polish fixes. They came out of an audit of low-severity
CLI issues; none changes fund-movement behaviour, exit codes 9/12/13, or any wire contract.
Each is a separate commit, and each behavioural one has a red-then-green test.

### What's in here

| # | Fix | Before |
|---|---|---|
| 1 | Export `.vult` owner-only | Written with the default umask (0644, world-readable) into cwd incl. `$HOME`, while the vault store itself is 0600 — and `auth setup` auto-discovers an exported `.vult` as a credential anchor |
| 2 | Validate the chain arg for `tokens` / `swap-quote` | `tokens bogus-chain` → exit 0 + `{"success":true,...,"tokens":[]}`; `swap-quote bogus-chain …` → exit 7 + a raw `Cannot read properties of undefined (reading 'ticker')` |
| 3 | `rename` accepts ecosystem names | Rejected the `#` in names like "Vultisig Cluster #1" that creation/import happily accept — a one-way door |
| 4 | `NO_ACTIVE_VAULT` (15) / `CORRUPT_STATE` (16) | Both were a generic `UNKNOWN_ERROR`/7 with no hint |
| 5 | One envelope from `verify`; pending vaults in `vaults` | `verify -o json` wrote **two** JSON documents, so `JSON.parse` failed; pending vaults were invisible |
| 6 | Every mutation emits a result envelope | switch/rename/currency/address-book/import/export exited 0 with **empty** stdout in `-o json` |
| 7 | Completion generated from the registries | Shipped a stale hardcoded list: no sign/broadcast/tx-status/execute/discount/agent/auth/delete/join/rujira/add-mldsa, and 21 of 38 chains |
| 8 | Silence `bigint: Failed to load bindings` | Printed to stderr on **every** invocation, incl. `--version` |
| 9 | `send --dry-run` reports fee/total | JSON dropped both, even though the human preview printed the fee and `total` is what the insufficient-balance warning is computed from |

### Notes for review

- **#3** widens the vault-name policy from an alphanumeric allowlist to a denylist. The name is
  interpolated into the export filename, so path separators and control characters are still
  rejected; everything else printable is allowed. Creation/import already had no charset rule.
- **#4** adds two exit codes. This follows the existing pattern (8–14 were each carved out of the
  generic bucket for the same "let a headless caller branch on `$?`" reason) and the README table is
  pinned to the enum by the existing doc-lint test. Corruption is detected *positively* — a
  `StorageError` whose cause is a `JSON.parse` `SyntaxError` — so transient IO/permission failures
  keep their current classification rather than being mislabelled unrecoverable. The fail-open
  active-pointer reset from #1077 is untouched.
- **#8** is a `yarn patch` on `bigint-buffer`, which `console.warn`s at *module load* — before any
  flag parsing, so it can't be gated behind `--debug`. The SDK's node bundle inlines the patched
  copy. `--version` stderr goes 77 bytes → 0.
- **#2** deliberately leaves the same unchecked `findChainByName(x) || (x as Chain)` cast on the
  `send`/`swap` fund-movement paths — out of scope for a polish sweep.

### Not included

- **`@mysten/sui` / Node 20 `EBADENGINE`.** `.nvmrc` and CI (including `release.yml`, which
  publishes) are on Node 20, but the whole `@mysten/sui` 2.x line declares `node >=22`. Both fixes
  are maintainer calls: raising the engine floor is a breaking change for published consumers and
  contradicts the release toolchain, and the last Node-20-compatible Sui is 1.30.x — a major
  downgrade. No runtime break reproduces; the impact is an install-time warning.
- **Unifying the dry-run zero-balance contract across chain-kinds.** Would flip Tron/Sui `--dry-run`
  from exit 1 to exit 0 + warning — an exit-code change on a send-path command, and Tron/Sui aren't
  enabled on the test vault, so it can't be verified here.

### Heads-up: one deliberate behaviour change worth a maintainer opinion

**#5 shifts `verify`'s failure exit code from 1 to 4/5.** It previously threw a bare
`Error` with `exitCode = 1` attached (which `classifyError` ignored anyway); it now throws
`InvalidInputError` (4) for a wrong/expired code and `VaultNotFoundError` (5) for an unknown
pending vault. That's more correct and consistent with the documented table, but it IS a real
change on a published surface, and this PR's claim only fenced 9/12/13 — so flagging it rather
than burying it. Happy to pin `verify` failure back to 1 if anything is depending on it.

### Post-review fixes

A local multi-perspective review ran over this branch before it left draft and found a
regression I'd introduced, now fixed in the final commit:

- **`verify --resend` failure reported success.** The resend catch still did `return false`,
  but #5 removed the caller that converted false into a throw — so a rate-limited or
  bad-password resend exited 0 with empty stdout in JSON mode. Exactly the silent-success bug
  this PR is meant to kill. Now throws a typed error (keeping the SDK's classification when it's
  already precise, e.g. bad password → AUTH_REQUIRED).
- **`add-mldsa` had no envelope**, so #6's "every mutation" claim was false. Fixed.
- **Export TOCTOU**: writing straight to the target and chmod-ing afterwards left key shares in a
  pre-existing 0644 file for a window. Now writes a fresh 0600 temp file and renames over the
  target (atomic), matching what `storage.ts` already does.
- **Test gaps**: the chain-validation and exit-code tests only covered the helpers, so reverting
  the real call/throw sites left them green. Added tests that drive the actual CLI; both verified
  red on revert. Also added the missing `import`/`add-mldsa` envelope tests and an end-to-end
  `rename('Vultisig Cluster #1')`.
- Removed a new `core -> interactive -> core` module cycle; noted in `.yarnrc.yml` that the
  bigint-buffer `patch:` resolution also pins the version, so the advisory revisit must drop it.

### Validation


`yarn test:cli` (62 files / 853 tests), SDK unit suite (189 files / 2869 tests), `yarn typecheck`
(root + CLI workspace), and changed-file eslint + prettier all pass locally. Each fix was
red-checked by reverting it and observing the specific failure. No live transactions were made.
