### PR TITLE
fix(cosmos): validate secured asset chain prefixes

### DIFF
--- a/.changeset/guard-secured-asset-prefix.md
+++ b/.changeset/guard-secured-asset-prefix.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/core-mpc': patch
+---
+
+Reject secured-asset signing payloads whose chain prefix is not in the canonical native-swap registry.

--- a/packages/core/chain/swap/native/NativeSwapChain.ts
+++ b/packages/core/chain/swap/native/NativeSwapChain.ts
@@ -98,6 +98,14 @@ export type NativeSwapChainId = (typeof nativeSwapChainIds)[NativeSwapEnabledCha
 export const getNativeSwapChainId = (chain: Chain): NativeSwapChainId | null =>
   nativeSwapChainIds[chain as NativeSwapEnabledChain] ?? null
 
+const nativeSwapChainIdByDenomPrefix = new Map<string, NativeSwapChainId>(
+  (Object.values(nativeSwapChainIds) as NativeSwapChainId[]).map(chainId => [chainId.toLowerCase(), chainId])
+)
+
+/** Resolves a secured-asset denom prefix to its canonical native-swap chain ID. */
+export const getNativeSwapChainIdFromDenomPrefix = (prefix: string): NativeSwapChainId | undefined =>
+  nativeSwapChainIdByDenomPrefix.get(prefix.toLowerCase())
+
 type NativeSwapPayloadCase = 'thorchainSwapPayload' | 'mayachainSwapPayload'
 
 export const nativeSwapPayloadCase: Record<NativeSwapChain, NativeSwapPayloadCase> = {

--- a/packages/core/chain/swap/native/asset/toNativeSwapAsset.ts
+++ b/packages/core/chain/swap/native/asset/toNativeSwapAsset.ts
@@ -5,19 +5,13 @@ import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { EntityWithTicker } from '@vultisig/lib-utils/entities/EntityWithTicker'
 
 import { isFeeCoin } from '../../../coin/utils/isFeeCoin'
-import type { NativeSwapChain, NativeSwapChainId } from '../NativeSwapChain'
-import { nativeSwapChainIds, nativeSwapChains, nativeSwapEnabledChains } from '../NativeSwapChain'
-
-type NativeSwapDenomChainKey = Lowercase<NativeSwapChainId>
-
-const nativeSwapChainIdValues = Object.values(nativeSwapChainIds) as NativeSwapChainId[]
-
-const securedAssetDenomChainKeyToSwapId = Object.fromEntries(
-  nativeSwapChainIdValues.map(swapId => [swapId.toLowerCase() as NativeSwapDenomChainKey, swapId])
-) as Partial<Record<NativeSwapDenomChainKey, NativeSwapChainId>>
-
-const getSecuredAssetSwapId = (chainKey: string): NativeSwapChainId | undefined =>
-  securedAssetDenomChainKeyToSwapId[chainKey.toLowerCase() as NativeSwapDenomChainKey]
+import type { NativeSwapChain } from '../NativeSwapChain'
+import {
+  getNativeSwapChainIdFromDenomPrefix,
+  nativeSwapChainIds,
+  nativeSwapChains,
+  nativeSwapEnabledChains,
+} from '../NativeSwapChain'
 
 const formatSecuredAssetRest = (rest: string): string => {
   const evmTail = rest.match(/^(.+)-(0x[0-9a-fA-F]+)$/i)
@@ -49,7 +43,7 @@ const normalizeNativeSwapChainDenom = ({
 
   const segments = denom.split('-')
   if (segments.length >= 2) {
-    const swapId = getSecuredAssetSwapId(segments[0])
+    const swapId = getNativeSwapChainIdFromDenomPrefix(segments[0])
     if (swapId) {
       const rest = segments.slice(1).join('-')
       // THORChain secured assets settle on THORChain (a thor1 destination), so

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos.test.ts
@@ -345,4 +345,54 @@ describe('getCosmosSigningInputs gas limit', () => {
     })
     expect(depositCoin?.decimals.toString()).toBe('8')
   })
+
+  it.each(['bogus-usdc', '-usdc', '__proto__-usdc', 'constructor-usdc'])(
+    'rejects a secured-asset swap deposit with a non-canonical chain prefix (%s)',
+    contractAddress => {
+      const resolve = () =>
+        getCosmosSigningInputs({
+          keysignPayload: create(KeysignPayloadSchema, {
+            coin: create(CoinSchema, {
+              chain: Chain.THORChain,
+              ticker: 'RUNE',
+              address: thorSender,
+              decimals: 8,
+              isNativeToken: true,
+              hexPublicKey: publicKeyHex,
+            }),
+            toAddress: '',
+            toAmount: '41391997',
+            memo: `=:XRP-XRP:${thorSender}`,
+            blockchainSpecific: {
+              case: 'thorchainSpecific',
+              value: create(THORChainSpecificSchema, {
+                accountNumber: 7n,
+                sequence: 3n,
+                fee: 2_000_000n,
+                isDeposit: true,
+                transactionType: TransactionType.UNSPECIFIED,
+              }),
+            },
+            swapPayload: {
+              case: 'thorchainSwapPayload',
+              value: {
+                fromCoin: {
+                  chain: Chain.THORChain,
+                  ticker: 'USDC',
+                  contractAddress,
+                  decimals: 8,
+                },
+                fromAmount: '41391997',
+                vaultAddress: '',
+                routerAddress: '',
+                expirationTime: 0n,
+              },
+            },
+          }),
+          walletCore,
+        })
+
+      expect(resolve).toThrow('Unsupported secured asset chain prefix')
+    }
+  )
 })

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
@@ -5,7 +5,10 @@ import { resolveCosmosGasFee } from '@vultisig/core-chain/chains/cosmos/resolveC
 import { getCosmosChainKind } from '@vultisig/core-chain/chains/cosmos/utils/getCosmosChainKind'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { areEqualCoins } from '@vultisig/core-chain/coin/Coin'
-import { nativeSwapChainIds } from '@vultisig/core-chain/swap/native/NativeSwapChain'
+import {
+  getNativeSwapChainIdFromDenomPrefix,
+  nativeSwapChainIds,
+} from '@vultisig/core-chain/swap/native/NativeSwapChain'
 import { THORChainSpecific, TransactionType } from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
 import { fromBase64 } from '@cosmjs/encoding'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
@@ -81,10 +84,14 @@ const isSecuredAssetSwapCoin = (assetCoin: { chain: string; contractAddress?: st
 // secured asset referenced by the server-issued swap memo (`=:ETH-USDC:…`).
 const getSecuredAssetDepositAsset = (assetCoin: { contractAddress: string; ticker: string }) => {
   const [chainPrefix, ...symbolParts] = assetCoin.contractAddress.split('-')
+  const chainId = getNativeSwapChainIdFromDenomPrefix(chainPrefix)
+  if (!chainId) {
+    throw new Error(`Unsupported secured asset chain prefix: "${chainPrefix}"`)
+  }
   const symbol = symbolParts.join('-')
 
   return TW.Cosmos.Proto.THORChainAsset.create({
-    chain: chainPrefix.toUpperCase(),
+    chain: chainId,
     symbol: (symbol || assetCoin.ticker).toUpperCase(),
     ticker: assetCoin.ticker.toUpperCase().replace(/X\//g, ''),
     synth: false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Secured-asset signing now rejects deposits that use unsupported or non-canonical chain prefixes.
  - Native swap asset denom prefixes are interpreted case-insensitively for consistent chain resolution.
  - Prevents incorrect chain values from being included in secured-asset deposit payloads.

- **Tests**
  - Added parameterized coverage for secured assets using invalid chain prefixes and verified the correct “unsupported prefix” error is thrown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->