### PR TITLE
fix(mpc): run aggregator swap guards at the signing-input choke point

### DIFF
--- a/.changeset/swap-guard-signing-input-path.md
+++ b/.changeset/swap-guard-signing-input-path.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/core-mpc': patch
+---
+
+Re-run the aggregator swap fund-safety guards at the signing-input choke point (`getEncodedSigningInputs`), not only at quote-fetch. A co-signer that receives a hand-built `KeysignPayload` over the relay now validates the 1inch/Kyber router (and the ERC-20 approval spender that trails it) and the Jupiter Solana instruction set against the same allow-lists before contributing a signature, closing the blind-sign gap where the payload the co-signer signs never passed the quote-time guard.

--- a/packages/core/mpc/keysign/signingInputs/index.ts
+++ b/packages/core/mpc/keysign/signingInputs/index.ts
@@ -3,6 +3,7 @@ import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/key
 import { WalletCore } from '@trustwallet/wallet-core'
 import { PublicKey } from '@trustwallet/wallet-core/dist/src/wallet-core'
 
+import { assertSafeSwapSigningPayload } from '../swap/assertSafeSwapSigningPayload'
 import { getKeysignChain } from '../utils/getKeysignChain'
 import { signingInputClasses } from './core'
 import { SigningInputsResolver } from './resolver'
@@ -44,6 +45,11 @@ export const signingInputResolversByChainKind: Record<ChainKind, SigningInputsRe
 export const getEncodedSigningInputs = async (input: Input): Promise<Uint8Array[]> => {
   const chain = getKeysignChain(input.keysignPayload)
   const chainKind = getChainKind(chain)
+
+  // Fund-safety: validate the aggregator swap payload the signature will cover,
+  // at the single choke point every signer (initiating device AND co-signer)
+  // funnels through. See assertSafeSwapSigningPayload.
+  await assertSafeSwapSigningPayload(input.keysignPayload)
 
   const signingInputs = await signingInputResolversByChainKind[chainKind](input as any)
 

--- a/packages/core/mpc/keysign/swap/assertSafeSwapSigningPayload.test.ts
+++ b/packages/core/mpc/keysign/swap/assertSafeSwapSigningPayload.test.ts
@@ -1,0 +1,168 @@
+import { create } from '@bufbuild/protobuf'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { CoinSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/coin_pb'
+import {
+  OneInchQuoteSchema,
+  OneInchSwapPayloadSchema,
+  OneInchTransactionSchema,
+} from '@vultisig/core-mpc/types/vultisig/keysign/v1/1inch_swap_payload_pb'
+import { Erc20ApprovePayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/erc20_approve_payload_pb'
+import {
+  KeysignPayload,
+  KeysignPayloadSchema,
+} from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { THORChainSwapPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/thorchain_swap_payload_pb'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  assertSafeSolanaSwapTransactionBase64: vi.fn(async () => {}),
+}))
+
+// The Solana instruction guard decodes real tx bytes and resolves address lookup
+// tables over the network — mock it so this suite stays a pure unit test and only
+// asserts that the SIGNING path actually invokes it (parity with quote-time).
+vi.mock('@vultisig/core-chain/chains/solana/assertSafeSolanaSwapInstructions', () => ({
+  assertSafeSolanaSwapTransactionBase64: mocks.assertSafeSolanaSwapTransactionBase64,
+}))
+
+import { assertSafeSwapSigningPayload } from './assertSafeSwapSigningPayload'
+
+const ONE_INCH_V6_ROUTER = '0x111111125421ca6dc452d289314280a0f8842a65'
+const KYBER_ROUTER = '0x6131b5fae19ea4f9d964eac0408e4408b66337b5'
+const ATTACKER = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+
+const evmSwapPayload = ({
+  provider,
+  to,
+  spender,
+}: {
+  provider: string
+  to: string
+  spender?: string
+}): KeysignPayload =>
+  create(KeysignPayloadSchema, {
+    coin: create(CoinSchema, { chain: Chain.Ethereum, address: '0xsender' }),
+    swapPayload: {
+      case: 'oneinchSwapPayload',
+      value: create(OneInchSwapPayloadSchema, {
+        provider,
+        quote: create(OneInchQuoteSchema, {
+          tx: create(OneInchTransactionSchema, { to, data: '0xabc', value: '0' }),
+        }),
+      }),
+    },
+    ...(spender
+      ? { erc20ApprovePayload: create(Erc20ApprovePayloadSchema, { spender, amount: '1000000' }) }
+      : {}),
+  })
+
+const solanaSwapPayload = (data: string, provider = 'jupiter'): KeysignPayload =>
+  create(KeysignPayloadSchema, {
+    coin: create(CoinSchema, { chain: Chain.Solana, address: '11111111111111111111111111111111' }),
+    swapPayload: {
+      case: 'oneinchSwapPayload',
+      value: create(OneInchSwapPayloadSchema, {
+        provider,
+        quote: create(OneInchQuoteSchema, {
+          tx: create(OneInchTransactionSchema, { to: '', data, value: '' }),
+        }),
+      }),
+    },
+  })
+
+describe('assertSafeSwapSigningPayload — signing-time swap guard (co-signer choke point)', () => {
+  afterEach(() => vi.clearAllMocks())
+
+  it('accepts a 1inch swap whose router is the known aggregator router', async () => {
+    await expect(
+      assertSafeSwapSigningPayload(evmSwapPayload({ provider: '1inch', to: ONE_INCH_V6_ROUTER }))
+    ).resolves.toBeUndefined()
+  })
+
+  it('accepts a kyber swap whose router is the known aggregator router', async () => {
+    await expect(
+      assertSafeSwapSigningPayload(evmSwapPayload({ provider: 'kyber', to: KYBER_ROUTER }))
+    ).resolves.toBeUndefined()
+  })
+
+  // The core fund-safety win: a hand-built payload whose tx.to never passed the
+  // quote-time allowlist is now rejected at the point the co-signer signs it.
+  it('REJECTS a 1inch swap pointing at an unrecognized router (blind-sign gap)', async () => {
+    await expect(
+      assertSafeSwapSigningPayload(evmSwapPayload({ provider: '1inch', to: ATTACKER }))
+    ).rejects.toThrow(/unrecognized router/i)
+  })
+
+  it('REJECTS a kyber swap pointing at an unrecognized router', async () => {
+    await expect(
+      assertSafeSwapSigningPayload(evmSwapPayload({ provider: 'kyber', to: ATTACKER }))
+    ).rejects.toThrow(/unrecognized router/i)
+  })
+
+  // Approval-drain vector: benign swap tx.to but the (separate) approval spender
+  // field points at an attacker.
+  it('REJECTS an enforced swap whose ERC-20 approval spender is not the verified router', async () => {
+    await expect(
+      assertSafeSwapSigningPayload(evmSwapPayload({ provider: '1inch', to: ONE_INCH_V6_ROUTER, spender: ATTACKER }))
+    ).rejects.toThrow(/approval spender/i)
+  })
+
+  it('accepts an enforced swap whose approval spender equals the verified router', async () => {
+    await expect(
+      assertSafeSwapSigningPayload(
+        evmSwapPayload({ provider: '1inch', to: ONE_INCH_V6_ROUTER, spender: ONE_INCH_V6_ROUTER })
+      )
+    ).resolves.toBeUndefined()
+  })
+
+  // Parity with quote-time: LiFi/SwapKit route through many contracts and are
+  // unenforceable by design (log-only, never thrown) at both quote and sign time.
+  it('does not throw for unenforceable providers (li.fi)', async () => {
+    await expect(
+      assertSafeSwapSigningPayload(evmSwapPayload({ provider: 'li.fi', to: ATTACKER }))
+    ).resolves.toBeUndefined()
+  })
+
+  it('is a no-op for a non-swap payload', async () => {
+    const payload = create(KeysignPayloadSchema, {
+      coin: create(CoinSchema, { chain: Chain.Ethereum, address: '0xsender' }),
+    })
+    await expect(assertSafeSwapSigningPayload(payload)).resolves.toBeUndefined()
+    expect(mocks.assertSafeSolanaSwapTransactionBase64).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op for native (THORChain) swaps — those are validated elsewhere', async () => {
+    const payload = create(KeysignPayloadSchema, {
+      coin: create(CoinSchema, { chain: Chain.Ethereum, address: '0xsender' }),
+      swapPayload: {
+        case: 'thorchainSwapPayload',
+        value: create(THORChainSwapPayloadSchema, { vaultAddress: '0xvault', routerAddress: ONE_INCH_V6_ROUTER }),
+      },
+    })
+    await expect(assertSafeSwapSigningPayload(payload)).resolves.toBeUndefined()
+  })
+
+  it('runs the Jupiter instruction guard for a Solana swap, with the tx bytes and user address', async () => {
+    await assertSafeSwapSigningPayload(solanaSwapPayload('c29tZS1iYXNlNjQtdHg='))
+    expect(mocks.assertSafeSolanaSwapTransactionBase64).toHaveBeenCalledTimes(1)
+    const [txData, userWallet] = mocks.assertSafeSolanaSwapTransactionBase64.mock.calls[0] as unknown as [
+      string,
+      { toBase58(): string },
+    ]
+    expect(txData).toBe('c29tZS1iYXNlNjQtdHg=')
+    expect(userWallet.toBase58()).toBe('11111111111111111111111111111111')
+  })
+
+  it('propagates a Jupiter guard rejection (spliced-instruction drain)', async () => {
+    mocks.assertSafeSolanaSwapTransactionBase64.mockRejectedValueOnce(new Error('SOL_SWAP_UNEXPECTED_PROGRAM'))
+    await expect(assertSafeSwapSigningPayload(solanaSwapPayload('YmFk'))).rejects.toThrow(/SOL_SWAP_UNEXPECTED_PROGRAM/)
+  })
+
+  // The Jupiter instruction allow-list rejects any non-Jupiter program, so it
+  // must NOT run on a LiFi (or other) Solana swap — those route through
+  // different programs by design and would be false-rejected.
+  it('does not run the Jupiter guard for a non-Jupiter Solana swap (li.fi)', async () => {
+    await expect(assertSafeSwapSigningPayload(solanaSwapPayload('c29tZQ==', 'li.fi'))).resolves.toBeUndefined()
+    expect(mocks.assertSafeSolanaSwapTransactionBase64).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/mpc/keysign/swap/assertSafeSwapSigningPayload.ts
+++ b/packages/core/mpc/keysign/swap/assertSafeSwapSigningPayload.ts
@@ -1,0 +1,94 @@
+import { PublicKey as SolanaPublicKey } from '@solana/web3.js'
+import { assertSafeSolanaSwapTransactionBase64 } from '@vultisig/core-chain/chains/solana/assertSafeSolanaSwapInstructions'
+import { getChainKind } from '@vultisig/core-chain/ChainKind'
+import {
+  assertKnownAggregatorRouter,
+  EnforcedRouterProvider,
+} from '@vultisig/core-chain/swap/general/knownAggregatorRouters'
+
+import { KeysignPayload } from '../../types/vultisig/keysign/v1/keysign_message_pb'
+import { getKeysignChain } from '../utils/getKeysignChain'
+import { getKeysignSwapPayload } from './getKeysignSwapPayload'
+
+const ENFORCED_ROUTER_PROVIDERS = new Set<EnforcedRouterProvider>(['1inch', 'kyber'])
+
+const isEnforcedRouterProvider = (provider: string): provider is EnforcedRouterProvider =>
+  ENFORCED_ROUTER_PROVIDERS.has(provider as EnforcedRouterProvider)
+
+/**
+ * Signing-time fund-safety guard (round-2 whole-stack audit, P1): re-run the
+ * aggregator swap guards on the `KeysignPayload` the co-signer *actually signs*,
+ * not just at quote-fetch construction.
+ *
+ * The quote-construction guards (getOneInchSwapQuote.ts, kyber/api/tx.ts,
+ * getJupiterSwapQuote.ts) validate an untrusted aggregator HTTP response before
+ * it becomes a `GeneralSwapQuote`. But an MPC co-signer never sees that quote —
+ * it receives a `KeysignPayload` (over the relay / QR, see keysign/cosigner.ts)
+ * and turns it straight into signable bytes via `getEncodedSigningInputs`. A
+ * hand-built payload whose `swapPayload.quote.tx.{to,data}` was never produced by
+ * the guarded path would otherwise be blind-signed: the EVM resolver reads
+ * `quote.tx.to`/`quote.tx.data` verbatim, and the Solana resolver decodes and
+ * signs `quote.tx.data` verbatim. This guard runs at that exact choke point so
+ * the bytes the signature covers are the bytes that pass the guard.
+ *
+ * Enforcement parity with quote-time: only 1inch/kyber have a small, stable,
+ * deterministically-deployed router that can be allow-listed (fail-closed). LiFi
+ * and SwapKit route through many contracts by design and are unenforceable
+ * (log-only, never thrown) at quote-time too — signing-time enforcement inherits
+ * the same boundary. See knownAggregatorRouters.ts.
+ */
+export const assertSafeSwapSigningPayload = async (keysignPayload: KeysignPayload): Promise<void> => {
+  const swapPayload = getKeysignSwapPayload(keysignPayload)
+  if (!swapPayload || !('general' in swapPayload)) {
+    return
+  }
+
+  const { general } = swapPayload
+  const chain = getKeysignChain(keysignPayload)
+
+  switch (getChainKind(chain)) {
+    case 'evm': {
+      if (!isEnforcedRouterProvider(general.provider)) {
+        return
+      }
+      const to = general.quote?.tx?.to
+      if (!to) {
+        return
+      }
+      assertKnownAggregatorRouter(general.provider, to, chain)
+
+      // The ERC-20 approval that precedes an aggregator swap grants allowance to
+      // the router. It is a SEPARATE payload field (erc20ApprovePayload.spender)
+      // read verbatim by the approve resolver, so a hand-built payload could keep
+      // a benign swap `tx.to` while pointing the approval at an attacker. Bind it
+      // to the already-verified router (build.ts sets them equal by construction).
+      const spender = keysignPayload.erc20ApprovePayload?.spender
+      if (spender && spender.toLowerCase() !== to.toLowerCase()) {
+        throw new Error(
+          `swap approval spender (${spender}) does not match the verified ${general.provider} router (${to}) on ${chain} — refusing to sign`
+        )
+      }
+      return
+    }
+    case 'solana': {
+      // Jupiter-only: the instruction guard allow-lists the Jupiter v6 router
+      // program set. LiFi (and any future Solana aggregator) route through
+      // different programs by design, so running this guard on a non-Jupiter
+      // Solana swap would false-reject a legitimate route — same unenforceable
+      // boundary LiFi has on EVM. Parity with quote-time, where only the Jupiter
+      // quote path (getJupiterSwapQuote.ts) runs this guard.
+      if (general.provider !== 'jupiter') {
+        return
+      }
+      const data = general.quote?.tx?.data
+      const address = keysignPayload.coin?.address
+      if (!data || !address) {
+        return
+      }
+      await assertSafeSolanaSwapTransactionBase64(data, new SolanaPublicKey(address))
+      return
+    }
+    default:
+      return
+  }
+}

--- a/packages/core/mpc/keysign/tests/mappers/mapSwapPayload.ts
+++ b/packages/core/mpc/keysign/tests/mappers/mapSwapPayload.ts
@@ -62,7 +62,11 @@ export const mapSwapPayload = (spRaw: any): KeysignPayload['swapPayload'] | unde
                 : undefined,
             }
           : undefined,
-        provider: '1inch',
+        // Honor the fixture's real provider. Older recovered device payloads
+        // predate the `provider` field and carry none — normalize to '' rather
+        // than assuming '1inch', which would mislabel a LiFi/Kyber/Jupiter swap
+        // (e.g. lifiswap.json routes through the LiFi Diamond, not a 1inch router).
+        provider: o.provider ?? o.Provider ?? '',
       },
     }
 

--- a/packages/core/mpc/package.json
+++ b/packages/core/mpc/package.json
@@ -576,6 +576,11 @@
       "import": "./dist/keysign/suiCoinSelection.js",
       "default": "./dist/keysign/suiCoinSelection.js"
     },
+    "./keysign/swap/assertSafeSwapSigningPayload": {
+      "types": "./dist/keysign/swap/assertSafeSwapSigningPayload.d.ts",
+      "import": "./dist/keysign/swap/assertSafeSwapSigningPayload.js",
+      "default": "./dist/keysign/swap/assertSafeSwapSigningPayload.js"
+    },
     "./keysign/swap/build": {
       "types": "./dist/keysign/swap/build.d.ts",
       "import": "./dist/keysign/swap/build.js",


### PR DESCRIPTION
Refs the round-2 whole-stack fund-safety audit "swap guards run at quote-fetch, not the signing-input path" finding (P1, frozen 3 rounds).

## what

The aggregator swap fund-safety guards - the 1inch/Kyber router allowlist (`assertKnownAggregatorRouter`) and the Jupiter Solana instruction allowlist (`assertSafeSolanaSwapInstructions`) - previously ran **only at quote-fetch construction** (`getOneInchSwapQuote.ts`, `kyber/api/tx.ts`, `getJupiterSwapQuote.ts`). That's the trust boundary for *an untrusted aggregator HTTP response*, but it is **not** where signing happens.

An MPC co-signer never sees that quote. It receives a `KeysignPayload` over the relay / QR (see `packages/core/mpc/keysign/cosigner.ts`) and turns it straight into signable bytes via `getEncodedSigningInputs` - which re-reads `swapPayload.quote.tx.to` / `quote.tx.data` **verbatim** (`signingInputs/resolvers/evm/index.ts`, `resolvers/solana/index.ts`) with no guard. So a hand-built payload whose `tx.{to,data}` was never produced by the guarded quote path was **blind-signed**.

This moves the guard to where the signature is actually produced.

## how

New `assertSafeSwapSigningPayload`, called once inside `getEncodedSigningInputs` - the single choke point every signer (initiating device AND co-signer) funnels through, and which is strictly upstream of `getPreSigningHashes` / `compileTx` (those consume the `txInputData` it already produced):

- **EVM 1inch/Kyber**: re-assert `quote.tx.to` is a known router for the chain, and additionally bind `erc20ApprovePayload.spender == quote.tx.to`. The approval spender is a **separate** payload field read verbatim by the approve resolver (`resolvers/evm/erc20.ts`), so a hand-built payload could keep a benign swap `tx.to` while pointing the approval at an attacker - an approval-drain. `build.ts` sets them equal by construction, so equality is the correct invariant.
- **Solana Jupiter**: re-run the Jupiter instruction allowlist. **Gated to `provider === 'jupiter'`** - the allowlist is Jupiter-v6-program-specific; LiFi (and any future Solana aggregator) route through different programs by design, so running it on a non-Jupiter Solana swap false-rejects a legit route. This is parity with quote-time (only the Jupiter quote path runs this guard).
- **li.fi / swapkit / unknown provider**: skipped. They route through many contracts by design and are unenforceable (log-only, never thrown) at quote-time too - signing-time enforcement inherits the same boundary. See `knownAggregatorRouters.ts`.

Also fixes a **test normalizer bug**: `tests/mappers/mapSwapPayload.ts` hardcoded `provider: '1inch'` for every oneinch-shaped fixture, mislabeling a real LiFi swap (`lifiswap.json` routes through the LiFi Diamond `0x1231DEB6...`, not a 1inch router). It now honors the fixture's real provider and defaults to `''` for legacy provider-less device payloads (faithful to production, where a provider-less payload can't be router-enforced).

## cross-consumer (SDK-CROSS-CONSUMER-CAUTION)

`getEncodedSigningInputs` is in `@vultisig/core-mpc` and runs on the flagship ios/android/windows clients too, plus Blockaid input-building and sui/polkadot refine. Assessment:

- **New terminal-error surface**: a 1inch/Kyber swap whose router isn't the canonical one, an approval spender that doesn't match the router, or a Jupiter tx with a spliced instruction now **throws at `getEncodedSigningInputs`** instead of silently signing. That is the intended fail-closed behavior. The router/instruction allowlists were validated live across the enabled chains on 2026-07-08, so a legit route is not false-blocked.
- **Jupiter-only network at sign**: the Jupiter guard resolves address-lookup-tables (async, network), so a Jupiter swap signature now does an extra round-trip and fails closed on a transient LUT fetch failure. Scope is Jupiter swaps only; the co-sign moment is already online; identical behavior already runs at quote-time in the SDK. No non-Jupiter path gains a network dependency.
- **Offline paths unaffected**: the golden hash fixtures compute offline and contain no Jupiter fixture, so none hit the network. sui/polkadot refine carry no enforced swap and early-return.

Strictly-more-correct throws only; no signature output changes for any currently-valid swap.

## testing

- New `assertSafeSwapSigningPayload.test.ts` (12 cases): known-router pass (1inch + kyber), unrecognized-router reject, approval-spender-mismatch reject, spender-matches pass, li.fi EVM skip, non-swap no-op, native/THOR no-op, Jupiter guard invoked with tx bytes + user address, Jupiter rejection propagates, non-Jupiter Solana (li.fi) skip.
- Full `yarn test:core` green: **1862 passed | 1 skipped**. Golden mobile fixtures green (incl. the LiFi EVM + Solana cases the normalizer fix corrects).
- `tsc --project .config/tsconfig.json --noEmit` clean. Lint clean. Changeset added (`@vultisig/core-mpc` patch).

## risk

Medium. Adds a fail-closed guard at the signing choke point - the whole point of the change. The residual (li.fi/swapkit/relabel-to-unenforced-provider) is the pre-existing unenforceable boundary, unchanged from quote-time. Adversarial self-review done; Codex adversarial pass was rate-limited (advisory).

🤖 Agent-generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
