### PR TITLE
Fix browser storage backend stickiness

### DIFF
--- a/.changeset/calm-browsers-hold.md
+++ b/.changeset/calm-browsers-hold.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+Keep browser vault storage on the backend selected during initialization. IndexedDB failures and quota errors now surface without silently switching to a partial localStorage or in-memory view, while legacy localStorage vaults retain their backend across reloads.

--- a/packages/sdk/src/platforms/browser/storage.ts
+++ b/packages/sdk/src/platforms/browser/storage.ts
@@ -5,37 +5,115 @@
 import type { Storage, StorageMetadata, StoredValue } from '../../storage/types'
 import { STORAGE_VERSION, StorageError, StorageErrorCode } from '../../storage/types'
 
-type StorageMode = 'indexeddb' | 'localstorage' | 'memory'
+type StorageMode = 'indexeddb' | 'localstorage'
+
+const BACKEND_MARKER_KEY = '__vultisig_storage_backend__'
 
 export class BrowserStorage implements Storage {
   private db?: IDBDatabase
-  private mode: StorageMode = 'memory'
-  private memoryStore = new Map<string, StoredValue>()
+  private mode?: StorageMode
+  private initializationError?: StorageError
+  private readonly initialization: Promise<void>
   private readonly dbName = 'vultisig-vaults'
   private readonly storeName = 'vaults'
   private readonly dbVersion = 1
 
   constructor() {
-    this.initializeAsync().catch(err => console.warn('BrowserStorage initialization warning:', err))
+    this.initialization = this.initializeAsync().catch(error => {
+      this.initializationError =
+        error instanceof StorageError
+          ? error
+          : new StorageError(
+              StorageErrorCode.StorageUnavailable,
+              'Browser storage initialization failed',
+              error as Error
+            )
+    })
   }
 
   private async initializeAsync(): Promise<void> {
-    try {
-      await this.tryIndexedDB()
-      this.mode = 'indexeddb'
-    } catch {
-      try {
-        this.tryLocalStorage()
-        this.mode = 'localstorage'
-      } catch {
-        this.mode = 'memory'
-      }
+    const persistedMode = this.readPersistedMode()
+
+    if (persistedMode === 'localstorage') {
+      this.tryLocalStorage()
+      this.mode = 'localstorage'
+      return
     }
+
+    if (persistedMode === 'indexeddb' || typeof indexedDB !== 'undefined') {
+      await this.tryIndexedDB()
+      await this.verifyIndexedDB()
+
+      if (!persistedMode) {
+        const indexedDBKeys = await this.listFromIndexedDB()
+        const legacyLocalKeys = this.listLocalStorageSdkKeys()
+
+        if (legacyLocalKeys.length > 0 && indexedDBKeys.length === 0) {
+          this.db?.close()
+          this.db = undefined
+          this.tryLocalStorage()
+          this.mode = 'localstorage'
+          this.persistMode('localstorage')
+          return
+        }
+
+        if (legacyLocalKeys.length > 0 && indexedDBKeys.length > 0) {
+          this.db?.close()
+          this.db = undefined
+          throw new StorageError(
+            StorageErrorCode.StorageUnavailable,
+            'Browser storage contains unverified data in both IndexedDB and localStorage'
+          )
+        }
+      }
+
+      this.mode = 'indexeddb'
+      this.persistMode('indexeddb')
+      return
+    }
+
+    this.tryLocalStorage()
+    this.mode = 'localstorage'
+    this.persistMode('localstorage')
   }
 
   private async ensureInitialized(): Promise<void> {
-    if (this.mode === 'memory' && !this.db) {
-      await this.initializeAsync()
+    await this.initialization
+    if (this.initializationError) {
+      throw this.initializationError
+    }
+    if (!this.mode) {
+      throw new StorageError(StorageErrorCode.StorageUnavailable, 'Browser storage backend was not selected')
+    }
+  }
+
+  private readPersistedMode(): StorageMode | undefined {
+    if (typeof localStorage === 'undefined') return undefined
+
+    try {
+      const value = localStorage.getItem(BACKEND_MARKER_KEY)
+      return value === 'indexeddb' || value === 'localstorage' ? value : undefined
+    } catch (error) {
+      throw new StorageError(
+        StorageErrorCode.StorageUnavailable,
+        'Browser storage backend marker could not be read',
+        error as Error
+      )
+    }
+  }
+
+  private persistMode(mode: StorageMode): void {
+    if (typeof localStorage === 'undefined') return
+
+    try {
+      localStorage.setItem(BACKEND_MARKER_KEY, mode)
+    } catch {
+      // IndexedDB remains authoritative even when localStorage cannot retain the
+      // advisory marker. A localStorage backend has already passed its health
+      // check, so failure here is treated as initialization failure below.
+      if (mode === 'localstorage') {
+        throw new StorageError(StorageErrorCode.StorageUnavailable, 'Failed to persist browser storage backend')
+      }
     }
   }
 
@@ -46,11 +124,32 @@ export class BrowserStorage implements Storage {
 
     return new Promise<void>((resolve, reject) => {
       const request = indexedDB.open(this.dbName, this.dbVersion)
+      let settled = false
 
-      request.onerror = () => reject(request.error)
+      request.onerror = () => {
+        settled = true
+        reject(
+          new StorageError(
+            StorageErrorCode.StorageUnavailable,
+            'IndexedDB could not be opened',
+            request.error ?? undefined
+          )
+        )
+      }
+
+      request.onblocked = () => {
+        settled = true
+        reject(new StorageError(StorageErrorCode.StorageUnavailable, 'IndexedDB open was blocked'))
+      }
 
       request.onsuccess = () => {
+        if (settled) {
+          request.result.close()
+          return
+        }
+        settled = true
         this.db = request.result
+        this.db.onversionchange = () => this.db?.close()
         resolve()
       }
 
@@ -62,6 +161,16 @@ export class BrowserStorage implements Storage {
         }
       }
     })
+  }
+
+  private async verifyIndexedDB(): Promise<void> {
+    try {
+      await this.listFromIndexedDB()
+    } catch (error) {
+      this.db?.close()
+      this.db = undefined
+      throw new StorageError(StorageErrorCode.StorageUnavailable, 'IndexedDB health check failed', error as Error)
+    }
   }
 
   private tryLocalStorage(): void {
@@ -84,12 +193,11 @@ export class BrowserStorage implements Storage {
     try {
       if (this.mode === 'indexeddb' && this.db) {
         return await this.getFromIndexedDB<T>(key)
-      } else if (this.mode === 'localstorage') {
-        return this.getFromLocalStorage<T>(key)
       } else {
-        return this.getFromMemory<T>(key)
+        return this.getFromLocalStorage<T>(key)
       }
     } catch (error) {
+      if (error instanceof StorageError) throw error
       throw new StorageError(StorageErrorCode.Unknown, `Failed to get value for key "${key}"`, error as Error)
     }
   }
@@ -108,17 +216,15 @@ export class BrowserStorage implements Storage {
     try {
       if (this.mode === 'indexeddb' && this.db) {
         await this.setToIndexedDB(key, stored)
-      } else if (this.mode === 'localstorage') {
-        this.setToLocalStorage(key, stored)
       } else {
-        this.setToMemory(key, stored)
+        this.setToLocalStorage(key, stored)
       }
     } catch (error) {
       if ((error as Error).name === 'QuotaExceededError') {
-        await this.handleQuotaExceeded(key, stored)
-      } else {
-        throw new StorageError(StorageErrorCode.Unknown, `Failed to set value for key "${key}"`, error as Error)
+        throw new StorageError(StorageErrorCode.QuotaExceeded, 'Browser storage quota exceeded', error as Error)
       }
+      if (error instanceof StorageError) throw error
+      throw new StorageError(StorageErrorCode.Unknown, `Failed to set value for key "${key}"`, error as Error)
     }
   }
 
@@ -128,12 +234,11 @@ export class BrowserStorage implements Storage {
     try {
       if (this.mode === 'indexeddb' && this.db) {
         await this.removeFromIndexedDB(key)
-      } else if (this.mode === 'localstorage') {
-        localStorage.removeItem(key)
       } else {
-        this.memoryStore.delete(key)
+        localStorage.removeItem(key)
       }
     } catch (error) {
+      if (error instanceof StorageError) throw error
       throw new StorageError(StorageErrorCode.Unknown, `Failed to remove key "${key}"`, error as Error)
     }
   }
@@ -144,12 +249,11 @@ export class BrowserStorage implements Storage {
     try {
       if (this.mode === 'indexeddb' && this.db) {
         return await this.listFromIndexedDB()
-      } else if (this.mode === 'localstorage') {
-        return this.listFromLocalStorage()
       } else {
-        return Array.from(this.memoryStore.keys())
+        return this.listFromLocalStorage()
       }
     } catch (error) {
+      if (error instanceof StorageError) throw error
       throw new StorageError(StorageErrorCode.Unknown, 'Failed to list keys', error as Error)
     }
   }
@@ -160,18 +264,19 @@ export class BrowserStorage implements Storage {
     try {
       if (this.mode === 'indexeddb' && this.db) {
         await this.clearIndexedDB()
-      } else if (this.mode === 'localstorage') {
+      } else {
         const keys = this.listFromLocalStorage()
         keys.forEach(key => localStorage.removeItem(key))
-      } else {
-        this.memoryStore.clear()
       }
     } catch (error) {
+      if (error instanceof StorageError) throw error
       throw new StorageError(StorageErrorCode.Unknown, 'Failed to clear storage', error as Error)
     }
   }
 
   async getUsage(): Promise<number> {
+    await this.ensureInitialized()
+
     if (this.mode === 'indexeddb' && typeof navigator !== 'undefined' && navigator.storage) {
       try {
         const estimate = await navigator.storage.estimate()
@@ -192,6 +297,8 @@ export class BrowserStorage implements Storage {
   }
 
   async getQuota(): Promise<number | undefined> {
+    await this.ensureInitialized()
+
     if (this.mode === 'indexeddb' && typeof navigator !== 'undefined' && navigator.storage) {
       try {
         const estimate = await navigator.storage.estimate()
@@ -237,25 +344,17 @@ export class BrowserStorage implements Storage {
   }
 
   private async setToIndexedDB<T>(key: string, value: StoredValue<T>): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const transaction = this.db!.transaction(this.storeName, 'readwrite')
-      const store = transaction.objectStore(this.storeName)
-      const request = store.put(value, key)
-
-      request.onsuccess = () => resolve()
-      request.onerror = () => reject(request.error)
-    })
+    const transaction = this.db!.transaction(this.storeName, 'readwrite')
+    const completion = this.waitForTransaction(transaction)
+    transaction.objectStore(this.storeName).put(value, key)
+    return completion
   }
 
   private async removeFromIndexedDB(key: string): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const transaction = this.db!.transaction(this.storeName, 'readwrite')
-      const store = transaction.objectStore(this.storeName)
-      const request = store.delete(key)
-
-      request.onsuccess = () => resolve()
-      request.onerror = () => reject(request.error)
-    })
+    const transaction = this.db!.transaction(this.storeName, 'readwrite')
+    const completion = this.waitForTransaction(transaction)
+    transaction.objectStore(this.storeName).delete(key)
+    return completion
   }
 
   private async listFromIndexedDB(): Promise<string[]> {
@@ -270,13 +369,31 @@ export class BrowserStorage implements Storage {
   }
 
   private async clearIndexedDB(): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const transaction = this.db!.transaction(this.storeName, 'readwrite')
-      const store = transaction.objectStore(this.storeName)
-      const request = store.clear()
+    const transaction = this.db!.transaction(this.storeName, 'readwrite')
+    const completion = this.waitForTransaction(transaction)
+    transaction.objectStore(this.storeName).clear()
+    return completion
+  }
 
-      request.onsuccess = () => resolve()
-      request.onerror = () => reject(request.error)
+  private waitForTransaction(transaction: IDBTransaction): Promise<void> {
+    return new Promise((resolve, reject) => {
+      let settled = false
+      const rejectOnce = (error: DOMException | null | undefined) => {
+        if (settled) return
+        settled = true
+        reject(error ?? new DOMException('IndexedDB transaction failed', 'UnknownError'))
+      }
+
+      transaction.oncomplete = () => {
+        if (settled) return
+        settled = true
+        resolve()
+      }
+      transaction.onerror = event => {
+        const requestError = (event.target as IDBRequest | null)?.error
+        rejectOnce(requestError ?? transaction.error)
+      }
+      transaction.onabort = () => rejectOnce(transaction.error)
     })
   }
 
@@ -289,8 +406,12 @@ export class BrowserStorage implements Storage {
     try {
       const parsed = JSON.parse(stored) as StoredValue<T>
       return parsed.value
-    } catch {
-      return null
+    } catch (error) {
+      throw new StorageError(
+        StorageErrorCode.SerializationFailed,
+        `Stored value for key "${key}" is invalid`,
+        error as Error
+      )
     }
   }
 
@@ -302,43 +423,32 @@ export class BrowserStorage implements Storage {
     const keys: string[] = []
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i)
-      if (key) keys.push(key)
+      if (key && key !== BACKEND_MARKER_KEY) keys.push(key)
     }
     return keys
   }
 
-  // ===== Memory Operations =====
+  private listLocalStorageSdkKeys(): string[] {
+    if (typeof localStorage === 'undefined') return []
 
-  private getFromMemory<T>(key: string): T | null {
-    const stored = this.memoryStore.get(key)
-    return stored ? (stored.value as T) : null
-  }
-
-  private setToMemory<T>(key: string, value: StoredValue<T>): void {
-    this.memoryStore.set(key, value)
-  }
-
-  // ===== Fallback Handling =====
-
-  private async handleQuotaExceeded<T>(key: string, value: StoredValue<T>): Promise<void> {
-    if (this.mode === 'indexeddb') {
-      try {
-        this.tryLocalStorage()
-        this.mode = 'localstorage'
-        this.setToLocalStorage(key, value)
-        return
-      } catch {
-        // Fall through to memory
-      }
+    try {
+      return this.listFromLocalStorage().filter(
+        key =>
+          key.startsWith('vault:') ||
+          key.startsWith('pending:') ||
+          key.startsWith('cache:') ||
+          key.startsWith('addressBook:') ||
+          key === 'activeVaultId' ||
+          key === 'pushNotificationRegistrations' ||
+          key === 'config:defaultCurrency' ||
+          key === 'config:defaultChains'
+      )
+    } catch (error) {
+      throw new StorageError(
+        StorageErrorCode.StorageUnavailable,
+        'Legacy browser storage keys could not be inspected',
+        error as Error
+      )
     }
-
-    if (this.mode === 'localstorage') {
-      this.mode = 'memory'
-      this.setToMemory(key, value)
-      console.warn('Storage quota exceeded, falling back to memory storage')
-      return
-    }
-
-    throw new StorageError(StorageErrorCode.QuotaExceeded, 'Storage quota exceeded in all storage modes')
   }
 }

--- a/packages/sdk/src/platforms/browser/storage.ts
+++ b/packages/sdk/src/platforms/browser/storage.ts
@@ -12,23 +12,14 @@ const BACKEND_MARKER_KEY = '__vultisig_storage_backend__'
 export class BrowserStorage implements Storage {
   private db?: IDBDatabase
   private mode?: StorageMode
-  private initializationError?: StorageError
-  private readonly initialization: Promise<void>
+  private backendError?: StorageError
+  private initialization?: Promise<void>
   private readonly dbName = 'vultisig-vaults'
   private readonly storeName = 'vaults'
   private readonly dbVersion = 1
 
   constructor() {
-    this.initialization = this.initializeAsync().catch(error => {
-      this.initializationError =
-        error instanceof StorageError
-          ? error
-          : new StorageError(
-              StorageErrorCode.StorageUnavailable,
-              'Browser storage initialization failed',
-              error as Error
-            )
-    })
+    void this.startInitialization().catch(() => undefined)
   }
 
   private async initializeAsync(): Promise<void> {
@@ -46,14 +37,14 @@ export class BrowserStorage implements Storage {
 
       if (!persistedMode) {
         const indexedDBKeys = await this.listFromIndexedDB()
-        const legacyLocalKeys = this.listLocalStorageSdkKeys()
+        const legacyLocalKeys = this.listLegacyLocalStorageKeys()
 
         if (legacyLocalKeys.length > 0 && indexedDBKeys.length === 0) {
           this.db?.close()
           this.db = undefined
           this.tryLocalStorage()
-          this.mode = 'localstorage'
           this.persistMode('localstorage')
+          this.mode = 'localstorage'
           return
         }
 
@@ -73,18 +64,46 @@ export class BrowserStorage implements Storage {
     }
 
     this.tryLocalStorage()
-    this.mode = 'localstorage'
     this.persistMode('localstorage')
+    this.mode = 'localstorage'
   }
 
   private async ensureInitialized(): Promise<void> {
-    await this.initialization
-    if (this.initializationError) {
-      throw this.initializationError
+    if (this.backendError) {
+      throw this.backendError
+    }
+
+    try {
+      await this.startInitialization()
+    } catch (error) {
+      throw error instanceof StorageError
+        ? error
+        : new StorageError(StorageErrorCode.StorageUnavailable, 'Browser storage initialization failed', error as Error)
+    }
+
+    if (this.backendError) {
+      throw this.backendError
     }
     if (!this.mode) {
       throw new StorageError(StorageErrorCode.StorageUnavailable, 'Browser storage backend was not selected')
     }
+  }
+
+  private startInitialization(): Promise<void> {
+    if (this.mode) return Promise.resolve()
+    if (this.initialization) return this.initialization
+
+    const initialization = this.initializeAsync()
+    this.initialization = initialization
+    void initialization
+      .finally(() => {
+        if (this.initialization === initialization) {
+          this.initialization = undefined
+        }
+      })
+      .catch(() => undefined)
+
+    return initialization
   }
 
   private readPersistedMode(): StorageMode | undefined {
@@ -149,7 +168,14 @@ export class BrowserStorage implements Storage {
         }
         settled = true
         this.db = request.result
-        this.db.onversionchange = () => this.db?.close()
+        this.db.onversionchange = () => {
+          this.db?.close()
+          this.db = undefined
+          this.backendError = new StorageError(
+            StorageErrorCode.StorageUnavailable,
+            'IndexedDB connection was closed due to a version change'
+          )
+        }
         resolve()
       }
 
@@ -428,21 +454,31 @@ export class BrowserStorage implements Storage {
     return keys
   }
 
-  private listLocalStorageSdkKeys(): string[] {
+  private listLegacyLocalStorageKeys(): string[] {
     if (typeof localStorage === 'undefined') return []
 
     try {
-      return this.listFromLocalStorage().filter(
-        key =>
-          key.startsWith('vault:') ||
-          key.startsWith('pending:') ||
-          key.startsWith('cache:') ||
-          key.startsWith('addressBook:') ||
-          key === 'activeVaultId' ||
-          key === 'pushNotificationRegistrations' ||
-          key === 'config:defaultCurrency' ||
-          key === 'config:defaultChains'
-      )
+      return this.listFromLocalStorage().filter(key => {
+        const rawValue = localStorage.getItem(key)
+        if (rawValue === null) return false
+
+        try {
+          const storedValue = JSON.parse(rawValue) as Partial<StoredValue<unknown>>
+          const metadata = storedValue?.metadata
+
+          return (
+            typeof storedValue === 'object' &&
+            storedValue !== null &&
+            typeof metadata === 'object' &&
+            metadata !== null &&
+            typeof metadata.version === 'number' &&
+            typeof metadata.createdAt === 'number' &&
+            typeof metadata.lastModified === 'number'
+          )
+        } catch {
+          return false
+        }
+      })
     } catch (error) {
       throw new StorageError(
         StorageErrorCode.StorageUnavailable,

--- a/packages/sdk/tests/unit/platforms/browser/storage.test.ts
+++ b/packages/sdk/tests/unit/platforms/browser/storage.test.ts
@@ -8,6 +8,7 @@ class LocalStorageDouble implements Storage {
   private readonly values = new Map<string, string>()
   failReads = false
   failWrites = false
+  failMarkerWrites = false
 
   get length(): number {
     return this.values.size
@@ -36,7 +37,7 @@ class LocalStorageDouble implements Storage {
   }
 
   setItem(key: string, value: string): void {
-    if (this.failWrites) {
+    if (this.failWrites || (this.failMarkerWrites && key === '__vultisig_storage_backend__')) {
       throw new DOMException('quota exceeded', 'QuotaExceededError')
     }
     this.values.set(key, value)
@@ -102,6 +103,21 @@ describe('BrowserStorage backend selection', () => {
     expect(local.getItem('__vultisig_storage_backend__')).toBe('indexeddb')
   })
 
+  it('fails closed after an IndexedDB version change instead of switching to localStorage', async () => {
+    const storage = new BrowserStorage()
+    await storage.set('vault:indexeddb', { name: 'indexeddb' })
+    local.setItem('vault:fallback-only', stored({ name: 'fallback' }))
+    const database = (storage as any).db as IDBDatabase
+
+    database.onversionchange?.({} as IDBVersionChangeEvent)
+
+    expect((storage as any).db).toBeUndefined()
+    await expect(storage.get('vault:fallback-only')).rejects.toMatchObject({
+      code: StorageErrorCode.StorageUnavailable,
+    })
+    expect(local.getItem('__vultisig_storage_backend__')).toBe('indexeddb')
+  })
+
   it('uses localStorage only when IndexedDB is absent and keeps that choice across reloads', async () => {
     vi.stubGlobal('indexedDB', undefined)
     const first = new BrowserStorage()
@@ -124,6 +140,14 @@ describe('BrowserStorage backend selection', () => {
     const storage = new BrowserStorage()
 
     await expect(storage.get('vault:legacy')).resolves.toEqual({ name: 'legacy' })
+    expect(local.getItem('__vultisig_storage_backend__')).toBe('localstorage')
+  })
+
+  it('recovers an unmarked legacy record with an arbitrary public storage key', async () => {
+    local.setItem('custom', stored({ name: 'legacy' }))
+    const storage = new BrowserStorage()
+
+    await expect(storage.get('custom')).resolves.toEqual({ name: 'legacy' })
     expect(local.getItem('__vultisig_storage_backend__')).toBe('localstorage')
   })
 
@@ -169,6 +193,21 @@ describe('BrowserStorage backend selection', () => {
     await expect(storage.get('vault:new')).resolves.toBeNull()
   })
 
+  it('retries localStorage selection on the same instance after marker persistence fails', async () => {
+    vi.stubGlobal('indexedDB', undefined)
+    local.failMarkerWrites = true
+    const storage = new BrowserStorage()
+
+    await expect(storage.list()).rejects.toMatchObject({
+      code: StorageErrorCode.StorageUnavailable,
+    })
+
+    local.failMarkerWrites = false
+    await storage.set('custom', { name: 'recovered' })
+    await expect(storage.get('custom')).resolves.toEqual({ name: 'recovered' })
+    expect(local.getItem('__vultisig_storage_backend__')).toBe('localstorage')
+  })
+
   it('fails closed when IndexedDB is blocked instead of exposing a partial localStorage view', async () => {
     local.setItem('vault:fallback-only', stored({ name: 'fallback' }))
     vi.stubGlobal('indexedDB', {
@@ -186,7 +225,7 @@ describe('BrowserStorage backend selection', () => {
     expect(local.getItem('vault:fallback-only')).not.toBeNull()
   })
 
-  it('does not abandon a persisted IndexedDB store after a transient open failure', async () => {
+  it('retries a persisted IndexedDB store on the same instance after a transient open failure', async () => {
     local.setItem('__vultisig_storage_backend__', 'indexeddb')
     local.setItem('vault:partial-fallback', stored({ name: 'partial' }))
     vi.stubGlobal('indexedDB', {
@@ -198,19 +237,18 @@ describe('BrowserStorage backend selection', () => {
         return request
       },
     })
-    const degraded = new BrowserStorage()
+    const storage = new BrowserStorage()
 
-    await expect(degraded.get('vault:partial-fallback')).rejects.toMatchObject({
+    await expect(storage.get('vault:partial-fallback')).rejects.toMatchObject({
       code: StorageErrorCode.StorageUnavailable,
     })
 
     vi.stubGlobal('indexedDB', new IDBFactory())
-    const recovered = new BrowserStorage()
-    await recovered.set('vault:canonical', { name: 'canonical' })
-    await expect(recovered.get('vault:canonical')).resolves.toEqual({
+    await storage.set('vault:canonical', { name: 'canonical' })
+    await expect(storage.get('vault:canonical')).resolves.toEqual({
       name: 'canonical',
     })
-    await expect(recovered.get('vault:partial-fallback')).resolves.toBeNull()
+    await expect(storage.get('vault:partial-fallback')).resolves.toBeNull()
   })
 
   it('surfaces malformed localStorage records as typed serialization failures', async () => {

--- a/packages/sdk/tests/unit/platforms/browser/storage.test.ts
+++ b/packages/sdk/tests/unit/platforms/browser/storage.test.ts
@@ -1,0 +1,227 @@
+import { IDBFactory } from 'fake-indexeddb'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { BrowserStorage } from '../../../../src/platforms/browser/storage'
+import { StorageError, StorageErrorCode } from '../../../../src/storage/types'
+
+class LocalStorageDouble implements Storage {
+  private readonly values = new Map<string, string>()
+  failReads = false
+  failWrites = false
+
+  get length(): number {
+    return this.values.size
+  }
+
+  clear(): void {
+    this.values.clear()
+  }
+
+  getItem(key: string): string | null {
+    if (this.failReads) {
+      throw new DOMException('storage unavailable', 'SecurityError')
+    }
+    return this.values.get(key) ?? null
+  }
+
+  key(index: number): string | null {
+    if (this.failReads) {
+      throw new DOMException('storage unavailable', 'SecurityError')
+    }
+    return Array.from(this.values.keys())[index] ?? null
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key)
+  }
+
+  setItem(key: string, value: string): void {
+    if (this.failWrites) {
+      throw new DOMException('quota exceeded', 'QuotaExceededError')
+    }
+    this.values.set(key, value)
+  }
+}
+
+const stored = (value: unknown) =>
+  JSON.stringify({
+    value,
+    metadata: { version: 1, createdAt: 1, lastModified: 1 },
+  })
+
+describe('BrowserStorage backend selection', () => {
+  let local: LocalStorageDouble
+
+  beforeEach(() => {
+    local = new LocalStorageDouble()
+    vi.stubGlobal('localStorage', local)
+    vi.stubGlobal('indexedDB', new IDBFactory())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('shares one IndexedDB initialization across concurrent operations', async () => {
+    const open = vi.spyOn(indexedDB, 'open')
+    const storage = new BrowserStorage()
+
+    await Promise.all([storage.get('missing'), storage.list(), storage.getQuota()])
+
+    expect(open).toHaveBeenCalledTimes(1)
+    expect(local.getItem('__vultisig_storage_backend__')).toBe('indexeddb')
+  })
+
+  it('surfaces IndexedDB quota without switching to localStorage or hiding existing keys', async () => {
+    const storage = new BrowserStorage()
+    await storage.set('vault:existing', { name: 'existing' })
+    const database = (storage as any).db as IDBDatabase
+    const quotaError = new DOMException('quota exceeded', 'QuotaExceededError')
+    vi.spyOn(database, 'transaction').mockImplementationOnce(() => {
+      const transaction = {
+        error: null,
+        objectStore: () => ({
+          put: () => queueMicrotask(() => transaction.onerror?.({ target: { error: quotaError } } as unknown as Event)),
+        }),
+        onabort: null,
+        oncomplete: null,
+        onerror: null,
+      } as unknown as IDBTransaction
+      return transaction
+    })
+
+    await expect(storage.set('vault:new', { name: 'new' })).rejects.toMatchObject({
+      code: StorageErrorCode.QuotaExceeded,
+    })
+    await expect(storage.get('vault:existing')).resolves.toEqual({
+      name: 'existing',
+    })
+    await expect(storage.get('vault:new')).resolves.toBeNull()
+    expect(local.getItem('vault:new')).toBeNull()
+    expect(local.getItem('__vultisig_storage_backend__')).toBe('indexeddb')
+  })
+
+  it('uses localStorage only when IndexedDB is absent and keeps that choice across reloads', async () => {
+    vi.stubGlobal('indexedDB', undefined)
+    const first = new BrowserStorage()
+    await first.set('vault:local', { name: 'local' })
+
+    const availableIndexedDB = new IDBFactory()
+    const open = vi.spyOn(availableIndexedDB, 'open')
+    vi.stubGlobal('indexedDB', availableIndexedDB)
+    const reloaded = new BrowserStorage()
+
+    await expect(reloaded.get('vault:local')).resolves.toEqual({
+      name: 'local',
+    })
+    expect(open).not.toHaveBeenCalled()
+    expect(local.getItem('__vultisig_storage_backend__')).toBe('localstorage')
+  })
+
+  it('recovers an unmarked legacy localStorage vault set when IndexedDB is empty', async () => {
+    local.setItem('vault:legacy', stored({ name: 'legacy' }))
+    const storage = new BrowserStorage()
+
+    await expect(storage.get('vault:legacy')).resolves.toEqual({ name: 'legacy' })
+    expect(local.getItem('__vultisig_storage_backend__')).toBe('localstorage')
+  })
+
+  it('fails closed while legacy localStorage is unreadable and recovers it on reload', async () => {
+    local.setItem('vault:legacy', stored({ name: 'legacy' }))
+    local.failReads = true
+    const degraded = new BrowserStorage()
+
+    await expect(degraded.list()).rejects.toMatchObject({
+      code: StorageErrorCode.StorageUnavailable,
+    })
+
+    local.failReads = false
+    const recovered = new BrowserStorage()
+    await expect(recovered.get('vault:legacy')).resolves.toEqual({ name: 'legacy' })
+    expect(local.getItem('__vultisig_storage_backend__')).toBe('localstorage')
+  })
+
+  it('surfaces unmarked cross-backend divergence instead of exposing either partial set', async () => {
+    const canonical = new BrowserStorage()
+    await canonical.set('vault:indexeddb', { name: 'indexeddb' })
+    local.removeItem('__vultisig_storage_backend__')
+    local.setItem('vault:local', stored({ name: 'local' }))
+
+    const divergent = new BrowserStorage()
+    await expect(divergent.list()).rejects.toMatchObject({
+      code: StorageErrorCode.StorageUnavailable,
+    })
+  })
+
+  it('surfaces localStorage quota without switching to an empty memory store', async () => {
+    vi.stubGlobal('indexedDB', undefined)
+    const storage = new BrowserStorage()
+    await storage.set('vault:existing', { name: 'existing' })
+    local.failWrites = true
+
+    await expect(storage.set('vault:new', { name: 'new' })).rejects.toMatchObject({
+      code: StorageErrorCode.QuotaExceeded,
+    })
+    await expect(storage.get('vault:existing')).resolves.toEqual({
+      name: 'existing',
+    })
+    await expect(storage.get('vault:new')).resolves.toBeNull()
+  })
+
+  it('fails closed when IndexedDB is blocked instead of exposing a partial localStorage view', async () => {
+    local.setItem('vault:fallback-only', stored({ name: 'fallback' }))
+    vi.stubGlobal('indexedDB', {
+      open: () => {
+        const request: Record<string, unknown> = {}
+        queueMicrotask(() => (request.onblocked as (() => void) | undefined)?.())
+        return request
+      },
+    })
+    const storage = new BrowserStorage()
+
+    await expect(storage.list()).rejects.toMatchObject({
+      code: StorageErrorCode.StorageUnavailable,
+    })
+    expect(local.getItem('vault:fallback-only')).not.toBeNull()
+  })
+
+  it('does not abandon a persisted IndexedDB store after a transient open failure', async () => {
+    local.setItem('__vultisig_storage_backend__', 'indexeddb')
+    local.setItem('vault:partial-fallback', stored({ name: 'partial' }))
+    vi.stubGlobal('indexedDB', {
+      open: () => {
+        const request: Record<string, unknown> = {
+          error: new DOMException('open failed', 'UnknownError'),
+        }
+        queueMicrotask(() => (request.onerror as (() => void) | undefined)?.())
+        return request
+      },
+    })
+    const degraded = new BrowserStorage()
+
+    await expect(degraded.get('vault:partial-fallback')).rejects.toMatchObject({
+      code: StorageErrorCode.StorageUnavailable,
+    })
+
+    vi.stubGlobal('indexedDB', new IDBFactory())
+    const recovered = new BrowserStorage()
+    await recovered.set('vault:canonical', { name: 'canonical' })
+    await expect(recovered.get('vault:canonical')).resolves.toEqual({
+      name: 'canonical',
+    })
+    await expect(recovered.get('vault:partial-fallback')).resolves.toBeNull()
+  })
+
+  it('surfaces malformed localStorage records as typed serialization failures', async () => {
+    vi.stubGlobal('indexedDB', undefined)
+    local.setItem('__vultisig_storage_backend__', 'localstorage')
+    local.setItem('vault:corrupt', '{')
+    const storage = new BrowserStorage()
+
+    await expect(storage.get('vault:corrupt')).rejects.toBeInstanceOf(StorageError)
+    await expect(storage.get('vault:corrupt')).rejects.toMatchObject({
+      code: StorageErrorCode.SerializationFailed,
+    })
+  })
+})


### PR DESCRIPTION
Closes #1209
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Browser vault storage now reliably preserves the initially selected backend across reloads and avoids silent fallbacks.
  * IndexedDB/localStorage failures (including quota issues and malformed stored data) now surface explicit errors instead of returning partial state.
  * Improved legacy vault recovery and safer fail-closed behavior for blocked/unavailable IndexedDB and cross-backend inconsistencies.
* **Tests**
  * Added unit coverage for backend selection, concurrency, backend recovery, quota/serialization error handling, and legacy vault scenarios.
* **Chores**
  * Added a Changesets entry for patch releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->