### PR TITLE
fix(sdk): publish tools/prep subpath

### DIFF
--- a/.changeset/sdk-tools-prep-subpath.md
+++ b/.changeset/sdk-tools-prep-subpath.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+Publish the documented `@vultisig/sdk/tools/prep` subpath with dedicated JS and type bundles.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -98,6 +98,19 @@
       "import": "./dist/tools/defi/index.js",
       "require": "./dist/tools/defi/index.cjs",
       "default": "./dist/tools/defi/index.cjs"
+    },
+    "./tools/prep": {
+      "types": "./dist/tools/prep/index.d.ts",
+      "browser": "./dist/tools/prep/index.js",
+      "worker": "./dist/tools/prep/index.js",
+      "react-native": "./dist/tools/prep/index.js",
+      "node": {
+        "import": "./dist/tools/prep/index.js",
+        "require": "./dist/tools/prep/index.cjs"
+      },
+      "import": "./dist/tools/prep/index.js",
+      "require": "./dist/tools/prep/index.cjs",
+      "default": "./dist/tools/prep/index.cjs"
     }
   },
   "scripts": {

--- a/packages/sdk/rollup.platforms.config.js
+++ b/packages/sdk/rollup.platforms.config.js
@@ -326,6 +326,10 @@ const configs = {
       input: './src/tools/defi/index.ts',
       distBase: 'tools/defi',
     }),
+    ...createToolsSubpathConfigs({
+      input: './src/tools/prep/index.ts',
+      distBase: 'tools/prep',
+    }),
   ],
   browser: {
     input: './src/platforms/browser/index.ts',

--- a/packages/sdk/rollup.types.config.js
+++ b/packages/sdk/rollup.types.config.js
@@ -102,4 +102,5 @@ export default defineConfig([
   // declarations instead of the root index type graph.
   createSubpathTypesConfig('src/tools/parse/index.ts', 'dist/tools/parse/index.d.ts'),
   createSubpathTypesConfig('src/tools/defi/index.ts', 'dist/tools/defi/index.d.ts'),
+  createSubpathTypesConfig('src/tools/prep/index.ts', 'dist/tools/prep/index.d.ts'),
 ])

--- a/packages/sdk/tests/unit/public-api/toolsSubpathExports.test.ts
+++ b/packages/sdk/tests/unit/public-api/toolsSubpathExports.test.ts
@@ -10,9 +10,10 @@ const platformRollupConfig = readFileSync(path.join(sdkRoot, 'rollup.platforms.c
 const typesRollupConfig = readFileSync(path.join(sdkRoot, 'rollup.types.config.js'), 'utf8')
 
 describe('public API tools subpath exports', () => {
-  it('publishes dedicated export-map entries for parse and defi', () => {
+  it('publishes dedicated export-map entries for parse, defi, and prep', () => {
     const parseExport = sdkPackageJson.exports['./tools/parse']
     const defiExport = sdkPackageJson.exports['./tools/defi']
+    const prepExport = sdkPackageJson.exports['./tools/prep']
 
     expect(parseExport).toMatchObject({
       types: './dist/tools/parse/index.d.ts',
@@ -26,22 +27,34 @@ describe('public API tools subpath exports', () => {
       require: './dist/tools/defi/index.cjs',
       default: './dist/tools/defi/index.cjs',
     })
+    expect(prepExport).toMatchObject({
+      types: './dist/tools/prep/index.d.ts',
+      import: './dist/tools/prep/index.js',
+      require: './dist/tools/prep/index.cjs',
+      default: './dist/tools/prep/index.cjs',
+    })
 
     expect(JSON.stringify(parseExport)).not.toContain('dist/index.node')
     expect(JSON.stringify(defiExport)).not.toContain('dist/index.node')
+    expect(JSON.stringify(prepExport)).not.toContain('dist/index.node')
   })
 
-  it('keeps dedicated JS and d.ts bundle generation wired for both subpaths', () => {
+  it('keeps dedicated JS and d.ts bundle generation wired for all tool subpaths', () => {
     expect(platformRollupConfig).toContain("input: './src/tools/parse/index.ts'")
     expect(platformRollupConfig).toContain("distBase: 'tools/parse'")
     expect(platformRollupConfig).toContain("input: './src/tools/defi/index.ts'")
     expect(platformRollupConfig).toContain("distBase: 'tools/defi'")
+    expect(platformRollupConfig).toContain("input: './src/tools/prep/index.ts'")
+    expect(platformRollupConfig).toContain("distBase: 'tools/prep'")
 
     expect(typesRollupConfig).toContain(
       "createSubpathTypesConfig('src/tools/parse/index.ts', 'dist/tools/parse/index.d.ts')"
     )
     expect(typesRollupConfig).toContain(
       "createSubpathTypesConfig('src/tools/defi/index.ts', 'dist/tools/defi/index.d.ts')"
+    )
+    expect(typesRollupConfig).toContain(
+      "createSubpathTypesConfig('src/tools/prep/index.ts', 'dist/tools/prep/index.d.ts')"
     )
   })
 })

--- a/scripts/smoke-sdk-subpath-exports.mjs
+++ b/scripts/smoke-sdk-subpath-exports.mjs
@@ -52,15 +52,20 @@ try {
       "const require = createRequire(import.meta.url)",
       "const parsePath = require.resolve('@vultisig/sdk/tools/parse')",
       "const defiPath = require.resolve('@vultisig/sdk/tools/defi')",
+      "const prepPath = require.resolve('@vultisig/sdk/tools/prep')",
       "assert.match(parsePath, /dist\\/tools\\/parse\\/index\\.cjs$/)",
       "assert.match(defiPath, /dist\\/tools\\/defi\\/index\\.cjs$/)",
+      "assert.match(prepPath, /dist\\/tools\\/prep\\/index\\.cjs$/)",
       "const parse = await import('@vultisig/sdk/tools/parse')",
       "const defiModule = await import('@vultisig/sdk/tools/defi')",
+      "const prep = await import('@vultisig/sdk/tools/prep')",
       "assert.equal(parse.parseChain('Ethereum').success, true)",
       "assert.equal(typeof parse.parseTicker, 'function')",
       "assert.equal(typeof defiModule.defi, 'object')",
       "assert.equal(typeof defiModule.osmosis.buildSwapExactAmountIn, 'function')",
-      "console.log(JSON.stringify({ parsePath, defiPath, parseOk: true, defiOk: true }))",
+      "assert.equal(typeof prep.prepareSendTxFromKeys, 'function')",
+      "assert.equal(typeof prep.prepareIbcTransfer, 'function')",
+      "console.log(JSON.stringify({ parsePath, defiPath, prepPath, parseOk: true, defiOk: true, prepOk: true }))",
       '',
     ].join('\n')
   )
@@ -69,11 +74,16 @@ try {
     [
       "import { parseChain, type ParseChainResult } from '@vultisig/sdk/tools/parse'",
       "import { defi, type Defi } from '@vultisig/sdk/tools/defi'",
+      "import { prepareIbcTransfer, prepareSendTxFromKeys, type PrepareSendTxFromKeysParams } from '@vultisig/sdk/tools/prep'",
       '',
       "const chainResult: ParseChainResult = parseChain('Ethereum')",
       'void chainResult',
       'const tools: Defi = defi',
       'void tools',
+      'void prepareIbcTransfer',
+      'void prepareSendTxFromKeys',
+      'type _PrepParams = PrepareSendTxFromKeysParams',
+      'void (0 as unknown as _PrepParams)',
       '',
     ].join('\n')
   )


### PR DESCRIPTION
## Summary
- publish `@vultisig/sdk/tools/prep` as a real package subpath
- add export-map / bundle / d.ts regression coverage for the new prep surface
- extend the tarball smoke proof to resolve and import `tools/prep`

## Test plan
- [x] yarn install --immutable
- [x] yarn workspace @vultisig/sdk vitest run --config tests/unit/vitest.config.ts tests/unit/public-api/toolsSubpathExports.test.ts
- [x] yarn build:sdk
- [x] yarn cli:build
- [x] yarn build:all
- [x] yarn lint
- [x] yarn sdk:smoke:subpaths

Closes #1409
Report: https://gist.github.com/gomesalexandre/57b4cc32aaae78161d6421e0080cc9ad
