### PR TITLE
fix(swap): honor quote approval spender

### DIFF
--- a/.changeset/safe-lions-approve.md
+++ b/.changeset/safe-lions-approve.md
@@ -1,0 +1,8 @@
+---
+'@vultisig/core-mpc': patch
+'@vultisig/sdk': patch
+---
+
+For EVM swap providers that legitimately distinguish the allowance executor
+from the swap router, use the quote's approval address for SDK allowance checks
+and approval payloads while retaining the router as the signed destination.

--- a/package.json
+++ b/package.json
@@ -192,6 +192,7 @@
     "readable-stream": "3.6.2",
     "@grpc/grpc-js": "1.14.4",
     "@cosmjs/encoding/@scure/base": "1.2.6",
+    "axios": "1.18.1",
     "esbuild@npm:~0.28.0": "0.28.1",
     "shell-quote": "1.10.0",
     "js-yaml@npm:4.1.1": "^4.3.0",

--- a/packages/core/mpc/keysign/swap/build.agg02RouterCoverage.test.ts
+++ b/packages/core/mpc/keysign/swap/build.agg02RouterCoverage.test.ts
@@ -1,26 +1,28 @@
 import { create } from '@bufbuild/protobuf'
+import { initWasm, type WalletCore } from '@trustwallet/wallet-core'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { SwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
 import { getBlockchainSpecificValue } from '@vultisig/core-mpc/keysign/chainSpecific/KeysignChainSpecific'
+import { getEvmSigningInputs } from '@vultisig/core-mpc/keysign/signingInputs/resolvers/evm'
 import { getKeysignSwapPayload } from '@vultisig/core-mpc/keysign/swap/getKeysignSwapPayload'
 import { KeysignSwapPayload } from '@vultisig/core-mpc/keysign/swap/KeysignSwapPayload'
 import { EthereumSpecificSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // AGG-02 (round-2 spec-level fund-safety audit): the aggregator-returned tx.to used to be
-// trusted with NO allowlist, and it fed TWO INDEPENDENT downstream consumers — the ERC-20
-// approval spender (this file, buildSwapKeysignPayload's allowance check) AND the actual
-// swap transaction's on-chain destination (swapPayload.value.quote.tx.to, read by
-// packages/core/mpc/keysign/signingInputs/resolvers/evm/index.ts:65's WalletCore
-// SigningInput). Fixing only one would have left the other unguarded — that's why the real
-// fix (getOneInchSwapQuote.ts / kyber tx.ts / getLifiSwapQuote.ts / getSwapKitQuote.ts) is at
-// QUOTE CONSTRUCTION, so a GeneralSwapQuote literally cannot exist with a bad tx.to for an
-// enforced provider (1inch/Kyber). This test proves BOTH downstream fields agree once that's
-// true — i.e. that build.ts has no THIRD, independent path that could diverge from the
-// validated address.
+// trusted with NO allowlist, and it feeds the actual swap transaction's on-chain destination
+// (swapPayload.value.quote.tx.to, read by the EVM signing-input resolver). Quote construction
+// now validates that outer router. A quote may separately identify the ERC-20 transferFrom
+// executor in approvalAddress, so this suite locks both valid cases: without an executor the
+// allowance/approve spender falls back to the validated router; with one, approval uses the
+// executor while signing still targets the validated router.
 const ONE_INCH_V6_ROUTER = '0x111111125421ca6dc452d289314280a0f8842a65'
+const LIFI_ROUTER = '0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE'
+const INNER_EXECUTOR = '0x2222222222222222222222222222222222222222'
+const SENDER = '0x1234567890123456789012345678901234567890'
+const USDC = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
 
 const mocks = vi.hoisted(() => ({
   getChainSpecific: vi.fn(async () => ({
@@ -50,7 +52,17 @@ import { buildSwapKeysignPayload } from './build'
 
 const publicKey = { data: () => new Uint8Array([1, 2, 3]) } as never
 
-describe('buildSwapKeysignPayload — AGG-02: both downstream router consumers agree', () => {
+describe('buildSwapKeysignPayload — EVM approval spender and signed destination routing', () => {
+  let walletCore: WalletCore
+
+  beforeAll(async () => {
+    walletCore = await initWasm()
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('the ERC-20 approval spender AND the swap tx destination (read by the evm signingInputs resolver) both carry the SAME validated router address', async () => {
     // This quote shape is exactly what getOneInchSwapQuote returns AFTER its AGG-02
     // allowlist check passes — production code can never construct this object with
@@ -60,15 +72,34 @@ describe('buildSwapKeysignPayload — AGG-02: both downstream router consumers a
         general: {
           provider: '1inch',
           dstAmount: '1000000',
-          tx: { evm: { from: '0xsender', to: ONE_INCH_V6_ROUTER, data: '0xabc', value: '0' } },
+          tx: {
+            evm: {
+              from: '0xsender',
+              to: ONE_INCH_V6_ROUTER,
+              data: '0xabc',
+              value: '0',
+            },
+          },
         },
       },
       discounts: [],
     } as never
 
     const payload = await buildSwapKeysignPayload({
-      fromCoin: { chain: Chain.Ethereum, address: '0xsender', id: '0xusdc', ticker: 'USDC', decimals: 6 },
-      toCoin: { chain: Chain.Ethereum, address: '0xdest', id: '0xdai', ticker: 'DAI', decimals: 18 },
+      fromCoin: {
+        chain: Chain.Ethereum,
+        address: SENDER,
+        id: USDC,
+        ticker: 'USDC',
+        decimals: 6,
+      },
+      toCoin: {
+        chain: Chain.Ethereum,
+        address: '0xdest',
+        id: '0xdai',
+        ticker: 'DAI',
+        decimals: 18,
+      },
       amount: 1,
       swapQuote,
       vaultId: 'vault-id',
@@ -79,8 +110,8 @@ describe('buildSwapKeysignPayload — AGG-02: both downstream router consumers a
       walletCore: {} as never,
     })
 
-    // Consumer 1: the ERC-20 approval spender (build.ts's allowance check reads
-    // keysignPayload.toAddress as the spender when allowance is insufficient).
+    // Without approvalAddress, the ERC-20 allowance/approve spender falls back
+    // to keysignPayload.toAddress.
     expect(payload.toAddress).toBe(ONE_INCH_V6_ROUTER)
     expect(payload.erc20ApprovePayload?.spender).toBe(ONE_INCH_V6_ROUTER)
 
@@ -98,7 +129,11 @@ describe('buildSwapKeysignPayload — AGG-02: both downstream router consumers a
     // coincidentally-equal constants) — confirm getErc20Allowance was called with
     // exactly this spender, proving the flow used through build.ts's real branch.
     expect(mocks.getErc20Allowance).toHaveBeenCalledWith(
-      expect.objectContaining({ chain: Chain.Ethereum, address: '0xsender', spender: ONE_INCH_V6_ROUTER })
+      expect.objectContaining({
+        chain: Chain.Ethereum,
+        address: SENDER,
+        spender: ONE_INCH_V6_ROUTER,
+      })
     )
 
     // Codex review (PR #1079): don't just assert on the payload's field path — replicate
@@ -117,5 +152,83 @@ describe('buildSwapKeysignPayload — AGG-02: both downstream router consumers a
       general: ({ quote }) => shouldBePresent(quote?.tx?.to),
     })
     expect(toAddressTheEvmResolverWouldUse).toBe(ONE_INCH_V6_ROUTER)
+  })
+
+  it('uses approvalAddress for an unenforced-provider allowance/approve while retaining the router as the signed swap destination', async () => {
+    const swapQuote: SwapQuote = {
+      quote: {
+        general: {
+          provider: 'li.fi',
+          dstAmount: '1000000',
+          tx: {
+            evm: {
+              from: SENDER,
+              to: LIFI_ROUTER,
+              approvalAddress: INNER_EXECUTOR,
+              data: '0xabc',
+              value: '0',
+            },
+          },
+        },
+      },
+      discounts: [],
+    } as never
+
+    const payload = await buildSwapKeysignPayload({
+      fromCoin: {
+        chain: Chain.Ethereum,
+        address: SENDER,
+        id: USDC,
+        ticker: 'USDC',
+        decimals: 6,
+      },
+      toCoin: {
+        chain: Chain.Ethereum,
+        address: '0xdest',
+        id: '0xdai',
+        ticker: 'DAI',
+        decimals: 18,
+      },
+      amount: 1,
+      swapQuote,
+      vaultId: 'vault-id',
+      localPartyId: 'local-party',
+      fromPublicKey: publicKey,
+      toPublicKey: publicKey,
+      libType: 'DKLS' as const,
+      walletCore: {} as never,
+    })
+
+    expect(mocks.getErc20Allowance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chain: Chain.Ethereum,
+        address: SENDER,
+        spender: INNER_EXECUTOR,
+      })
+    )
+    expect(payload.erc20ApprovePayload?.spender).toBe(INNER_EXECUTOR)
+    expect(payload.toAddress).toBe(LIFI_ROUTER)
+
+    const swapPayload = shouldBePresent(getKeysignSwapPayload(payload))
+    const toAddressTheEvmResolverWouldUse = matchRecordUnion<KeysignSwapPayload, string>(swapPayload, {
+      native: () => {
+        throw new Error('unreachable in this test — quote is a general/li.fi swap')
+      },
+      general: ({ quote }) => shouldBePresent(quote?.tx?.to),
+    })
+    expect(toAddressTheEvmResolverWouldUse).toBe(LIFI_ROUTER)
+
+    // Exercise the real signing resolver, including its approval-spender guard. Providers such as
+    // li.fi legitimately distinguish the allowance executor from the swap transaction destination,
+    // so the payload must produce both the approve and swap signing inputs without weakening the
+    // stricter spender===router binding for enforced providers such as 1inch and Kyber.
+    const signingInputs = await getEvmSigningInputs({
+      keysignPayload: payload,
+      walletCore,
+    })
+    expect(signingInputs).toHaveLength(2)
+    expect(signingInputs[0]?.toAddress).toBe(USDC)
+    expect(signingInputs[0]?.transaction?.erc20Approve?.spender).toBe(INNER_EXECUTOR)
+    expect(signingInputs[1]?.toAddress).toBe(LIFI_ROUTER)
   })
 })

--- a/packages/core/mpc/keysign/swap/build.ts
+++ b/packages/core/mpc/keysign/swap/build.ts
@@ -366,7 +366,11 @@ export const buildSwapKeysignPayload = async ({
   }
 
   if (isChainOfKind(chain, 'evm') && fromCoin.id) {
-    const spender = keysignPayload.toAddress
+    const approvalAddress = matchRecordUnion<SwapQuoteResult, string | undefined>(swapQuote.quote, {
+      native: () => undefined,
+      general: ({ tx }) => ('evm' in tx ? tx.evm.approvalAddress : undefined),
+    })
+    const spender = approvalAddress ?? keysignPayload.toAddress
     const allowance = await getErc20Allowance({
       chain,
       id: fromCoin.id,

--- a/packages/sdk/src/vault/services/SwapService.ts
+++ b/packages/sdk/src/vault/services/SwapService.ts
@@ -329,7 +329,7 @@ export class SwapService {
   private getSpenderFromQuote(quoteData: SwapQuote['quote']): string | undefined {
     if ('general' in quoteData && quoteData.general.tx) {
       if ('evm' in quoteData.general.tx) {
-        return quoteData.general.tx.evm.to
+        return quoteData.general.tx.evm.approvalAddress ?? quoteData.general.tx.evm.to
       }
       // UTXO/Cosmos deposit-channel swaps: no ERC-20 spender approval needed.
       if ('transfer' in quoteData.general.tx) {

--- a/packages/sdk/tests/unit/services/SwapService.test.ts
+++ b/packages/sdk/tests/unit/services/SwapService.test.ts
@@ -286,6 +286,60 @@ describe('SwapService', () => {
       expect(result.approvalInfo?.spender).toBe('0x1111111254fb6c44bAC0beD2854e76F90643097d')
     })
 
+    it('should use the quote approvalAddress as the ERC-20 spender when it differs from the router', async () => {
+      const { findSwapQuote } = await import('@vultisig/core-chain/swap/quote/findSwapQuote')
+      const { getErc20Allowance } = await import('@vultisig/core-chain/chains/evm/erc20/getErc20Allowance')
+      const router = '0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE'
+      const approvalAddress = '0x2222222222222222222222222222222222222222'
+      const owner = '0x1234567890abcdef1234567890abcdef12345678'
+      const token = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+
+      vi.mocked(findSwapQuote).mockResolvedValue({
+        quote: {
+          general: {
+            dstAmount: '50000000000000000',
+            provider: 'li.fi' as const,
+            tx: {
+              evm: {
+                from: owner,
+                to: router,
+                approvalAddress,
+                data: '0x...',
+                value: '0',
+              },
+            },
+          },
+        },
+        discounts: [],
+      })
+      vi.mocked(getErc20Allowance).mockResolvedValue(0n)
+
+      const result = await service.getQuote({
+        fromCoin: {
+          chain: Chain.Ethereum,
+          address: owner,
+          id: token,
+          ticker: 'USDC',
+          decimals: 6,
+        },
+        toCoin: {
+          chain: Chain.Ethereum,
+          address: owner,
+          ticker: 'ETH',
+          decimals: 18,
+        },
+        amount: 100,
+      })
+
+      expect(getErc20Allowance).toHaveBeenCalledWith({
+        chain: Chain.Ethereum,
+        id: token,
+        address: owner,
+        spender: approvalAddress,
+      })
+      expect(result.approvalInfo?.spender).toBe(approvalAddress)
+    })
+
     it('should not require approval when allowance is sufficient', async () => {
       const { findSwapQuote } = await import('@vultisig/core-chain/swap/quote/findSwapQuote')
       const { getErc20Allowance } = await import('@vultisig/core-chain/chains/evm/erc20/getErc20Allowance')

--- a/yarn.lock
+++ b/yarn.lock
@@ -8079,19 +8079,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.16.0":
-  version: 1.17.0
-  resolution: "axios@npm:1.17.0"
-  dependencies:
-    follow-redirects: "npm:^1.16.0"
-    form-data: "npm:^4.0.5"
-    https-proxy-agent: "npm:^5.0.1"
-    proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/c4fa19ff3a3a63bde48beec03ad816b133b9a6385cccffffe172577ab18c6a70e299280d57f12c80c867fe25df41f92cb91d3a8258708a6d2be3e9e085f92650
-  languageName: node
-  linkType: hard
-
-"axios@npm:^1.18.1":
+"axios@npm:1.18.1":
   version: 1.18.1
   resolution: "axios@npm:1.18.1"
   dependencies:


### PR DESCRIPTION
Closes #1198
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ERC-20 allowance and approval preparation to use the swap quote’s `approvalAddress` as the spender/executor when provided (while still signing the swap with the router destination).
* **Tests**
  * Expanded AGG-02 routing and unit coverage to validate both approval and no-approval quote scenarios, including spender selection and signed destination behavior.
* **Chores**
  * Applied patch-level dependency/version updates (including an axios resolution).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->