### PR TITLE
fix(swap): reject 0X-prefixed burn recipient on native cross-chain routes

### DIFF
--- a/.changeset/fix-0x-prefix-burn-slip.md
+++ b/.changeset/fix-0x-prefix-burn-slip.md
@@ -1,0 +1,14 @@
+---
+'@vultisig/core-chain': patch
+---
+
+Fix a `0X`-prefixed (uppercase-X) burn recipient slipping the custom-recipient
+guard on native THOR/Maya cross-chain swaps.
+
+`findSwapQuote`'s `isEvmAddress` shape check was case-sensitive on the `0x`
+prefix, so a recipient like `0X000…dEaD` failed the check, skipped the
+zero/burn-address branch, and — on a native route where the CowSwap format
+gate is unreachable — passed straight through as the swap destination, an
+unrecoverable sink. The gate is now case-insensitive on the prefix (`/i`),
+matching the Go guard; the burn comparison already lowercases, so this only
+closes the bypass without changing any accepted address.

--- a/packages/core/chain/swap/quote/findSwapQuote.recipient.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.recipient.test.ts
@@ -176,6 +176,30 @@ describe('findSwapQuote external recipient', () => {
     }
   )
 
+  it('rejects a 0X-prefixed (uppercase-X) burn recipient on a cross-chain native route', async () => {
+    // Regression: the case-sensitive isEvmAddress gate let `0X…dead` bypass the zero/burn
+    // check. On a BTC→ETH THORChain route the CowSwap path is unreachable, so the bypassed
+    // burn was passed straight through as the swap destination — an unrecoverable sink.
+    // assertValidCustomRecipient runs before any provider, so this throws up front.
+    vi.mocked(getNativeSwapQuote).mockResolvedValue({
+      expected_amount_out: '10000000',
+      swapChain: Chain.THORChain,
+    } as never)
+
+    await expect(
+      findSwapQuote({
+        from: { chain: Chain.Bitcoin, address: 'bc1qsender', decimals: 8, ticker: 'BTC' },
+        to: { chain: Chain.Ethereum, address: '0xowner', decimals: 18, ticker: 'ETH' },
+        amount: 1_000_000n,
+        recipient: '0X000000000000000000000000000000000000dEaD',
+      })
+    ).rejects.toMatchObject({
+      code: SwapErrorCode.InvalidConfig,
+      message: expect.stringContaining('zero/burn address'),
+    })
+    expect(getNativeSwapQuote).not.toHaveBeenCalled()
+  })
+
   it('accepts a valid 40-hex EVM address and forwards it to CowSwap as receiver', async () => {
     vi.mocked(getCowSwapQuote).mockResolvedValue(generalQuote)
     vi.mocked(getNativeSwapQuote).mockRejectedValue(new Error('skip native'))

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -507,7 +507,12 @@ const assertValidSlippageTolerance = (slippageTolerance: number | undefined): vo
 }
 
 // Matches a checksummed or lowercase EVM address: 0x followed by exactly 40 hex chars.
-const isEvmAddress = (address: string): boolean => /^0x[0-9a-fA-F]{40}$/.test(address)
+// Case-insensitive on the `0x` prefix too (`/i`) so a `0X…`-prefixed burn can't slip the
+// gate: without it, `0X…dead` failed this shape check, skipped the zero/burn branch, and —
+// on a native THOR/Maya cross-chain route where the CowSwap path is unreachable — passed
+// straight through as the swap destination (an unspendable sink). The burn comparison below
+// already lowercases, so tolerating the uppercase prefix only closes the bypass.
+const isEvmAddress = (address: string): boolean => /^0x[0-9a-fA-F]{40}$/i.test(address)
 
 // Validate a custom swap recipient is a properly-formatted EVM address before it
 // reaches CowSwap. CowSwap lowercases the receiver but does zero format validation —


### PR DESCRIPTION
## what

`findSwapQuote`'s `isEvmAddress` shape check (`/^0x[0-9a-fA-F]{40}$/`) is case-sensitive on the `0x` prefix. A recipient like `0X000…dEaD` (uppercase X) fails the check, so it **skips the zero/burn-address branch**. On a native THOR/Maya cross-chain route (BTC→ETH) the CowSwap format gate is unreachable, so `assertValidCustomRecipient` falls through without throwing and the burn is passed straight through as the swap destination — an **unrecoverable sink**.

This makes the prefix match case-insensitive (`/i`), matching the Go guard. The burn comparison already lowercases the recipient, so **no accepted address changes** — this only closes the bypass.

## why a separate PR

Surfaced while re-reviewing #1193 (reconcile + export dangerous/burn-address guard). #1193 routes this guard through the shared canonical table and its changeset states a `0X…` burn "can't slip past", but it preserves this case-sensitive *local* gate that sits in front of the (case-insensitive) shared check — so on the native route the slip persists. The gate predates #1193 (introduced by `5926f3be`, already on `main`), so this is an independent pre-existing fix rather than a change to #1193's diff. The `isEvmAddress` line is byte-identical on `main` and on #1193's HEAD, so this one-line change merges cleanly either way.

## test

Added a red-on-revert test on the BTC→ETH THORChain route: `0X000…dEaD` must be rejected with `InvalidConfig` before any provider is called. Reverting the `/i` flips it to PASS-THROUGH (proven standalone). Lowercase `0x…dead` still blocks and a valid `0x…` recipient still passes — no false-positive regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation for burn and zero addresses using an uppercase `0X` prefix.
  * Invalid recipients are now rejected before swap processing, preventing transactions from being sent to unrecoverable destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->