### PR TITLE
fix(cli): only call a non-EVM broadcast failure permanent when the bytes are at fault

### DIFF
--- a/.changeset/olive-donkeys-repeat.md
+++ b/.changeset/olive-donkeys-repeat.md
@@ -1,0 +1,11 @@
+---
+'@vultisig/cli': patch
+---
+
+Correct the non-EVM permanent broadcast classification so it only declares a failure permanent when the fault is in the signed bytes themselves.
+
+- Cosmos: `insufficient funds` (5), `insufficient fee` (13) and `unknown address` (9) are no longer permanent. A CheckTx rejection does not increment the account sequence, so these stay replayable verbatim once the account is funded, a cheaper node accepts the fee, or the account exists — they now classify as retryable (`EXTERNAL_SERVICE`, exit 6) instead of `INVALID_INPUT`, exit 4.
+- UTXO: dropped matching on bitcoind's `-26`/`-27` reject codes. Blockchair is the only UTXO broadcast backend and does not preserve those codes — it reformats the node's reply as `Invalid transaction. Error: <reason>` — so the branch never fired, and `-26` is a bucket that also covers recoverable rejections (`non-final`, `too-long-mempool-chain`, `min relay fee not met`) that must not be stranded.
+- Chain detection now reads the SDK's own wrapper rather than scanning the whole error text for any ` on <chain>:` substring, so chain-labelled text inside a wrapped payload (e.g. a Solana program log) can no longer route an error to another family's vocabulary.
+
+EVM classification and the exit 9/13 broadcast-safety semantics are unchanged.

--- a/clients/cli/src/core/errors.test.ts
+++ b/clients/cli/src/core/errors.test.ts
@@ -1,4 +1,4 @@
-import { VaultError, VaultErrorCode, VaultImportError, VaultImportErrorCode } from '@vultisig/sdk'
+import { Chain, VaultError, VaultErrorCode, VaultImportError, VaultImportErrorCode } from '@vultisig/sdk'
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -533,23 +533,56 @@ describe('anticipated CLI taxonomy regressions', () => {
       expect(result.retryable).toBe(true)
     }
 
-    it.each([
-      ['-26', 'mandatory-script-verify-flag-failed'],
-      ['-27', 'transaction already in block chain'],
-    ])('maps a UTXO bitcoind %s rejection preserved by Blockchair to non-retryable input', (code, reason) => {
+    // Verbatim `context.error` captured from api.blockchair.com/bitcoin/push/transaction
+    // (2026-07-17) by pushing an undecodable payload. Blockchair reformats bitcoind's
+    // reply and drops the numeric reject code, so this sentence — not `RPC error -26:` —
+    // is what actually reaches the classifier.
+    const BLOCKCHAIR_DECODE_FAILURE =
+      'Invalid transaction. Error: TX decode failed. Make sure the tx has at least one input.'
+
+    it('maps the real Blockchair decode rejection to non-retryable input', () => {
       expectPermanent(
         new VaultError(
           VaultErrorCode.BroadcastFailed,
-          `Failed to broadcast raw transaction on Bitcoin: Failed to broadcast transaction: RPC error ${code}: ${reason}`
+          `Failed to broadcast raw transaction on Bitcoin: Failed to broadcast transaction: ${BLOCKCHAIR_DECODE_FAILURE}`
         )
       )
     })
 
-    it('maps a UTXO decode rejection preserved by Blockchair to non-retryable input', () => {
+    it('maps the same decode rejection through the signed-resolver wrapper too', () => {
       expectPermanent(
         new VaultError(
           VaultErrorCode.BroadcastFailed,
-          'Failed to broadcast raw transaction on Bitcoin: Failed to broadcast transaction: TX decode failed'
+          `Failed to broadcast transaction on Bitcoin: Failed to broadcast transaction: ${BLOCKCHAIR_DECODE_FAILURE}`
+        )
+      )
+    })
+
+    // bitcoind's -26 is a bucket ("rejected by network rules"), not a verdict: it also
+    // covers cases where the identical signed bytes succeed later. Blockchair never
+    // surfaces the code anyway, so matching the bucket would only ever strand these.
+    it.each([
+      ['non-final', 'locktime has not yet been reached'],
+      ['too-long-mempool-chain', 'unconfirmed ancestors still in the mempool'],
+      ['min relay fee not met', 'mempool min fee falls as congestion clears'],
+    ])('keeps a recoverable UTXO rejection (%s) retryable', (reason, _why) => {
+      expectTransient(
+        new VaultError(
+          VaultErrorCode.BroadcastFailed,
+          `Failed to broadcast raw transaction on Bitcoin: Failed to broadcast transaction: Invalid transaction. Error: ${reason}`
+        )
+      )
+    })
+
+    // "Already in block chain" means the tx LANDED. It must never be reported as invalid
+    // input — telling a user their encoding is bad about a confirmed tx can push them to
+    // rebuild and pay twice. The signed path swallows this via verifyBroadcastByHash;
+    // if it ever reaches the CLI, retryable is the lesser evil (an idempotent no-op).
+    it('never calls an already-confirmed UTXO tx invalid input', () => {
+      expectTransient(
+        new VaultError(
+          VaultErrorCode.BroadcastFailed,
+          'Failed to broadcast raw transaction on Bitcoin: Failed to broadcast transaction: Invalid transaction. Error: Transaction already in block chain'
         )
       )
     })
@@ -646,11 +679,18 @@ describe('anticipated CLI taxonomy regressions', () => {
       )
     })
 
-    it('maps a Cosmos insufficient-funds rejection to non-retryable input', () => {
-      expectPermanent(
+    // A CheckTx rejection never increments the account sequence, so a tx rejected on
+    // mutable chain state stays replayable verbatim once that state changes. These are
+    // recoverable and must not be declared permanent.
+    it.each([
+      [5, '100000uatom is smaller than 500000uatom: insufficient funds', 'the account can be funded'],
+      [13, 'insufficient fee: got 100uatom, required 500uatom', 'min-gas-prices is node-local config'],
+      [9, 'account vultisig1abc does not exist: unknown address', 'the account materializes on first receipt'],
+    ])('keeps a state-dependent Cosmos rejection (code %i) retryable', (code, log, _why) => {
+      expectTransient(
         new VaultError(
           VaultErrorCode.BroadcastFailed,
-          'Failed to broadcast transaction on Cosmos: Broadcasting transaction failed with code 5 (codespace: sdk). Log: 100000uatom is smaller than 500000uatom: insufficient funds'
+          `Failed to broadcast transaction on Cosmos: Broadcasting transaction failed with code ${code} (codespace: sdk). Log: ${log}`
         )
       )
     })
@@ -669,13 +709,27 @@ describe('anticipated CLI taxonomy regressions', () => {
     })
 
     it('keeps a Cosmos rejection from a non-root codespace retryable', () => {
-      // A module-specific codespace (e.g. wasm) can reuse root-codespace-style
-      // numeric codes for unrelated conditions, so the allowlist only applies to
-      // "codespace: sdk".
+      // A module-specific codespace (e.g. wasm) can reuse root-codespace-style numeric
+      // codes for unrelated conditions, so the allowlist only applies to "codespace: sdk".
+      // The code AND log below both match an allowlist entry, so the codespace gate is the
+      // only thing keeping this retryable — delete that gate and this test goes red.
       expectTransient(
         new VaultError(
           VaultErrorCode.BroadcastFailed,
-          'Failed to broadcast transaction on Cosmos: Broadcasting transaction failed with code 5 (codespace: wasm). Log: execute wasm contract failed'
+          'Failed to broadcast transaction on Cosmos: Broadcasting transaction failed with code 2 (codespace: wasm). Log: tx parse error'
+        )
+      )
+    })
+
+    it('keeps a Cosmos rejection whose log contradicts its code retryable', () => {
+      // Code 2 is allowlisted, but its canonical message is "tx parse error". A log that
+      // reports something else means we have not positively identified the failure, so it
+      // stays retryable. The code/log pairing requirement is the only thing keeping this
+      // retryable — drop the log match and this test goes red.
+      expectTransient(
+        new VaultError(
+          VaultErrorCode.BroadcastFailed,
+          'Failed to broadcast transaction on Cosmos: Broadcasting transaction failed with code 2 (codespace: sdk). Log: insufficient fee: got 100uatom, required 500uatom'
         )
       )
     })
@@ -683,6 +737,33 @@ describe('anticipated CLI taxonomy regressions', () => {
     it('keeps a Cosmos RPC transport failure retryable', () => {
       expectTransient(
         new VaultError(VaultErrorCode.BroadcastFailed, 'Failed to broadcast transaction on Cosmos: request timed out')
+      )
+    })
+
+    // Chains whose kind has no family predicate (ripple/ton/tron/polkadot/cardano/...)
+    // must fall through to retryable rather than borrow another family's vocabulary.
+    it.each([Chain.Ripple, Chain.Tron, Chain.Polkadot])(
+      'keeps a rejection on a family without a classifier (%s) retryable',
+      chain => {
+        expectTransient(
+          new VaultError(
+            VaultErrorCode.BroadcastFailed,
+            `Failed to broadcast transaction on ${chain}: invalid signature`
+          )
+        )
+      }
+    )
+
+    it('resolves the chain from the SDK wrapper, not from chain-labelled text inside the payload', () => {
+      // Solana folds program logs into the message and a program controls its own `msg!`
+      // text. A log mentioning another chain must not hand this error to that chain's
+      // predicate — here the EVM one, whose vocabulary would match "invalid signature"
+      // and wrongly strand a Solana failure as permanent.
+      expectTransient(
+        new VaultError(
+          VaultErrorCode.BroadcastFailed,
+          'Failed to broadcast transaction on Solana: Simulation failed. Message: Error processing Instruction 0. Logs: ["Program log: bridged on Ethereum: invalid signature"]'
+        )
       )
     })
   })

--- a/clients/cli/src/core/errors.ts
+++ b/clients/cli/src/core/errors.ts
@@ -327,7 +327,21 @@ export class DuplicateBroadcastRefusedError extends VsigError {
 const EVM_PERMANENT_BROADCAST_INPUT_RE =
   /failed to decode signed transaction|could not decode (?:signed )?transaction|invalid raw transaction|invalid transaction encoding|invalid (?:transaction )?signature|invalid sender|invalid rlp|rlp:|unsupported transaction type/i
 
-const UTXO_PERMANENT_BROADCAST_INPUT_RE = /\bTX decode failed\b|\b(?:RPC error|code|error code)\s*:?\s*-(?:26|27)\b/i
+// Blockchair is the only UTXO broadcast backend on both the signed resolver and the
+// raw path, and it does NOT preserve bitcoind's numeric reject code: it reformats the
+// node's reply as `Invalid transaction. Error: <reason>` and drops the code entirely.
+// (Probed 2026-07-17 against api.blockchair.com/bitcoin/push/transaction: an undecodable
+// payload returns "Invalid transaction. Error: TX decode failed. Make sure the tx has at
+// least one input." — no code, no "RPC error" prefix.) So only the reason text is
+// matchable here.
+//
+// Deliberately limited to the one reason we have actually observed. bitcoind's -26
+// ("rejected by network rules") is a bucket, not a verdict: it also covers `non-final`
+// (locktime not yet reached), `too-long-mempool-chain`, and `min relay fee not met`,
+// where the identical signed bytes succeed later. Matching the bucket would strand those.
+// Extending this list requires a captured Blockchair response for the reason — not a
+// guess at bitcoind's wording, which never reaches us verbatim.
+const UTXO_PERMANENT_BROADCAST_INPUT_RE = /\bTX decode failed\b/i
 
 const SOLANA_PERMANENT_BROADCAST_INPUT_RE =
   /failed to deserialize(?: transaction)?|failed to sanitize|(?:transaction )?signature verification (?:failed|failure)|non-base58 character|invalid base58/i
@@ -344,24 +358,30 @@ const SUI_REQUIRED_FIELDS_GUARD_RE = /Sui broadcast requires JSON with "unsigned
 const SUI_PERMANENT_EXECUTION_MESSAGE_RE =
   /invalid (?:user )?signature|signature verification (?:failed|failure)|malformed transaction|invalid transaction (?:data|bytes)/i
 
-// Cosmos SDK RootCodespace error codes (codespace "sdk") whose message is a
-// genuinely non-recoverable rejection of THIS signed tx — the identical bytes can
-// never succeed regardless of retries or waiting. See
-// https://github.com/cosmos/cosmos-sdk/blob/main/types/errors/errors.go. Deliberately
-// narrow: any other codespace, any unlisted code (notably 32 "incorrect account
-// sequence" — a transient MPC-race shape that can resolve once the intervening
-// sequence lands), or a code/message mismatch falls through to retryable.
+// Cosmos SDK RootCodespace error codes (codespace "sdk") whose rejection is intrinsic
+// to THIS signed tx — the fault is in the bytes themselves, so no amount of retrying or
+// waiting makes them valid. See
+// https://github.com/cosmos/cosmos-sdk/blob/main/types/errors/errors.go.
+//
+// The line is bytes-intrinsic vs state-dependent, and it matters: a CheckTx rejection
+// does NOT increment the account sequence, so a tx rejected on mutable chain state stays
+// replayable verbatim once that state changes. Codes excluded for that reason —
+// 5 "insufficient funds" (fund the account and the identical bytes land), 13
+// "insufficient fee" (min-gas-prices is node-local config; another node accepts the same
+// bytes), 9 "unknown address" (the account materializes on first receipt) — are
+// recoverable and must stay retryable. So is 32 "incorrect account sequence", a transient
+// MPC-race shape that resolves once the intervening sequence lands.
+//
+// Any other codespace, any unlisted code, or a code/message mismatch falls through to
+// retryable.
 const COSMOS_PERMANENT_SDK_CODES: Partial<Record<number, RegExp>> = {
   2: /tx parse error/i,
   4: /unauthorized|signature verification failed/i,
-  5: /insufficient funds/i,
   6: /unknown request/i,
   7: /invalid address/i,
   8: /invalid pubkey/i,
-  9: /unknown address/i,
   10: /invalid coins/i,
   12: /memo too large/i,
-  13: /insufficient fee/i,
   14: /maximum number of signatures exceeded/i,
   15: /no signatures supplied/i,
   18: /invalid request/i,
@@ -393,21 +413,32 @@ const permanentBroadcastInputClassifiers: Partial<Record<ChainKind, PermanentBro
   cosmos: (_err, details) => isCosmosPermanentBroadcastInput(details),
 }
 
-function getBroadcastErrorChain(details: string): Chain | undefined {
-  const normalized = details.toLowerCase()
-  const wrappedChain = Object.values(Chain).find(chain => normalized.includes(` on ${chain.toLowerCase()}:`))
-  if (wrappedChain) return wrappedChain
+// Matches only the SDK's own wrapper phrasing (BroadcastService / RawBroadcastService),
+// and only its FIRST occurrence, which is always the genuine outermost wrapper.
+// Both matter: chain-labelled text can also appear DOWNSTREAM inside the wrapped payload
+// — Solana folds program logs into the message, and a program controls its own `msg!`
+// text — so a bare " on <chain>:" scan over the whole string lets foreign text pick the
+// classifier family.
+const BROADCAST_CHAIN_WRAPPER_RE = /failed to broadcast (?:raw )?transaction on (.+?):/i
+
+function getBroadcastErrorChain(message: string): Chain | undefined {
+  const wrappedChain = message.match(BROADCAST_CHAIN_WRAPPER_RE)?.[1]?.toLowerCase()
+  if (wrappedChain) {
+    return Object.values(Chain).find(chain => chain.toLowerCase() === wrappedChain)
+  }
 
   // RawBroadcastService deliberately rethrows its local required-fields
   // VaultError without the standard "on <chain>:" wrapper.
-  if (normalized.startsWith('sui broadcast ')) return Chain.Sui
+  if (/^sui broadcast /i.test(message)) return Chain.Sui
 
   return undefined
 }
 
 function isPermanentBroadcastInputError(err: VaultError): boolean {
   const details = `${err.message}\n${err.originalError?.message ?? ''}`
-  const chain = getBroadcastErrorChain(details)
+  // Chain identity comes from the wrapper on the error's OWN message, never from the
+  // wrapped originalError text.
+  const chain = getBroadcastErrorChain(err.message)
 
   if (chain) {
     const classifier = permanentBroadcastInputClassifiers[getChainKind(chain)]


### PR DESCRIPTION
## Summary

Follow-up to #1346, which added per-chain-family permanent-vs-retryable broadcast classification. That PR's design is right — the family split, the EVM preservation, and the fail-toward-retryable default all hold up. This corrects three places where the implementation drifts from that stated policy, all in the same direction: a recoverable failure was being declared permanent, or a match could never fire at all.

### 1. Cosmos: `insufficient funds` / `insufficient fee` / `unknown address` are not permanent

The allowlist comment claimed these are codes where "the identical bytes can never succeed regardless of retries or waiting." That is true for the bytes-intrinsic codes (tx parse error, invalid pubkey, tx too large, …) but not for three of them:

- **5 `insufficient funds`** — a CheckTx rejection never increments the account sequence, so once the account is funded the *identical signed bytes* land.
- **13 `insufficient fee`** — `minimum-gas-prices` is node-local config; another RPC accepts the same bytes.
- **9 `unknown address`** — the account materialises on first receipt.

All three now fall through to retryable. This also resolves the misleading-hint point raised in review on #1346: an insufficient-funds rejection no longer answers with "Check the signed transaction encoding and signature", because it is no longer classified as an encoding problem.

The remaining allowlist entries are unchanged, and the comment now states the actual rule (bytes-intrinsic vs state-dependent) rather than a claim that was untrue for these three.

### 2. UTXO: the `-26` / `-27` numeric match never fired, and `-26` is a bucket

Blockchair is the only UTXO broadcast backend on both the signed resolver and the raw path, and it does not preserve bitcoind's numeric reject code — it reformats the reply and drops it. Probed against the live endpoint:

```
$ curl -X POST https://api.blockchair.com/bitcoin/push/transaction -d "data=00"
{"data":null,"context":{"code":400,"source":"R",
 "error":"Invalid transaction. Error: TX decode failed. Make sure the tx has at least one input.", ...}}
```

No `-26`, no `RPC error` prefix. So `\b(?:RPC error|code|error code)\s*:?\s*-(?:26|27)\b` could not match in production, and the tests asserting it passed only because they fed a hand-built string straight into the classifier.

Removing it is also a latent-risk fix: `-26` is `RPC_TRANSACTION_REJECTED`, a bucket rather than a verdict. It covers `non-final` (locktime not yet reached), `too-long-mempool-chain` (ancestors unconfirmed) and `min relay fee not met` (mempool min fee falls as congestion clears) — all cases where the identical bytes succeed later. Had the code ever reached us, matching the bucket would have stranded them.

`TX decode failed` — the one reason we have actually observed — still classifies permanent, and the tests now use the captured response verbatim. Extending this list should start from a captured Blockchair response, not from bitcoind's wording, which never reaches us intact.

`-27` ("already in block chain") means the tx **landed**; there is now an explicit test that it is never reported as invalid input.

### 3. Chain detection reads the SDK wrapper, not any chain-labelled text

`getBroadcastErrorChain` scanned the whole error string (wrapper + `originalError.message`) for any ` on <chain>:` substring, first match by enum order — and EVM chains sort first. Solana folds program logs into the message, and a program controls its own `msg!` text, so a log line mentioning another chain could hand a Solana failure to the EVM predicate, whose vocabulary would match and wrongly strand it. Detection now matches the SDK's own wrapper phrasing on the error's own message.

## Test changes

- UTXO fixtures replaced with the live-captured Blockchair response; added recoverable-`-26`-reason and already-in-block-chain guards.
- Cosmos codes 5/9/13 pinned retryable.
- Two existing Cosmos negative tests were passing for the wrong reason — deleting the `codespace: sdk` gate, or dropping the code/log pairing requirement, left the suite green. Their fixtures now exercise the gate they document (mutation-checked: each mutant is killed).
- Added coverage for families with no classifier (Ripple/Tron/Polkadot) and for the wrapper-vs-payload chain detection.

## Validation

- `yarn build:all`
- `yarn test:cli` — **797/797** (53/53 files)
- `yarn workspace @vultisig/cli typecheck` — clean
- `eslint` + `prettier --check` on the touched files — clean
- Red proofs: re-adding codes 5/9/13 → 3 red; deleting the codespace gate → 1 red; dropping the code/log pairing → 1 red; restoring the unanchored chain scan (Sui fallback left intact) → 1 red. The UTXO production change is dead-code removal, so it has no red proof by construction — the evidence is the live probe above.

EVM classification and the exit 9/13 broadcast-safety semantics are untouched.

No live transactions were attempted. The only network call was the Blockchair probe above, with an undecodable payload that cannot be a transaction.

## Note for the reviewer

Changeset is `patch`, matching #1346's precedent, but this does change exit codes on paths a scripted consumer may branch on (a Cosmos insufficient-funds broadcast moves from exit 4 `retryable:false` to exit 6 `retryable:true`). Happy to make it `minor` if you'd rather.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CLI broadcast error classification across Cosmos, Bitcoin, Solana, Ripple, Tron, and Polkadot.
  - Recoverable funding, fee, account, and UTXO rejection errors are now correctly marked as retryable.
  - Permanent failures are identified more accurately, reducing cases where valid transactions are incorrectly stranded.
  - Improved chain detection prevents misleading error details from causing incorrect classifications.
  - Existing EVM error handling and broadcast-safety behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->