### PR TITLE
fix(cli): make machine output tell the truth about what happened

### DIFF
--- a/.changeset/cli-truthful-output-batch.md
+++ b/.changeset/cli-truthful-output-batch.md
@@ -1,0 +1,23 @@
+---
+'@vultisig/cli': patch
+---
+
+Make CLI machine output tell the truth about what happened:
+
+- Emit a result envelope from every successful mutation in `-o json`
+  (switch/rename/currency/address-book/import/export/add-mldsa previously exited 0
+  with no output at all).
+- Emit exactly one JSON envelope from a failed `verify` — it previously wrote two
+  documents, so `JSON.parse` on the output failed — and list vaults pending
+  verification in `vaults`, which were otherwise only named in the create-time output.
+- Validate the chain argument for `tokens` and `swap-quote`, which previously reported
+  `success: true` with an empty list / a raw TypeError for an unknown chain. Both now
+  throw a typed `INVALID_CHAIN` (exit 4).
+- Add `NO_ACTIVE_VAULT` (15) and `CORRUPT_STATE` (16) exit codes with recovery hints,
+  replacing a generic `UNKNOWN_ERROR`/7 for both states.
+- Report `fee` and `total` from `send --dry-run` in JSON — the human preview already
+  printed the fee, and `total` is the number the insufficient-balance warning is
+  derived from.
+
+Note: a failed `verify` now exits 4 (wrong/expired code) or 5 (unknown pending vault)
+instead of 1. This is a deliberate change on a published surface — see the PR body.

--- a/clients/cli/README.md
+++ b/clients/cli/README.md
@@ -1262,6 +1262,8 @@ Configuration is stored in `~/.vultisig/`:
 | 12   | Interactive confirmation/input required but the session is non-interactive — pass --yes/--confirm or the required flag |
 | 13   | agent ask: transaction broadcast but the overall request may be incomplete — inspect the hash, do NOT blindly retry    |
 | 14   | agent ask: duplicate keyed turn rejected — inspect the conversation for the original result                            |
+| 15   | No active vault selected — create, import, or switch to one                                                            |
+| 16   | Stored state is unreadable — repair it or re-import the vault from a .vult backup                                      |
 
 > These are generated from the `ExitCode` enum in `src/core/errors.ts` (the single source of
 > truth) and are covered by a doc-lint test that fails if this table drifts from the code. Run

--- a/clients/cli/src/commands/__tests__/chainArgCallSites.test.ts
+++ b/clients/cli/src/commands/__tests__/chainArgCallSites.test.ts
@@ -1,0 +1,72 @@
+// The `tokens` / `swap-quote` CALL SITES validate their chain argument
+// (vultisig-sdk sdkcli2-13 P2-6 / P2-10).
+//
+// core/chain-resolver.test.ts covers the helper in isolation — but the reported bug
+// lived at the call sites (`findChainByName(x) || (x as Chain)`), so that file stays
+// green even if the call sites regress. This drives the real CLI end-to-end instead:
+//   tokens bogus-chain      -> was exit 0 + {"success":true,"data":{"tokens":[]}}
+//   swap-quote bogus-chain  -> was exit 7 + a raw "reading 'ticker'" TypeError
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import { ExitCode } from '../../core/errors'
+
+const CLI_ENTRY = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'index.ts')
+
+function run(args: string[]) {
+  const env: NodeJS.ProcessEnv = { ...process.env, NO_COLOR: '1' }
+  delete env.COMP_LINE
+  delete env.COMP_POINT
+  delete env.COMP_CWORD
+  const r = spawnSync(process.execPath, ['--import', 'tsx', CLI_ENTRY, ...args], {
+    input: '',
+    encoding: 'utf8',
+    timeout: 120_000,
+    env,
+  })
+  return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' }
+}
+
+describe('tokens <chain> validation', () => {
+  it('rejects an unknown chain with INVALID_CHAIN / exit 4 instead of an empty success', () => {
+    const { status, stdout } = run(['tokens', 'bogus-chain', '-o', 'json'])
+
+    expect(status).toBe(ExitCode.INVALID_INPUT)
+    const parsed = JSON.parse(stdout)
+    expect(parsed.success).toBe(false)
+    expect(parsed.error.code).toBe('INVALID_CHAIN')
+  })
+
+  it('never reports success:true with an empty token list for a chain that does not exist', () => {
+    const { stdout } = run(['tokens', 'bogus-chain', '-o', 'json'])
+
+    expect(stdout).not.toMatch(/"success":\s*true/)
+  })
+})
+
+describe('swap-quote <fromChain> <toChain> validation', () => {
+  it('rejects an unknown source chain with INVALID_CHAIN / exit 4, not a raw TypeError', () => {
+    const { status, stdout } = run(['swap-quote', 'bogus-chain', 'Bitcoin', '1', '-o', 'json'])
+
+    expect(status).toBe(ExitCode.INVALID_INPUT)
+    const parsed = JSON.parse(stdout)
+    expect(parsed.error.code).toBe('INVALID_CHAIN')
+    expect(parsed.error.message).not.toMatch(/Cannot read properties of undefined/)
+  })
+
+  it('rejects an unknown destination chain too, and says which side was wrong', () => {
+    const { status, stdout } = run(['swap-quote', 'Ethereum', 'bogus-chain', '1', '-o', 'json'])
+
+    expect(status).toBe(ExitCode.INVALID_INPUT)
+    expect(JSON.parse(stdout).error.message).toMatch(/destination chain/)
+  })
+
+  it('emits exactly one parseable JSON document', () => {
+    const { stdout } = run(['swap-quote', 'bogus-chain', 'Bitcoin', '1', '-o', 'json'])
+
+    expect(() => JSON.parse(stdout)).not.toThrow()
+  })
+})

--- a/clients/cli/src/commands/__tests__/mutationEnvelopes.test.ts
+++ b/clients/cli/src/commands/__tests__/mutationEnvelopes.test.ts
@@ -1,0 +1,195 @@
+// Mutations always emit an envelope in JSON mode (vultisig-sdk sdkcli2-13 P1-5 / P2-11).
+//
+// Regression guard: switch/rename/currency/address-book-add/address-book-remove/
+// import/export all ended in success(), which JSON mode suppresses — so each exited 0
+// with ZERO bytes on stdout, while delete/chains-add DID emit envelopes. A machine
+// caller got an empty string back from a successful mutation and could not tell it
+// from a no-op.
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { FastVault } from '@vultisig/sdk'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { CommandContext } from '../../core'
+import { configureOutput, resetOutput } from '../../lib/output'
+import { executeAddressBook, executeCurrency } from '../settings'
+import {
+  executeAddPostQuantumKeys,
+  executeExport,
+  executeImport,
+  executeRename,
+  executeSwitch,
+} from '../vault-management'
+
+let stdout: string[]
+let writeSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  stdout = []
+  writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(chunk => {
+    stdout.push(String(chunk))
+    return true
+  })
+  configureOutput({ format: 'json' })
+})
+
+afterEach(() => {
+  writeSpy.mockRestore()
+  vi.restoreAllMocks()
+  resetOutput()
+})
+
+/** Parse the single envelope a mutation is expected to write. */
+function envelope(): { success: boolean; v: number; data: Record<string, unknown> } {
+  const raw = stdout.join('')
+  expect(raw, 'mutation wrote nothing to stdout').not.toBe('')
+  return JSON.parse(raw)
+}
+
+const vaultStub = {
+  id: 'vault-1',
+  name: 'Vultisig Cluster #1',
+  type: 'fast',
+  chains: ['Ethereum', 'Bitcoin'],
+}
+
+describe('currency set', () => {
+  function makeCtx() {
+    return {
+      ensureActiveVault: async () => ({ currency: 'usd', setCurrency: vi.fn(async () => {}) }),
+    } as unknown as CommandContext
+  }
+
+  it('emits a versioned envelope naming the new currency', async () => {
+    await executeCurrency(makeCtx(), 'eur')
+
+    const env = envelope()
+    expect(env.success).toBe(true)
+    expect(env.v).toBe(1)
+    expect(env.data).toMatchObject({ currency: 'eur', updated: true })
+  })
+})
+
+describe('address book mutations', () => {
+  function makeCtx() {
+    return {
+      sdk: {
+        addAddressBookEntry: vi.fn(async () => {}),
+        removeAddressBookEntry: vi.fn(async () => {}),
+      },
+    } as unknown as CommandContext
+  }
+
+  it('--add emits an envelope describing the stored entry', async () => {
+    await executeAddressBook(makeCtx(), {
+      add: true,
+      chain: 'Ethereum' as never,
+      address: '0xabc',
+      name: 'treasury',
+    })
+
+    expect(envelope().data.added).toMatchObject({ chain: 'Ethereum', address: '0xabc', name: 'treasury' })
+  })
+
+  it('--remove emits an envelope naming what was removed', async () => {
+    await executeAddressBook(makeCtx(), { remove: '0xabc', chain: 'Ethereum' as never })
+
+    expect(envelope().data.removed).toMatchObject({ address: '0xabc', chain: 'Ethereum' })
+  })
+})
+
+describe('switch', () => {
+  it('emits an envelope identifying the now-active vault', async () => {
+    // setupVaultEvents() subscribes to the vault's emitter.
+    const vault = { ...vaultStub, on: vi.fn() }
+    const ctx = {
+      sdk: { getVaultById: vi.fn(async () => vault), listVaults: vi.fn(async () => [vault]) },
+      setActiveVault: vi.fn(async () => {}),
+    } as unknown as CommandContext
+
+    await executeSwitch(ctx, 'vault-1')
+
+    const env = envelope()
+    expect(env.data).toMatchObject({ switched: true, isActive: true })
+    expect(env.data.vault).toMatchObject({ id: 'vault-1', name: 'Vultisig Cluster #1' })
+  })
+})
+
+describe('rename', () => {
+  it('emits an envelope carrying both the new and previous name', async () => {
+    const vault = { ...vaultStub, rename: vi.fn(async () => {}) }
+    const ctx = { ensureActiveVault: async () => vault } as unknown as CommandContext
+
+    await executeRename(ctx, 'Renamed Vault')
+
+    expect(envelope().data).toMatchObject({
+      renamed: true,
+      previousName: 'Vultisig Cluster #1',
+      vault: { id: 'vault-1', name: 'Renamed Vault' },
+    })
+  })
+})
+
+describe('import', () => {
+  it('emits an envelope identifying the imported vault', async () => {
+    const vault = { ...vaultStub, on: vi.fn() }
+    const ctx = {
+      sdk: { importVault: vi.fn(async () => vault) },
+      setActiveVault: vi.fn(async () => {}),
+    } as unknown as CommandContext
+
+    const file = path.join(await fs.mkdtemp(path.join(os.tmpdir(), 'vsig-import-')), 'v.vult')
+    await fs.writeFile(file, 'VULT-BYTES')
+
+    await executeImport(ctx, file, 'pw')
+
+    const env = envelope()
+    expect(env.data).toMatchObject({ imported: true, isActive: true })
+    expect(env.data.vault).toMatchObject({ id: 'vault-1', name: 'Vultisig Cluster #1' })
+  })
+})
+
+describe('add-mldsa', () => {
+  it('emits an envelope after mutating the vault file', async () => {
+    // FastVault instance check: executeAddPostQuantumKeys refuses anything else.
+    // id/name are prototype getters, so define them rather than assigning.
+    const vault = Object.create(FastVault.prototype, {
+      id: { value: vaultStub.id },
+      name: { value: vaultStub.name },
+    })
+    const ctx = {
+      ensureActiveVault: async () => vault,
+      getPassword: vi.fn(async () => 'pw'),
+      sdk: { addPostQuantumKeysToFastVault: vi.fn(async () => {}) },
+    } as unknown as CommandContext
+
+    await executeAddPostQuantumKeys(ctx, { email: 'e@x.io', password: 'pw' })
+
+    expect(envelope().data).toMatchObject({ added: true, backupRecommended: true })
+  })
+})
+
+describe('export', () => {
+  let tmpDir: string
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vsig-export-envelope-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('emits an envelope naming the written path', async () => {
+    const outputPath = path.join(tmpDir, 'out.vult')
+    const ctx = {
+      ensureActiveVault: async () => ({ export: vi.fn(async () => ({ data: 'BYTES', filename: 'v.vult' })) }),
+    } as unknown as CommandContext
+
+    await executeExport(ctx, { outputPath, exportPassword: 'pw' })
+
+    expect(envelope().data).toMatchObject({ exported: true, path: outputPath, encrypted: true })
+  })
+})

--- a/clients/cli/src/commands/__tests__/sendDryRunFee.test.ts
+++ b/clients/cli/src/commands/__tests__/sendDryRunFee.test.ts
@@ -1,0 +1,104 @@
+// `send --dry-run` reports what the build actually cost (vultisig-sdk sdkcli2-13 P3-1).
+//
+// Regression guard: the SDK's dry-run returns { fee, total, keysignPayload }, and the
+// human preview printed the fee — but the JSON result dropped fee and total entirely,
+// so `--dry-run -o json` returned only amount/balance/chain/dryRun/symbol/to. It read
+// as a bare balance check with no cost information, even though `total` is the very
+// number the insufficient-balance warning compares against.
+import { Chain } from '@vultisig/sdk'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SendDryRunResult } from '../../core'
+import { configureOutput, resetOutput } from '../../lib/output'
+import { sendTransaction } from '../transaction'
+
+let stdout: string[]
+let writeSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  stdout = []
+  writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(chunk => {
+    stdout.push(String(chunk))
+    return true
+  })
+})
+
+afterEach(() => {
+  writeSpy.mockRestore()
+  vi.restoreAllMocks()
+  resetOutput()
+})
+
+function makeVault(opts: { fee: string; total: string; balance: string }) {
+  return {
+    send: vi.fn(async () => ({
+      dryRun: true,
+      fee: opts.fee,
+      total: opts.total,
+      keysignPayload: { some: 'payload' },
+    })),
+    balance: vi.fn(async () => ({
+      formattedAmount: opts.balance,
+      symbol: 'ETH',
+      amount: '0',
+      decimals: 18,
+      chainId: 'ethereum',
+    })),
+    gas: vi.fn(async () => ({})),
+    address: vi.fn(async () => '0xfrom'),
+  } as never
+}
+
+const params = {
+  chain: Chain.Ethereum,
+  to: '0xdead',
+  amount: '1.0',
+  dryRun: true,
+} as never
+
+describe('send --dry-run preview', () => {
+  it('returns the fee and total the build produced', async () => {
+    const result = (await sendTransaction(
+      makeVault({ fee: '0.0021', total: '1.0021', balance: '5.0' }),
+      params
+    )) as SendDryRunResult
+
+    expect(result.fee).toBe('0.0021')
+    expect(result.total).toBe('1.0021')
+  })
+
+  it('carries fee and total into the JSON envelope, not just the human preview', async () => {
+    configureOutput({ format: 'json' })
+
+    await sendTransaction(makeVault({ fee: '0.0021', total: '1.0021', balance: '5.0' }), params)
+
+    const data = JSON.parse(stdout.join('')).data
+    expect(data).toMatchObject({
+      dryRun: true,
+      chain: Chain.Ethereum,
+      fee: '0.0021',
+      total: '1.0021',
+      balance: '5.0',
+    })
+  })
+
+  it('still warns when the total exceeds the balance, and reports the numbers behind it', async () => {
+    configureOutput({ format: 'json' })
+
+    await sendTransaction(makeVault({ fee: '0.5', total: '10.5', balance: '1.0' }), params)
+
+    const data = JSON.parse(stdout.join('')).data
+    expect(data.warning).toMatch(/Insufficient balance/)
+    // The warning is only checkable by a caller if the numbers behind it are present.
+    expect(data.total).toBe('10.5')
+    expect(data.balance).toBe('1.0')
+  })
+
+  it('does not warn when the balance covers the total', async () => {
+    configureOutput({ format: 'json' })
+
+    await sendTransaction(makeVault({ fee: '0.0021', total: '1.0021', balance: '5.0' }), params)
+
+    expect(JSON.parse(stdout.join('')).data.warning).toBeUndefined()
+  })
+})

--- a/clients/cli/src/commands/__tests__/verifySingleEnvelope.test.ts
+++ b/clients/cli/src/commands/__tests__/verifySingleEnvelope.test.ts
@@ -208,9 +208,10 @@ describe('vaults pending visibility', () => {
   })
 })
 
-// executeVerify runs verifyVault() AND setActiveVault() inside one try, so the catch also
-// sees failures that happen after the code was accepted. Those must not be reported as a
-// bad code: the whole point of the CORRUPT_STATE work is that a broken store says so.
+// executeVerify verifies the code, then persists the active-vault pointer. A failure in the
+// second phase happens AFTER the code was accepted, so it must never be reported as a bad
+// code: it carries its own classification (a broken store says CORRUPT_STATE; anything else
+// stays a generic UNKNOWN) and never suggests re-checking or re-sending the code.
 describe('verify failure classification after the code was accepted', () => {
   function ctxWhereActivationFails(err: Error): CommandContext {
     // `on` matters: executeVerify calls setupVaultEvents(vault) between verifyVault()
@@ -237,6 +238,24 @@ describe('verify failure classification after the code was accepted', () => {
     // suggestion — advice for a problem the user does not have, since the code was correct.
     expect(err).toBeInstanceOf(CorruptStateError)
     expect((err as CorruptStateError).exitCode).toBe(ExitCode.CORRUPT_STATE)
+  })
+
+  it('does not blame the code for a non-corrupt post-accept failure either', async () => {
+    // e.g. a full disk / EACCES while writing the pointer: a StorageError whose cause is
+    // NOT a JSON SyntaxError, so it is deliberately NOT corruption. It must still not be
+    // reported as a wrong code — the code was accepted.
+    const ioFailure = new StorageError(
+      StorageErrorCode.Unknown,
+      'Failed to write value for key "activeVaultId"',
+      new Error('ENOSPC: no space left on device')
+    )
+
+    const err = await executeVerify(ctxWhereActivationFails(ioFailure), 'v1', { code: '123456' }).catch(
+      (e: unknown) => e
+    )
+
+    expect(err).not.toBeInstanceOf(InvalidInputError)
+    expect((err as { exitCode?: number }).exitCode).not.toBe(ExitCode.INVALID_INPUT)
   })
 
   it('still treats a genuinely rejected code as InvalidInputError / exit 4', async () => {

--- a/clients/cli/src/commands/__tests__/verifySingleEnvelope.test.ts
+++ b/clients/cli/src/commands/__tests__/verifySingleEnvelope.test.ts
@@ -8,11 +8,19 @@
 //  - The failure message parroted SDK jargon ("...with createFastVault()").
 //  - Two-step vaults awaiting verification appeared nowhere in `vaults`: only the
 //    create-time output named the id, so an agent that lost it could not resume.
-import { VaultError, VaultErrorCode } from '@vultisig/sdk'
+import { StorageError, StorageErrorCode, VaultError, VaultErrorCode } from '@vultisig/sdk'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { withExit } from '../../adapters/cli-runner'
 import type { CommandContext } from '../../core'
-import { type AuthRequiredError, type ExternalServiceError, VaultNotFoundError } from '../../core/errors'
+import {
+  type AuthRequiredError,
+  CorruptStateError,
+  ExitCode,
+  type ExternalServiceError,
+  InvalidInputError,
+  VaultNotFoundError,
+} from '../../core/errors'
 import { configureOutput, resetOutput } from '../../lib/output'
 import { executeVaults, executeVerify } from '../vault-management'
 
@@ -197,5 +205,80 @@ describe('vaults pending visibility', () => {
 
     await expect(executeVaults(ctx)).resolves.toBeDefined()
     expect(JSON.parse(jsonOut()).data.pending).toEqual([])
+  })
+})
+
+// executeVerify runs verifyVault() AND setActiveVault() inside one try, so the catch also
+// sees failures that happen after the code was accepted. Those must not be reported as a
+// bad code: the whole point of the CORRUPT_STATE work is that a broken store says so.
+describe('verify failure classification after the code was accepted', () => {
+  function ctxWhereActivationFails(err: Error): CommandContext {
+    // `on` matters: executeVerify calls setupVaultEvents(vault) between verifyVault()
+    // and setActiveVault(), so a vault without it throws a TypeError before the code
+    // under test is ever reached.
+    const vault = { id: 'v1', name: 'V', chains: [], on: vi.fn() }
+    return {
+      sdk: { verifyVault: vi.fn().mockResolvedValue(vault) },
+      setActiveVault: vi.fn().mockRejectedValue(err),
+      dispose: () => {},
+    } as unknown as CommandContext
+  }
+
+  it('surfaces a corrupt store as CORRUPT_STATE, not "your code is wrong"', async () => {
+    const corrupt = new StorageError(
+      StorageErrorCode.Unknown,
+      'Failed to read value for key "activeVaultId"',
+      new SyntaxError('Unexpected end of JSON input')
+    )
+
+    const err = await executeVerify(ctxWhereActivationFails(corrupt), 'v1', { code: '123456' }).catch((e: unknown) => e)
+
+    // Was InvalidInputError/4 with "the code may be incorrect or expired" plus a --resend
+    // suggestion — advice for a problem the user does not have, since the code was correct.
+    expect(err).toBeInstanceOf(CorruptStateError)
+    expect((err as CorruptStateError).exitCode).toBe(ExitCode.CORRUPT_STATE)
+  })
+
+  it('still treats a genuinely rejected code as InvalidInputError / exit 4', async () => {
+    const ctx = {
+      sdk: { verifyVault: vi.fn().mockRejectedValue(new Error('Invalid code')) },
+      setActiveVault: vi.fn(async () => {}),
+      dispose: () => {},
+    } as unknown as CommandContext
+
+    const err = await executeVerify(ctx, 'v1', { code: '000000' }).catch((e: unknown) => e)
+
+    expect(err).toBeInstanceOf(InvalidInputError)
+    expect((err as InvalidInputError).exitCode).toBe(ExitCode.INVALID_INPUT)
+  })
+})
+
+// The single-envelope claim is about what the CLI actually WRITES, which is withExit's job.
+// Asserting only that executeVerify throws leaves the count unproven: the old two-document
+// bug lived in the seam between the two.
+describe('verify through the real withExit wrapper', () => {
+  it('writes exactly one parseable JSON document and exits with the typed code', async () => {
+    configureOutput({ format: 'json' })
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('__exit__')
+    }) as never)
+
+    const ctx = {
+      sdk: { verifyVault: vi.fn().mockRejectedValue(new Error('Invalid code')) },
+      setActiveVault: vi.fn(async () => {}),
+      dispose: () => {},
+    } as unknown as CommandContext
+
+    await expect(
+      withExit(async () => {
+        await executeVerify(ctx, 'v1', { code: '000000' })
+      })()
+    ).rejects.toThrow('__exit__')
+
+    const out = jsonOut()
+    expect(() => JSON.parse(out)).not.toThrow()
+    expect(out.trim().split(/\}\s*\{/).length).toBe(1)
+    expect(JSON.parse(out).success).toBe(false)
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_INPUT)
   })
 })

--- a/clients/cli/src/commands/__tests__/verifySingleEnvelope.test.ts
+++ b/clients/cli/src/commands/__tests__/verifySingleEnvelope.test.ts
@@ -1,0 +1,201 @@
+// `verify` emits one JSON envelope, and `vaults` surfaces pending vaults
+// (vultisig-sdk sdkcli2-13 P2-7).
+//
+// Regression guards:
+//  - A failed `verify ... -o json` wrote a success-shaped {verified:false} envelope
+//    AND THEN threw, so the caller emitted a second {success:false} envelope. stdout
+//    carried two JSON documents and JSON.parse(output) threw.
+//  - The failure message parroted SDK jargon ("...with createFastVault()").
+//  - Two-step vaults awaiting verification appeared nowhere in `vaults`: only the
+//    create-time output named the id, so an agent that lost it could not resume.
+import { VaultError, VaultErrorCode } from '@vultisig/sdk'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { CommandContext } from '../../core'
+import { type AuthRequiredError, type ExternalServiceError, VaultNotFoundError } from '../../core/errors'
+import { configureOutput, resetOutput } from '../../lib/output'
+import { executeVaults, executeVerify } from '../vault-management'
+
+let stdout: string[]
+let writeSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  stdout = []
+  writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(chunk => {
+    stdout.push(String(chunk))
+    return true
+  })
+})
+
+afterEach(() => {
+  writeSpy.mockRestore()
+  vi.restoreAllMocks()
+  resetOutput()
+})
+
+const jsonOut = () => stdout.join('')
+
+describe('verify failure output', () => {
+  function makeCtx(err: Error): CommandContext {
+    return {
+      sdk: { verifyVault: vi.fn().mockRejectedValue(err) },
+      setActiveVault: vi.fn(async () => {}),
+      dispose: () => {},
+    } as unknown as CommandContext
+  }
+
+  it('writes NO envelope of its own on failure — the caller emits exactly one', async () => {
+    configureOutput({ format: 'json' })
+
+    await expect(executeVerify(makeCtx(new Error('Invalid code')), 'v1', { code: '000000' })).rejects.toThrow()
+
+    // Previously this wrote a success-shaped {"success":true,...,"verified":false}.
+    expect(jsonOut()).toBe('')
+  })
+
+  it('throws instead of returning false, so stdout can never carry two documents', async () => {
+    configureOutput({ format: 'json' })
+
+    const result = await executeVerify(makeCtx(new Error('Invalid code')), 'v1', { code: '000000' }).then(
+      () => 'resolved',
+      () => 'threw'
+    )
+
+    expect(result).toBe('threw')
+  })
+
+  it('does not leak SDK jargon for a missing pending vault, and points at CLI commands', async () => {
+    const sdkErr = new Error('No pending vault found for this ID. Create a vault first with createFastVault().')
+
+    await executeVerify(makeCtx(sdkErr), 'v-missing', { code: '000000' }).then(
+      () => {
+        throw new Error('expected executeVerify to throw')
+      },
+      (err: unknown) => {
+        expect(err).toBeInstanceOf(VaultNotFoundError)
+        const e = err as VaultNotFoundError
+        expect(e.message).not.toMatch(/createFastVault/)
+        expect(e.message).toContain('v-missing')
+        expect(e.suggestions).toEqual(expect.arrayContaining(['vultisig vaults']))
+      }
+    )
+  })
+
+  it('suggests --resend for a wrong or expired code', async () => {
+    await executeVerify(makeCtx(new Error('Invalid code')), 'v1', { code: '000000' }).then(
+      () => {
+        throw new Error('expected executeVerify to throw')
+      },
+      (err: unknown) => {
+        expect((err as VaultNotFoundError).suggestions).toEqual(expect.arrayContaining(['vultisig verify v1 --resend']))
+      }
+    )
+  })
+})
+
+describe('verify --resend failure', () => {
+  // A resend that failed must not look like one that succeeded. When executeVerify
+  // stopped signalling failure via `return false`, this path kept returning false —
+  // and the caller no longer converts that into an error, so a rate-limited or
+  // bad-password resend reported exit 0 with empty stdout in JSON mode.
+  function makeCtx(err: Error): CommandContext {
+    return {
+      sdk: { resendVaultVerification: vi.fn().mockRejectedValue(err) },
+      dispose: () => {},
+    } as unknown as CommandContext
+  }
+
+  const resendOpts = { resend: true, email: 'e@x.io', password: 'password123' }
+
+  it('throws rather than resolving, so a failed resend is not reported as success', async () => {
+    const outcome = await executeVerify(makeCtx(new Error('rate limited')), 'v1', resendOpts).then(
+      r => `resolved:${r}`,
+      () => 'threw'
+    )
+
+    expect(outcome).toBe('threw')
+  })
+
+  it('writes no success envelope for an email that was never sent', async () => {
+    configureOutput({ format: 'json' })
+
+    await expect(executeVerify(makeCtx(new Error('rate limited')), 'v1', resendOpts)).rejects.toThrow()
+
+    expect(jsonOut()).toBe('')
+  })
+
+  it('classifies an unrecognised resend failure as retryable, hinting at rate limiting', async () => {
+    await executeVerify(makeCtx(new Error('rate limited')), 'v1', resendOpts).then(
+      () => {
+        throw new Error('expected executeVerify to throw')
+      },
+      (err: unknown) => {
+        const e = err as ExternalServiceError
+        expect(e.code).toBe('EXTERNAL_SERVICE')
+        expect(e.retryable).toBe(true)
+        expect(e.hint).toMatch(/rate-limit/i)
+      }
+    )
+  })
+
+  it('keeps the SDK classification when it is already precise (bad password -> auth)', async () => {
+    const authErr = new VaultError(VaultErrorCode.InvalidConfig, 'Failed to unlock vault: invalid password')
+
+    await executeVerify(makeCtx(authErr), 'v1', resendOpts).then(
+      () => {
+        throw new Error('expected executeVerify to throw')
+      },
+      (err: unknown) => {
+        expect((err as AuthRequiredError).code).toBe('AUTH_REQUIRED')
+      }
+    )
+  })
+})
+
+describe('vaults pending visibility', () => {
+  function makeCtx(pending: string[], vaults: unknown[] = []) {
+    return {
+      sdk: {
+        listVaults: vi.fn(async () => vaults),
+        listPendingVaults: vi.fn(async () => pending),
+      },
+      getActiveVault: () => null,
+      dispose: () => {},
+    } as unknown as CommandContext
+  }
+
+  it('reports pending vault ids and status in the JSON envelope', async () => {
+    configureOutput({ format: 'json' })
+
+    await executeVaults(makeCtx(['pending-abc']))
+
+    const parsed = JSON.parse(jsonOut())
+    expect(parsed.success).toBe(true)
+    expect(parsed.data.pending).toEqual([{ id: 'pending-abc', status: 'pending_verification' }])
+  })
+
+  it('emits exactly one parseable JSON document', async () => {
+    configureOutput({ format: 'json' })
+
+    await executeVaults(makeCtx(['pending-abc']))
+
+    expect(() => JSON.parse(jsonOut())).not.toThrow()
+  })
+
+  it('reports an empty pending list when there are none', async () => {
+    configureOutput({ format: 'json' })
+
+    await executeVaults(makeCtx([]))
+
+    expect(JSON.parse(jsonOut()).data.pending).toEqual([])
+  })
+
+  it('does not let a pending-store read failure take down vaults', async () => {
+    configureOutput({ format: 'json' })
+    const ctx = makeCtx([])
+    ;(ctx.sdk.listPendingVaults as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('storage exploded'))
+
+    await expect(executeVaults(ctx)).resolves.toBeDefined()
+    expect(JSON.parse(jsonOut()).data.pending).toEqual([])
+  })
+})

--- a/clients/cli/src/commands/settings.ts
+++ b/clients/cli/src/commands/settings.ts
@@ -47,6 +47,11 @@ export async function executeCurrency(ctx: CommandContext, newCurrency?: string)
   spinner.succeed('Currency updated')
 
   const currencyName = fiatCurrencyNameRecord[currency]
+  if (isJsonOutput()) {
+    outputJson({ currency, name: currencyName, updated: true })
+    return currency
+  }
+
   success(`\n+ Currency preference set to ${currency.toUpperCase()} (${currencyName})`)
 
   return currency
@@ -154,16 +159,20 @@ export async function executeAddressBook(
     }
 
     const spinner = createSpinner('Adding address to address book...')
-    await ctx.sdk.addAddressBookEntry([
-      {
-        chain: chain!,
-        address: address!,
-        name: name!,
-        source: 'saved' as const,
-        dateAdded: Date.now(),
-      },
-    ])
+    const entry = {
+      chain: chain!,
+      address: address!,
+      name: name!,
+      source: 'saved' as const,
+      dateAdded: Date.now(),
+    }
+    await ctx.sdk.addAddressBookEntry([entry])
     spinner.succeed('Address added')
+
+    if (isJsonOutput()) {
+      outputJson({ added: entry })
+      return []
+    }
 
     success(`\n+ Added ${name} (${chain}: ${address})`)
     return []
@@ -173,6 +182,11 @@ export async function executeAddressBook(
     const spinner = createSpinner('Removing address from address book...')
     await ctx.sdk.removeAddressBookEntry([{ address: options.remove, chain: options.chain }])
     spinner.succeed('Address removed')
+
+    if (isJsonOutput()) {
+      outputJson({ removed: { address: options.remove, chain: options.chain } })
+      return []
+    }
 
     success(`\n+ Removed ${options.remove}`)
     return []

--- a/clients/cli/src/commands/transaction.ts
+++ b/clients/cli/src/commands/transaction.ts
@@ -84,12 +84,18 @@ export async function sendTransaction(
   if (params.dryRun) {
     const balance = await vault.balance(params.chain, params.tokenId)
     const hasInsufficientBalance = parseFloat(dryResult.total) > parseFloat(balance.formattedAmount)
+    // fee/total come straight from the build the SDK just did. They were previously
+    // dropped from the JSON result even though the human preview below prints the fee
+    // and `total` is what the insufficient-balance check compares against — so
+    // `--dry-run -o json` looked like a bare balance check with no cost information.
     const result: SendDryRunResult = {
       dryRun: true,
       chain: params.chain,
       to,
       amount: params.amount,
       symbol: balance.symbol,
+      fee: dryResult.fee,
+      total: dryResult.total,
       balance: balance.formattedAmount,
       destinationTag,
     }
@@ -104,7 +110,8 @@ export async function sendTransaction(
       info(`  To:      ${result.to}`)
       info(`  Amount:  ${result.amount} ${result.symbol}`)
       if (result.destinationTag !== undefined) info(`  Destination tag: ${result.destinationTag}`)
-      info(`  Fee:     ${dryResult.fee} ${result.symbol}`)
+      info(`  Fee:     ${result.fee} ${result.symbol}`)
+      info(`  Total:   ${result.total} ${result.symbol}`)
       info(`  Balance: ${result.balance} ${result.symbol}`)
       if (result.warning) warn(`  Warning: ${result.warning}`)
     }

--- a/clients/cli/src/commands/vault-management.ts
+++ b/clients/cli/src/commands/vault-management.ts
@@ -10,6 +10,14 @@ import qrcode from 'qrcode-terminal'
 
 import type { CommandContext } from '../core'
 import {
+  classifyError,
+  ExternalServiceError,
+  InvalidInputError,
+  UnknownError,
+  VaultNotFoundError,
+  type VsigError,
+} from '../core/errors'
+import {
   createSpinner,
   error,
   info,
@@ -307,6 +315,15 @@ export async function executeImport(ctx: CommandContext, file: string, flagPassw
   await ctx.setActiveVault(vault)
   spinner.succeed(`Vault imported: ${vault.name}`)
 
+  if (isJsonOutput()) {
+    outputJson({
+      imported: true,
+      vault: { id: vault.id, name: vault.name, type: vault.type, chains: vault.chains.length },
+      isActive: true,
+    })
+    return vault
+  }
+
   success('\n+ Vault imported successfully!')
   info('\nRun "vultisig balance" to view balances')
 
@@ -367,8 +384,11 @@ export async function executeVerify(
       info('Check your inbox for the new verification code.')
     } catch (resendErr: any) {
       spinner.fail('Failed to resend verification email')
-      error(resendErr.message || 'Could not resend email. You may need to wait a few minutes.')
-      return false
+      // Throw rather than `return false`: the caller no longer converts a false
+      // return into an error, so returning here would report the resend as a
+      // success (exit 0, and empty stdout in JSON mode) for an email that was
+      // never sent.
+      throw resendFailureError(resendErr as Error, vaultId)
     }
 
     // Non-interactive sessions can't fall through to the OTP prompt below — resend
@@ -422,20 +442,48 @@ export async function executeVerify(
     return true
   } catch (err: any) {
     spinner.fail('Verification failed')
-
-    if (isJsonOutput()) {
-      outputJson({
-        verified: false,
-        error: err.message || 'Verification failed. Please check the code and try again.',
-      })
-      return false
-    }
-
-    error(`\n✗ ${err.message || 'Verification failed. Please check the code and try again.'}`)
-    warn('\nTip: Use --resend to get a new verification code:')
-    info(`  vultisig verify ${vaultId} --resend`)
-    return false
+    // Throw a single typed error rather than pre-writing a result and returning
+    // false: the caller used to turn that false into a second throw, so `-o json`
+    // emitted TWO documents — a success-shaped {verified:false} envelope followed
+    // by an error envelope — and JSON.parse on the output failed. withExit renders
+    // message/hint/suggestions, so the human path keeps the same guidance.
+    throw verificationFailureError(err as Error, vaultId)
   }
+}
+
+/**
+ * A resend that failed must not look like one that succeeded. Keep the SDK's own
+ * classification when it produced a precise one (a bad password is AUTH_REQUIRED,
+ * a dropped connection is NETWORK); only an otherwise-unclassifiable failure gets
+ * the resend-specific wording, since rate-limiting is the common cause.
+ */
+function resendFailureError(err: Error, vaultId: string): VsigError {
+  const classified = classifyError(err)
+  if (!(classified instanceof UnknownError)) return classified
+  return new ExternalServiceError(
+    err.message || 'Could not resend the verification email.',
+    'The server may be rate-limiting resends — you may need to wait a few minutes',
+    [`vultisig verify ${vaultId} --resend`]
+  )
+}
+
+/** The SDK words this case for library callers ("...with createFastVault()"), which
+ *  is meaningless in a shell. The CLI owns its own copy. */
+const PENDING_VAULT_MISSING_RE = /no pending vault found/i
+
+function verificationFailureError(err: Error, vaultId: string): VsigError {
+  if (PENDING_VAULT_MISSING_RE.test(err.message ?? '')) {
+    return new VaultNotFoundError(
+      `No pending vault found for ID "${vaultId}".`,
+      'It may already be verified, or the ID may be wrong',
+      ['vultisig vaults', 'vultisig create --two-step']
+    )
+  }
+  return new InvalidInputError(
+    err.message || 'Verification failed. Please check the code and try again.',
+    'The code may be incorrect or expired',
+    [`vultisig verify ${vaultId} --resend`]
+  )
 }
 
 export type AddPostQuantumKeysOptions = {
@@ -475,6 +523,12 @@ export async function executeAddPostQuantumKeys(
       },
     })
     spinner.succeed('ML-DSA keys added. Vault file updated — export a backup if needed.')
+
+    if (isJsonOutput()) {
+      outputJson({ added: true, vault: { id: vault.id, name: vault.name }, backupRecommended: true })
+      return
+    }
+
     success('Post-quantum signing is now available for this vault (where supported).')
   } catch (e) {
     spinner.fail('Failed to add ML-DSA keys')
@@ -551,6 +605,11 @@ export async function executeExport(ctx: CommandContext, options: ExportVaultOpt
 
   spinner.succeed(`Vault exported: ${outputPath}`)
 
+  if (isJsonOutput()) {
+    outputJson({ exported: true, path: outputPath, encrypted: exportPassword !== undefined })
+    return outputPath
+  }
+
   success('\n+ Vault exported successfully!')
   info(`File: ${outputPath}`)
 
@@ -563,6 +622,11 @@ export async function executeExport(ctx: CommandContext, options: ExportVaultOpt
 export async function executeVaults(ctx: CommandContext): Promise<VaultBase[]> {
   const spinner = createSpinner('Loading vaults...')
   const vaults = await ctx.sdk.listVaults()
+  // A two-step vault awaiting verification is only named in the create-time output.
+  // An agent that lost that output had no way to rediscover the id and finish
+  // verifying, so list pending vaults here too. Best-effort: a pending-store read
+  // failure must not take down `vaults`, the command used to diagnose vault state.
+  const pending = await listPendingVaultsSafely(ctx)
   spinner.succeed('Vaults loaded')
 
   if (isJsonOutput()) {
@@ -577,21 +641,42 @@ export async function executeVaults(ctx: CommandContext): Promise<VaultBase[]> {
         createdAt: v.createdAt,
         isActive: activeVault?.id === v.id,
       })),
+      pending: pending.map(id => ({ id, status: 'pending_verification' })),
     })
     return vaults
   }
 
-  if (vaults.length === 0) {
+  if (vaults.length === 0 && pending.length === 0) {
     warn('\nNo vaults found. Create or import a vault first.')
     return []
   }
 
   const activeVault = ctx.getActiveVault()
-  displayVaultsList(vaults, activeVault)
+  if (vaults.length > 0) {
+    displayVaultsList(vaults, activeVault)
+  }
 
-  info(chalk.gray('\nUse "vultisig switch <id>" to switch active vault'))
+  if (pending.length > 0) {
+    warn(`\nPending verification (${pending.length}):`)
+    for (const id of pending) {
+      info(`  ${id}`)
+    }
+    info(chalk.gray('Finish with "vultisig verify <id> --code <OTP>"'))
+  }
+
+  if (vaults.length > 0) {
+    info(chalk.gray('\nUse "vultisig switch <id>" to switch active vault'))
+  }
 
   return vaults
+}
+
+async function listPendingVaultsSafely(ctx: CommandContext): Promise<string[]> {
+  try {
+    return await ctx.sdk.listPendingVaults()
+  } catch {
+    return []
+  }
 }
 
 /**
@@ -630,6 +715,15 @@ export async function executeSwitch(ctx: CommandContext, vaultId: string): Promi
   setupVaultEvents(vault)
   spinner.succeed('Vault switched')
 
+  if (isJsonOutput()) {
+    outputJson({
+      switched: true,
+      vault: { id: vault.id, name: vault.name, type: vault.type, chains: vault.chains.length },
+      isActive: true,
+    })
+    return vault
+  }
+
   success(`\n+ Switched to vault: ${vault.name}`)
   info(`  Type: ${vault.type}`)
   info(`  Chains: ${vault.chains.length}`)
@@ -648,6 +742,11 @@ export async function executeRename(ctx: CommandContext, newName: string): Promi
   const spinner = createSpinner('Renaming vault...')
   await vault.rename(newName)
   spinner.succeed('Vault renamed')
+
+  if (isJsonOutput()) {
+    outputJson({ renamed: true, vault: { id: vault.id, name: newName }, previousName: oldName })
+    return
+  }
 
   success(`\n+ Vault renamed from "${oldName}" to "${newName}"`)
 }

--- a/clients/cli/src/commands/vault-management.ts
+++ b/clients/cli/src/commands/vault-management.ts
@@ -422,33 +422,46 @@ export async function executeVerify(
 
   const spinner = createSpinner('Verifying email code...')
 
+  // Two phases with two different failure meanings. Only the verify call itself can mean
+  // "the code was wrong", so it is the only thing that maps to verificationFailureError.
+  let vault: VaultBase
   try {
-    // verifyVault now returns the vault directly (throws on failure)
-    const vault = await ctx.sdk.verifyVault(vaultId, code!)
-    spinner.succeed('Vault verified successfully!')
-
-    setupVaultEvents(vault)
-    await ctx.setActiveVault(vault)
-
-    if (isJsonOutput()) {
-      outputJson({
-        verified: true,
-        vault: { id: vaultId, name: vault.name, type: 'fast' },
-      })
-      return true
-    }
-
-    success(`\n+ Vault "${vault.name}" is now ready to use!`)
-    return true
+    // verifyVault returns the vault directly and throws on a bad/expired code or an
+    // unknown pending vault.
+    vault = await ctx.sdk.verifyVault(vaultId, code!)
   } catch (err: any) {
     spinner.fail('Verification failed')
-    // Throw a single typed error rather than pre-writing a result and returning
-    // false: the caller used to turn that false into a second throw, so `-o json`
-    // emitted TWO documents — a success-shaped {verified:false} envelope followed
-    // by an error envelope — and JSON.parse on the output failed. withExit renders
+    // Throw a single typed error rather than pre-writing a result and returning false:
+    // the caller used to turn that false into a second throw, so `-o json` emitted TWO
+    // documents — a success-shaped {verified:false} envelope followed by an error
+    // envelope — and JSON.parse on the output failed. withExit renders
     // message/hint/suggestions, so the human path keeps the same guidance.
     throw verificationFailureError(err as Error, vaultId)
   }
+
+  spinner.succeed('Vault verified successfully!')
+
+  // The code has already been accepted. Anything that fails from here — persisting the
+  // active-vault pointer, wiring events — is NOT a bad code, so it must carry its own
+  // classification (a corrupt store is CORRUPT_STATE, a full disk stays UNKNOWN) and must
+  // never send the user back to re-check or re-send a code that was fine.
+  try {
+    setupVaultEvents(vault)
+    await ctx.setActiveVault(vault)
+  } catch (err) {
+    throw classifyError(err as Error)
+  }
+
+  if (isJsonOutput()) {
+    outputJson({
+      verified: true,
+      vault: { id: vaultId, name: vault.name, type: 'fast' },
+    })
+    return true
+  }
+
+  success(`\n+ Vault "${vault.name}" is now ready to use!`)
+  return true
 }
 
 /**

--- a/clients/cli/src/commands/vault-management.ts
+++ b/clients/cli/src/commands/vault-management.ts
@@ -479,6 +479,15 @@ function verificationFailureError(err: Error, vaultId: string): VsigError {
       ['vultisig vaults', 'vultisig create --two-step']
     )
   }
+  // The whole verify path — verifyVault(), then setActiveVault() — sits in one try, so
+  // this also catches failures AFTER the code was already accepted. Keep the SDK's own
+  // classification when it produced a precise one, exactly as resendFailureError does:
+  // a StorageError from persisting the active-vault pointer means the code was RIGHT and
+  // the stored state is broken, so it has to surface as CORRUPT_STATE rather than "the
+  // code may be incorrect" — which would send someone to re-send an OTP that was never
+  // the problem.
+  const classified = classifyError(err)
+  if (!(classified instanceof UnknownError)) return classified
   return new InvalidInputError(
     err.message || 'Verification failed. Please check the code and try again.',
     'The code may be incorrect or expired',

--- a/clients/cli/src/core/chain-resolver.test.ts
+++ b/clients/cli/src/core/chain-resolver.test.ts
@@ -1,0 +1,55 @@
+// Chain-argument validation (vultisig-sdk sdkcli2-13 P2-6 / P2-10).
+//
+// Regression guards:
+//  - `tokens <bogus-chain>` exited 0 with `{"success":true,"data":{"tokens":[]}}` — a
+//    machine caller could not distinguish "chain has no tokens" from "no such chain".
+//  - `swap-quote <bogus-chain> ...` exited 7/UNKNOWN_ERROR with a raw
+//    "Cannot read properties of undefined (reading 'ticker')" TypeError.
+// Both call sites cast an unresolved name straight to `Chain`
+// (`findChainByName(x) || (x as Chain)`); resolving up front turns both into
+// INVALID_CHAIN / exit 4.
+import { Chain } from '@vultisig/sdk'
+import { describe, expect, it } from 'vitest'
+
+import { resolveChainOrThrow } from './chain-resolver'
+import { ExitCode, InvalidChainError } from './errors'
+
+describe('resolveChainOrThrow', () => {
+  it('resolves a known chain name case-insensitively', () => {
+    expect(resolveChainOrThrow('Ethereum')).toBe(Chain.Ethereum)
+    expect(resolveChainOrThrow('ethereum')).toBe(Chain.Ethereum)
+    expect(resolveChainOrThrow('ETHEREUM')).toBe(Chain.Ethereum)
+  })
+
+  it('throws INVALID_CHAIN / exit 4 for an unknown chain instead of casting it through', () => {
+    try {
+      resolveChainOrThrow('bogus-chain')
+      throw new Error('expected resolveChainOrThrow to throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(InvalidChainError)
+      const chainErr = err as InvalidChainError
+      expect(chainErr.code).toBe('INVALID_CHAIN')
+      expect(chainErr.exitCode).toBe(ExitCode.INVALID_INPUT)
+      expect(chainErr.retryable).toBe(false)
+    }
+  })
+
+  it('carries the offending name in the error context and message', () => {
+    try {
+      resolveChainOrThrow('bogus-chain')
+      throw new Error('expected resolveChainOrThrow to throw')
+    } catch (err) {
+      expect((err as InvalidChainError).context).toMatchObject({ chain: 'bogus-chain' })
+      expect((err as InvalidChainError).message).toContain('bogus-chain')
+    }
+  })
+
+  it('names which side of a two-chain command was wrong', () => {
+    expect(() => resolveChainOrThrow('nope', 'source chain')).toThrow(/Unsupported source chain: "nope"/)
+    expect(() => resolveChainOrThrow('nope', 'destination chain')).toThrow(/Unsupported destination chain: "nope"/)
+  })
+
+  it('does not accept the empty string as a chain', () => {
+    expect(() => resolveChainOrThrow('')).toThrow(InvalidChainError)
+  })
+})

--- a/clients/cli/src/core/chain-resolver.ts
+++ b/clients/cli/src/core/chain-resolver.ts
@@ -1,0 +1,32 @@
+import type { Chain } from '@vultisig/sdk'
+
+// Imported from the leaf module rather than the '../interactive' barrel: the barrel
+// pulls in the shell session, which imports '../core' back, and that cycle would make
+// core transitively load the whole shell + command tree.
+import { findChainByName } from '../interactive/completer'
+import { InvalidChainError } from './errors'
+
+/**
+ * Resolve a user-supplied chain name, or throw INVALID_CHAIN.
+ *
+ * Call sites historically wrote `findChainByName(input) || (input as Chain)`, which
+ * launders an unknown name into a `Chain` and defers the failure to whatever the
+ * command does next — `tokens bogus-chain` reported `success: true` with an empty
+ * list, and `swap-quote bogus-chain ...` surfaced a raw TypeError. Resolving up
+ * front turns both into the same typed, non-retryable INVALID_CHAIN.
+ *
+ * `label` names the argument in the message, so a two-chain command can say which
+ * side was wrong.
+ */
+export function resolveChainOrThrow(input: string, label = 'chain'): Chain {
+  const chain = findChainByName(input)
+  if (!chain) {
+    throw new InvalidChainError(
+      `Unsupported ${label}: "${input}"`,
+      'Run "vultisig chains" to see the supported chains, or check the spelling.',
+      undefined,
+      { chain: input }
+    )
+  }
+  return chain
+}

--- a/clients/cli/src/core/command-context.ts
+++ b/clients/cli/src/core/command-context.ts
@@ -9,6 +9,8 @@
  */
 import type { VaultBase, Vultisig } from '@vultisig/sdk'
 
+import { NoActiveVaultError } from './errors'
+
 /**
  * Password cache entry with expiration
  */
@@ -87,7 +89,7 @@ export abstract class BaseCommandContext implements CommandContext {
     }
 
     if (!this._activeVault) {
-      throw new Error('No active vault. Create or import a vault first.')
+      throw new NoActiveVaultError()
     }
 
     return this._activeVault

--- a/clients/cli/src/core/errors.ts
+++ b/clients/cli/src/core/errors.ts
@@ -2,6 +2,7 @@ import {
   Chain,
   type ChainKind,
   getChainKind,
+  StorageError,
   VaultError,
   VaultErrorCode,
   VaultImportError,
@@ -55,6 +56,16 @@ export enum ExitCode {
   // request did not execute or consume credits; inspect the conversation for
   // the first attempt's persisted result before starting a fresh attempt.
   IDEMPOTENT_TURN_DUPLICATE = 14,
+  // The command needs an active vault and there isn't one selected. This is an
+  // expected, actionable state (create/import/switch), NOT a failure — distinct
+  // from UNKNOWN (7) so a headless caller can tell "you have no vault yet" from
+  // "something broke". Vaults may well exist; none is selected.
+  NO_ACTIVE_VAULT = 15,
+  // On-disk CLI/vault state is present but unparseable (truncated or hand-edited
+  // JSON). Retrying cannot help and no amount of waiting fixes it — the state must
+  // be repaired or re-imported from a .vult backup. Distinct from UNKNOWN (7) so a
+  // headless caller can stop retrying and surface a recovery path.
+  CORRUPT_STATE = 16,
 }
 
 export const EXIT_CODE_DESCRIPTIONS: Record<ExitCode, string> = {
@@ -76,6 +87,8 @@ export const EXIT_CODE_DESCRIPTIONS: Record<ExitCode, string> = {
     'agent ask: transaction broadcast but the overall request may be incomplete — inspect the hash, do NOT blindly retry',
   [ExitCode.IDEMPOTENT_TURN_DUPLICATE]:
     'agent ask: duplicate keyed turn rejected — inspect the conversation for the original result',
+  [ExitCode.NO_ACTIVE_VAULT]: 'No active vault selected — create, import, or switch to one',
+  [ExitCode.CORRUPT_STATE]: 'Stored state is unreadable — repair it or re-import the vault from a .vult backup',
 }
 
 export abstract class VsigError extends Error {
@@ -295,6 +308,37 @@ function keyedTurnContext(conversationId?: string, firstRequestAt?: string): Rec
   return Object.keys(context).length > 0 ? context : undefined
 }
 
+/** A command needs an active vault and none is selected. Expected and actionable —
+ *  vaults may exist, none is current. */
+export class NoActiveVaultError extends VsigError {
+  readonly exitCode = ExitCode.NO_ACTIVE_VAULT
+  readonly code = 'NO_ACTIVE_VAULT'
+
+  constructor(message?: string) {
+    super(
+      message ?? 'No active vault. Create or import a vault first.',
+      'Select an existing vault with "vultisig switch <id>", or create/import one',
+      ['vultisig vaults', 'vultisig switch <id>', 'vultisig create', 'vultisig import <file.vult>']
+    )
+  }
+}
+
+/** Stored state exists but is unparseable. Not retryable: the bytes on disk are
+ *  broken, so the caller needs a repair/re-import path rather than another attempt. */
+export class CorruptStateError extends VsigError {
+  readonly exitCode = ExitCode.CORRUPT_STATE
+  readonly code = 'CORRUPT_STATE'
+
+  constructor(message: string, context?: Record<string, string>) {
+    super(
+      message,
+      'The stored file is present but unreadable — it was likely truncated or hand-edited',
+      ['Re-import the vault from its .vult backup: vultisig import <file.vult>', 'vultisig vaults'],
+      context
+    )
+  }
+}
+
 export class UnknownError extends VsigError {
   readonly exitCode = ExitCode.UNKNOWN
   readonly code = 'UNKNOWN_ERROR'
@@ -504,8 +548,28 @@ function classifyVaultError(err: VaultError): VsigError {
   }
 }
 
+/**
+ * A StorageError means "the read/write itself failed", which covers both broken
+ * bytes and ordinary IO trouble. Only the former is CORRUPT_STATE: retrying an
+ * unparseable file is futile, whereas a permission/IO error may well clear. The
+ * node/RN/extension backends all wrap the underlying failure as `cause`, so a
+ * JSON.parse SyntaxError there is the positive signal that the stored value is
+ * genuinely malformed. Anything else deliberately falls through to the existing
+ * classification rather than being mislabelled unrecoverable.
+ */
+function corruptStateErrorFrom(err: StorageError): CorruptStateError | undefined {
+  if (!(err.cause instanceof SyntaxError)) return undefined
+  const keyMatch = err.message.match(/key "([^"]+)"/)
+  return new CorruptStateError(err.message, keyMatch ? { key: keyMatch[1] } : undefined)
+}
+
 export function classifyError(err: Error): VsigError {
   if (err instanceof VsigError) return err
+
+  if (err instanceof StorageError) {
+    const corrupt = corruptStateErrorFrom(err)
+    if (corrupt) return corrupt
+  }
 
   // The journal's duplicate/concurrent refusals aren't VaultErrors — they carry
   // a stable `code === 'DUPLICATE_BROADCAST'`. Map them to exit 9 before the

--- a/clients/cli/src/core/index.ts
+++ b/clients/cli/src/core/index.ts
@@ -3,6 +3,7 @@
  */
 export * from './active-vault'
 export * from './broadcastGuard'
+export * from './chain-resolver'
 export * from './command-context'
 export * from './config-store'
 export * from './credential-store'

--- a/clients/cli/src/core/state-errors.test.ts
+++ b/clients/cli/src/core/state-errors.test.ts
@@ -1,0 +1,128 @@
+// Typed state errors (vultisig-sdk sdkcli2-13 P1-6 / P7a-2).
+//
+// Regression guards:
+//  - "No active vault" threw a plain Error, so `balance -o json` on an empty store
+//    exited 7/UNKNOWN_ERROR with no hint — indistinguishable from a real crash.
+//  - A readable pointer naming a vault whose data file is corrupt propagated the raw
+//    storage failure ("Failed to read value for key X") as UNKNOWN_ERROR/7, with no
+//    remediation path.
+// Both now carry stable codes and recovery hints. Corruption is detected positively
+// (a JSON.parse SyntaxError cause) so transient IO/permission failures are NOT
+// mislabelled unrecoverable.
+import { StorageError, StorageErrorCode } from '@vultisig/sdk'
+import { describe, expect, it, vi } from 'vitest'
+
+import { BaseCommandContext } from './command-context'
+import { classifyError, CorruptStateError, ExitCode, NoActiveVaultError, toErrorJson, UnknownError } from './errors'
+
+describe('ensureActiveVault throw site', () => {
+  // The tests below construct NoActiveVaultError directly, which would stay green if
+  // the throw site regressed to a plain Error. Drive the real code path too.
+  class TestContext extends BaseCommandContext {
+    get isInteractive() {
+      return false
+    }
+    async getPassword() {
+      return ''
+    }
+  }
+
+  function makeCtx(activeVault: unknown) {
+    return new TestContext({
+      getActiveVault: vi.fn(async () => activeVault),
+      dispose: vi.fn(),
+    } as never)
+  }
+
+  it('throws NoActiveVaultError — not a plain Error — when no vault is active', async () => {
+    await expect(makeCtx(null).ensureActiveVault()).rejects.toBeInstanceOf(NoActiveVaultError)
+  })
+
+  it('gives that throw exit 15 with a hint, rather than UNKNOWN_ERROR/7', async () => {
+    const err = await makeCtx(null)
+      .ensureActiveVault()
+      .catch((e: unknown) => e)
+
+    const classified = classifyError(err as Error)
+    expect(classified.code).toBe('NO_ACTIVE_VAULT')
+    expect(classified.exitCode).toBe(ExitCode.NO_ACTIVE_VAULT)
+    expect(classified.hint).toBeTruthy()
+  })
+
+  it('still returns the vault when one is active', async () => {
+    const vault = { id: 'v1', name: 'Vault' }
+    await expect(makeCtx(vault).ensureActiveVault()).resolves.toBe(vault)
+  })
+})
+
+describe('NoActiveVaultError', () => {
+  it('is NO_ACTIVE_VAULT / exit 15, not UNKNOWN / 7', () => {
+    const err = new NoActiveVaultError()
+    expect(err.code).toBe('NO_ACTIVE_VAULT')
+    expect(err.exitCode).toBe(ExitCode.NO_ACTIVE_VAULT)
+    expect(err.exitCode).not.toBe(ExitCode.UNKNOWN)
+  })
+
+  it('is not retryable and carries an actionable recovery path', () => {
+    const err = new NoActiveVaultError()
+    expect(err.retryable).toBe(false)
+    expect(err.hint).toBeTruthy()
+    expect(err.suggestions).toEqual(expect.arrayContaining(['vultisig switch <id>', 'vultisig create']))
+  })
+
+  it('survives classifyError unchanged and serialises the hint into the JSON envelope', () => {
+    const json = toErrorJson(classifyError(new NoActiveVaultError()))
+    expect(json.success).toBe(false)
+    expect(json.error.code).toBe('NO_ACTIVE_VAULT')
+    expect(json.error.exitCode).toBe(15)
+    expect(json.error.retryable).toBe(false)
+    expect(json.error.hint).toBeTruthy()
+    expect(json.error.suggestions?.length).toBeGreaterThan(0)
+  })
+})
+
+describe('CorruptStateError classification', () => {
+  // What the node storage backend actually throws for an unparseable file.
+  function storageParseFailure(key = 'activeVaultId') {
+    return new StorageError(
+      StorageErrorCode.Unknown,
+      `Failed to read value for key "${key}"`,
+      new SyntaxError('Unexpected end of JSON input')
+    )
+  }
+
+  it('maps an unparseable stored value to CORRUPT_STATE / exit 16', () => {
+    const classified = classifyError(storageParseFailure())
+    expect(classified).toBeInstanceOf(CorruptStateError)
+    expect(classified.code).toBe('CORRUPT_STATE')
+    expect(classified.exitCode).toBe(ExitCode.CORRUPT_STATE)
+  })
+
+  it('offers a re-import recovery path instead of a bare storage message', () => {
+    const classified = classifyError(storageParseFailure())
+    expect(classified.hint).toBeTruthy()
+    expect(classified.suggestions?.some(s => s.includes('import'))).toBe(true)
+    expect(classified.retryable).toBe(false)
+  })
+
+  it('names the offending storage key in the error context', () => {
+    const classified = classifyError(storageParseFailure('vault-abc123'))
+    expect(classified.context).toMatchObject({ key: 'vault-abc123' })
+  })
+
+  it('does NOT label a permission/IO storage failure as corrupt — retrying those can work', () => {
+    const ioFailure = new StorageError(
+      StorageErrorCode.Unknown,
+      'Failed to read value for key "activeVaultId"',
+      Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' })
+    )
+    expect(classifyError(ioFailure)).not.toBeInstanceOf(CorruptStateError)
+  })
+
+  it('does NOT label a StorageError with no cause as corrupt', () => {
+    const bare = new StorageError(StorageErrorCode.Unknown, 'Failed to read value for key "activeVaultId"')
+    const classified = classifyError(bare)
+    expect(classified).not.toBeInstanceOf(CorruptStateError)
+    expect(classified).toBeInstanceOf(UnknownError)
+  })
+})

--- a/clients/cli/src/core/types.ts
+++ b/clients/cli/src/core/types.ts
@@ -29,6 +29,10 @@ export type SendDryRunResult = {
   to: string
   amount: string
   symbol: string
+  /** Network fee the build estimated for this transaction. */
+  fee: string
+  /** amount + fee — what the send actually costs, and what `balance` is checked against. */
+  total: string
   balance: string
   destinationTag?: number
   warning?: string

--- a/clients/cli/src/index.ts
+++ b/clients/cli/src/index.ts
@@ -57,7 +57,7 @@ import {
   executeVerify,
   resolveTxStatusParams,
 } from './commands'
-import { cachePassword, createPasswordCallback, loadActiveVaultSafely } from './core'
+import { cachePassword, createPasswordCallback, loadActiveVaultSafely, resolveChainOrThrow } from './core'
 import { EXIT_CODE_DESCRIPTIONS, ExitCode, InvalidInputError } from './core/errors'
 import { parseServerEndpointOverridesFromArgv, resolveServerEndpoints } from './core/server-endpoints'
 import { findChainByName } from './interactive'
@@ -593,12 +593,10 @@ program
     withExit(
       async (vaultId: string, options: { resend?: boolean; code?: string; email?: string; password?: string }) => {
         const context = await init(program.opts().vault)
-        const verified = await executeVerify(context, vaultId, options)
-        if (!verified) {
-          const err: any = new Error('Verification failed')
-          err.exitCode = 1
-          throw err
-        }
+        // executeVerify throws a typed error on failure; it no longer signals
+        // failure via a `false` return that this had to re-throw (which produced a
+        // second JSON document on stdout).
+        await executeVerify(context, vaultId, options)
       }
     )
   )
@@ -1077,9 +1075,10 @@ Examples:
           decimals?: string
         }
       ) => {
+        const chain = resolveChainOrThrow(chainStr)
         const context = await init(program.opts().vault)
         await executeTokens(context, {
-          chain: findChainByName(chainStr) || (chainStr as Chain),
+          chain,
           add: options.add,
           remove: options.remove,
           discover: options.discover,
@@ -1130,10 +1129,12 @@ Examples:
       ) => {
         if (!amountStr && !options.max) throw new Error('Provide an amount or use --max')
         if (amountStr && options.max) throw new Error('Cannot specify both amount and --max')
+        const fromChain = resolveChainOrThrow(fromChainStr, 'source chain')
+        const toChain = resolveChainOrThrow(toChainStr, 'destination chain')
         const context = await init(program.opts().vault)
         await executeSwapQuote(context, {
-          fromChain: findChainByName(fromChainStr) || (fromChainStr as Chain),
-          toChain: findChainByName(toChainStr) || (toChainStr as Chain),
+          fromChain,
+          toChain,
           amount: options.max ? 'max' : parseFloat(amountStr!),
           fromToken: options.fromToken,
           toToken: options.toToken,


### PR DESCRIPTION
Five CLI fixes that share one theme: a machine consumer of the CLI couldn't trust what it got
back. Each is from an audit of low-severity CLI issues, and each has a red-then-green test. No
fund-movement behaviour, no wire contract, and no change to exit codes 9/12/13.

Split out of #1354, which batched nine of these fixes and was too big to review in one sitting.
No code was dropped in the split.

### What's in here

| # | Fix | Before |
|---|---|---|
| 1 | Every mutation emits a result envelope | switch/rename/currency/address-book/import/export/add-mldsa exited 0 with **empty** stdout in `-o json`, while delete/chains-add already emitted envelopes |
| 2 | One envelope from `verify`; pending vaults in `vaults` | `verify -o json` wrote **two** JSON documents, so `JSON.parse` failed; pending two-step vaults were invisible |
| 3 | Validate the chain arg for `tokens` / `swap-quote` | `tokens bogus-chain` → exit 0 + `{"success":true,...,"tokens":[]}`; `swap-quote bogus-chain …` → exit 7 + a raw `Cannot read properties of undefined (reading 'ticker')` |
| 4 | `NO_ACTIVE_VAULT` (15) / `CORRUPT_STATE` (16) | Both were a generic `UNKNOWN_ERROR`/7 with no hint |
| 5 | `send --dry-run` reports fee/total | JSON dropped both, even though the human preview printed the fee and `total` is what the insufficient-balance warning is computed from |

### Notes for review

- **#2** lists pending vaults best-effort — a pending-store read failure must not take down
  `vaults`, which is the command you use to diagnose vault state in the first place. The SDK's
  own wording for a missing pending vault mentions `createFastVault()`, which is legitimate for
  library callers but meaningless in a shell, so the CLI owns its copy rather than editing the SDK.
- **#4** adds two exit codes. This follows the existing pattern (8–14 were each carved out of the
  generic bucket for the same "let a headless caller branch on `$?`" reason) and the README table
  is pinned to the enum by the existing doc-lint test. Corruption is detected *positively* — a
  `StorageError` whose cause is a `JSON.parse` `SyntaxError` — so transient IO/permission failures
  keep their current classification rather than being mislabelled unrecoverable. The fail-open
  active-pointer reset from #1077 is untouched.
- **#3** deliberately leaves the same unchecked `findChainByName(x) || (x as Chain)` cast on the
  `send`/`swap` fund-movement paths — out of scope for a polish sweep.

### Heads-up: one deliberate behaviour change worth a maintainer opinion

**#2 shifts `verify`'s failure exit code from 1 to 4/5.** It previously threw a bare `Error` with
`exitCode = 1` attached (which `classifyError` ignored anyway); it now throws `InvalidInputError`
(4) for a wrong/expired code and `VaultNotFoundError` (5) for an unknown pending vault. That's
more correct and consistent with the documented table, but it IS a real change on a published
surface, and this PR's claim only fences 9/12/13 — so flagging it rather than burying it. It's
called out in the changeset too. Happy to pin `verify` failure back to 1 if anything depends on it.

### Sibling PRs

#1354 was split into three PRs off `main`. The other two are #1386 (keyshare file safety) and
#1387 (CLI DX polish). This PR and #1386 both touch `executeExport` in
`clients/cli/src/commands/vault-management.ts` — this one adds its JSON envelope, that one
changes how the file is written — so whichever lands first leaves the other a trivial rebase.
No other file is shared with either sibling.

### Validation

`yarn test:cli`, `yarn typecheck` (root + CLI workspace), and changed-file eslint + prettier all
pass locally. Each fix was red-checked by reverting it and observing the specific failure. No live
transactions were made.

### Post-review fix

A local multi-perspective review ran over this branch before it left draft and found one
correctness issue, now fixed in commit `43c2dc61`:

- **`verify` misclassified a post-acceptance failure as a bad code.** `executeVerify` runs
  `verifyVault()` and `setActiveVault()` in one `try`, so the catch also sees failures *after*
  the server accepted the code — e.g. a `StorageError` persisting the active-vault pointer. Those
  were routed to `InvalidInputError` (exit 4, "the code may be incorrect or expired"), which for a
  corrupt store is doubly wrong: the code was right, and it sends the user to re-send an OTP that
  was never the problem — masking the `CORRUPT_STATE`/16 signal this PR adds. Now classifies first
  (mirroring the `--resend` path in the same file) so a corrupt store surfaces as `CORRUPT_STATE`.
  Regression test added (red on revert), plus a test that drives the real `withExit` wrapper so
  the "exactly one JSON document" claim is proven end-to-end rather than only at the `executeVerify`
  layer where the old two-document bug didn't live.

A second re-review round noted the first fix was narrower than its commit title implied — the
`try` still spanned the post-acceptance steps, so a *non*-corruption failure there (a full disk
writing the pointer) could still surface as "code may be incorrect." Fixed in `cc11dae7` by
splitting `executeVerify` into two phases: only the verify call maps to a bad-code error; once the
code is accepted, activation failures classify directly (corrupt store → CORRUPT_STATE/16,
everything else → generic UNKNOWN/7, never a bad-code claim). Test added, red on revert.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * JSON-mode mutations now consistently return one structured result.
  * `send --dry-run` JSON output includes estimated fees and totals.
  * Vault listings now show pending verifications.
  * Added actionable exit codes for missing active vaults and unreadable state.

* **Bug Fixes**
  * Invalid chain names now produce clear, parseable errors.
  * Verification failures no longer produce duplicate JSON output.
  * Verification and resend errors now provide more accurate status and recovery guidance.
  * Vault import, export, switching, renaming, and key-management commands now report structured JSON results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->