### PR TITLE
fix(sdk): export RN pure validation/normalization/policy helpers

### DIFF
--- a/.changeset/rn-pure-helper-parity-r40.md
+++ b/.changeset/rn-pure-helper-parity-r40.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+Export the newer pure validation, normalization, known-contract, and policy helpers from the React Native SDK entrypoint so RN consumers can use the same canonical SDK surfaces as node/browser consumers.

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -589,6 +589,54 @@ export async function parseKeygenQR(...args: unknown[]) {
   const mod = await import('../../utils/parseKeygenQR')
   return mod.parseKeygenQR(...(args as Parameters<typeof mod.parseKeygenQR>))
 }
+export type {
+  AmountUnits,
+  AssetRef,
+  Envelope,
+  FieldDiff,
+  IntentClaim,
+  InvariantInput,
+  InvariantViolation,
+  Verdict,
+} from '../../tools/policy'
+export { Invariant, policy,ResultKind } from '../../tools/policy'
+export type { NormalizeArgs, NormalizedTx } from '../../tx'
+export { normalizeTx, splitMultiTx, TxNormalizeError } from '../../tx'
+export {
+  canonicalChainTag,
+  classifyAddress,
+  isAddressValidForChain,
+  isSolanaAddress,
+  supportedChainTags,
+} from '../../utils/addressFormat'
+export type { AddressFamily, AddressRole, ChainPrefixResult } from '../../utils/addressValidation'
+export { address, validate } from '../../utils/addressValidation'
+export { checkChainPrefix } from '../../utils/chainPrefix'
+export {
+  canonicalEvmContracts,
+  canonicalSolanaAddresses,
+  canonicalTronContracts,
+  isCanonicalEvmContract,
+  isCanonicalEvmContractEllipsized,
+  isCanonicalSolanaAddress,
+  isCanonicalSolanaAddressEllipsized,
+  isCanonicalTronContract,
+  isEvmAddressFormat,
+  isKnownContract,
+  knownContracts,
+} from '../../utils/knownContracts'
+export {
+  amountMatches,
+  computeEvmFee,
+  decimalsFor,
+  feeMatches,
+  isValidTokenSymbolFormat,
+  normalizeTokenSymbol,
+  scaleHumanToRaw,
+  scaleRawToHuman,
+  tokenDecimals,
+  ValidateNormalizerError,
+} from '../../utils/validateNormalizers'
 export { ValidationHelpers } from '../../utils/validation'
 
 // Storage

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -78,4 +78,28 @@ describe('RN entry wires configureCrypto and configureDefaultStorage', () => {
       rn.Chain.Dash,
     ])
   })
+
+  it('exports the newer pure validation / normalization / policy helpers from the RN entry', async () => {
+    const rn = await import('../../../../src/platforms/react-native/index')
+    const validateNormalizers = await import('../../../../src/utils/validateNormalizers')
+    const addressFormat = await import('../../../../src/utils/addressFormat')
+    const tx = await import('../../../../src/tx')
+    const knownContracts = await import('../../../../src/utils/knownContracts')
+    const policy = await import('../../../../src/tools/policy')
+
+    expect(rn.amountMatches).toBe(validateNormalizers.amountMatches)
+    expect(rn.classifyAddress).toBe(addressFormat.classifyAddress)
+    expect(rn.normalizeTx).toBe(tx.normalizeTx)
+    expect(rn.isKnownContract).toBe(knownContracts.isKnownContract)
+    expect(rn.policy).toBe(policy.policy)
+
+    expect(rn.classifyAddress('0x1234567890123456789012345678901234567890')).toBe('evm')
+    expect(rn.scaleHumanToRaw('1.5', 6)).toBe(1500000n)
+    expect(rn.isKnownContract('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')).toBe(true)
+    expect(rn.checkChainPrefix('0x1234567890123456789012345678901234567890', 'Ethereum')).toMatchObject({
+      valid: true,
+      canonicalChain: 'ethereum',
+    })
+    expect(rn.policy.evaluate).toBe(policy.evaluatePolicy)
+  })
 })


### PR DESCRIPTION
## Summary

Exports the newer pure helper family from  so RN consumers can use the same canonical SDK surfaces as node/browser consumers instead of deep imports or local copies.

Closes 1406

## What changed

- re-exported RN-safe pure helpers from 
  - validation normalizers (, , , etc.)
  - address / chain-prefix helpers (, , , etc.)
  - tx normalization (, )
  - known-contract helpers (, , canonical contract sets)
  - policy namespace + related runtime constants / types (, , , etc.)
- extended  to assert symbol identity and a few representative runtime calls
- added 

## Verification

- ➤ YN0000: · Yarn 4.16.0
➤ YN0000: ┌ Resolution step
➤ YN0000: └ Completed
➤ YN0000: ┌ Post-resolution validation
➤ YN0060: │ @vitest/coverage-v8 is listed by your project with version 4.1.9 (p314426), which doesn't satisfy what vitest requests (4.1.8).
➤ YN0060: │ @vitest/coverage-v8 is listed by your project with version 4.1.9 (p5ea16a), which doesn't satisfy what vitest requests (4.1.8).
➤ YN0060: │ @vitest/coverage-v8 is listed by your project with version 4.1.9 (p8b5072), which doesn't satisfy what vitest requests (4.1.8).
➤ YN0060: │ eslint is listed by your project with version 10.6.0 (p8b7932), which doesn't satisfy what eslint-plugin-jsx-a11y and other dependencies request (but they have non-overlapping ranges!).
➤ YN0060: │ react is listed by your project with version 19.2.7 (p444e5f), which doesn't satisfy what @vultisig/examples-shared and other dependencies request (but they have non-overlapping ranges!).
➤ YN0060: │ react is listed by your project with version 19.2.7 (pfe4e79), which doesn't satisfy what @vultisig/examples-shared and other dependencies request (but they have non-overlapping ranges!).
➤ YN0060: │ react-dom is listed by your project with version 19.2.7 (p41aed6), which doesn't satisfy what @vultisig/examples-shared requests (^18.0.0).
➤ YN0060: │ react-dom is listed by your project with version 19.2.7 (p6ad760), which doesn't satisfy what @vultisig/examples-shared requests (^18.0.0).
➤ YN0060: │ vitest is listed by your project with version 4.1.8 (p423780), which doesn't satisfy what @vitest/coverage-v8 requests (4.1.9).
➤ YN0060: │ vitest is listed by your project with version 4.1.8 (p5a1762), which doesn't satisfy what @vitest/coverage-v8 requests (4.1.9).
➤ YN0060: │ vitest is listed by your project with version 4.1.8 (p7afe31), which doesn't satisfy what @vitest/coverage-v8 requests (4.1.9).
➤ YN0002: │ @vultisig/cli@workspace:clients/cli doesn't provide vite (pc11d91), requested by @vultisig/sdk.
➤ YN0002: │ @vultisig/client-shared@workspace:packages/client-shared doesn't provide vite (p103194), requested by @vultisig/sdk.
➤ YN0002: │ @vultisig/examples-shared@workspace:examples/shared [80144] doesn't provide vite (p3ba78b), requested by @vultisig/sdk.
➤ YN0002: │ @vultisig/examples-shared@workspace:examples/shared doesn't provide react (p7d8055), requested by qrcode.react.
➤ YN0002: │ @vultisig/examples-shared@workspace:examples/shared doesn't provide vite (pc25c5f), requested by @vultisig/sdk.
➤ YN0002: │ @vultisig/mcp@workspace:clients/mcp doesn't provide vite (p207b86), requested by @vultisig/sdk.
➤ YN0002: │ @vultisig/mpc-native@workspace:packages/mpc-native doesn't provide react (p15ceed), requested by expo.
➤ YN0002: │ @vultisig/mpc-native@workspace:packages/mpc-native doesn't provide react-native (pd57913), requested by expo.
➤ YN0002: │ @vultisig/rujira@workspace:packages/rujira doesn't provide vite (pba85cd), requested by @vultisig/sdk.
➤ YN0002: │ @vultisig/sdk@workspace:packages/sdk [80144] doesn't provide esbuild (p553f49), requested by rollup-plugin-esbuild.
➤ YN0002: │ @vultisig/sdk@workspace:packages/sdk [c71db] doesn't provide esbuild (p339bdc), requested by rollup-plugin-esbuild.
➤ YN0002: │ @vultisig/sdk@workspace:packages/sdk doesn't provide esbuild (p99a80e), requested by rollup-plugin-esbuild.
➤ YN0002: │ @vultisig/sdk@workspace:packages/sdk doesn't provide vite (p5b3903), requested by vite-plugin-node-polyfills and other dependencies.
➤ YN0002: │ @vultisig/walletcore-native@workspace:packages/walletcore-native doesn't provide react (p61a5c8), requested by expo.
➤ YN0002: │ @vultisig/walletcore-native@workspace:packages/walletcore-native doesn't provide react-native (pa53498), requested by expo.
➤ YN0002: │ vultisig-sdk@workspace:. doesn't provide react (p40fe05), requested by @react-native-async-storage/async-storage.
➤ YN0002: │ vultisig-sdk@workspace:. doesn't provide react-native (p8600bb), requested by @react-native-async-storage/async-storage.
➤ YN0002: │ vultisig-sdk@workspace:. doesn't provide rollup (p1a1fc5), requested by @rollup/plugin-commonjs and other dependencies.
➤ YN0002: │ vultisig-sdk@workspace:. doesn't provide storybook (pc2c262), requested by eslint-plugin-storybook.
➤ YN0086: │ Some peer dependencies are incorrectly met by your project; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code.
➤ YN0086: │ Some peer dependencies are incorrectly met by dependencies; run yarn explain peer-requirements for details.
➤ YN0000: └ Completed
➤ YN0000: ┌ Fetch step
➤ YN0000: └ Completed in 0s 752ms
➤ YN0000: ┌ Link step
➤ YN0000: └ Completed in 0s 208ms
➤ YN0000: · Done with warnings in 1s 197ms
- Shared packages synced to packages/*/dist
- 
[1m[30m[46m RUN [49m[39m[22m [36mv4.1.8 [39m[90m/private/tmp/vultisig-improve-r40/vultisig-sdk/packages/sdk[39m

 [32m✓[39m tests/unit/platforms/react-native/entry.test.ts[2m > [22mRN entry wires configureCrypto and configureDefaultStorage[2m > [22mregisters crypto + storage on module load so Vultisig({}) does not throw[33m 2890[2mms[22m[39m
 [32m✓[39m tests/unit/platforms/react-native/entry.test.ts[2m > [22mRN entry wires configureCrypto and configureDefaultStorage[2m > [22mexports the canonical Cosmos fee-denom helpers from the RN entry[32m 1[2mms[22m[39m
 [32m✓[39m tests/unit/platforms/react-native/entry.test.ts[2m > [22mRN entry wires configureCrypto and configureDefaultStorage[2m > [22mexports the generic CosmWasm execute message builder from the RN root surface[32m 0[2mms[22m[39m
 [32m✓[39m tests/unit/platforms/react-native/entry.test.ts[2m > [22mRN entry wires configureCrypto and configureDefaultStorage[2m > [22mexports the canonical prep constants from the RN entry[32m 0[2mms[22m[39m
 [32m✓[39m tests/unit/platforms/react-native/entry.test.ts[2m > [22mRN entry wires configureCrypto and configureDefaultStorage[2m > [22mexports the newer pure validation / normalization / policy helpers from the RN entry[32m 1[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m5 passed[39m[22m[90m (5)[39m
[2m   Start at [22m 19:34:04
[2m   Duration [22m 3.00s[2m (transform 1.01s, setup 36ms, import 6ms, tests 2.89s, environment 0ms)[22m
- 
- Shared packages synced to packages/*/dist
[1] [36m
[1] [1m./src/platforms/browser/index.ts[22m → [1m./dist/index.browser.js[22m...[39m
[5] [36m
[5] [1m./src/vite/index.ts[22m → [1m./dist/vite/index.js[22m...[39m
[5] [1m[33m(!) Unresolved dependencies[39m[22m
[5] [90mhttps://rollupjs.org/troubleshooting/#warning-treating-module-as-external-dependency[39m
[5] [1mnode:fs[22m (imported by "src/vite/index.ts")
[5] [1mnode:module[22m (imported by "src/vite/index.ts")
[5] [1mnode:path[22m (imported by "src/vite/index.ts")
[5] [1mnode:url[22m (imported by "src/vite/index.ts")
[5] [1mvite-plugin-wasm[22m (imported by "src/vite/index.ts")
[5] [32mcreated [1m./dist/vite/index.js[22m in [1m35ms[22m[39m
[5] [36m
[5] [1m./src/vite/index.ts[22m → [1m./dist/vite/index.cjs[22m...[39m
[5] [1m[33m(!) Unresolved dependencies[39m[22m
[5] [90mhttps://rollupjs.org/troubleshooting/#warning-treating-module-as-external-dependency[39m
[5] [1mnode:fs[22m (imported by "src/vite/index.ts")
[5] [1mnode:module[22m (imported by "src/vite/index.ts")
[5] [1mnode:path[22m (imported by "src/vite/index.ts")
[5] [1mnode:url[22m (imported by "src/vite/index.ts")
[5] [1mvite-plugin-wasm[22m (imported by "src/vite/index.ts")
[5] [32mcreated [1m./dist/vite/index.cjs[22m in [1m14ms[22m[39m
[5] yarn build:platform:vite exited with code 0
[0] [36m
[0] [1m./src/platforms/node/index.ts[22m → [1m./dist/index.node.esm.js[22m...[39m
[4] [36m
[4] [1m./src/platforms/react-native/preamble.ts[22m → [1m./dist/index.rn-preamble.js[22m...[39m
[4] [32mcreated [1m./dist/index.rn-preamble.js[22m in [1m35ms[22m[39m
[4] [36m
[4] [1m./src/platforms/react-native/index.ts[22m → [1m./dist/index.react-native.js[22m...[39m
[3] [36m
[3] [1m./src/platforms/chrome-extension/index.ts[22m → [1m./dist/index.chrome-extension.js[22m...[39m
[2] [36m
[2] [1m./src/platforms/electron-main/index.ts[22m → [1m./dist/index.electron-main.cjs[22m...[39m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/coin/balance/resolvers/solana.ts → src/platforms/react-native/overrides/resolverSolana.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/coin/balance/resolvers/solana.ts → src/platforms/react-native/overrides/resolverSolana.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/coin/balance/resolvers/solana.ts → src/platforms/react-native/overrides/resolverSolana.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/coin/balance/resolvers/solana.ts → src/platforms/react-native/overrides/resolverSolana.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] ./resolvers/solana → src/platforms/react-native/overrides/resolverSolana.ts[22m
[1] [1m[33m(!) ../../node_modules/@polkadot/x-global/index.js (9:23): A comment
[1] 
[1] "/*#__PURE__*/"
[1] 
[1] in "../../node_modules/@polkadot/x-global/index.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.[39m[22m
[1] [90mhttps://rollupjs.org/configuration-options/#pure[39m
[1] [1m/private/tmp/vultisig-improve-r40/vultisig-sdk/node_modules/@polkadot/x-global/index.js:9:23[22m
[1] [90m 7:  * A cross-environment implementation for globalThis
[1]  8:  */
[1]  9: export const xglobal = /*#__PURE__*/ (typeof globalThis !== 'undefined'
[1]                            ^
[1] 10:     ? globalThis
[1] 11:     : typeof global !== 'undefined'[39m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/swap/general/lifi/LifiSwapEnabledChains.ts → src/platforms/react-native/overrides/lifiSwapEnabledChains.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[0] [1m[33m(!) ../../node_modules/@polkadot/x-global/index.js (9:23): A comment
[0] 
[0] "/*#__PURE__*/"
[0] 
[0] in "../../node_modules/@polkadot/x-global/index.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.[39m[22m
[0] [90mhttps://rollupjs.org/configuration-options/#pure[39m
[0] [1m/private/tmp/vultisig-improve-r40/vultisig-sdk/node_modules/@polkadot/x-global/index.js:9:23[22m
[0] [90m 7:  * A cross-environment implementation for globalThis
[0]  8:  */
[0]  9: export const xglobal = /*#__PURE__*/ (typeof globalThis !== 'undefined'
[0]                            ^
[0] 10:     ? globalThis
[0] 11:     : typeof global !== 'undefined'[39m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/swap/general/lifi/LifiSwapEnabledChains.ts → src/platforms/react-native/overrides/lifiSwapEnabledChains.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts → src/platforms/react-native/overrides/getLifiSwapQuote.ts[22m
[3] [1m[33m(!) ../../node_modules/@polkadot/x-global/index.js (9:23): A comment
[3] 
[3] "/*#__PURE__*/"
[3] 
[3] in "../../node_modules/@polkadot/x-global/index.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.[39m[22m
[3] [90mhttps://rollupjs.org/configuration-options/#pure[39m
[3] [1m/private/tmp/vultisig-improve-r40/vultisig-sdk/node_modules/@polkadot/x-global/index.js:9:23[22m
[3] [90m 7:  * A cross-environment implementation for globalThis
[3]  8:  */
[3]  9: export const xglobal = /*#__PURE__*/ (typeof globalThis !== 'undefined'
[3]                            ^
[3] 10:     ? globalThis
[3] 11:     : typeof global !== 'undefined'[39m
[2] [1m[33m(!) ../../node_modules/@polkadot/x-global/index.js (9:23): A comment
[2] 
[2] "/*#__PURE__*/"
[2] 
[2] in "../../node_modules/@polkadot/x-global/index.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.[39m[22m
[2] [90mhttps://rollupjs.org/configuration-options/#pure[39m
[2] [1m/private/tmp/vultisig-improve-r40/vultisig-sdk/node_modules/@polkadot/x-global/index.js:9:23[22m
[2] [90m 7:  * A cross-environment implementation for globalThis
[2]  8:  */
[2]  9: export const xglobal = /*#__PURE__*/ (typeof globalThis !== 'undefined'
[2]                            ^
[2] 10:     ? globalThis
[2] 11:     : typeof global !== 'undefined'[39m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/spl/getSplAccounts.ts → src/platforms/react-native/overrides/getSplAccounts.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/swap/general/lifi/LifiSwapEnabledChains.ts → src/platforms/react-native/overrides/lifiSwapEnabledChains.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/swap/general/lifi/LifiSwapEnabledChains.ts → src/platforms/react-native/overrides/lifiSwapEnabledChains.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/spl/getSplAssociatedAccount.ts → src/platforms/react-native/overrides/getSplAssociatedAccount.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts → src/platforms/react-native/overrides/getLifiSwapQuote.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/spl/getSplAccounts.ts → src/platforms/react-native/overrides/getSplAccounts.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/swap/general/lifi/LifiSwapEnabledChains.ts → src/platforms/react-native/overrides/lifiSwapEnabledChains.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/swap/general/lifi/LifiSwapEnabledChains.ts → src/platforms/react-native/overrides/lifiSwapEnabledChains.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/spl/getSplAssociatedAccount.ts → src/platforms/react-native/overrides/getSplAssociatedAccount.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts → src/platforms/react-native/overrides/getLifiSwapQuote.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/spl/getSplAccounts.ts → src/platforms/react-native/overrides/getSplAccounts.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/swap/general/lifi/LifiSwapEnabledChains.ts → src/platforms/react-native/overrides/lifiSwapEnabledChains.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/swap/general/lifi/LifiSwapEnabledChains.ts → src/platforms/react-native/overrides/lifiSwapEnabledChains.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/spl/getSplAssociatedAccount.ts → src/platforms/react-native/overrides/getSplAssociatedAccount.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/spl/getSplAccounts.ts → src/platforms/react-native/overrides/getSplAccounts.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts → src/platforms/react-native/overrides/getLifiSwapQuote.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/sui/client.ts → src/platforms/react-native/overrides/suiClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] ./client → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/spl/getSplAssociatedAccount.ts → src/platforms/react-native/overrides/getSplAssociatedAccount.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/swap/general/lifi/LifiSwapEnabledChains.ts → src/platforms/react-native/overrides/lifiSwapEnabledChains.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/swap/general/lifi/LifiSwapEnabledChains.ts → src/platforms/react-native/overrides/lifiSwapEnabledChains.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/swap/general/lifi/LifiSwapEnabledChains.ts → src/platforms/react-native/overrides/lifiSwapEnabledChains.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] ./client → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/swap/general/lifi/LifiSwapEnabledChains.ts → src/platforms/react-native/overrides/lifiSwapEnabledChains.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [1m[plugin vultisig-rn-path-override] [vultisig-rn-path-override] /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/core/chain/chains/solana/client.ts → src/platforms/react-native/overrides/solanaClient.ts[22m
[4] [32mcreated [1m./dist/index.react-native.js[22m in [1m12.1s[22m[39m
[4] yarn build:platform:react-native exited with code 0
[1] [32mcreated [1m./dist/index.browser.js[22m in [1m17.3s[22m[39m
[1] yarn build:platform:browser exited with code 0
[3] [32mcreated [1m./dist/index.chrome-extension.js[22m in [1m17.4s[22m[39m
[3] yarn build:platform:chrome-extension exited with code 0
[0] [32mcreated [1m./dist/index.node.esm.js[22m in [1m18.8s[22m[39m
[0] [36m
[0] [1m./src/platforms/node/index.ts[22m → [1m./dist/index.node.cjs[22m...[39m
[2] [32mcreated [1m./dist/index.electron-main.cjs[22m in [1m18.9s[22m[39m
[2] yarn build:platform:electron exited with code 0
[0] [1m[33m(!) ../../node_modules/@polkadot/x-global/index.js (9:23): A comment
[0] 
[0] "/*#__PURE__*/"
[0] 
[0] in "../../node_modules/@polkadot/x-global/index.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.[39m[22m
[0] [90mhttps://rollupjs.org/configuration-options/#pure[39m
[0] [1m/private/tmp/vultisig-improve-r40/vultisig-sdk/node_modules/@polkadot/x-global/index.js:9:23[22m
[0] [90m 7:  * A cross-environment implementation for globalThis
[0]  8:  */
[0]  9: export const xglobal = /*#__PURE__*/ (typeof globalThis !== 'undefined'
[0]                            ^
[0] 10:     ? globalThis
[0] 11:     : typeof global !== 'undefined'[39m
[0] [1m[33m(!) Circular dependencies[39m[22m
[0] ../../node_modules/viem/_esm/utils/encoding/fromHex.js -> ../../node_modules/viem/_esm/utils/encoding/toBytes.js -> ../../node_modules/viem/_esm/utils/encoding/fromHex.js
[0] ../../node_modules/viem/_esm/utils/encoding/fromHex.js -> ../../node_modules/viem/_esm/utils/encoding/toBytes.js -> ../../node_modules/viem/_esm/utils/encoding/toHex.js -> ../../node_modules/viem/_esm/utils/encoding/fromHex.js
[0] ../../node_modules/viem/_esm/utils/transaction/serializeTransaction.js -> ../../node_modules/viem/_esm/utils/authorization/serializeAuthorizationList.js -> ../../node_modules/viem/_esm/utils/transaction/serializeTransaction.js
[0] ...and 59 more
[0] [1m[33m(!) "this" has been rewritten to "undefined"[39m[22m
[0] [90mhttps://rollupjs.org/troubleshooting/#error-this-is-undefined[39m
[0] [1m../../node_modules/@bufbuild/protobuf/dist/esm/wire/size-delimited.js[22m
[0] [90m12: // See the License for the specific language governing permissions and
[0] 13: // limitations under the License.
[0] 14: var __asyncValues = (this && this.__asyncValues) || function (o) {
[0]                          ^
[0] 15:     if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
[0] 16:     var m = o[Symbol.asyncIterator], i;[39m
[0] ...and 5 other occurrences
[0] [32mcreated [1m./dist/index.node.cjs[22m in [1m11.2s[22m[39m
[0] [36m
[0] [1m./src/tools/parse/index.ts[22m → [1m./dist/tools/parse/index.js[22m...[39m
[0] [32mcreated [1m./dist/tools/parse/index.js[22m in [1m82ms[22m[39m
[0] [36m
[0] [1m./src/tools/parse/index.ts[22m → [1m./dist/tools/parse/index.cjs[22m...[39m
[0] [32mcreated [1m./dist/tools/parse/index.cjs[22m in [1m79ms[22m[39m
[0] [36m
[0] [1m./src/tools/defi/index.ts[22m → [1m./dist/tools/defi/index.js[22m...[39m
[0] [32mcreated [1m./dist/tools/defi/index.js[22m in [1m1.6s[22m[39m
[0] [36m
[0] [1m./src/tools/defi/index.ts[22m → [1m./dist/tools/defi/index.cjs[22m...[39m
[0] [1m[33m(!) Circular dependencies[39m[22m
[0] ../../node_modules/viem/_esm/utils/encoding/fromHex.js -> ../../node_modules/viem/_esm/utils/encoding/toBytes.js -> ../../node_modules/viem/_esm/utils/encoding/fromHex.js
[0] ../../node_modules/viem/_esm/utils/encoding/fromHex.js -> ../../node_modules/viem/_esm/utils/encoding/toBytes.js -> ../../node_modules/viem/_esm/utils/encoding/toHex.js -> ../../node_modules/viem/_esm/utils/encoding/fromHex.js
[0] ../../node_modules/viem/_esm/utils/transaction/serializeTransaction.js -> ../../node_modules/viem/_esm/utils/authorization/serializeAuthorizationList.js -> ../../node_modules/viem/_esm/utils/transaction/serializeTransaction.js
[0] ...and 21 more
[0] [32mcreated [1m./dist/tools/defi/index.cjs[22m in [1m1.7s[22m[39m
[0] yarn build:platform:node exited with code 0
- Built @vultisig/cli v2.20.0
- 
- ➤ YN0036: Calling the "prepack" lifecycle script
➤ YN0000: CHANGELOG.md
➤ YN0000: LICENSE
➤ YN0000: README.md
➤ YN0000: dist/index.browser.js
➤ YN0000: dist/index.browser.js.map
➤ YN0000: dist/index.chrome-extension.js
➤ YN0000: dist/index.chrome-extension.js.map
➤ YN0000: dist/index.d.ts
➤ YN0000: dist/index.electron-main.cjs
➤ YN0000: dist/index.electron-main.cjs.map
➤ YN0000: dist/index.electron-main.d.ts
➤ YN0000: dist/index.node.cjs
➤ YN0000: dist/index.node.cjs.map
➤ YN0000: dist/index.node.d.ts
➤ YN0000: dist/index.node.esm.js
➤ YN0000: dist/index.node.esm.js.map
➤ YN0000: dist/index.react-native.d.ts
➤ YN0000: dist/index.react-native.js
➤ YN0000: dist/index.react-native.js.map
➤ YN0000: dist/index.rn-preamble.d.ts
➤ YN0000: dist/index.rn-preamble.js
➤ YN0000: dist/index.rn-preamble.js.map
➤ YN0000: dist/tools/defi/index.cjs
➤ YN0000: dist/tools/defi/index.cjs.map
➤ YN0000: dist/tools/defi/index.d.ts
➤ YN0000: dist/tools/defi/index.js
➤ YN0000: dist/tools/defi/index.js.map
➤ YN0000: dist/tools/parse/index.cjs
➤ YN0000: dist/tools/parse/index.cjs.map
➤ YN0000: dist/tools/parse/index.d.ts
➤ YN0000: dist/tools/parse/index.js
➤ YN0000: dist/tools/parse/index.js.map
➤ YN0000: dist/vite/index.cjs
➤ YN0000: dist/vite/index.cjs.map
➤ YN0000: dist/vite/index.d.ts
➤ YN0000: dist/vite/index.js
➤ YN0000: dist/vite/index.js.map
➤ YN0000: package.json
➤ YN0000: scripts/live-web-push-e2e/README.md
➤ YN0000: tests/e2e/README.md
➤ YN0000: Package archive generated in /private/tmp/vultisig-improve-r40/vultisig-sdk/packages/sdk/package.tgz
➤ YN0000: Done in 1s 677ms
- tarball inspection of  proving the new RN exports are published

## Report

https://gist.github.com/gomesalexandre/3a7220996dff79bd01387feb0ba93ffc

## Risk

Low. This is a public-surface parity change for RN-safe pure helpers only; no signing/broadcast behavior changed.
