### PR TITLE
fix(swap): bind erc-20 approval spender to the verified router on the signing path

### DIFF
--- a/.changeset/swap-approval-spender-bind.md
+++ b/.changeset/swap-approval-spender-bind.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/core-mpc': patch
+---
+
+Bind the ERC-20 approval spender to the verified swap router on the co-signer signing-input path for enforced aggregator providers (1inch/kyber). Follow-up to the signing-path router guard: `quote.tx.to` was re-asserted, but `erc20ApprovePayload.spender` is a separate wire field the approve resolver reads verbatim, so a payload could pass the router check yet still carry an approve granting an attacker an allowance (approval-drain). The bind runs in the approve branch (where the field is still present) and requires `spender === quote.tx.to` for enforced providers; unenforced providers stay unbound (notably cowswap, whose spender is legitimately the GPv2VaultRelayer, not `tx.to`). Monotonic gate: throws or no-ops, never mutates signed bytes. Initiators set the two equal by construction, so only a hand-built/tampered payload trips it.

--- a/packages/core/chain/swap/general/knownAggregatorRouters.ts
+++ b/packages/core/chain/swap/general/knownAggregatorRouters.ts
@@ -101,6 +101,37 @@ export function assertKnownAggregatorRouterOnSigningPath(provider: string, addre
 }
 
 /**
+ * Signing-path approval-spender bind (sdk#1358 review follow-up, requested by neavra). The
+ * follow-on to {@link assertKnownAggregatorRouterOnSigningPath}: that guard validates the swap-leg
+ * destination (`quote.tx.to`), but a general swap that needs an allowance also carries a SEPARATE,
+ * independent wire field - `erc20ApprovePayload.spender` - which the approve resolver (erc20.ts)
+ * reads verbatim and nothing binds to `quote.tx.to`. So a payload can pass the router check with a
+ * genuine 1inch/kyber `tx.to` yet still carry an approve granting an ATTACKER an allowance over the
+ * user's token (a classic approval-drain the co-signer would otherwise sign blind).
+ *
+ * On the initiator these coincide by construction (build.ts sets the approve spender to
+ * `getSwapDestinationAddress` === `tx.to`), so this only ever fires on a hand-built/tampered payload.
+ * Enforced providers (1inch/kyber) MUST have `spender === routerDestination`; unenforced providers are
+ * NOT bound - notably cowswap, whose spender is legitimately the GPv2VaultRelayer, not `tx.to`. Like
+ * its sibling this is a MONOTONIC gate: it only throws or no-ops, never changes the signed bytes.
+ */
+export function assertEnforcedSwapApprovalSpenderBound(
+  provider: string,
+  spender: string,
+  routerDestination: string,
+  chain: Chain
+): void {
+  if (!ENFORCED_ROUTER_PROVIDERS.has(provider)) {
+    return
+  }
+  if (spender.toLowerCase() !== routerDestination.toLowerCase()) {
+    throw new Error(
+      `${provider} swap approval spender (${spender}) does not match the verified swap router (${routerDestination}) on ${chain} — refusing to sign an approval to an unbound spender.`
+    )
+  }
+}
+
+/**
  * Throws if `address` isn't the known router for `provider` on `chain`. Call this at quote
  * construction, before a GeneralSwapQuote carrying `address` as `tx.evm.to` can exist.
  */

--- a/packages/core/mpc/keysign/signingInputs/resolvers/evm/index.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/evm/index.ts
@@ -13,7 +13,10 @@ import { assertField } from '@vultisig/lib-utils/record/assertField'
 import { TW } from '@trustwallet/wallet-core'
 
 import { KeysignPayloadSchema } from '../../../../types/vultisig/keysign/v1/keysign_message_pb'
-import { assertKnownAggregatorRouterOnSigningPath } from '@vultisig/core-chain/swap/general/knownAggregatorRouters'
+import {
+  assertEnforcedSwapApprovalSpenderBound,
+  assertKnownAggregatorRouterOnSigningPath,
+} from '@vultisig/core-chain/swap/general/knownAggregatorRouters'
 
 import { getBlockchainSpecificValue } from '../../../chainSpecific/KeysignChainSpecific'
 import { getKeysignSwapPayload } from '../../../swap/getKeysignSwapPayload'
@@ -33,6 +36,22 @@ export const getEvmSigningInputs: SigningInputsResolver<'evm'> = async ({ keysig
   const { erc20ApprovePayload, ...restOfKeysignPayload } = keysignPayload
 
   if (erc20ApprovePayload) {
+    // sdk#1358 review follow-up: bind the approve spender to the verified swap router HERE, where
+    // erc20ApprovePayload is still present (the recursion below strips it, so the router guard's
+    // sibling can't see the spender). The router allow-list runs on quote.tx.to in that recursion;
+    // this binds the INDEPENDENT erc20ApprovePayload.spender field to it for enforced providers, so
+    // a payload can't pass the router check yet still approve an attacker. cowswap (relayer spender)
+    // and other unenforced providers are intentionally not bound. See assertEnforcedSwapApprovalSpenderBound.
+    const approveSwapPayload = getKeysignSwapPayload(keysignPayload)
+    if (approveSwapPayload && 'general' in approveSwapPayload) {
+      assertEnforcedSwapApprovalSpenderBound(
+        approveSwapPayload.general.provider,
+        erc20ApprovePayload.spender,
+        approveSwapPayload.general.quote?.tx?.to ?? '',
+        chain
+      )
+    }
+
     const approveSigningInput = getErc20ApproveSigningInput({
       keysignPayload,
       walletCore,

--- a/packages/core/mpc/keysign/signingInputs/resolvers/evm/swapRouterGuard.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/evm/swapRouterGuard.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@vultisig/core-mpc/types/vultisig/keysign/v1/1inch_swap_payload_pb'
 import { EthereumSpecificSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
 import { CoinSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/coin_pb'
+import { Erc20ApprovePayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/erc20_approve_payload_pb'
 import { KeysignPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
 import { beforeAll, describe, expect, it } from 'vitest'
 
@@ -83,5 +84,43 @@ describe('getEvmSigningInputs — sdk#1358 aggregator router guard on the signin
     })
 
     expect(inputs[0]?.toAddress).toBe(ONE_INCH_V6_ROUTER)
+  })
+})
+
+// sdk#1358 review follow-up (neavra): the router guard covers quote.tx.to, but the ERC-20 approval
+// spender is an INDEPENDENT wire field (erc20ApprovePayload.spender) the approve resolver reads
+// verbatim. A payload can pass the router check with a genuine router yet still approve an attacker -
+// a classic approval-drain the co-signer would sign blind. Bind spender === router for enforced providers.
+const buildApprovePayload = ({ routerTo, spender }: { routerTo: string; spender: string }) => {
+  const payload = buildPayload(routerTo)
+  payload.erc20ApprovePayload = create(Erc20ApprovePayloadSchema, { amount: '1000000', spender })
+  return payload
+}
+
+describe('getEvmSigningInputs — sdk#1358 approval-spender bind on the signing-input path', () => {
+  let walletCore: WalletCore
+
+  beforeAll(async () => {
+    walletCore = await initWasm()
+  })
+
+  it('throws when a 1inch swap carries a valid router but the approve spender is an attacker address', async () => {
+    await expect(
+      getEvmSigningInputs({
+        keysignPayload: buildApprovePayload({ routerTo: ONE_INCH_V6_ROUTER, spender: ATTACKER_ROUTER }),
+        walletCore,
+      })
+    ).rejects.toThrow(/approval spender .* does not match the verified swap router/i)
+  })
+
+  it('signs cleanly when the approve spender matches the verified router (approve + swap legs)', async () => {
+    const inputs = await getEvmSigningInputs({
+      keysignPayload: buildApprovePayload({ routerTo: ONE_INCH_V6_ROUTER, spender: ONE_INCH_V6_ROUTER }),
+      walletCore,
+    })
+
+    // [0] = ERC-20 approve leg, [1] = the swap leg targeting the router.
+    expect(inputs).toHaveLength(2)
+    expect(inputs[1]?.toAddress).toBe(ONE_INCH_V6_ROUTER)
   })
 })


### PR DESCRIPTION
Stacked on #1377 (base = its branch; GitHub retargets to `main` when #1377 merges). Closes the ERC-20 approval-spender follow-up neavra requested in the #1377 review.

## what

#1377 re-asserts the aggregator router allow-list on the co-signer signing path, but its own SCOPE comment (and neavra's review) flag that it covers the **swap-leg destination only** — `quote.tx.to`. The **ERC-20 approval spender** is a SEPARATE, independent wire field (`erc20ApprovePayload.spender`) that the approve resolver (`erc20.ts`) reads verbatim, and nothing bound it to `quote.tx.to`.

neavra red-proofed the gap on #1377: a payload with `provider:'1inch'` + a genuine 1inch router as `quote.tx.to` (so the router guard **passes**) + `erc20ApprovePayload.spender = 0x…dEaD` → **no throw**; `inputs[0]` is an ERC-20 approve granting the attacker an allowance over the user's token, while `inputs[1]` still targets the real router so nothing else looks wrong. A classic approval-drain the co-signer signs blind.

## how

Bind `spender === quote.tx.to` for enforced providers (1inch/kyber), via `assertEnforcedSwapApprovalSpenderBound`, called in the **approve branch** of `getEvmSigningInputs` — the one place `erc20ApprovePayload` is still present (the recursion strips it before #1377's router guard runs on the swap leg). Combined with #1377's `tx.to` allow-list, the spender is provably the canonical router.

- **Unenforced providers stay unbound** — notably **cowswap**, whose spender is legitimately the `GPv2VaultRelayer`, not `tx.to`. Gating on the enforced set skips it (same reason its router isn't allow-listed).
- **Native (thorchain/maya) swaps** are `'native'`, not `'general'` → skipped (they have their own vault validation, e.g. the native-swap broadcast guard).
- **Plain token approves** (no general swap payload) → skipped.
- **Monotonic gate**: throws or no-ops, never mutates signed bytes → cannot desync the cross-device pre-signing hash. Same `provider`-is-a-free-string threat model as #1377: spoofing to an unenforced value degrades to the pre-fix state, not a new bypass.

## cross-consumer (SDK-CROSS-CONSUMER-CAUTION)

`@vultisig/core-chain` + `@vultisig/core-mpc` ship to the flagship ios/android/windows clients. This adds a **new fail-closed throw** for an enforced-provider swap whose approve spender ≠ the router. On the initiator, `build.ts` sets the approve spender to `getSwapDestinationAddress` === `tx.to` by construction, so the two are always equal for a legitimately-produced swap → **no false-block**. Only a hand-built/tampered payload trips it. Strictly-more-correct.

## testing

- +2 cases in #1377's `swapRouterGuard.test.ts`: valid router + attacker spender → rejects (`approval spender … does not match the verified swap router`); spender === router → signs cleanly (approve + swap legs, 2 inputs).
- Full `yarn test:core`: **1857 passed | 1 skipped**. `tsc` + eslint clean. Changeset: `core-chain` + `core-mpc` patch.
- Opus adversarial self-review (codex capped til Jul 25): enumerated relabel-bypass (monotonic, not new), cowswap/native/plain-approve skips, empty-tx.to fail-closed, address casing.

## risk

Low, fund-safety-positive. Additive fail-closed bind on a field already on the payload; no wire/encoder change; no false-block for any initiator-produced swap.

🤖 Agent-generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
