### PR TITLE
fix(cli): keep exported key shares owner-only, and stop rename locking names out

### DIFF
--- a/.changeset/cli-keyshare-file-safety.md
+++ b/.changeset/cli-keyshare-file-safety.md
@@ -1,0 +1,16 @@
+---
+'@vultisig/cli': patch
+'@vultisig/sdk': patch
+---
+
+Tighten the handling of files that carry key shares:
+
+- Write exported `.vult` files owner-only (0600) instead of with the default umask
+  (0644, world-readable), matching the SDK's own vault store. The export is written to
+  a fresh temp file and renamed over the target, so the shares are never on disk at a
+  looser mode — `writeFile`'s `mode` only applies when it creates the file, so writing
+  straight to a pre-existing path would have left the shares world-readable for a window.
+- Stop `rename` rejecting vault names the ecosystem itself creates (e.g. the `#` in
+  "Vultisig Cluster #1"), which made rename a one-way door. The alphanumeric allowlist
+  is replaced with a denylist of what is genuinely unsafe for the export filename the
+  name is interpolated into: path separators and control characters.

--- a/.changeset/cli-keyshare-file-safety.md
+++ b/.changeset/cli-keyshare-file-safety.md
@@ -14,3 +14,9 @@ Tighten the handling of files that carry key shares:
   "Vultisig Cluster #1"), which made rename a one-way door. The alphanumeric allowlist
   is replaced with a denylist of what is genuinely unsafe for the export filename the
   name is interpolated into: path separators and control characters.
+- Enforce that denylist at the real lifecycle boundary — `export()` — rather than only
+  at rename. A vault imported or created via a path that ran no name validation could
+  otherwise carry an unsafe name or `localPartyId` (path separators, control chars, a
+  bare `..`) straight into the export filename. `export()` now encodes every filename
+  component to a single safe path segment (same policy as rename), encoding rather than
+  refusing so a legitimately-imported vault is never stranded behind its own backup file.

--- a/clients/cli/src/commands/__tests__/exportVaultMode.test.ts
+++ b/clients/cli/src/commands/__tests__/exportVaultMode.test.ts
@@ -95,3 +95,57 @@ describe('export file permissions', () => {
     expect(await fs.readFile(outputPath, 'utf-8')).toBe('VULT-KEYSHARE-BYTES')
   })
 })
+
+// The temp file is the whole mechanism, so it needs the same guarantee as the target.
+// `mode` applying only at creation is exactly why writing straight to the target was
+// unsafe — and that cuts both ways: if the TEMP path already exists, writeFile truncates
+// it in place and keeps its old permissions, putting the shares right back in a
+// world-readable file. Hence random bytes in the name and an exclusive ('wx') create.
+describe('export temp file cannot be pre-empted', () => {
+  let tmpDir: string
+  let originalUmask: number
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vsig-export-temp-'))
+    originalUmask = process.umask(0o022)
+  })
+
+  afterEach(async () => {
+    process.umask(originalUmask)
+    await fs.rm(tmpDir, { recursive: true, force: true })
+    vi.restoreAllMocks()
+    vi.resetModules()
+    resetOutput()
+  })
+
+  it('refuses rather than writing shares into a pre-created temp file', async () => {
+    // Pin the random component so the temp path is knowable, standing in for an
+    // attacker who can predict or brute-force it.
+    vi.resetModules()
+    vi.doMock('crypto', async importOriginal => ({
+      ...(await importOriginal<typeof import('crypto')>()),
+      randomBytes: () => Buffer.from('deadbeefcafe', 'hex'),
+    }))
+    const { executeExport: exportWithPinnedRandom } = await import('../vault-management')
+
+    // Pin the clock too, or the millisecond could tick between here and the export.
+    const FIXED_NOW = 1_700_000_000_000
+    vi.spyOn(Date, 'now').mockReturnValue(FIXED_NOW)
+
+    const outputPath = path.join(tmpDir, 'preempt.vult')
+    const tempPath = `${outputPath}.${process.pid}.${FIXED_NOW}.deadbeefcafe.tmp`
+    await fs.writeFile(tempPath, '')
+    await fs.chmod(tempPath, 0o644)
+
+    await expect(exportWithPinnedRandom(makeCtx(), { outputPath, exportPassword: 'pw' })).rejects.toThrow()
+
+    // The decisive assertion: the shares must never reach the pre-created 0644 file.
+    // The failure path also unlinks the temp path, so absent is as good as empty —
+    // what must not happen is keyshare bytes landing in a world-readable file.
+    const leaked = await fs.readFile(tempPath, 'utf-8').catch(() => '')
+    expect(leaked).not.toContain('VULT-KEYSHARE-BYTES')
+
+    // ...and the export must not have silently succeeded to the real target either.
+    await expect(fs.access(outputPath)).rejects.toThrow()
+  })
+})

--- a/clients/cli/src/commands/__tests__/exportVaultMode.test.ts
+++ b/clients/cli/src/commands/__tests__/exportVaultMode.test.ts
@@ -1,0 +1,97 @@
+// `export` writes the keyshare file owner-only (vultisig-sdk sdkcli2-13 P1-7 / P4-4).
+//
+// Regression guard: the export used to be written with the default umask (0644 —
+// world-readable) into the cwd, including $HOME, even though the SDK's own vault
+// store is 0600. `auth setup` then auto-discovers that file as a credential anchor.
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resetOutput } from '../../lib/output'
+import { executeExport } from '../vault-management'
+
+function makeCtx() {
+  const vault = {
+    export: vi.fn(async () => ({ data: 'VULT-KEYSHARE-BYTES', filename: 'test-vault.vult' })),
+  }
+  return { ensureActiveVault: vi.fn(async () => vault) } as never
+}
+
+async function modeOf(file: string): Promise<string> {
+  const stat = await fs.stat(file)
+  return (stat.mode & 0o777).toString(8)
+}
+
+describe('export file permissions', () => {
+  let tmpDir: string
+  let originalUmask: number
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vsig-export-mode-'))
+    // Force a permissive umask for the duration. Otherwise a developer/CI umask of
+    // 0077 would mask the bug: a plain writeFile would land 0600 by accident and the
+    // fresh-file assertion below would pass even with the fix reverted.
+    originalUmask = process.umask(0o022)
+  })
+
+  afterEach(async () => {
+    process.umask(originalUmask)
+    await fs.rm(tmpDir, { recursive: true, force: true })
+    vi.restoreAllMocks()
+    resetOutput()
+  })
+
+  it('creates a new export 0600, not world-readable, even under a permissive umask', async () => {
+    const outputPath = path.join(tmpDir, 'fresh.vult')
+
+    await executeExport(makeCtx(), { outputPath, exportPassword: 'pw' })
+
+    expect(await modeOf(outputPath)).toBe('600')
+  })
+
+  it('replaces a pre-existing world-readable file with an owner-only one', async () => {
+    // The keyshare must never land in the pre-existing 0644 file: writeFile's `mode`
+    // only applies when it CREATES the file, so writing in place would put shares in a
+    // world-readable file and only tighten it afterwards. The export writes a fresh
+    // 0600 temp file and renames over the target instead.
+    const outputPath = path.join(tmpDir, 'stale.vult')
+    await fs.writeFile(outputPath, 'old', { mode: 0o644 })
+    expect(await modeOf(outputPath)).toBe('644')
+
+    await executeExport(makeCtx(), { outputPath, exportPassword: 'pw' })
+
+    expect(await modeOf(outputPath)).toBe('600')
+    expect(await fs.readFile(outputPath, 'utf-8')).toBe('VULT-KEYSHARE-BYTES')
+  })
+
+  it('never writes the keyshare into the pre-existing world-readable inode', async () => {
+    // Directly pins the TOCTOU the temp+rename closes: if the shares were written in
+    // place and chmod'd after, the ORIGINAL inode would hold them at 0644 for a window.
+    // After a rename the target is a different inode, and the old one never saw them.
+    const outputPath = path.join(tmpDir, 'watched.vult')
+    await fs.writeFile(outputPath, 'old', { mode: 0o644 })
+    const inodeBefore = (await fs.stat(outputPath)).ino
+
+    await executeExport(makeCtx(), { outputPath, exportPassword: 'pw' })
+
+    expect((await fs.stat(outputPath)).ino).not.toBe(inodeBefore)
+  })
+
+  it('leaves no temp file behind', async () => {
+    const outputPath = path.join(tmpDir, 'clean.vult')
+
+    await executeExport(makeCtx(), { outputPath, exportPassword: 'pw' })
+
+    expect(await fs.readdir(tmpDir)).toEqual(['clean.vult'])
+  })
+
+  it('still writes the keyshare content it was given', async () => {
+    const outputPath = path.join(tmpDir, 'content.vult')
+
+    await executeExport(makeCtx(), { outputPath, exportPassword: 'pw' })
+
+    expect(await fs.readFile(outputPath, 'utf-8')).toBe('VULT-KEYSHARE-BYTES')
+  })
+})

--- a/clients/cli/src/commands/vault-management.ts
+++ b/clients/cli/src/commands/vault-management.ts
@@ -563,7 +563,12 @@ export async function executeExport(ctx: CommandContext, options: ExportVaultOpt
     await fs.writeFile(tempPath, vultContent, { encoding: 'utf-8', mode: 0o600, flag: 'wx' })
     await fs.rename(tempPath, outputPath)
   } catch (err) {
-    await fs.rm(tempPath, { force: true }).catch(() => {})
+    // Only remove the temp file if the exclusive create is what succeeded. On EEXIST we
+    // never created it — something was already at that path — so deleting it would remove
+    // a file we do not own.
+    if ((err as NodeJS.ErrnoException)?.code !== 'EEXIST') {
+      await fs.rm(tempPath, { force: true }).catch(() => {})
+    }
     throw err
   }
 

--- a/clients/cli/src/commands/vault-management.ts
+++ b/clients/cli/src/commands/vault-management.ts
@@ -4,6 +4,7 @@
 import type { Chain, VaultBase } from '@vultisig/sdk'
 import { FastVault } from '@vultisig/sdk'
 import chalk from 'chalk'
+import { randomBytes } from 'crypto'
 import { promises as fs } from 'fs'
 import path from 'path'
 import qrcode from 'qrcode-terminal'
@@ -552,9 +553,14 @@ export async function executeExport(ctx: CommandContext, options: ExportVaultOpt
   // straight to an existing (or attacker-pre-created) path would put the shares in a
   // world-readable file and only tighten it afterwards. Creating a new file first
   // means the shares are never on disk at anything but 0600, and the rename is atomic.
-  const tempPath = `${outputPath}.${process.pid}.${Date.now()}.tmp`
+  //
+  // The temp name carries random bytes and the write is exclusive ('wx') for the same
+  // reason: 'mode' applying only at creation cuts both ways, so a temp path an attacker
+  // could predict and pre-create would put the shares straight back into their 0644 file.
+  // Unpredictable name + fail-closed create means that path cannot be won.
+  const tempPath = `${outputPath}.${process.pid}.${Date.now()}.${randomBytes(6).toString('hex')}.tmp`
   try {
-    await fs.writeFile(tempPath, vultContent, { encoding: 'utf-8', mode: 0o600 })
+    await fs.writeFile(tempPath, vultContent, { encoding: 'utf-8', mode: 0o600, flag: 'wx' })
     await fs.rename(tempPath, outputPath)
   } catch (err) {
     await fs.rm(tempPath, { force: true }).catch(() => {})

--- a/clients/cli/src/commands/vault-management.ts
+++ b/clients/cli/src/commands/vault-management.ts
@@ -546,8 +546,20 @@ export async function executeExport(ctx: CommandContext, options: ExportVaultOpt
   const parentDir = path.dirname(outputPath)
   await fs.mkdir(parentDir, { recursive: true })
 
-  // Write the vault file
-  await fs.writeFile(outputPath, vultContent, 'utf-8')
+  // An export carries key shares, so it gets the same owner-only mode as the SDK's
+  // vault store. Write to a fresh temp path and rename over the target, mirroring
+  // storage.ts: `mode` only applies when writeFile CREATES the file, so writing
+  // straight to an existing (or attacker-pre-created) path would put the shares in a
+  // world-readable file and only tighten it afterwards. Creating a new file first
+  // means the shares are never on disk at anything but 0600, and the rename is atomic.
+  const tempPath = `${outputPath}.${process.pid}.${Date.now()}.tmp`
+  try {
+    await fs.writeFile(tempPath, vultContent, { encoding: 'utf-8', mode: 0o600 })
+    await fs.rename(tempPath, outputPath)
+  } catch (err) {
+    await fs.rm(tempPath, { force: true }).catch(() => {})
+    throw err
+  }
 
   spinner.succeed(`Vault exported: ${outputPath}`)
 

--- a/packages/sdk/src/vault/VaultBase.ts
+++ b/packages/sdk/src/vault/VaultBase.ts
@@ -466,14 +466,17 @@ export abstract class VaultBase extends UniversalEventEmitter<VaultEvents> {
     // Only reject what is actually unsafe. The name is interpolated into the export
     // filename (see export()), so path separators and control characters are out —
     // but the previous alphanumeric allowlist also rejected the `#` in ecosystem-created
-    // names like "Vultisig Cluster #1", which creation and import both accept. That made
-    // rename a one-way door: rename away from such a name, and you could never rename back.
+    // names like "Vultisig Cluster #1". Creation and import run no name validation at all,
+    // so they already accept such names; rename was the sole validator, which made it a
+    // one-way door: rename away from such a name, and you could never rename back.
     if (/[/\\]/.test(name)) {
       errors.push('Vault name cannot contain path separators')
     }
 
+    // C0 + DEL + C1: C1 (U+0080-U+009F) includes CSI (U+009B), which a terminal can treat
+    // as an escape introducer when the name is echoed, so deny the whole range too.
     // eslint-disable-next-line no-control-regex
-    if (/[\u0000-\u001f\u007f]/.test(name)) {
+    if (/[\u0000-\u001f\u007f\u0080-\u009f]/.test(name)) {
       errors.push('Vault name cannot contain control characters')
     }
 

--- a/packages/sdk/src/vault/VaultBase.ts
+++ b/packages/sdk/src/vault/VaultBase.ts
@@ -463,8 +463,18 @@ export abstract class VaultBase extends UniversalEventEmitter<VaultEvents> {
       errors.push(`Vault name cannot exceed ${vaultConfig.maxNameLength} characters`)
     }
 
-    if (!/^[a-zA-Z0-9\s\-_]+$/.test(name)) {
-      errors.push('Vault name can only contain letters, numbers, spaces, hyphens, and underscores')
+    // Only reject what is actually unsafe. The name is interpolated into the export
+    // filename (see export()), so path separators and control characters are out —
+    // but the previous alphanumeric allowlist also rejected the `#` in ecosystem-created
+    // names like "Vultisig Cluster #1", which creation and import both accept. That made
+    // rename a one-way door: rename away from such a name, and you could never rename back.
+    if (/[/\\]/.test(name)) {
+      errors.push('Vault name cannot contain path separators')
+    }
+
+    // eslint-disable-next-line no-control-regex
+    if (/[\u0000-\u001f\u007f]/.test(name)) {
+      errors.push('Vault name cannot contain control characters')
     }
 
     return {

--- a/packages/sdk/src/vault/VaultBase.ts
+++ b/packages/sdk/src/vault/VaultBase.ts
@@ -90,6 +90,42 @@ function determineVaultType(signers: string[]): 'fast' | 'secure' {
   return signers.some(signer => signer.startsWith('Server-')) ? 'fast' : 'secure'
 }
 
+// ===== Vault-name / export-filename safety policy (single source of truth) =====
+//
+// A vault's name and localPartyId are interpolated into the export filename (see
+// export()). Two independently-unsafe things must never reach a filename component:
+//   - path separators ("/" or "\"), which would split the component across directories
+//   - control characters (C0/DEL/C1); C1 U+009B (CSI) is a terminal escape introducer
+//
+// rename() (validateVaultName) and export() (encodeFilenameComponent) BOTH derive
+// their rules from these two regexes — one policy, two dispositions. rename() refuses
+// an unsafe name; export() cannot, so it encodes. Keep the regexes here the only
+// definition so the reject path and the encode path can never drift apart.
+const PATH_SEPARATOR_RE = /[/\\]/
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHAR_RE = /[\u0000-\u001f\u007f\u0080-\u009f]/
+
+/**
+ * Encode one filename component so it stays a single safe path segment.
+ *
+ * Mirrors the rename-time name policy (PATH_SEPARATOR_RE, CONTROL_CHAR_RE) but
+ * ENCODES rather than rejects: rename() is the going-forward chokepoint, yet a vault
+ * imported — or created via a path that ran no name validation — may already carry an
+ * unsafe name or localPartyId. Refusing to export such a vault would strand a
+ * legitimate user behind their own backup file, so we replace the unsafe bytes with
+ * "_" instead. The result is always a single component that cannot escape the target
+ * directory, while staying recognizable enough for a human to identify the vault.
+ */
+function encodeFilenameComponent(component: string): string {
+  const encoded = component
+    .replace(new RegExp(PATH_SEPARATOR_RE.source, 'g'), '_')
+    .replace(new RegExp(CONTROL_CHAR_RE.source, 'g'), '_')
+    // A component of "." or ".." (or any leading dot-run) is a traversal / hidden-file
+    // hazard once used as a filename; neutralize only the leading dots ("a..b" is fine).
+    .replace(/^\.+/, '_')
+  return encoded.length > 0 ? encoded : '_'
+}
+
 /**
  * VaultBase - Abstract base class for all vault types
  *
@@ -469,14 +505,15 @@ export abstract class VaultBase extends UniversalEventEmitter<VaultEvents> {
     // names like "Vultisig Cluster #1". Creation and import run no name validation at all,
     // so they already accept such names; rename was the sole validator, which made it a
     // one-way door: rename away from such a name, and you could never rename back.
-    if (/[/\\]/.test(name)) {
+    // The two regexes below are the shared policy that export() also enforces (by
+    // encoding rather than rejecting) — see encodeFilenameComponent.
+    if (PATH_SEPARATOR_RE.test(name)) {
       errors.push('Vault name cannot contain path separators')
     }
 
     // C0 + DEL + C1: C1 (U+0080-U+009F) includes CSI (U+009B), which a terminal can treat
     // as an escape introducer when the name is echoed, so deny the whole range too.
-    // eslint-disable-next-line no-control-regex
-    if (/[\u0000-\u001f\u007f\u0080-\u009f]/.test(name)) {
+    if (CONTROL_CHAR_RE.test(name)) {
       errors.push('Vault name cannot contain control characters')
     }
 
@@ -767,7 +804,16 @@ export abstract class VaultBase extends UniversalEventEmitter<VaultEvents> {
     const localPartyIndex = this.vaultData.signers.indexOf(this.vaultData.localPartyId) + 1
 
     // Format: {vaultName}-{localPartyId}-share{index}of{total}.vult
-    const filename = `${this.vaultData.name}-${this.vaultData.localPartyId}-share${localPartyIndex}of${totalSigners}.vult`
+    //
+    // Encode name and localPartyId rather than trusting them: rename() enforces the
+    // name policy going forward, but a vault imported — or created via a path that ran
+    // no validation — may already carry an unsafe name or localPartyId (path separators,
+    // control chars, a bare ".."). Refusing to export such a vault would strand the user
+    // behind their own backup, so we encode to a safe single path component (same policy
+    // as rename, see encodeFilenameComponent) instead of throwing.
+    const safeName = encodeFilenameComponent(this.vaultData.name)
+    const safeLocalPartyId = encodeFilenameComponent(this.vaultData.localPartyId)
+    const filename = `${safeName}-${safeLocalPartyId}-share${localPartyIndex}of${totalSigners}.vult`
 
     // Generate base64-encoded backup (possibly encrypted)
     const data = await createVaultBackup(this.coreVault, password)

--- a/packages/sdk/tests/unit/vaultNamePolicy.test.ts
+++ b/packages/sdk/tests/unit/vaultNamePolicy.test.ts
@@ -151,4 +151,14 @@ describe('export() filename safety — pre-existing unsafe metadata', () => {
       expect(filename.endsWith('.vult')).toBe(true)
     })
   }
+
+  it('replaces a component that encodes to empty with a placeholder, never a blank segment', async () => {
+    // Exercises the `length > 0 ? encoded : '_'` fallback: a name that is empty, or is
+    // ONLY unsafe characters, must still yield a real component — otherwise the filename
+    // would begin with the "-" separator and lose a segment.
+    for (const emptyish of ['', '/', String.fromCharCode(0x00)]) {
+      const { filename } = await makeVault(emptyish, 'device-1').export()
+      expect(filename).toBe('_-device-1-share1of1.vult')
+    }
+  })
 })

--- a/packages/sdk/tests/unit/vaultNamePolicy.test.ts
+++ b/packages/sdk/tests/unit/vaultNamePolicy.test.ts
@@ -1,0 +1,92 @@
+// Vault-name policy on rename (vultisig-sdk sdkcli2-13 P2-12).
+//
+// Regression guard: rename enforced an alphanumeric allowlist
+// (/^[a-zA-Z0-9\s\-_]+$/) that rejected the `#` in ecosystem-created names like
+// "Vultisig Cluster #1" — names creation and import both accept. That made rename a
+// one-way door: rename away from such a name and you could never rename back.
+// The policy now rejects only what is genuinely unsafe for the export filename the
+// name is interpolated into: path separators and control characters.
+import { describe, expect, it, vi } from 'vitest'
+
+import { VaultBase } from '../../src/vault/VaultBase'
+
+// validateVaultName is private; exercise it through the class the way rename() does.
+function validate(name: string): { isValid: boolean; errors?: string[] } {
+  return (
+    VaultBase.prototype as unknown as {
+      validateVaultName(name: string): { isValid: boolean; errors?: string[] }
+    }
+  ).validateVaultName(name)
+}
+
+describe('vault name policy', () => {
+  it('accepts the ecosystem-created "#" name that rename used to reject', () => {
+    expect(validate('Vultisig Cluster #1').isValid).toBe(true)
+  })
+
+  it('still accepts plain alphanumeric names', () => {
+    for (const name of ['My Vault', 'vault-1', 'vault_2', 'Vault 3']) {
+      expect(validate(name).isValid).toBe(true)
+    }
+  })
+
+  it('accepts other printable punctuation the ecosystem may produce', () => {
+    for (const name of ['Vault (main)', "Avran's Vault", 'Vault #2 — primary', 'Fund 100%']) {
+      expect(validate(name).isValid).toBe(true)
+    }
+  })
+
+  it('rejects path separators, which would escape the export filename', () => {
+    expect(validate('../etc/passwd').isValid).toBe(false)
+    expect(validate('a/b').errors).toContain('Vault name cannot contain path separators')
+    expect(validate('a\\b').errors).toContain('Vault name cannot contain path separators')
+  })
+
+  it('rejects control characters', () => {
+    expect(validate('bad\u0000name').errors).toContain('Vault name cannot contain control characters')
+    expect(validate('bad\nname').errors).toContain('Vault name cannot contain control characters')
+    expect(validate('bad\u007fname').errors).toContain('Vault name cannot contain control characters')
+  })
+
+  it('keeps the pre-existing length and emptiness rules', () => {
+    expect(validate('').isValid).toBe(false)
+    expect(validate('a').isValid).toBe(false)
+    expect(validate('x'.repeat(500)).isValid).toBe(false)
+  })
+})
+
+// The suite above reaches the private validator directly. Drive rename() itself too,
+// so the policy can't pass here while the real one-way door stays shut.
+describe('rename() end-to-end', () => {
+  // rename() reads vaultData.name, writes vaultData/coreVault, then persists via
+  // save(). Stub only persistence so the real validator + real rename() body run.
+  function makeVault(initialName: string) {
+    const vault = Object.create(VaultBase.prototype) as VaultBase
+    Object.assign(vault, {
+      vaultData: { name: initialName },
+      coreVault: { name: initialName },
+      save: vi.fn(async () => {}),
+      emit: vi.fn(),
+    })
+    return vault
+  }
+
+  it('accepts the ecosystem-created "#" name it used to reject', async () => {
+    const vault = makeVault('Old Name')
+
+    await expect(vault.rename('Vultisig Cluster #1')).resolves.not.toThrow()
+  })
+
+  it('lets a vault renamed away from a "#" name be renamed back — the one-way door', async () => {
+    const vault = makeVault('Vultisig Cluster #1')
+
+    await vault.rename('Temporary Name')
+    await expect(vault.rename('Vultisig Cluster #1')).resolves.not.toThrow()
+  })
+
+  it('still rejects a name carrying a path separator', async () => {
+    const vault = makeVault('Old Name')
+
+    await expect(vault.rename('../evil')).rejects.toThrow(/path separators/)
+  })
+})

--- a/packages/sdk/tests/unit/vaultNamePolicy.test.ts
+++ b/packages/sdk/tests/unit/vaultNamePolicy.test.ts
@@ -46,6 +46,8 @@ describe('vault name policy', () => {
     expect(validate('bad\u0000name').errors).toContain('Vault name cannot contain control characters')
     expect(validate('bad\nname').errors).toContain('Vault name cannot contain control characters')
     expect(validate('bad\u007fname').errors).toContain('Vault name cannot contain control characters')
+    // C1 range: U+009B is CSI, an escape introducer once the name is echoed to a terminal.
+    expect(validate('bad\u009bname').errors).toContain('Vault name cannot contain control characters')
   })
 
   it('keeps the pre-existing length and emptiness rules', () => {

--- a/packages/sdk/tests/unit/vaultNamePolicy.test.ts
+++ b/packages/sdk/tests/unit/vaultNamePolicy.test.ts
@@ -10,6 +10,13 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { VaultBase } from '../../src/vault/VaultBase'
 
+// export() base64-encodes the real key shares; stub only that side effect so the
+// filename-construction logic runs for real against whatever metadata the vault carries.
+vi.mock('../../src/utils/export', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../src/utils/export')>()),
+  createVaultBackup: vi.fn(async () => 'BASE64_BACKUP_DATA'),
+}))
+
 // validateVaultName is private; exercise it through the class the way rename() does.
 function validate(name: string): { isValid: boolean; errors?: string[] } {
   return (
@@ -91,4 +98,57 @@ describe('rename() end-to-end', () => {
 
     await expect(vault.rename('../evil')).rejects.toThrow(/path separators/)
   })
+})
+
+// The rename validator only guards names set AFTER it existed. A vault imported, or
+// created via a path that ran no name validation, can reach export() carrying an unsafe
+// name or localPartyId — the real gap CodeRabbit flagged. export() must therefore encode
+// every filename component (same policy as rename, but encoding instead of rejecting so a
+// legitimately-imported vault is never stranded behind its own backup file).
+describe('export() filename safety — pre-existing unsafe metadata', () => {
+  // Build the unsafe characters programmatically so no raw control byte lives in source.
+  const BACKSLASH = String.fromCharCode(0x5c)
+  const NUL = String.fromCharCode(0x00)
+  const LF = String.fromCharCode(0x0a)
+  const CSI = String.fromCharCode(0x9b) // C1 control, a terminal escape introducer
+
+  // export() lazy-loads shares then base64-encodes them; both are stubbed (share loading
+  // here, encoding via the module mock above) so the real filename construction runs.
+  function makeVault(name: string, localPartyId: string) {
+    const vault = Object.create(VaultBase.prototype) as VaultBase
+    Object.assign(vault, {
+      vaultData: { name, localPartyId, signers: [localPartyId] },
+      coreVault: {},
+      ensureKeySharesLoaded: vi.fn(async () => {}),
+    })
+    return vault
+  }
+
+  const cases = [
+    { label: 'forward-slash path separators', name: '../../etc/passwd', localPartyId: 'device-1' },
+    { label: 'backslash path separators', name: `a${BACKSLASH}b`, localPartyId: `dev${BACKSLASH}ice` },
+    { label: 'control characters (incl. C1 CSI)', name: `bad${NUL}${LF}name`, localPartyId: `dev${CSI}ice` },
+    { label: 'a bare dot-dot component', name: '..', localPartyId: '..' },
+  ]
+
+  for (const { label, name, localPartyId } of cases) {
+    it(`encodes ${label} into a safe single-component filename`, async () => {
+      const { filename } = await makeVault(name, localPartyId).export()
+
+      // Single path component: no separator survives anywhere in the filename.
+      expect(filename.includes('/')).toBe(false)
+      expect(filename.includes(BACKSLASH)).toBe(false)
+      // No control character (C0 / DEL / C1) survives into the filename.
+      const hasControlChar = [...filename].some(ch => {
+        const code = ch.charCodeAt(0)
+        return code <= 0x1f || code === 0x7f || (code >= 0x80 && code <= 0x9f)
+      })
+      expect(hasControlChar).toBe(false)
+      // No leading dot-run that could resolve to "." / ".." traversal.
+      expect(filename.startsWith('.')).toBe(false)
+      // The stable suffix stays intact, so the file is still a recognizable share backup.
+      expect(filename.includes('share1of1')).toBe(true)
+      expect(filename.endsWith('.vult')).toBe(true)
+    })
+  }
 })


### PR DESCRIPTION
Two fixes that both concern the file an exported `.vult` lands in. From an audit of low-severity
CLI issues; each has a red-then-green test. No fund-movement behaviour and no wire contract.

Split out of #1354, which batched nine fixes and was too big to review in one sitting. This is
the security-touching slice, which is why it's on its own. No code was dropped in the split.

### What's in here

| # | Fix | Before |
|---|---|---|
| 1 | Export `.vult` owner-only | Written with the default umask (0644, world-readable) into cwd incl. `$HOME`, while the vault store itself is 0600 — and `auth setup` auto-discovers an exported `.vult` as a credential anchor |
| 2 | `rename` accepts ecosystem names | Rejected the `#` in names like "Vultisig Cluster #1" that creation/import happily accept — a one-way door |

### Notes for review

- **#1** writes a fresh 0600 temp file and renames over the target rather than writing then
  chmod-ing. `writeFile`'s `mode` only applies when it *creates* the file, so writing straight to
  a pre-existing (or attacker-pre-created) 0644 path would put the shares in a world-readable
  file and only tighten it afterwards. Temp+rename means the shares are never on disk at anything
  looser than 0600, the replacement is atomic, and it closes the symlink-follow at the output path
  for free. This matches what `packages/sdk/src/platforms/node/storage.ts` already does.

  The temp path itself gets the same guarantee: `mode`-only-at-creation cuts both ways, so the
  temp name carries random bytes and the write is exclusive (`flag: 'wx'`). Without that, an
  attacker who can predict and pre-create the temp path (it's in a user-chosen, possibly
  world-writable export directory) gets the shares written into *their* 0644 file — the exact
  bug one filename over. `storage.ts` gets away with a `Math.random()` suffix and no `wx` only
  because it writes into a `mode: 0o700` store dir where nothing can pre-create the temp; the
  export path has no such precondition, so it needs the stronger create. (This hardening came out
  of the local security review — see below.)

- **#2** widens the vault-name policy from an alphanumeric allowlist to a denylist. The name is
  interpolated into the export filename, so path separators and control characters are still
  rejected; everything else printable is allowed.

  The thing worth checking here is that the name reaches a filename, so the traversal-safety tests
  are the point of the test file rather than an afterthought. Two properties make the denylist
  sufficient: the filename template always appends `-{localPartyId}-share{i}of{n}.vult`
  (`VaultBase.ts`), so the name can never be the whole basename; and with both separators denied,
  the result is always a single path component, so `path.join`/`path.resolve` can't escape.
  Enumerated and rejected: `..`, leading `-` (no shell involved — `fs.writeFile`, not exec, so no
  argv injection), `~`, U+2215/U+FF0F unicode slashes, `C:` (becomes `dir\C:x`, not absolute),
  NTFS ADS, CON/PRN/AUX/NUL, and newlines/escape (both inside the denied control range, so
  ANSI/log injection stays closed).

  It also *removes* an asymmetry rather than adding one: creation and import run no vault-name
  validation at all (`VaultBase.validateVaultName` is reachable only from `rename`), so they
  already accept `#` and much else. Rename stays strictly stricter than the creation path — this
  change just narrows the gap to the genuinely-unsafe set instead of an arbitrary allowlist.

### Sibling PRs

#1354 was split into three PRs off `main`. The other two are #1385 (truthful CLI output) and
#1387 (CLI DX polish). This PR and #1385 both touch `executeExport` in
`clients/cli/src/commands/vault-management.ts` — this one changes how the file is written, that
one adds a JSON envelope — so whichever lands first leaves the other a trivial rebase. No other
file is shared with either sibling.

### Validation

`yarn test:cli`, the SDK unit suite, `yarn typecheck` (root + CLI workspace), and changed-file
eslint + prettier all pass locally. Both fixes were red-checked by reverting them and observing
the specific failure. No secret-bearing `.vult` was exported to prove the mode — the tests cover
it with a throwaway vault. No live transactions were made.

### Post-review fix

A local security-tier review ran over this branch before it left draft. It independently
reproduced a HIGH issue — the temp-file write reintroduced the world-readable window on the temp
path — now fixed in commit `21c2784c` and described in the note on #1 above (unpredictable name +
exclusive `wx` create, with a regression test that pre-creates the temp path and asserts the
shares never land there). Two smaller items from the same review: the control-char denylist now
covers the C1 range (U+009B is CSI), and the rationale comment was corrected to say creation/import
run no name validation at all rather than sharing a validator.

The review separately **verified the denylist is safe**: 43 candidate names (`..`, leading `-`,
`~`, U+2215/U+FF0F, `C:`, ADS, CON/PRN/AUX/NUL, newlines, `%2e%2e%2f`, …) were run through the
real filename template on both POSIX and Windows path semantics with zero escapes. The
load-bearing property is that the name is always a *prefix* of the filename
(`${name}-${partyId}-share{i}of{n}.vult`), so it can never be a whole path component.

A second re-review round confirmed the HIGH fully closed (`flag: 'wx'` = O_EXCL refuses to follow
a planted symlink and fails closed on any pre-existing path) and raised one LOW nit: the failure
cleanup removed the temp file even when the exclusive create had failed with EEXIST — i.e. deleting
a colliding file the export never created. Fixed in `f0cc9cd4` (skip cleanup on EEXIST).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Exported key-share and vault export files are now written with owner-only permissions (`0600`) using an atomic temp-file + rename approach.
  * Export safely handles pre-existing temp-file conflicts to prevent leaking/overwriting with incorrect permissions.
  * Vault-name and export filename handling is hardened by safely encoding unsafe components, allowing ecosystem-style names (e.g., `#`) while still blocking path separators/control characters.
* **Tests**
  * Added Vitest coverage for file-mode hardening, atomic replacement/cleanup, conflict behavior, and expanded vault-name/export filename safety cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->