### PR TITLE
fix(cli): silence bigint stderr noise and generate completion from the registries

### DIFF
--- a/.changeset/cli-dx-polish.md
+++ b/.changeset/cli-dx-polish.md
@@ -1,0 +1,16 @@
+---
+'@vultisig/cli': patch
+'@vultisig/sdk': patch
+---
+
+Two CLI developer-experience fixes:
+
+- Silence the `bigint: Failed to load bindings, pure JS will be used` warning that
+  `bigint-buffer` printed to stderr on every invocation, including `--version`. It
+  warns at module load, before any flag has been parsed, so it cannot be gated behind
+  `--debug`; it is silenced with a `yarn patch`. The SDK's node bundle inlines the
+  patched copy, which is why `@vultisig/sdk` is bumped here too.
+- Generate shell completion from the Commander command table and the SDK chain
+  registry instead of a stale hardcoded list, which was missing eleven commands
+  (sign/broadcast/tx-status/execute/discount/agent/auth/delete/join/rujira/add-mldsa)
+  and 17 of 38 chains.

--- a/.yarn/patches/bigint-buffer-npm-1.1.5-785f4ccd92.patch
+++ b/.yarn/patches/bigint-buffer-npm-1.1.5-785f4ccd92.patch
@@ -1,0 +1,18 @@
+diff --git a/dist/node.js b/dist/node.js
+index 513168c89e387668a79b6beb109587b3eb41a7d0..73d35813858e8fda34541200d0ecff0977a8683c 100644
+--- a/dist/node.js
++++ b/dist/node.js
+@@ -7,7 +7,12 @@ let converter;
+         converter = require('bindings')('bigint_buffer');
+     }
+     catch (e) {
+-        console.warn('bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)');
++        // Patched by vultisig-sdk: the native binding has no darwin-arm64 (and most
++        // other) prebuild, so this fires on EVERY process start and printed
++        // "bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)"
++        // to stderr on every CLI invocation, including --version. The pure-JS fallback
++        // below is fully functional, "npm run rebuild" is meaningless advice for a
++        // globally installed CLI, and the noise made a working CLI look broken.
+     }
+ }
+ /**

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,6 +6,9 @@ npmAuditIgnoreAdvisories:
   # GHSA-3gc7-fjrx-p6mg: bigint-buffer has no patched npm release yet.
   # Owner: SDK maintainers. Revisit when @solana/spl-token removes bigint-buffer
   # or bigint-buffer publishes a fixed version.
-  - "1103747"
+  # NOTE: package.json also pins bigint-buffer to a `patch:` resolution (to silence a
+  # module-load console.warn). That pin holds it at 1.1.5, so a published fix would NOT
+  # be picked up by `yarn up` — drop the patch resolution as well when revisiting this.
+  - '1103747'
 
 yarnPath: .yarn/releases/yarn-4.16.0.cjs

--- a/clients/cli/src/lib/completion.ts
+++ b/clients/cli/src/lib/completion.ts
@@ -3,7 +3,8 @@
  *
  * Provides tab completion for bash, zsh, and fish shells using tabtab
  */
-import type { Command } from 'commander'
+import { SUPPORTED_CHAINS } from '@vultisig/sdk'
+import { type Command, program } from 'commander'
 import { existsSync, readdirSync, readFileSync } from 'fs'
 import { homedir } from 'os'
 import { join } from 'path'
@@ -30,60 +31,25 @@ async function getTabtab() {
 }
 
 /**
- * All available commands for completion
+ * Command names for completion, read from Commander itself.
+ *
+ * These lists used to be hand-maintained and had drifted badly: the command array
+ * was missing sign/broadcast/tx-status/execute/discount/agent/auth/delete/join/
+ * rujira/add-mldsa, and the chain list was a hand-picked subset. Reading the real
+ * registries means completion cannot go stale again when a command or chain is added.
+ *
+ * Resolved lazily rather than at module load: `program` is Commander's singleton and
+ * the CLI registers its commands as its module body runs, so the list is only complete
+ * once that has happened — every caller here runs after it.
  */
-const COMMANDS = [
-  'create',
-  'import',
-  'verify',
-  'balance',
-  'send',
-  'portfolio',
-  'currency',
-  'server',
-  'export',
-  'addresses',
-  'address-book',
-  'chains',
-  'vaults',
-  'switch',
-  'rename',
-  'info',
-  'tokens',
-  'swap-chains',
-  'swap-quote',
-  'swap',
-  'completion',
-  'version',
-  'update',
-]
+function getCommands(): string[] {
+  return program.commands.map(cmd => cmd.name()).sort()
+}
 
-/**
- * Common chains for completion
- */
-const CHAINS = [
-  'Ethereum',
-  'Bitcoin',
-  'Solana',
-  'Polygon',
-  'Arbitrum',
-  'Optimism',
-  'Avalanche',
-  'BSC',
-  'Base',
-  'Cosmos',
-  'THORChain',
-  'Maya',
-  'Dydx',
-  'Kujira',
-  'Sui',
-  'Polkadot',
-  'Ripple',
-  'Dogecoin',
-  'Litecoin',
-  'Dash',
-  'Zcash',
-]
+/** Chain names for completion, from the SDK's chain registry. */
+function getChains(): string[] {
+  return [...SUPPORTED_CHAINS]
+}
 
 /**
  * Get stored vault names for completion
@@ -136,7 +102,7 @@ export async function handleCompletion(): Promise<boolean> {
 
   if (!cmd || parts.length === 1 || (parts.length === 2 && lastPartial)) {
     // Complete command names
-    completions = COMMANDS.filter(c => c.startsWith(lastPartial || ''))
+    completions = getCommands().filter(c => c.startsWith(lastPartial || ''))
   } else {
     // Command-specific completions
     switch (cmd) {
@@ -145,7 +111,7 @@ export async function handleCompletion(): Promise<boolean> {
       case 'send':
         // Complete chain names
         if (parts.length === 2 || (parts.length === 3 && lastPartial)) {
-          completions = CHAINS.filter(c => c.toLowerCase().startsWith((lastPartial || '').toLowerCase()))
+          completions = getChains().filter(c => c.toLowerCase().startsWith((lastPartial || '').toLowerCase()))
         }
         break
 
@@ -167,7 +133,7 @@ export async function handleCompletion(): Promise<boolean> {
         if (lastPartial?.startsWith('-')) {
           completions = ['--add', '--remove'].filter(o => o.startsWith(lastPartial))
         } else if (parts.includes('--add') || parts.includes('--remove')) {
-          completions = CHAINS.filter(c => c.toLowerCase().startsWith((lastPartial || '').toLowerCase()))
+          completions = getChains().filter(c => c.toLowerCase().startsWith((lastPartial || '').toLowerCase()))
         }
         break
 
@@ -175,7 +141,7 @@ export async function handleCompletion(): Promise<boolean> {
       case 'swap-quote':
         // Complete chain names for from/to
         if (parts.length <= 3 || (parts.length === 4 && lastPartial)) {
-          completions = CHAINS.filter(c => c.toLowerCase().startsWith((lastPartial || '').toLowerCase()))
+          completions = getChains().filter(c => c.toLowerCase().startsWith((lastPartial || '').toLowerCase()))
         }
         break
 
@@ -318,19 +284,19 @@ _vultisig_completions() {
   local cmd="\${COMP_WORDS[1]}"
 
   if [ "\${COMP_CWORD}" -eq 1 ]; then
-    COMPREPLY=($(compgen -W "${COMMANDS.join(' ')}" -- "\${cur}"))
+    COMPREPLY=($(compgen -W "${getCommands().join(' ')}" -- "\${cur}"))
     return
   fi
 
   case "\${cmd}" in
     balance|tokens|send)
-      COMPREPLY=($(compgen -W "${CHAINS.join(' ')}" -- "\${cur}"))
+      COMPREPLY=($(compgen -W "${getChains().join(' ')}" -- "\${cur}"))
       ;;
     chains)
-      COMPREPLY=($(compgen -W "--add --remove ${CHAINS.join(' ')}" -- "\${cur}"))
+      COMPREPLY=($(compgen -W "--add --remove ${getChains().join(' ')}" -- "\${cur}"))
       ;;
     swap|swap-quote)
-      COMPREPLY=($(compgen -W "${CHAINS.join(' ')}" -- "\${cur}"))
+      COMPREPLY=($(compgen -W "${getChains().join(' ')}" -- "\${cur}"))
       ;;
     completion)
       COMPREPLY=($(compgen -W "install uninstall bash zsh fish" -- "\${cur}"))
@@ -358,8 +324,10 @@ function getZshCompletionScript(): string {
 
 _vultisig() {
   local -a commands chains
-  commands=(${COMMANDS.map(c => `'${c}:${c} command'`).join(' ')})
-  chains=(${CHAINS.join(' ')})
+  commands=(${getCommands()
+    .map(c => `'${c}:${c} command'`)
+    .join(' ')})
+  chains=(${getChains().join(' ')})
 
   _arguments -C \\
     '1: :->command' \\
@@ -396,11 +364,11 @@ function getFishCompletionScript(): string {
   // Generate completions for both vultisig and vsig
   const commands = ['vultisig', 'vsig']
   const commandCompletions = commands
-    .flatMap(cmd => COMMANDS.map(c => `complete -c ${cmd} -n "__fish_use_subcommand" -a "${c}"`))
+    .flatMap(cmd => getCommands().map(c => `complete -c ${cmd} -n "__fish_use_subcommand" -a "${c}"`))
     .join('\n')
   const chainCompletions = commands
     .flatMap(cmd =>
-      CHAINS.map(
+      getChains().map(
         c => `complete -c ${cmd} -n "__fish_seen_subcommand_from balance tokens send swap swap-quote" -a "${c}"`
       )
     )

--- a/clients/cli/src/lib/completionRegistry.test.ts
+++ b/clients/cli/src/lib/completionRegistry.test.ts
@@ -1,0 +1,116 @@
+// Shell completion is generated from the real registries (vultisig-sdk sdkcli2-13 P2-13).
+//
+// Regression guard: completion.ts hand-maintained COMMANDS and CHAINS arrays that had
+// drifted. The shipped zsh/bash/fish scripts offered a command list missing
+// sign/broadcast/tx-status/execute/discount/agent/auth/delete/join/rujira/add-mldsa,
+// and a hand-picked subset of chains. Commands now come from Commander and chains from
+// the SDK registry, so the scripts cannot silently go stale again.
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { SUPPORTED_CHAINS } from '@vultisig/sdk'
+import { describe, expect, it } from 'vitest'
+
+const CLI_ENTRY = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'index.ts')
+
+/** Commands that exist in the CLI but were absent from the old hardcoded array. */
+const PREVIOUSLY_MISSING = [
+  'sign',
+  'broadcast',
+  'tx-status',
+  'execute',
+  'discount',
+  'agent',
+  'auth',
+  'delete',
+  'join',
+  'rujira',
+  'add-mldsa',
+]
+
+function completionScript(shell: string): string {
+  const env: NodeJS.ProcessEnv = { ...process.env, NO_COLOR: '1' }
+  // Strip ambient completion env so the run isn't diverted into handleCompletion().
+  delete env.COMP_LINE
+  delete env.COMP_POINT
+  delete env.COMP_CWORD
+
+  const result = spawnSync(process.execPath, ['--import', 'tsx', CLI_ENTRY, 'completion', shell], {
+    input: '',
+    encoding: 'utf8',
+    timeout: 120_000,
+    env,
+  })
+  // Fail loudly rather than returning '' and letting a "missing X" assertion report
+  // the wrong cause.
+  if (result.status !== 0) {
+    throw new Error(`completion ${shell} exited ${result.status}: ${result.stderr ?? ''}`)
+  }
+  return result.stdout ?? ''
+}
+
+function escapeRe(word: string): string {
+  return word.replace(/[.*+?^${}()|[\]\\-]/g, '\\$&')
+}
+
+/**
+ * Whether the script offers `cmd` as its own command token, rather than merely
+ * containing it somewhere. A bare substring check would match 'sign' inside a
+ * description or inside a longer word, and pass even if the token were absent.
+ *
+ * Each shell spells its command list differently: zsh emits 'name:description'
+ * pairs, bash a space-separated `compgen -W` list, fish `-a "name"`.
+ */
+function offersCommand(script: string, shell: string, cmd: string): boolean {
+  const c = escapeRe(cmd)
+  const patterns: Record<string, RegExp> = {
+    zsh: new RegExp(`'${c}:`),
+    bash: new RegExp(`(^|[\\s"])${c}([\\s"]|$)`, 'm'),
+    fish: new RegExp(`__fish_use_subcommand" -a "${c}"`),
+  }
+  return patterns[shell].test(script)
+}
+
+/** Same idea for chains, which every shell emits as a bare space-separated token. */
+function offersChain(script: string, shell: string, chain: string): boolean {
+  const c = escapeRe(chain)
+  const patterns: Record<string, RegExp> = {
+    zsh: new RegExp(`(^|[\\s(])${c}([\\s)]|$)`, 'm'),
+    bash: new RegExp(`(^|[\\s"])${c}([\\s"]|$)`, 'm'),
+    fish: new RegExp(`swap-quote" -a "${c}"`),
+  }
+  return patterns[shell].test(script)
+}
+
+describe('generated completion scripts', () => {
+  const shells = ['zsh', 'bash', 'fish'] as const
+
+  for (const shell of shells) {
+    describe(shell, () => {
+      const script = completionScript(shell)
+
+      it('is non-empty', () => {
+        expect(script.trim().length).toBeGreaterThan(0)
+      })
+
+      it('offers the commands the hardcoded list had drifted away from', () => {
+        for (const cmd of PREVIOUSLY_MISSING) {
+          expect(offersCommand(script, shell, cmd), `${shell} completion does not offer "${cmd}"`).toBe(true)
+        }
+      })
+
+      it('offers chains from the SDK registry, not a hand-picked subset', () => {
+        // Cardano and Tron are in the registry but were absent from the old CHAINS array.
+        expect(offersChain(script, shell, 'Cardano')).toBe(true)
+        expect(offersChain(script, shell, 'Tron')).toBe(true)
+      })
+
+      it('offers every chain the SDK supports', () => {
+        for (const chain of SUPPORTED_CHAINS) {
+          expect(offersChain(script, shell, chain), `${shell} completion does not offer chain "${chain}"`).toBe(true)
+        }
+      })
+    })
+  }
+})

--- a/clients/cli/src/lib/stderrCleanliness.test.ts
+++ b/clients/cli/src/lib/stderrCleanliness.test.ts
@@ -1,0 +1,53 @@
+// The CLI does not print dependency noise to stderr (vultisig-sdk sdkcli2-13 P1-3).
+//
+// Regression guard: bigint-buffer console.warn()s at module load when its native
+// binding is absent — which it always is, since the package ships no darwin-arm64 (or
+// most other) prebuild. Every single invocation, `--version` included, emitted
+//   bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)
+// to stderr. The pure-JS fallback works fine and "npm run rebuild" is meaningless for
+// a globally installed CLI, so this was pure noise that made a working CLI look broken.
+// Silenced via a yarn patch (.yarn/patches/bigint-buffer-*.patch), which the SDK's node
+// bundle then inlines.
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const CLI_ENTRY = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'index.ts')
+
+function run(args: string[]) {
+  const env: NodeJS.ProcessEnv = { ...process.env, NO_COLOR: '1' }
+  delete env.COMP_LINE
+  delete env.COMP_POINT
+  delete env.COMP_CWORD
+  return spawnSync(process.execPath, ['--import', 'tsx', CLI_ENTRY, ...args], {
+    input: '',
+    encoding: 'utf8',
+    timeout: 120_000,
+    env,
+  })
+}
+
+describe('stderr cleanliness', () => {
+  it('does not warn about bigint bindings on --version', () => {
+    const { stderr } = run(['--version'])
+    expect(stderr).not.toMatch(/Failed to load bindings/)
+  })
+
+  it('leaves stderr completely empty on a successful --version', () => {
+    const { stdout, stderr, status } = run(['--version'])
+    expect(status).toBe(0)
+    expect(stdout).toMatch(/vultisig\//)
+    expect(stderr).toBe('')
+  })
+
+  it('does not warn about bigint bindings on --help', () => {
+    expect(run(['--help']).stderr).not.toMatch(/Failed to load bindings/)
+  })
+
+  it('never advises "npm run rebuild", which cannot help a global install', () => {
+    const { stdout, stderr } = run(['--version'])
+    expect(stdout + stderr).not.toMatch(/npm run rebuild/)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -213,6 +213,7 @@
     "form-data@npm:^4.0.5": "^4.0.6",
     "hono@npm:^4.11.4": "4.12.25",
     "undici": "^7.28.0",
-    "linkify-it": "5.0.1"
+    "linkify-it": "5.0.1",
+    "bigint-buffer@npm:^1.1.5": "patch:bigint-buffer@npm%3A1.1.5#~/.yarn/patches/bigint-buffer-npm-1.1.5-785f4ccd92.patch"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8330,13 +8330,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bigint-buffer@npm:^1.1.5":
+"bigint-buffer@npm:1.1.5":
   version: 1.1.5
   resolution: "bigint-buffer@npm:1.1.5"
   dependencies:
     bindings: "npm:^1.3.0"
     node-gyp: "npm:latest"
   checksum: 10c0/aa41e53d38242a2f05f85b08eaf592635f92e5328822784cda518232b1644efdbf29ab3664951b174cc645848add4605488e25c9439bcc749660c885b4ff6118
+  languageName: node
+  linkType: hard
+
+"bigint-buffer@patch:bigint-buffer@npm%3A1.1.5#~/.yarn/patches/bigint-buffer-npm-1.1.5-785f4ccd92.patch":
+  version: 1.1.5
+  resolution: "bigint-buffer@patch:bigint-buffer@npm%3A1.1.5#~/.yarn/patches/bigint-buffer-npm-1.1.5-785f4ccd92.patch::version=1.1.5&hash=3d0962"
+  dependencies:
+    bindings: "npm:^1.3.0"
+    node-gyp: "npm:latest"
+  checksum: 10c0/5efb16aacaaf49a110f3803bdb83bd34fb457bcee2fab9488fb6c24bbf425773d0a3c2fed0d3221da6d37e9a80ddf5af9633bc62edda7cac02c5226c18b3a80a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Two developer-experience fixes from an audit of low-severity CLI issues. Each has a red-then-green
test. No fund-movement behaviour, no exit-code change, and no wire contract.

Split out of #1354, which batched nine fixes and was too big to review in one sitting. No code was
dropped in the split.

### What's in here

| # | Fix | Before |
|---|---|---|
| 1 | Silence `bigint: Failed to load bindings` | Printed to stderr on **every** invocation, incl. `--version` |
| 2 | Completion generated from the registries | Shipped a stale hardcoded list: no sign/broadcast/tx-status/execute/discount/agent/auth/delete/join/rujira/add-mldsa, and 21 of 38 chains |

### Notes for review

- **#1** is a `yarn patch` on `bigint-buffer`, which `console.warn`s at *module load* — before any
  flag parsing, so it can't be gated behind `--debug`. The advice it gives ("try npm run rebuild?")
  is meaningless for a global install, and the pure-JS fallback works fine, so this is pure noise
  that makes a working CLI look broken on first contact. `--version` stderr goes 77 bytes → 0.

  **Build-order caveat:** the SDK's node bundle inlines the patched copy, so `build:sdk:bundle`
  must run after install for the fix to appear. CI's order is `install --immutable` →
  `build:shared` → `build:all`, so the patch lands before the bundle is built. A stale local
  `dist` yields a false **red**, not a false green.

  The patch itself is one hunk against `dist/node.js`: it deletes a `console.warn` and adds
  comments. Zero crypto or parsing change. It does **not** mask GHSA-3gc7-fjrx-p6mg (the existing
  audit-ignore): that warn fires only when the native binding *fails* to load — i.e. exactly the
  safe pure-JS path. The vulnerable native path was always silent.

  One thing worth a maintainer opinion: the `patch:` resolution also **pins `bigint-buffer` at
  1.1.5**, so `yarn up bigint-buffer` — the documented exit from that audit-ignore — is now a
  no-op, and a published fix would be silently overridden. I've put a note next to the ignore in
  `.yarnrc.yml` so whoever revisits the advisory drops the pin too. `@solana/buffer-layout-utils`
  is the only dependent today and declares exactly `^1.1.5`.

- **#2** reads commands from Commander's singleton and chains from `SUPPORTED_CHAINS`. Ordering is
  safe: `handleCompletion()` awaits a dynamic `import()` before it ever reaches `getCommands()`, so
  the IIFE yields, `index.ts`'s module body registers every command synchronously, and only then
  does the microtask resume — `getCommands()` can't observe an empty `program.commands`.
  `SUPPORTED_CHAINS` is `Object.values(Chain)`, the same source `findChainByName` reads, so
  completion can't suggest a chain the resolver would then reject.

### Why `@vultisig/sdk` is in the changeset

The bigint patch only touches root `package.json`, but the SDK's published node bundle inlines the
patched copy — so without an SDK version bump, consumers of `@vultisig/sdk` never actually get the
fix. `scripts/check-sdk-bundled-changeset.mjs` doesn't catch this (it guards `packages/core/*` and
`packages/lib/utils/` prefixes), so the bump is deliberate rather than CI-driven. Shout if you'd
rather ship it CLI-only.

### Sibling PRs

#1354 was split into three PRs off `main`. The other two are #1385 (truthful CLI output) and #1386
(keyshare file safety). This PR shares no files with either, so it can land in any order without
a rebase.

### Validation

`yarn test:cli`, `yarn typecheck` (root + CLI workspace), and changed-file eslint + prettier all
pass locally. Both fixes were red-checked by reverting them and observing the specific failure
(`--version` stderr non-empty; zsh completion missing `sign`). No live transactions were made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved shell completion for Bash, Zsh, and Fish.
  - Completion suggestions now include all available CLI commands and supported chains.

- **Bug Fixes**
  - Removed an unnecessary `bigint-buffer` warning from CLI output.
  - CLI version and help commands now produce cleaner output without native-binding or rebuild warnings.

- **Tests**
  - Added coverage to verify shell completion and clean CLI output across supported commands and chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->