### PR TITLE
fix(sdk): raw cosmos broadcast reports false success on delivertx failure

### DIFF
--- a/.changeset/rawbroadcast-cosmos-delivertx-false-success.md
+++ b/.changeset/rawbroadcast-cosmos-delivertx-false-success.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Fix `vault.broadcastRawTx` reporting a false success for a Cosmos transaction that was included but failed execution. `RawBroadcastService.broadcastCosmosRawTx` returned `result.transactionHash` whenever `StargateClient.broadcastTx` didn't throw, but that client resolves (does not throw) once a tx is included even when DeliverTx failed (`code !== 0` — out-of-gas, wasm revert, a THORChain/Maya deposit-handler rejection). The tx is on-chain but nothing moved, so the raw path now asserts DeliverTx success and throws `BroadcastFailed` on execution failure, matching the signing-input broadcast resolver (#1316).

--- a/packages/sdk/src/vault/services/RawBroadcastService.ts
+++ b/packages/sdk/src/vault/services/RawBroadcastService.ts
@@ -1,3 +1,4 @@
+import { assertIsDeliverTxSuccess } from '@cosmjs/stargate'
 import { Chain, CosmosChain, EvmChain, OtherChain, UtxoBasedChain } from '@vultisig/core-chain/Chain'
 import { isChainOfKind } from '@vultisig/core-chain/ChainKind'
 import { bittensorRpcUrl } from '@vultisig/core-chain/chains/bittensor/client'
@@ -272,6 +273,24 @@ export class RawBroadcastService {
     }
 
     if (!result) throw new Error('No broadcast result returned')
+
+    // `StargateClient.broadcastTx` RESOLVES (does not throw) once the tx is included in a block,
+    // even when execution failed (DeliverTx `code !== 0` — out-of-gas, wasm revert, a THORChain/Maya
+    // deposit-handler rejection). The tx is on-chain but nothing moved, so returning its hash here
+    // would be a false success. The signing-input broadcast resolver (tx/broadcast/resolvers/cosmos.ts,
+    // #1316) already asserts this; this raw path — reachable via the public `vault.broadcastRawTx` —
+    // must fail closed the same way.
+    try {
+      assertIsDeliverTxSuccess(result)
+    } catch (deliverTxError) {
+      const message = deliverTxError instanceof Error ? deliverTxError.message : String(deliverTxError)
+      throw new VaultError(
+        VaultErrorCode.BroadcastFailed,
+        `Cosmos transaction was included but execution failed: ${message}`,
+        deliverTxError instanceof Error ? deliverTxError : new Error(message)
+      )
+    }
+
     return result.transactionHash
   }
 

--- a/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
+++ b/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
@@ -165,6 +165,27 @@ describe('RawBroadcastService', () => {
     expect(mockGetCosmosClient).toHaveBeenCalledWith(Chain.Osmosis)
   })
 
+  // Fund-safety: StargateClient.broadcastTx RESOLVES (does not throw) on a tx that was included but
+  // failed execution (DeliverTx code !== 0). The raw path must not report that as a success hash.
+  it('throws instead of returning a hash when the Cosmos tx is included but DeliverTx-fails', async () => {
+    mockCosmosBroadcastTx.mockResolvedValueOnce({
+      transactionHash: 'reverted-hash',
+      code: 5,
+      height: 100,
+      rawLog: 'out of gas: gasWanted: 200000, gasUsed: 250000',
+    })
+
+    await expect(
+      service.broadcastRawTx({
+        chain: Chain.Cosmos,
+        rawTx: JSON.stringify({ tx_bytes: Buffer.from([1, 2, 3]).toString('base64') }),
+      })
+    ).rejects.toMatchObject({
+      code: VaultErrorCode.BroadcastFailed,
+      message: expect.stringContaining('execution failed'),
+    })
+  })
+
   it('rejects Sui payload missing unsignedTx or signature', async () => {
     await expect(
       service.broadcastRawTx({


### PR DESCRIPTION
Found in the R2 SDK fund-safety audit (broadcast false-success class).

## what

`vault.broadcastRawTx({ chain, rawTx })` → `RawBroadcastService.broadcastCosmosRawTx` reported a **false success** for a Cosmos transaction that was included in a block but **failed execution**.

## why

`StargateClient.broadcastTx` **resolves** (does not throw) once a tx is included, even when DeliverTx failed (`code !== 0` — out-of-gas, wasm revert, a THORChain/Maya deposit-handler rejection). The raw path returned `result.transactionHash` whenever the client didn't throw (`RawBroadcastService.ts:275`), so a reverted cosmos tx came back as a success hash — the tx is on-chain but nothing moved, and the caller (agent / SDK consumer) is told it succeeded.

The signing-input broadcast resolver (`tx/broadcast/resolvers/cosmos.ts:32-42`) already asserts DeliverTx success — that's the **#1316** fix. But this raw path **reimplements** broadcast without it. Same class the R2 audit found still open on the QBTC send resolver (separate PR incoming).

## how

`assertIsDeliverTxSuccess(result)` before returning the hash; throw `VaultError(BroadcastFailed)` on execution failure. `assertIsDeliverTxSuccess` uses `!!result.code`, so a successful tx (`code: 0` or absent) is unaffected — only a genuine `code !== 0` inclusion now fails closed.

## testing

- New regression test: a `code: 5` (out-of-gas) included tx now throws `BroadcastFailed` ("execution failed") instead of returning `reverted-hash`. Existing cosmos raw-broadcast tests unchanged (their mocks have no `code`, i.e. success).
- Full sdk unit suite green; `tsc` + eslint clean. Changeset: `@vultisig/sdk` patch.

## cross-consumer

`@vultisig/sdk` ships to flagship clients. Strictly-more-correct fail-closed: turns a silent broadcast-of-a-reverted-tx into a clear `BroadcastFailed`. No behavior change for a successful tx.

## risk

Low, fund-safety-positive. One added assertion on the raw cosmos path; the signing-input path already behaves this way.

🤖 Agent-generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cosmos raw transaction broadcasts now report failure when on-chain execution fails, rather than incorrectly indicating success.
  * Failed broadcasts provide a clear execution-failed error and no longer return a transaction hash as a successful result.

* **Tests**
  * Added coverage to verify that reverted Cosmos transactions are rejected correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->