### PR TITLE
fix(bittensor): don't assume success on a malformed rpc response

### DIFF
--- a/.changeset/bittensor-malformed-response-false-success.md
+++ b/.changeset/bittensor-malformed-response-false-success.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/core-chain': patch
+---
+
+Fix the Bittensor broadcast assuming success on a malformed RPC response. `broadcastBittensorTx` only inspected `response.error`; a body with neither `error` nor `result` (truncated / malformed gateway response) fell through and returned `undefined` — reported as a successful broadcast. It now forces hash verification when `result` is absent, mirroring the Polkadot resolver's JSON-RPC 2.0 guard.

--- a/packages/core/chain/tx/broadcast/resolvers/bittensor.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/bittensor.test.ts
@@ -10,6 +10,7 @@ vi.mock('../verifyBroadcastByHash', () => ({ verifyBroadcastByHash: mocks.verify
 vi.mock('@vultisig/core-chain/chains/bittensor/client', () => ({ bittensorRpcUrl: 'https://bittensor.test' }))
 
 import { OtherChain } from '../../../Chain'
+import { isTransientBroadcastError } from '../transientRetry'
 import { broadcastBittensorTx } from './bittensor'
 
 describe('broadcastBittensorTx', () => {
@@ -41,5 +42,21 @@ describe('broadcastBittensorTx', () => {
     mocks.queryUrl.mockResolvedValue({})
     await broadcastBittensorTx({ chain, tx })
     expect(mocks.verifyBroadcastByHash).toHaveBeenCalledOnce()
+  })
+
+  // #1430-class retry-interlock: bittensor runs inside `withTransientBroadcastRetry`
+  // (index.ts hasResolverOwnedRetry = evm|solana only). When hash verification
+  // cannot confirm the tx, verifyBroadcastByHash rethrows the original error and
+  // it escapes to the retry wrapper. That error MUST be classified non-transient
+  // so a genuinely-failed/unconfirmed broadcast is not silently re-sent up to 3×.
+  it('surfaces the malformed-response failure as a NON-transient error (must not be re-broadcast)', async () => {
+    mocks.queryUrl.mockResolvedValue({})
+    // Simulate verification unable to confirm the tx on-chain → rethrow.
+    mocks.verifyBroadcastByHash.mockImplementation(async ({ error }) => {
+      throw error
+    })
+    await expect(broadcastBittensorTx({ chain, tx })).rejects.toThrow(/missing extrinsic hash/)
+    const err = await broadcastBittensorTx({ chain, tx }).catch(e => e)
+    expect(isTransientBroadcastError(err)).toBe(false)
   })
 })

--- a/packages/core/chain/tx/broadcast/resolvers/bittensor.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/bittensor.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  queryUrl: vi.fn(),
+  verifyBroadcastByHash: vi.fn(),
+}))
+
+vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({ queryUrl: mocks.queryUrl }))
+vi.mock('../verifyBroadcastByHash', () => ({ verifyBroadcastByHash: mocks.verifyBroadcastByHash }))
+vi.mock('@vultisig/core-chain/chains/bittensor/client', () => ({ bittensorRpcUrl: 'https://bittensor.test' }))
+
+import { OtherChain } from '../../../Chain'
+import { broadcastBittensorTx } from './bittensor'
+
+describe('broadcastBittensorTx', () => {
+  const tx = { encoded: new Uint8Array([0x84, 0x00, 0x01]) } as never
+  const chain = OtherChain.Bittensor
+
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns silently when the node accepts the extrinsic (result present)', async () => {
+    mocks.queryUrl.mockResolvedValue({ result: '0xhash' })
+    await expect(broadcastBittensorTx({ chain, tx })).resolves.toBeUndefined()
+    expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
+  })
+
+  it('swallows the idempotent "Already Imported" peer-race error', async () => {
+    mocks.queryUrl.mockResolvedValue({ error: { code: 1013, message: 'Transaction Already Imported' } })
+    await expect(broadcastBittensorTx({ chain, tx })).resolves.toBeUndefined()
+    expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
+  })
+
+  it('verifies by hash on a genuine error', async () => {
+    mocks.queryUrl.mockResolvedValue({ error: { code: 1010, message: 'Invalid Transaction' } })
+    await broadcastBittensorTx({ chain, tx })
+    expect(mocks.verifyBroadcastByHash).toHaveBeenCalledOnce()
+  })
+
+  // The gap: a malformed/truncated body with neither error nor result used to return undefined = success.
+  it('does NOT assume success on a malformed response (neither error nor result) — verifies by hash', async () => {
+    mocks.queryUrl.mockResolvedValue({})
+    await broadcastBittensorTx({ chain, tx })
+    expect(mocks.verifyBroadcastByHash).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/core/chain/tx/broadcast/resolvers/bittensor.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/bittensor.ts
@@ -31,5 +31,14 @@ export const broadcastBittensorTx: BroadcastTxResolver<OtherChain.Bittensor> = a
     }
     const err = new Error(`Bittensor broadcast failed: ${message || `code ${response.error.code}`}`)
     await verifyBroadcastByHash({ chain, tx, error: err })
+    return
+  }
+
+  // Per JSON-RPC 2.0 a valid response carries exactly one of `result` / `error`. Neither present
+  // (malformed / truncated gateway body) must NOT be assumed a success — force hash verification.
+  // Mirrors the polkadot resolver's guard; without it a truncated body returned `undefined` = success.
+  if (!response.result) {
+    const err = new Error('Bittensor broadcast failed: missing extrinsic hash in RPC response')
+    await verifyBroadcastByHash({ chain, tx, error: err })
   }
 }


### PR DESCRIPTION
R2 broadcast-audit LOW. Last of the reported broadcast false-success cluster.

## what

`broadcastBittensorTx` only inspected `response.error`. A JSON-RPC body with **neither** `error` **nor** `result` — a truncated / malformed gateway response — fell through the error block and returned `undefined`, which the broadcast layer reports as a **successful broadcast** even though the node never confirmed it took the extrinsic.

## how

Force hash verification when `result` is absent, mirroring the Polkadot resolver's JSON-RPC 2.0 guard (`polkadot.ts:79`, "a valid response must have exactly one of result/error"). Added a `return` after the error branch so the new check only runs on a no-error response (no double-verify).

## testing

- +4 cases: accept on `result` present; swallow the idempotent `Already Imported` peer-race; verify-by-hash on a genuine error; **verify-by-hash on a malformed `{}` body** (the gap). Broadcast suite green; `tsc` + eslint clean. Changeset: `core-chain` patch.

## cross-consumer

`@vultisig/core-chain` ships to flagship. Strictly-more-correct: a malformed response now triggers hash verification (which resolves the real state) instead of a silent success. A well-formed accept (`result` present) is unaffected.

## risk

Low. One added guard mirroring an existing sibling resolver.

🤖 Agent-generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Bittensor transaction broadcasting when RPC responses are incomplete or malformed.
  - Transactions are now verified by hash instead of being incorrectly reported as successful when no result is returned.
  - Preserved handling for already imported transactions.
  - Prevented failed hash verification from triggering an unnecessary rebroadcast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->