### PR TITLE
fix(mpc-wasm): implement createMigrateSession on the Schnorr engine

### DIFF
--- a/.changeset/schnorr-migrate-session.md
+++ b/.changeset/schnorr-migrate-session.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/mpc-wasm': patch
+---
+
+Implement `createMigrateSession` on the WASM Schnorr engine so GG20→DKLS vault upgrades can migrate the EdDSA keyshare. Previously the EdDSA migration step threw `schnorr engine does not support createMigrateSession` because the method was declared optional on `SchnorrEngine` and never wired up, even though the underlying `SchnorrKeygenSession.migrate` WASM binding exists. Mirrors the existing DKLS engine implementation.

--- a/packages/mpc-wasm/src/index.ts
+++ b/packages/mpc-wasm/src/index.ts
@@ -212,6 +212,11 @@ class WasmSchnorrEngine implements SchnorrEngine {
     return wrapSession(session, s => wrapKeyshare(s.finish()))
   }
 
+  createMigrateSession(setup: Uint8Array, localPartyId: string, localUI: Uint8Array, publicKey: Uint8Array, rootChainCode: Uint8Array): MpcSession<MpcKeyshare> {
+    const session = SchnorrKeygenSession.migrate(setup, localPartyId, localUI, publicKey, rootChainCode)
+    return wrapSession(session, s => wrapKeyshare(s.finish()))
+  }
+
   signSetup(keyId: Uint8Array, chainPath: string, messageHash: Uint8Array | null | undefined, partyIds: string[]): Uint8Array {
     if (!messageHash) {
       throw new Error('Schnorr (EdDSA) signing requires a message hash')


### PR DESCRIPTION
## Problem

GG20 → DKLS vault upgrades run two migrate keygen sessions: ECDSA via the DKLS
engine (works) and EdDSA via the Schnorr engine (fails). The EdDSA step threw:

```
Error: schnorr engine does not support createMigrateSession
```

so the upgrade always failed right after the ECDSA step.

## Root cause

`WasmSchnorrEngine` (`packages/mpc-wasm/src/index.ts`) never implemented
`createMigrateSession`, even though:

- it is declared (optional) on the `SchnorrEngine` interface — which is why this
  compiled and only failed at runtime,
- the underlying WASM binding already exists:
  `SchnorrKeygenSession.migrate(setup, id, s_i_0, public_key, root_chain_code)`,
- the sibling `WasmDklsEngine` already implements the exact analog.

The guard in `packages/core/mpc/schnorr/schnorrKeygen.ts` therefore threw before
starting the session. EdDSA migration has effectively never worked in the WASM engine.

## Fix

Wire up `WasmSchnorrEngine.createMigrateSession`, mirroring
`WasmDklsEngine.createMigrateSession` but calling `SchnorrKeygenSession.migrate`.
The migrate action provider already passes the correct inputs (EdDSA local secret
share, EdDSA public key, chain code), so no caller changes are needed.

## Notes

- Native parity: `NativeSchnorrEngine` (`packages/mpc-native/src/index.ts`) has the
  same gap and would need a corresponding native binding — out of scope here, tracked
  separately for the mobile clients.
- Changeset included (`@vultisig/mpc-wasm` patch).

## Related

Fixes the desktop bug reported in vultisig/vultisig-windows#4388 (cross-repo — the
issue must be closed manually or via the windows dependency bump; GitHub closing
keywords do not auto-close issues across repositories).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vault upgrade migrations from GG20 to DKLS when migrating EdDSA keyshares.
  * Improved Schnorr migration session handling to prevent failures during the migration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->