### PR TITLE
fix(rujira): FIN limit BUY orders encode the base quantity where the contract expects the offer amount (vultisig-ops-p8bch)

### DIFF
--- a/.changeset/fin-buy-order-offer-amount.md
+++ b/.changeset/fin-buy-order-offer-amount.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/rujira': patch
+---
+
+Fix FIN limit **buy** orders encoding the base quantity where the contract expects the offer amount. `placeOrder`/`buildPlaceOrder` put `params.amount` (base) into `OrderTarget[2]` while attaching `amount x price` (quote) as funds, so on a buy the two disagreed by a factor of `price`. FIN documents `OrderTarget` as a "target offer amount" and requires "funds sent must be equal to the net change of balances", so the contract read the msg value as quote units: buys below parity under-funded and reverted with `InsufficientFunds`, and buys above parity silently created an order far smaller than intended, refunding the excess. Both paths now use the single `calculateOfferAmount()` value for the msg and the funds. Sell orders are unaffected — the base quantity is already the offer amount.

--- a/packages/rujira/src/__tests__/orderbook.test.ts
+++ b/packages/rujira/src/__tests__/orderbook.test.ts
@@ -235,4 +235,53 @@ describe('RujiraOrderbook', () => {
       expect(book.timestamp).toBeLessThanOrEqual(after)
     })
   })
+  // FUND SAFETY (vultisig-ops-p8bch): FIN's OrderTarget is documented as a
+  // "target offer amount", and the contract requires "funds sent must be equal
+  // to the net change of balances". buildPlaceOrder used to put the BASE
+  // quantity in the msg while attaching amount x price as funds, so on a buy
+  // the two disagreed by a factor of `price`. On-chain reality (every one of
+  // ~600 order txs scanned on thor1y8g3yhz...ts7ud7): msg amount == funds.
+  describe('buildPlaceOrder() offer-amount encoding', () => {
+    const pair = {
+      base: 'THOR.RUNE',
+      quote: 'ETH.USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48',
+      contractAddress: 'thor1paircontract',
+      tick: '0',
+      takerFee: '0',
+      makerFee: '0',
+    }
+
+    const build = async (side: 'buy' | 'sell', price: string, amount: string) => {
+      const orderbook = new RujiraOrderbook(createMockClient() as any)
+      return orderbook.buildPlaceOrder({ pair, side, price, amount } as any)
+    }
+
+    it('buy: msg amount equals the attached quote funds, not the base quantity', async () => {
+      // buy 2 RUNE at 4 USDC -> escrow 8 USDC. price > 1: the old encoding
+      // silently created an order 4x too small and refunded the excess.
+      const { msg, funds } = await build('buy', '4', '200000000')
+
+      expect(funds[0].amount).toBe('800000000')
+      expect(msg.order[0][0][2]).toBe(funds[0].amount)
+      expect(msg.order[0][0][0]).toBe('quote')
+    })
+
+    it('buy below parity: msg amount equals funds (old encoding under-funded and reverted)', async () => {
+      // buy 0.5 RUNE at 0.44 USDC -> escrow 0.22 USDC. price < 1: the old
+      // encoding asked the contract for 0.5 USDC of order while sending 0.22,
+      // tripping ContractError::InsufficientFunds.
+      const { msg, funds } = await build('buy', '0.44', '50000000')
+
+      expect(funds[0].amount).toBe('22000000')
+      expect(msg.order[0][0][2]).toBe(funds[0].amount)
+    })
+
+    it('sell: unchanged — base quantity is already the offer amount', async () => {
+      const { msg, funds } = await build('sell', '2', '300000000')
+
+      expect(funds[0].amount).toBe('300000000')
+      expect(msg.order[0][0][2]).toBe(funds[0].amount)
+      expect(msg.order[0][0][0]).toBe('base')
+    })
+  })
 })

--- a/packages/rujira/src/modules/orderbook.ts
+++ b/packages/rujira/src/modules/orderbook.ts
@@ -176,7 +176,11 @@ export class RujiraOrderbook {
 
     // Convert SDK side to contract's Side enum format
     const contractSide = toContractSide(params.side)
-    const orderTarget: OrderTarget = [contractSide, { fixed: params.price }, params.amount]
+    // OrderTarget[2] is the target OFFER amount and must equal the attached
+    // funds — see calculateOfferAmount() for why that is not params.amount
+    // on a buy.
+    const offerAmount = this.calculateOfferAmount(params)
+    const orderTarget: OrderTarget = [contractSide, { fixed: params.price }, offerAmount]
 
     const msg: FinExecuteMsg = {
       order: [[orderTarget], null],
@@ -185,7 +189,7 @@ export class RujiraOrderbook {
     const funds: Coin[] = [
       {
         denom: assetInfo.denom,
-        amount: this.calculateOfferAmount(params),
+        amount: offerAmount,
       },
     ]
 
@@ -252,13 +256,17 @@ export class RujiraOrderbook {
     }
 
     const contractSide = toContractSide(params.side)
-    const orderTarget: OrderTarget = [contractSide, { fixed: params.price }, params.amount]
+    // OrderTarget[2] is the target OFFER amount and must equal the attached
+    // funds — see calculateOfferAmount() for why that is not params.amount
+    // on a buy.
+    const offerAmount = this.calculateOfferAmount(params)
+    const orderTarget: OrderTarget = [contractSide, { fixed: params.price }, offerAmount]
 
     const msg: FinExecuteMsg = {
       order: [[orderTarget], null],
     }
 
-    const funds: Coin[] = [{ denom: assetInfo.denom, amount: this.calculateOfferAmount(params) }]
+    const funds: Coin[] = [{ denom: assetInfo.denom, amount: offerAmount }]
 
     return { contractAddress, msg, funds }
   }
@@ -477,6 +485,15 @@ export class RujiraOrderbook {
     return config.base ? getAssetInfo(config.base) : undefined
   }
 
+  /**
+   * The amount of the OFFERED asset an order escrows.
+   *
+   * `params.amount` is the BASE quantity for both sides, so a sell offers it
+   * directly while a buy offers `amount x price` of the quote asset. FIN's
+   * `OrderTarget` is documented as "target offer amounts", and the contract
+   * requires "funds sent must be equal to the net change of balances" — so
+   * this single value belongs in BOTH the order msg and the attached funds.
+   */
   private calculateOfferAmount(params: LimitOrderParams): string {
     if (params.side === 'buy') {
       const amount = Big(params.amount)

--- a/packages/rujira/src/modules/orderbook.ts
+++ b/packages/rujira/src/modules/orderbook.ts
@@ -12,6 +12,7 @@ import { RujiraError, RujiraErrorCode } from '../errors.js'
 import type {
   ContractSide,
   FinExecuteMsg,
+  FinOrderExecuteMsg,
   FinQueryMsg,
   LimitOrderParams,
   Order,
@@ -241,7 +242,7 @@ export class RujiraOrderbook {
    */
   async buildPlaceOrder(params: LimitOrderParams): Promise<{
     contractAddress: string
-    msg: FinExecuteMsg
+    msg: FinOrderExecuteMsg
     funds: Coin[]
   }> {
     this.validateOrderParams(params)
@@ -262,7 +263,7 @@ export class RujiraOrderbook {
     const offerAmount = this.calculateOfferAmount(params)
     const orderTarget: OrderTarget = [contractSide, { fixed: params.price }, offerAmount]
 
-    const msg: FinExecuteMsg = {
+    const msg: FinOrderExecuteMsg = {
       order: [[orderTarget], null],
     }
 

--- a/packages/rujira/src/types.ts
+++ b/packages/rujira/src/types.ts
@@ -312,10 +312,16 @@ export type Base64Binary = string
  * FIN contract ExecuteMsg variants
  * @internal
  */
-export type FinExecuteMsg =
-  | { swap: SwapRequest }
-  | { order: [OrderTarget[], CallbackData | null] }
-  | { arb: { then?: Base64Binary } }
+export type FinExecuteMsg = { swap: SwapRequest } | FinOrderExecuteMsg | { arb: { then?: Base64Binary } }
+
+/**
+ * The `order` variant of FinExecuteMsg, used to place/cancel limit orders.
+ * Named separately so callers that only ever build order messages (e.g.
+ * buildPlaceOrder/buildCancelOrder) can return this narrower type instead of
+ * the full FinExecuteMsg union.
+ * @internal
+ */
+export type FinOrderExecuteMsg = { order: [OrderTarget[], CallbackData | null] }
 
 /**
  * Swap request variants


### PR DESCRIPTION
## Summary

FIN limit **buy** orders are built with a msg amount that doesn't match the funds they attach. Depending on which side of parity the price sits, the order either **reverts** or is **silently created at the wrong size**. Sells are fine.

Found while dogfooding the agent backend, then confirmed against the contract source and real on-chain transactions.

## What the SDK produced

`placeOrder` / `buildPlaceOrder` put `params.amount` (the BASE quantity) into `OrderTarget[2]`, but attached `calculateOfferAmount()` = `amount x price` as funds:

| request | msg `OrderTarget[2]` | attached funds |
|---|---|---|
| buy 2 RUNE @ 4 USDC | `200000000` | `800000000` USDC |
| buy 0.5 RUNE @ 0.44 USDC | `50000000` | `22000000` USDC |
| sell 3 RUNE @ 2 USDC | `300000000` | `300000000` RUNE ✅ |

## Why the msg value must be the offer amount

**Contract source** — `code-423n4/2025-12-rujira` @ `88aae83`, `packages/rujira-rs/src/interfaces/fin/execute.rs`:

```rust
pub type OrderTarget = (Side, Price, Option<Uint128>);

/// Manage all orders
/// Submit a list of price and target offer amounts
/// ...
/// Funds sent must be equal to the net change of balances.
Order((Vec<OrderTarget>, Option<CallbackData>)),
```

Same wording in the generated schema `contracts/rujira-fin/schema/rujira-fin.json`.

**Handler** — `contracts/rujira-fin/src/order_manager.rs` feeds `target` into the `Swapper` as the offer amount, then:

```rust
self.send += coin(order.amount().u128(), self.config.denoms.bid(side));
```

and `denoms.rs` has `bid(Side::Quote) => quote`. So for a buy the contract reads the msg value in **quote** units. `execute_orders` then computes `receive = funds - send` and raises `ContractError::InsufficientFunds` if it goes negative.

**On-chain** — pair `thor1y8g3yhz...ts7ud7` (`denoms: ["rune", "eth-usdc-0xa0b8...eb48"]`), tx `0758F65D...F3E2` @ height 27081633, code 0:

```
msg:   {"order": [[["quote", {"fixed": "0.412000000000"}, "41300000000"]], null]}
funds: [{"denom":"eth-usdc-0xa0b8...eb48","amount":"41300000000"}]
```

Amount **equals** funds, in the quote denom, at price 0.412 — so not a `price≈1` coincidence. Base-side control `17A54665...6AC5` likewise has amount == funds in `rune`. Across ~600 order txs scanned on this pair, **every** one had msg amount == attached funds. Zero counterexamples.

## Impact

- **price < 1** (e.g. RUNE/USDC ≈ 0.445): funds < target → `InsufficientFunds` → **the tx reverts** and the user eats the network fee.
- **price > 1** (e.g. BTC/USDC): funds > target → an order is created at `target` quote units, **drastically smaller than intended**, and the excess is refunded via `DoOrder`'s `res.withdraw`. No error surfaces — the user just gets the wrong order.

## The fix

Compute `calculateOfferAmount()` once and use it for **both** the msg and the funds, in `placeOrder` and `buildPlaceOrder`. Callers keep passing the base quantity, so there is **no public API change** — `agent-backend-ts` and `mcp-ts` need no update. Sells are untouched, since the base quantity already *is* the offer amount.

## Verification

- **Mutation-checked**: both new buy assertions fail against the unpatched `orderbook.ts`; the sell assertion passes before and after (it was already correct).
- `@vultisig/rujira` tests: **550 passed**, 4 skipped, 0 failed (24 files).
- `tsc --noEmit` on the package: clean.
- `prettier --check` and `eslint` on both touched files: clean.
- No other consumer of `placeOrder`/`buildPlaceOrder` exists in this repo.
- Changeset added (`@vultisig/rujira` patch).

## Noted, not changed here

`placeOrder`'s returned `order.amount` / `order.remaining` echo the caller's **base** amount, while `getOrders()` maps `amount: o.offer` from the contract — so the SDK's read and write surfaces still report different units for buys. Worth reconciling, but changing the returned shape is a separate, API-visible decision.

Bead: `vultisig-ops-p8bch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed FIN limit **buy** orders to encode the correct offer amount and align the attached funds with contract escrow expectations.
  * Resolved failures for buy orders below parity caused by underfunding.
  * Ensured buys above parity refund only the correct excess while using the intended offer amount.
  * Preserved existing **sell** order encoding behavior.
* **Tests**
  * Added coverage to validate offer-amount encoding for buy/sell orders across parity edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->