### PR TITLE
test: exotic-chain golden hardening + root-cause the 2 masked mobile divergences

### DIFF
--- a/packages/core/mpc/keysign/tests/mobileFixtures.golden.test.ts
+++ b/packages/core/mpc/keysign/tests/mobileFixtures.golden.test.ts
@@ -67,6 +67,74 @@ const compareHashesAsSet = ({ chain, fixtureFile }: { chain: Chain; fixtureFile:
 // Keep the restored Android/iOS JSON expected hashes unchanged. These cases
 // currently differ through the SDK path, so the test pins SDK output here and
 // makes each difference explicit instead of silently rewriting mobile fixtures.
+//
+// Root-cause notes (golden-vector hardening pass, sdk#1367):
+//
+// - cardano.json::Send ADA - max amount
+//   Root cause CONFIRMED: this repo's pinned wallet-core (4.7.0) has a real
+//   bug/regression for Cardano `Transfer.useMaxAmount: true` combined with a
+//   client-supplied `forceFee`. Verified via TWO independent WalletCore entry
+//   points — `TransactionCompiler.preImageHashes` (what this SDK calls) AND
+//   `AnySigner.plan` (the "official" planning API) — both return
+//   `TransactionPlan{ amount: <full input UTXO, unadjusted>, fee: 0 }` for
+//   this fixture's `useMaxAmount: true` input, ignoring `forceFee` entirely.
+//   A fee=0 Cardano tx is invalid on-chain (real nodes require
+//   fee >= minFeeA + minFeeB*txSize) — a "send max" Cardano transaction built
+//   by this SDK today would be rejected at broadcast, not silently mis-signed.
+//   Separately CONFIRMED via exhaustive brute force (fee in [150_000,
+//   200_000] lovelace) that fee=164_515 / amount=9_835_485 reproduces the
+//   recorded device hash byte-for-byte — proving the device's original
+//   signer DID compute a real minimum fee for this send, and that a correct
+//   fix is possible in principle. However, 164_515 does NOT factor as an
+//   integer solution of the standard Cardano linear-fee formula
+//   (minFeeA=155_381 + minFeeB=44 * txSizeBytes) against this transaction's
+//   actual encoded size (90-byte body + a single ed25519 witness) — so the
+//   exact algorithm the device used (a different WalletCore version? a
+//   different placeholder-size assumption for the fee-convergence loop?)
+//   was NOT recoverable from this fixture alone. Applying a fix without a
+//   verified-general formula risks silently mis-computing fees on other
+//   real max-amount Cardano sends — worse than the current (loudly broken,
+//   fee=0) behavior. Follow-up: implement client-side fee convergence for
+//   Cardano max-amount sends (mirroring how the UTXO/Bitcoin resolver already
+//   calls `AnySigner.plan` before hashing) using the CURRENT wallet-core's
+//   own Cardano linear-fee behavior, validated against multiple max-amount
+//   fixtures (not just this one) before removing this override.
+//
+// - terra.json::Send USTC on terra classic
+//   Root cause LIKELY (not conclusively reproduced): `getCosmosSigningInputs`
+//   has a dedicated Terra Classic stability-tax surcharge for USTC (`uusd`)
+//   sends (see `getFee`'s `areEqualCoins(coin, { chain: TerraClassic, id:
+//   'uusd' })` branch) — a burn-tax amount is meant to be pre-computed by the
+//   ASYNC `getCosmosChainSpecific` resolver (an `x/treasury` LCD query, see
+//   `terraClassicTax.ts`) and threaded through as an extra `Fee.amounts`
+//   coin via `CosmosSpecific.ibcDenomTraces.baseDenom`. This offline fixture
+//   JSON carries no `ibc_denom_traces`/`base_denom` field (that mechanism
+//   post-dates when this Android/iOS hash was captured), so replaying it
+//   through the current resolver always computes `burnTaxAmount = 0` and
+//   emits a single-coin fee — plausibly NOT what the device signed if the
+//   real on-chain tax rate was nonzero at capture time (the live rate is
+//   governance-set and is `0` today, per `terraClassicTax.ts`, but was
+//   historically ~1.2%). This is consistent with LUNC/uluna sends in this
+//   same fixture file matching exactly (uluna is tax-exempt — see
+//   `applyTerraClassicTax`) while only the uusd case diverges. However,
+//   exhaustive brute-force search did NOT find an exact reproduction: tried
+//   (a) reducing the send amount by 0-5% and by a wide absolute window
+//   ([199_000_000, 200_000_000] and curated tax-rate/cap candidates), (b)
+//   adding a second `uusd` fee coin (both appended and prepended) over
+//   [0, 5_000_000] uusd, (c) the two combined (amount reduced AND fee coin
+//   added) over [0, 3_000_000], and (d) replacing the fee entirely with a
+//   uusd-only coin over [0, 3_000_000] — none reproduce the recorded device
+//   hash. So either the historical tax rate/cap active at capture time falls
+//   outside these windows, or an additional structural difference is
+//   involved that this pass did not identify. Given the live tax rate is 0
+//   today, hard-coding ANY historical nonzero value into the resolver would
+//   be an active regression for present-day sends, not a fix. Follow-up:
+//   either (a) confirm the mechanism end-to-end with a FRESH device-recorded
+//   USTC fixture under the current rate=0 regime (should match trivially
+//   with `burnTaxAmount = 0`, validating the plumbing), or (b) if
+//   reproducing this exact historical hash matters, recover the exact
+//   `tax_rate`/`tax_cap` that was live on `columbus-5` at capture time from
+//   chain history and extend the brute-force window accordingly.
 const sdkExpectedHashOverrides: Record<string, string[]> = {
   'cardano.json::Send ADA - max amount': ['d681b85a798708c5d0e3cfd491363527889c72c6812419c2de246773a31fc120'],
   'terra.json::Send USTC on terra classic': ['0122eb10508372f69c521d7206a8d06aa6c569b1d4a9e449d4de5f32853dc6f8'],

--- a/packages/core/mpc/tx/compile/compileTx.golden.test.ts
+++ b/packages/core/mpc/tx/compile/compileTx.golden.test.ts
@@ -17,6 +17,23 @@
  *   does not include Bittensor's current signed extensions.
  * - QBTC pins the custom Cosmos TxRaw assembly used for MLDSA signatures, which
  *   WalletCore cannot verify or assemble.
+ * - Bitcoin-Cash, Litecoin, Dogecoin, Dash, and Zcash pin WalletCore
+ *   compileWithSignatures output for the generic (non-SwapKit-PSBT) UTXO send
+ *   path, cross-checked against walletCore.AnySigner.sign with an embedded
+ *   private key — the same second-implementation pattern used for EVM/Solana/
+ *   Cosmos above. Bitcoin itself is already covered end-to-end against real
+ *   device hashes by mobileFixtures.golden.test.ts, so it is not duplicated
+ *   here.
+ * - Dogecoin and Dash serialize to byte-identical output for equivalent
+ *   inputs: both share Bitcoin's original legacy P2PKH sighash algorithm with
+ *   no chain-specific wire marker, so the only chain-identifying artifact is
+ *   the address encoding (base58 version byte), not the transaction bytes.
+ * - Zcash pins WalletCore's *current* output, which is version-4 (Sapling)
+ *   framing signed with a NU5+ consensus branch id — WalletCore does not
+ *   implement true NU5 v5 (ZIP-244/Orchard) transaction framing. This suite
+ *   only guards against a wire-format regression in that WalletCore output;
+ *   the SDK's independent NU5 v5-aware UTXO builder is verified separately
+ *   elsewhere in this audit and is out of scope here.
  */
 import { Buffer } from 'buffer'
 
@@ -32,8 +49,12 @@ import { beforeAll, describe, expect, it } from 'vitest'
 
 import { Chain } from '@vultisig/core-chain/Chain'
 import { getCardanoTxTtl } from '@vultisig/core-chain/chains/cardano/cip30/cardanoTxTtl'
+import { utxoChainScriptType } from '@vultisig/core-chain/chains/utxo/tx/UtxoScriptType'
+import { zcashBranchIdToWalletCoreHex } from '@vultisig/core-chain/chains/utxo/zcashBranchId'
+import { getCoinType } from '@vultisig/core-chain/coin/coinType'
 
 import { getPreSigningHashes } from '../preSigningHashes'
+import { encodeDERSignature } from '../../derSignature'
 import { KeysignSignature } from '../../keysign/KeysignSignature'
 import {
   CardanoChainSpecificSchema,
@@ -56,6 +77,31 @@ const EXPECTED_BITTENSOR_EXTRINSIC =
   '2d0284008a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c00e86599818c154d1b4e6ce0bca1e46a0bf39aab36908b067efc08474a1e005cc72e2770e37b1e8c3c246d4972ba4f1dff5e054a2fe1d0ad091c211db81bc0f90a250200000500008a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c04'
 const EXPECTED_QBTC_SERIALIZED =
   '{"tx_bytes":"Cp4BCokBChwvY29zbW9zLmJhbmsudjFiZXRhMS5Nc2dTZW5kEmkKKnFidGMxc2VuZGVyMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMBIrcWJ0YzFyZWNlaXZlcjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMBoOCgRxYnRjEgYxMjM0NTYSEGNvbXBpbGVUeCBnb2xkZW4SYQpLCkEKGy9jb3Ntb3MuY3J5cHRvLm1sZHNhLlB1YktleRIiCiCqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqhIECgIIARgDEhIKDAoEcWJ0YxIEMjUwMBDgpxIaQFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVU=","mode":"BROADCAST_MODE_SYNC"}'
+
+const EXPECTED_BCH_RAW_TX =
+  '01000000012222222222222222222222222222222222222222222222222222222222222222000000006a47304402205cc7b73d7f848464b886c1262e876e9d5a080563dd3be2721d3786f3c3272c43022024b68bde9094789eddeffb05291886d3ed8fe177001bc261a1922fdea5ee22874121031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078fffffffff0250c30000000000001976a914ebc0ee0b2ab9e8277a600c251475e22a3241a1c188acaac00000000000001976a91479b000887626b294a914501a4cd226b58b23598388ac00000000'
+const EXPECTED_LTC_RAW_TX =
+  '0100000000010133333333333333333333333333333333333333333333333333333333333333330000000000ffffffff0260ea000000000000160014ebc0ee0b2ab9e8277a600c251475e22a3241a1c146e900000000000016001479b000887626b294a914501a4cd226b58b23598302483045022100ff471204dd7e4f52e4dda18cc63956ef70c4b67d4e8a8d0b4643c6a2354fd5ac02204c375cf8ab833f20359eb2625cb4116ced23f3de67f52fbc1c8095e855f40b530121031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f00000000'
+const EXPECTED_DOGE_RAW_TX =
+  '01000000014444444444444444444444444444444444444444444444444444444444444444000000006a47304402207048fb061ed4502f7c4517a4bcfa152f406e9f3cfc46639e15488b1a197fd2a002202b853ec92c43c36eb1a342df8182c3ec2f9762c717645cc296b313af5a67e5830121031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078fffffffff0270110100000000001976a914ebc0ee0b2ab9e8277a600c251475e22a3241a1c188ac28b90000000000001976a91479b000887626b294a914501a4cd226b58b23598388ac00000000'
+const EXPECTED_DASH_RAW_TX =
+  '01000000015555555555555555555555555555555555555555555555555555555555555555000000006b4830450221008e10337a586413f4dc93616bb07a1eee4ff23a42b4bbc7a6198789760beaca5f0220024ce21dfa1c31017715ee638677c1aa2c3af6ce04f903d9c0f195e35c82d9080121031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078fffffffff0280380100000000001976a914ebc0ee0b2ab9e8277a600c251475e22a3241a1c188ac16340100000000001976a91479b000887626b294a914501a4cd226b58b23598388ac00000000'
+const EXPECTED_ZEC_RAW_TX =
+  '0400008085202f89016666666666666666666666666666666666666666666666666666666666666666000000006a473044022065cf6eff680bc0bdbb40c07b05f8f9791213e3791a4ea94d59056d808ffefa6e0220058f39d10fbe41932e58097ce95e4f40b35a4f5e69ca4a2405f0b966cb6c76820121031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078fffffffff02905f0100000000001976a914ebc0ee0b2ab9e8277a600c251475e22a3241a1c188ac80380100000000001976a91479b000887626b294a914501a4cd226b58b23598388ac00000000000000000000000000000000000000'
+
+/**
+ * NU6.2 consensus branch id (Zcash mainnet). Mirrors ZCASH_BRANCH_ID_NU6_2 in
+ * packages/sdk/src/chains/utxo/tx.ts (duplicated as a literal here — core
+ * must not depend on the sdk package).
+ */
+const ZCASH_TEST_BRANCH_ID_HEX = '5437f330'
+
+const EXPECTED_THORCHAIN_DEPOSIT_SERIALIZED =
+  '{"mode":"BROADCAST_MODE_SYNC","tx_bytes":"CpEBCo4BChEvdHlwZXMuTXNnRGVwb3NpdBJ5Ch8KEgoEVEhPUhIEUlVORRoEUlVORRIJMTUwMDAwMDAwEkBTV0FQOlRIT1IuUlVORTp0aG9yMXp6enp6enp6enp6enp6enp6enp6enp6enp6enp6enp6enp6enp6enp6ejowGhR5sACIdiaylKkUUBpM0ia1iyNZgxJqClAKRgofL2Nvc21vcy5jcnlwdG8uc2VjcDI1NmsxLlB1YktleRIjCiEDG4TFVnsSZECZXT7VqroFZdceGDRgSBn/nBf16dXdB48SBAoCCAEYBBIWCg8KBHJ1bmUSBzIwMDAwMDAQgK3iBBpARomVjU5JqlRGm+O4BDGBzhE2mo+mP6H7RH69nZJahZEK4JbsQZ0eKjj0YxacejBKog7QLTVON7eWDWyJuqOjjA=="}'
+const EXPECTED_TRON_SIGNED_JSON =
+  '{"raw_data":{"contract":[{"parameter":{"type_url":"type.googleapis.com/protocol.TransferContract","value":{"amount":250000000,"owner_address":"411a642f0e3c3af545e7acbd38b07251b3990914f1","to_address":"415050a4f4b3f9338c3472dcc01a87c76a144b3c9c"}},"type":"TransferContract"}],"data":"636f6d70696c65547820676f6c64656e","expiration":1700000060000,"ref_block_bytes":"7e00","ref_block_hash":"bedca608b7fe9e66","timestamp":1700000000000},"raw_data_hex":"0a027e002208bedca608b7fe9e6640e0a499ffbc315210636f6d70696c65547820676f6c64656e5a68080112640a2d747970652e676f6f676c65617069732e636f6d2f70726f746f636f6c2e5472616e73666572436f6e747261637412330a15411a642f0e3c3af545e7acbd38b07251b3990914f11215415050a4f4b3f9338c3472dcc01a87c76a144b3c9c1880e59a777080d095ffbc31","signature":["32fa1b2b51742d4cba60f870d53971ce7aa4c146303dca2aca387e528dd6ceec22171c5902e7dfb6f26194e35f83d051a9dc8fd40b1e922b7d95298739d8962800"],"txID":"9218ce3af35e09858b9dd95b3ac0b4ce131b2f7bc53c56f0a64c8fd01ed461de"}'
+const EXPECTED_RIPPLE_PAYMENT_RAW_TX =
+  '12000022000000002400000005201b01e848006140000000000f424068400000000000000c7321031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f74463044022020ac2b295f5f993ec6a00bdf62cf483e8b0f0a6dd5df6cc6c0a59d604df4b9b3022061862ddb85172cd2ca7e4c6ae14def2595f188803762fe1e736d3db6ff96210d811479b000887626b294a914501a4cd226b58b2359838314ebc0ee0b2ab9e8277a600c251475e22a3241a1c1'
 
 const hex = (bytes: Uint8Array) => Buffer.from(bytes).toString('hex')
 
@@ -84,6 +130,8 @@ const bigIntBytes = (value: bigint) => {
   return bytesFromHex(raw.length % 2 === 0 ? raw : `0${raw}`)
 }
 
+type SignatureFormat = 'raw' | 'rawWithRecoveryId' | 'der'
+
 const signatureForHash = ({
   privateKey,
   hash,
@@ -93,7 +141,7 @@ const signatureForHash = ({
   privateKey: PrivateKey
   hash: Uint8Array
   curve: WalletCore['Curve']['secp256k1']
-  format: 'raw' | 'rawWithRecoveryId'
+  format: SignatureFormat
 }): KeysignSignature => {
   const signature = privateKey.sign(hash, curve)
 
@@ -104,6 +152,15 @@ const signatureForHash = ({
       s: hex(signature.slice(32, 64)),
       der_signature: '',
       recovery_id: hex(signature.slice(64, 65)),
+    }
+  }
+
+  if (format === 'der') {
+    return {
+      msg: '',
+      r: '',
+      s: '',
+      der_signature: hex(encodeDERSignature(signature.slice(0, 32), signature.slice(32, 64))),
     }
   }
 
@@ -124,7 +181,7 @@ const signaturesFor = ({
   privateKey: PrivateKey
   hashes: Uint8Array[]
   curve: WalletCore['Curve']['secp256k1']
-  format: 'raw' | 'rawWithRecoveryId'
+  format: SignatureFormat
 }) => Object.fromEntries(hashes.map(hash => [hex(hash), signatureForHash({ privateKey, hash, curve, format })]))
 
 const compile = ({
@@ -142,7 +199,7 @@ const compile = ({
   publicKey: PublicKey
   privateKey: PrivateKey
   curve: WalletCore['Curve']['secp256k1']
-  format: 'raw' | 'rawWithRecoveryId'
+  format: SignatureFormat
 }) => {
   const hashes = getPreSigningHashes({ walletCore, chain, txInputData })
   const signatures = signaturesFor({
@@ -325,6 +382,271 @@ describe('compileTx golden vectors', () => {
     )
 
     expect(compiledOutput.serialized).toBe(signedByWalletCore.serialized)
+  })
+
+  it('matches WalletCore for a THORChain types.MsgDeposit (native RUNE swap)', () => {
+    const privateKey = walletCore.PrivateKey.createWithData(ECDSA_PRIVATE_KEY)
+    const publicKey = privateKey.getPublicKeySecp256k1(true)
+    const signerAddress = walletCore.AnyAddress.createWithPublicKey(
+      publicKey,
+      walletCore.CoinType.thorchain
+    ).description()
+    // Mirrors toTwAddress(): the resolver hands MsgDeposit.signer the raw
+    // bech32-decoded address bytes, not the string.
+    const signerBytes = walletCore.AnyAddress.createWithString(signerAddress, walletCore.CoinType.thorchain).data()
+
+    const signingInput = TW.Cosmos.Proto.SigningInput.create({
+      signingMode: TW.Cosmos.Proto.SigningMode.Protobuf,
+      accountNumber: Long.fromNumber(88),
+      chainId: 'thorchain-1',
+      sequence: Long.fromNumber(4),
+      mode: TW.Cosmos.Proto.BroadcastMode.SYNC,
+      publicKey: publicKey.data(),
+      // TxBody-level memo is always empty for MsgDeposit — the swap memo lives
+      // inside the message itself (MsgDeposit.memo), not the outer envelope.
+      memo: '',
+      fee: TW.Cosmos.Proto.Fee.create({
+        gas: Long.fromNumber(10_000_000),
+        amounts: [TW.Cosmos.Proto.Amount.create({ denom: 'rune', amount: '2000000' })],
+      }),
+      messages: [
+        TW.Cosmos.Proto.Message.create({
+          thorchainDepositMessage: TW.Cosmos.Proto.Message.THORChainDeposit.create({
+            signer: signerBytes,
+            memo: 'SWAP:THOR.RUNE:thor1zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz:0',
+            coins: [
+              TW.Cosmos.Proto.THORChainCoin.create({
+                asset: TW.Cosmos.Proto.THORChainAsset.create({
+                  chain: 'THOR',
+                  symbol: 'RUNE',
+                  ticker: 'RUNE',
+                  synth: false,
+                  secured: false,
+                }),
+                amount: '150000000',
+              }),
+            ],
+          }),
+        }),
+      ],
+    })
+    const txInputData = TW.Cosmos.Proto.SigningInput.encode(signingInput).finish()
+    const { compiled } = compile({
+      walletCore,
+      chain: Chain.THORChain,
+      txInputData,
+      publicKey,
+      privateKey,
+      curve: walletCore.Curve.secp256k1,
+      format: 'rawWithRecoveryId',
+    })
+
+    const compiledOutput = TW.Cosmos.Proto.SigningOutput.decode(compiled)
+    const signedByWalletCore = TW.Cosmos.Proto.SigningOutput.decode(
+      walletCore.AnySigner.sign(
+        TW.Cosmos.Proto.SigningInput.encode({
+          ...signingInput,
+          privateKey: privateKey.data(),
+        }).finish(),
+        walletCore.CoinType.thorchain
+      )
+    )
+
+    expect(compiledOutput.serialized).toBe(EXPECTED_THORCHAIN_DEPOSIT_SERIALIZED)
+    expect(compiledOutput.serialized).toBe(signedByWalletCore.serialized)
+  })
+
+  it('matches WalletCore for a Tron TransferContract', () => {
+    const privateKey = walletCore.PrivateKey.createWithData(ECDSA_PRIVATE_KEY)
+    const publicKey = privateKey.getPublicKeySecp256k1(false)
+    const sender = walletCore.AnyAddress.createWithPublicKey(publicKey, walletCore.CoinType.tron).description()
+    const recipientPrivateKey = walletCore.PrivateKey.createWithData(new Uint8Array(32).fill(2))
+    const recipientPublicKey = recipientPrivateKey.getPublicKeySecp256k1(false)
+    const recipient = walletCore.AnyAddress.createWithPublicKey(
+      recipientPublicKey,
+      walletCore.CoinType.tron
+    ).description()
+
+    const signingInput = TW.Tron.Proto.SigningInput.create({
+      transaction: TW.Tron.Proto.Transaction.create({
+        transfer: TW.Tron.Proto.TransferContract.create({
+          ownerAddress: sender,
+          toAddress: recipient,
+          amount: Long.fromNumber(250_000_000),
+        }),
+        timestamp: Long.fromNumber(1_700_000_000_000),
+        blockHeader: TW.Tron.Proto.BlockHeader.create({
+          timestamp: Long.fromNumber(1_700_000_000_000),
+          number: Long.fromNumber(56_000_000),
+          version: 31,
+          txTrieRoot: bytesFromHex('01'.repeat(32)),
+          parentHash: bytesFromHex('02'.repeat(32)),
+          witnessAddress: bytesFromHex('03'.repeat(21)),
+        }),
+        expiration: Long.fromNumber(1_700_000_060_000),
+        memo: 'compileTx golden',
+      }),
+    })
+    const txInputData = TW.Tron.Proto.SigningInput.encode(signingInput).finish()
+    const { compiled } = compile({
+      walletCore,
+      chain: Chain.Tron,
+      txInputData,
+      publicKey,
+      privateKey,
+      curve: walletCore.Curve.secp256k1,
+      format: 'rawWithRecoveryId',
+    })
+
+    const compiledOutput = TW.Tron.Proto.SigningOutput.decode(compiled)
+    const signedByWalletCore = TW.Tron.Proto.SigningOutput.decode(
+      walletCore.AnySigner.sign(
+        TW.Tron.Proto.SigningInput.encode({
+          ...signingInput,
+          privateKey: privateKey.data(),
+        }).finish(),
+        walletCore.CoinType.tron
+      )
+    )
+
+    expect(compiledOutput.json).toBe(EXPECTED_TRON_SIGNED_JSON)
+    expect(compiledOutput.json).toBe(signedByWalletCore.json)
+    expect(hex(compiledOutput.id)).toBe(hex(signedByWalletCore.id))
+  })
+
+  it('matches WalletCore for a Ripple Payment', () => {
+    const privateKey = walletCore.PrivateKey.createWithData(ECDSA_PRIVATE_KEY)
+    const publicKey = privateKey.getPublicKeySecp256k1(true)
+    const account = walletCore.AnyAddress.createWithPublicKey(publicKey, walletCore.CoinType.xrp).description()
+    const recipientPrivateKey = walletCore.PrivateKey.createWithData(new Uint8Array(32).fill(2))
+    const recipientPublicKey = recipientPrivateKey.getPublicKeySecp256k1(true)
+    const destination = walletCore.AnyAddress.createWithPublicKey(
+      recipientPublicKey,
+      walletCore.CoinType.xrp
+    ).description()
+
+    const signingInput = TW.Ripple.Proto.SigningInput.create({
+      account,
+      fee: Long.fromNumber(12),
+      sequence: 5,
+      lastLedgerSequence: 32_000_000,
+      publicKey: publicKey.data(),
+      opPayment: TW.Ripple.Proto.OperationPayment.create({
+        destination,
+        amount: Long.fromNumber(1_000_000),
+      }),
+    })
+    const txInputData = TW.Ripple.Proto.SigningInput.encode(signingInput).finish()
+    const { compiled } = compile({
+      walletCore,
+      chain: Chain.Ripple,
+      txInputData,
+      publicKey,
+      privateKey,
+      curve: walletCore.Curve.secp256k1,
+      format: 'rawWithRecoveryId',
+    })
+
+    const compiledOutput = TW.Ripple.Proto.SigningOutput.decode(compiled)
+    const signedByWalletCore = TW.Ripple.Proto.SigningOutput.decode(
+      walletCore.AnySigner.sign(
+        TW.Ripple.Proto.SigningInput.encode({
+          ...signingInput,
+          privateKey: privateKey.data(),
+        }).finish(),
+        walletCore.CoinType.xrp
+      )
+    )
+
+    expect(hex(compiledOutput.encoded)).toBe(EXPECTED_RIPPLE_PAYMENT_RAW_TX)
+    expect(hex(compiledOutput.encoded)).toBe(hex(signedByWalletCore.encoded))
+  })
+
+  it('matches WalletCore for a Bitcoin-Cash transfer (cashaddr + FORKID sighash)', () => {
+    const { compiledRaw, signedRaw } = compileUtxoGolden({
+      walletCore,
+      chain: Chain.BitcoinCash,
+      utxoTxIdFill: 0x22,
+      amount: 50_000,
+      byteFee: 3,
+    })
+
+    expect(compiledRaw).toBe(EXPECTED_BCH_RAW_TX)
+    expect(compiledRaw).toBe(signedRaw)
+  })
+
+  it('matches WalletCore for a Litecoin transfer', () => {
+    const { compiledRaw, signedRaw } = compileUtxoGolden({
+      walletCore,
+      chain: Chain.Litecoin,
+      utxoTxIdFill: 0x33,
+      amount: 60_000,
+      byteFee: 2,
+    })
+
+    expect(compiledRaw).toBe(EXPECTED_LTC_RAW_TX)
+    expect(compiledRaw).toBe(signedRaw)
+  })
+
+  it('matches WalletCore for a Dogecoin transfer', () => {
+    const { compiledRaw, signedRaw } = compileUtxoGolden({
+      walletCore,
+      chain: Chain.Dogecoin,
+      utxoTxIdFill: 0x44,
+      amount: 70_000,
+      byteFee: 100,
+    })
+
+    expect(compiledRaw).toBe(EXPECTED_DOGE_RAW_TX)
+    expect(compiledRaw).toBe(signedRaw)
+  })
+
+  it('matches WalletCore for a Dash transfer', () => {
+    const { compiledRaw, signedRaw } = compileUtxoGolden({
+      walletCore,
+      chain: Chain.Dash,
+      utxoTxIdFill: 0x55,
+      amount: 80_000,
+      byteFee: 5,
+    })
+
+    expect(compiledRaw).toBe(EXPECTED_DASH_RAW_TX)
+    expect(compiledRaw).toBe(signedRaw)
+  })
+
+  it('produces byte-identical output for Dogecoin and Dash given equivalent inputs', () => {
+    // Both share Bitcoin's original legacy P2PKH sighash algorithm with no
+    // chain-specific wire marker, so the chain identity lives entirely in the
+    // address encoding (base58 version byte), not the transaction bytes.
+    const dogecoin = compileUtxoGolden({
+      walletCore,
+      chain: Chain.Dogecoin,
+      utxoTxIdFill: 0x77,
+      amount: 42_000,
+      byteFee: 4,
+    })
+    const dash = compileUtxoGolden({
+      walletCore,
+      chain: Chain.Dash,
+      utxoTxIdFill: 0x77,
+      amount: 42_000,
+      byteFee: 4,
+    })
+
+    expect(dogecoin.compiledRaw).toBe(dash.compiledRaw)
+  })
+
+  it('pins WalletCore output for a Zcash (NU5+ branch id, v4 Sapling framing) transfer', () => {
+    const { compiledRaw, signedRaw } = compileUtxoGolden({
+      walletCore,
+      chain: Chain.Zcash,
+      utxoTxIdFill: 0x66,
+      amount: 90_000,
+      byteFee: 10,
+    })
+
+    expect(compiledRaw).toBe(EXPECTED_ZEC_RAW_TX)
+    expect(compiledRaw).toBe(signedRaw)
   })
 
   it('pins the manual Cardano witness wrapper', () => {
@@ -609,4 +931,104 @@ const cardanoPublicKeyFromEd25519 = (walletCore: WalletCore, privateKey: Private
     concat([spendingKey, spendingKey, chainCode, chainCode]),
     walletCore.PublicKeyType.ed25519Cardano
   )
+}
+
+/**
+ * Builds a deterministic single-input UTXO send for the given chain, compiles
+ * it through the generic (non-SwapKit-PSBT) compileTx path, and cross-checks
+ * the result against walletCore.AnySigner.sign with the private key embedded
+ * directly in the SigningInput — mirroring the EVM/Solana/Cosmos pattern
+ * above. Mirrors getUtxoSigningInputs (the production resolver): the
+ * TransactionPlan comes from walletCore.AnySigner.plan, and Zcash gets a
+ * fixed post-NU5 consensus branch id instead of the resolver's network fetch.
+ */
+const compileUtxoGolden = ({
+  walletCore,
+  chain,
+  utxoTxIdFill,
+  amount,
+  byteFee,
+}: {
+  walletCore: WalletCore
+  chain: Chain
+  utxoTxIdFill: number
+  amount: number
+  byteFee: number
+}) => {
+  const coinType = getCoinType({ walletCore, chain })
+  const privateKey = walletCore.PrivateKey.createWithData(ECDSA_PRIVATE_KEY)
+  const recipientPrivateKey = walletCore.PrivateKey.createWithData(new Uint8Array(32).fill(2))
+  const publicKey = privateKey.getPublicKeySecp256k1(true)
+  const recipientPublicKey = recipientPrivateKey.getPublicKeySecp256k1(true)
+
+  const sender = walletCore.AnyAddress.createWithPublicKey(publicKey, coinType).description()
+  const recipient = walletCore.AnyAddress.createWithPublicKey(recipientPublicKey, coinType).description()
+
+  const lockScript = walletCore.BitcoinScript.lockScriptForAddress(sender, coinType)
+  const scriptType = utxoChainScriptType[chain as keyof typeof utxoChainScriptType]
+  const pubKeyHash =
+    scriptType === 'wpkh' ? lockScript.matchPayToWitnessPublicKeyHash() : lockScript.matchPayToPubkeyHash()
+  const scriptKey = hex(pubKeyHash)
+  const script =
+    scriptType === 'wpkh'
+      ? walletCore.BitcoinScript.buildPayToWitnessPubkeyHash(pubKeyHash).data()
+      : walletCore.BitcoinScript.buildPayToPublicKeyHash(pubKeyHash).data()
+
+  const input = TW.Bitcoin.Proto.SigningInput.create({
+    hashType: walletCore.BitcoinScript.hashTypeForCoin(coinType),
+    amount: Long.fromNumber(amount),
+    toAddress: recipient,
+    changeAddress: sender,
+    byteFee: Long.fromNumber(byteFee),
+    coinType: coinType.value,
+    scripts: { [scriptKey]: script },
+    utxo: [
+      TW.Bitcoin.Proto.UnspentTransaction.create({
+        amount: Long.fromNumber(amount * 2),
+        outPoint: TW.Bitcoin.Proto.OutPoint.create({
+          hash: bytesFromHex(utxoTxIdFill.toString(16).repeat(32)).reverse(),
+          index: 0,
+          sequence: 0xffffffff,
+        }),
+        script: lockScript.data(),
+      }),
+    ],
+    zip_0317: chain === Chain.Zcash,
+  })
+
+  input.plan = TW.Bitcoin.Proto.TransactionPlan.decode(
+    walletCore.AnySigner.plan(TW.Bitcoin.Proto.SigningInput.encode(input).finish(), coinType)
+  )
+
+  if (chain === Chain.Zcash) {
+    input.plan.branchId = bytesFromHex(zcashBranchIdToWalletCoreHex(ZCASH_TEST_BRANCH_ID_HEX))
+  }
+
+  const txInputData = TW.Bitcoin.Proto.SigningInput.encode(input).finish()
+
+  const { compiled } = compile({
+    walletCore,
+    chain,
+    txInputData,
+    publicKey,
+    privateKey,
+    curve: walletCore.Curve.secp256k1,
+    format: 'der',
+  })
+  const compiledOutput = TW.Bitcoin.Proto.SigningOutput.decode(compiled)
+
+  const signedByWalletCore = TW.Bitcoin.Proto.SigningOutput.decode(
+    walletCore.AnySigner.sign(
+      TW.Bitcoin.Proto.SigningInput.encode({
+        ...input,
+        privateKey: [privateKey.data()],
+      }).finish(),
+      coinType
+    )
+  )
+
+  return {
+    compiledRaw: hex(compiledOutput.encoded),
+    signedRaw: hex(signedByWalletCore.encoded),
+  }
 }


### PR DESCRIPTION
Closes #1368
Tackles #1367

## what

Golden-vector hardening across the two round-7 gaps (epic #1347), batched since they share the same testing surface:

**#1368 - exotic-encoder golden gaps (additive coverage):** `compileTx.golden.test.ts` goes 7 -> 16 cases.
- Per-coin UTXO goldens: BCH (cashaddr + FORKID sighash), LTC, DOGE, DASH, ZEC - a single generic `utxo.json` previously stood in for all six UTXO coins. Each new vector cross-checks the `compileTx` output byte-for-byte against `walletCore.AnySigner.sign` (independent second implementation), plus a pinned golden constant. A dedicated case proves DOGE and DASH serialize byte-identically for equivalent inputs (shared legacy P2PKH sighash).
- WalletCore second-implementation cross-checks for the swap-heavy THORChain `types.MsgDeposit` (native RUNE), Tron `TransferContract`, and Ripple `Payment` - these had Layer-2 (independent re-encode) coverage but no WalletCore second-impl cross-check.
- ZEC caveat documented in-code: WalletCore 4.7.0 emits v4-Sapling framing with an NU5+ branch id, not true NU5 v5/ZIP-244 - this suite pins that current output as a wire-format regression guard, NOT a v5-consensus correctness claim (the SDK's own v5-aware builder is out of scope here).

**#1367 - root-cause the 2 masked mobile divergences (investigation, no encoder touched):** both `sdkExpectedHashOverrides` divergences were root-caused; per the fund-safety rule, neither encoder was changed without a verifiably-correct fix, so both overrides stay - each now carries a detailed evidence comment. See findings below. #1367 stays open for the two dedicated follow-ups.

## findings (#1367)

- **Cardano `Send ADA - max amount` - a REAL BUG surfaced.** wallet-core 4.7.0 returns `TransactionPlan{ amount: <full input, unadjusted>, fee: 0 }` for `Transfer.useMaxAmount:true + forceFee` (verified via both `preImageHashes` and `AnySigner.plan`). A fee=0 Cardano tx is invalid on-chain (nodes require `fee >= minFeeA + minFeeB*size`), so **Cardano send-max is currently broken - it would be rejected at broadcast.** The one fee/amount pair that reproduces the device hash (`fee=164515, amount=9835485`) does not factor cleanly from Cardano's standard linear-fee formula, so no general correct algorithm could be derived here. Recommended follow-up: client-side fee-convergence (mirror how the Bitcoin UTXO resolver calls `AnySigner.plan` before hashing). Filed as a note for a dedicated fix - flagging separately as a live reliability bug.
- **Terra USTC `Send USTC on terra classic` - mechanism identified, not reproducible offline.** The divergence is `getCosmosSigningInputs`' Terra Classic stability-tax surcharge for `uusd` (an extra dynamically-LCD-fetched `Fee.amounts` coin). The offline fixture has no `ibc_denom_traces` (predates that field), so replay computes `burnTaxAmount=0` - consistent with every `uluna` (tax-exempt) fixture matching and only the `uusd` case diverging. Exhaustive brute-force over amount-reduction + surcharge combinations found no exact match. The live tax rate is governance-set to 0 today, so hardcoding a historical value would REGRESS present-day sends. Recommended follow-up: a fresh device-recorded fixture under the current rate=0 regime, or recovering the exact historical tax_rate/tax_cap from chain history.

## testing

`compileTx.golden.test.ts` + `mobileFixtures.golden.test.ts`: 88/88 green (compileTx 16/16, all new UTXO/second-impl cases cross-checked against AnySigner). Full affected core golden suites: 105/105. RN golden suites unaffected: 156/156. Root `tsc` 0 errors. prettier clean; the two test files fall under the repo's pre-existing `packages/core/mpc/**/*.test.ts` eslint ignore glob.

## risk

None to runtime - tests + evidence comments only, zero `src/` changes. The #1367 overrides are unchanged (the divergences are documented, not newly introduced), and #1367 stays open for the two follow-ups.