### PR TITLE
fix(sdk): fail closed on malformed XRPL account_info/account_lines in RN balance path

### DIFF
--- a/packages/sdk/src/platforms/react-native/chains/ripple/rpc.ts
+++ b/packages/sdk/src/platforms/react-native/chains/ripple/rpc.ts
@@ -99,7 +99,7 @@ export async function getXrpAccountState(
     { account: address, strict: true, ledger_index: 'current' },
     signal
   )
-  if (result.error === 'actNotFound' || !result.account_data) {
+  if (result.error === 'actNotFound') {
     return {
       address,
       sequence: 0,
@@ -108,6 +108,14 @@ export async function getXrpAccountState(
       funded: false,
       ownerCount: 0,
     }
+  }
+  // A non-`actNotFound` success envelope that is missing `account_data` is a
+  // malformed / partial upstream response, NOT an unfunded account. Fail
+  // closed here (matching the core-chain resolver, which threw on the same
+  // shape) rather than reporting a real-looking `0` balance for what may be a
+  // funded account.
+  if (!result.account_data) {
+    throw new Error(`XRP account_info returned no account_data without actNotFound: ${JSON.stringify(result)}`)
   }
   return {
     address,
@@ -201,7 +209,15 @@ export async function getXrpAccountLines(
       return []
     }
 
-    lines.push(...(result.lines ?? []))
+    // A funded account with no trust lines returns `lines: []`, so a missing /
+    // non-array `lines` on a non-`actNotFound` page is a malformed response.
+    // Fail closed rather than silently degrading to "no trust line" (which
+    // would report a real-looking `0` token balance for a held token).
+    if (!Array.isArray(result.lines)) {
+      throw new Error(`XRP account_lines returned no lines array without actNotFound: ${JSON.stringify(result)}`)
+    }
+
+    lines.push(...result.lines)
     marker = result.marker
   } while (marker !== undefined)
 

--- a/packages/sdk/src/platforms/react-native/chains/ripple/rpc.ts
+++ b/packages/sdk/src/platforms/react-native/chains/ripple/rpc.ts
@@ -130,15 +130,16 @@ export async function getXrpAccountState(
 /**
  * Fetch sequence + balance for an XRP address.
  *
- * Returns `funded: false` (with `sequence: 0` and `balanceDrops: '0'`) when
- * the address is not yet activated on-chain (`actNotFound`) or when the
- * server returns an empty `account_data` envelope. Activation requires a
- * minimum reserve of XRP, so an unfunded account is the expected first-time
- * state for a fresh receive address — the caller decides whether to proceed
- * with a top-up tx or abort.
+ * Returns `funded: false` (with `sequence: 0` and `balanceDrops: '0'`) only
+ * when the address is not yet activated on-chain (`actNotFound`). Activation
+ * requires a minimum reserve of XRP, so an unfunded account is the expected
+ * first-time state for a fresh receive address — the caller decides whether to
+ * proceed with a top-up tx or abort.
  *
- * Throws only for transport-level / unexpected RPC failures (everything
- * other than `actNotFound`), which `rippleCall` surfaces directly.
+ * Throws for transport-level / unexpected RPC failures and for malformed
+ * non-`actNotFound` envelopes (for example a success response with missing
+ * `account_data`), which must fail closed rather than surface a real-looking
+ * `0` balance for a funded account.
  */
 export async function getXrpAccountInfo(
   address: string,

--- a/packages/sdk/tests/unit/platforms/react-native/ripple-rpc.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/ripple-rpc.test.ts
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   getXrpAccountInfo,
+  getXrpAccountLines,
   getXrpBalance,
   submitXrpTx,
   XrpSubmitRejectedError,
@@ -107,6 +108,30 @@ describe('ripple/rpc — account_info error handling', () => {
     })
 
     await expect(getXrpAccountInfo(FUNDED, RPC_URL)).rejects.toThrow(/invalidParams/)
+  })
+
+  it('fails closed (throws) on a non-actNotFound response missing account_data instead of reporting funded:false', async () => {
+    mockFetchOnce({
+      result: {
+        status: 'success',
+      },
+    })
+
+    // A malformed / partial success envelope must NOT be misread as an
+    // unfunded account, which would surface a real-looking 0 balance.
+    await expect(getXrpAccountInfo(FUNDED, RPC_URL)).rejects.toThrow(/no account_data/)
+  })
+
+  it('fails closed (throws) on an account_lines page missing a lines array instead of returning no trust lines', async () => {
+    mockFetchOnce({
+      result: {
+        status: 'success',
+      },
+    })
+
+    // A missing `lines` array on a non-actNotFound page must NOT degrade to
+    // "no trust line" (a real-looking 0 token balance for a held token).
+    await expect(getXrpAccountLines(FUNDED, RPC_URL)).rejects.toThrow(/no lines array/)
   })
 })
 


### PR DESCRIPTION
Stacked follow-up on #1220 (targets its branch `fix/rn-ripple-getcoinbalance`).

## Why
Review of #1220 found the new RN Ripple balance path fails **open** on a narrow but fund-relevant class of response: an HTTP-200, non-`actNotFound` envelope that is missing `account_data` (native) or `lines` (token). In that case:
- `getXrpAccountState` returned `funded:false` → native balance `0n`
- `getXrpAccountLines` did `result.lines ?? []` → token balance `0n`

On a fund-critical balance surface that surfaces a **real-looking `0`** for what may be a funded account / held token. The core-chain resolver #1220 replaced threw on the same malformed shape (it destructured `account_data.Balance` / spread `result.lines`), so this restores the prior fail-closed posture.

`rippleCall` already throws on `!res.ok` and on unexpected `status:'error'` — this only tightens the residual malformed-but-200 gap.

## Change
- `getXrpAccountState`: return unfunded **only** on explicit `actNotFound`; throw on a non-error response missing `account_data`.
- `getXrpAccountLines`: throw when a non-`actNotFound` page lacks an `Array` `lines` (a funded account with zero trust lines legitimately returns `lines: []`, so this doesn't affect the empty case).

## Tests
- 2 new red-on-revert regression tests (proven to fail against #1220 HEAD, pass with the fix).
- Full RN Ripple suite green: 20/20 across `getCoinBalance.test.ts` + `ripple-rpc.test.ts`.
- `format:check` clean (repo `.config/.prettierrc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)