### PR TITLE
fix(core-chain): retry broadcast hash verification

### DIFF
--- a/.changeset/quiet-rivers-verify.md
+++ b/.changeset/quiet-rivers-verify.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/core-chain': patch
+---
+
+Retry transaction hash verification briefly when an RPC reports a broadcast error before the transaction has propagated or been indexed.

--- a/packages/core/chain/tx/broadcast/verifyBroadcastByHash.test.ts
+++ b/packages/core/chain/tx/broadcast/verifyBroadcastByHash.test.ts
@@ -1,4 +1,14 @@
+import { sleep } from '@vultisig/lib-utils/sleep'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Chain } from '../../Chain'
+import { getTxHash } from '../hash'
+import { getTxStatus } from '../status'
+import {
+  broadcastVerificationBaseDelayMs,
+  broadcastVerificationMaxAttempts,
+  verifyBroadcastByHash,
+} from './verifyBroadcastByHash'
 
 vi.mock('../hash', () => ({
   getTxHash: vi.fn(),
@@ -6,14 +16,13 @@ vi.mock('../hash', () => ({
 vi.mock('../status', () => ({
   getTxStatus: vi.fn(),
 }))
-
-import { Chain } from '../../Chain'
-import { getTxHash } from '../hash'
-import { getTxStatus } from '../status'
-import { verifyBroadcastByHash } from './verifyBroadcastByHash'
+vi.mock('@vultisig/lib-utils/sleep', () => ({
+  sleep: vi.fn(),
+}))
 
 const getTxHashMock = vi.mocked(getTxHash)
 const getTxStatusMock = vi.mocked(getTxStatus)
+const sleepMock = vi.mocked(sleep)
 
 describe('verifyBroadcastByHash', () => {
   const chain = Chain.Ethereum
@@ -45,6 +54,49 @@ describe('verifyBroadcastByHash', () => {
     getTxStatusMock.mockResolvedValue({ status: 'pending', isKnown: false })
 
     await expect(verifyBroadcastByHash({ chain, tx, error: originalError })).rejects.toBe(originalError)
+
+    expect(getTxStatusMock).toHaveBeenCalledTimes(broadcastVerificationMaxAttempts)
+    expect(sleepMock).toHaveBeenCalledTimes(broadcastVerificationMaxAttempts - 1)
+  })
+
+  it("retries a transient 'not_found' status before accepting success", async () => {
+    const originalError = new Error('Unexpected error (code=10055)')
+    getTxHashMock.mockResolvedValue('0xeb475a')
+    getTxStatusMock.mockResolvedValueOnce({ status: 'not_found', isKnown: false }).mockResolvedValueOnce({
+      status: 'success',
+    })
+
+    await expect(verifyBroadcastByHash({ chain, tx, error: originalError })).resolves.toBeUndefined()
+
+    expect(getTxHashMock).toHaveBeenCalledTimes(1)
+    expect(getTxStatusMock).toHaveBeenCalledTimes(2)
+    expect(sleepMock).toHaveBeenCalledOnce()
+    expect(sleepMock).toHaveBeenCalledWith(broadcastVerificationBaseDelayMs)
+  })
+
+  it("rethrows the original error after repeated 'not_found' statuses", async () => {
+    const originalError = new Error('broadcast failed')
+    getTxHashMock.mockResolvedValue('0xmissing')
+    getTxStatusMock.mockResolvedValue({ status: 'not_found', isKnown: false })
+
+    await expect(verifyBroadcastByHash({ chain, tx, error: originalError })).rejects.toBe(originalError)
+
+    expect(getTxStatusMock).toHaveBeenCalledTimes(broadcastVerificationMaxAttempts)
+    expect(sleepMock).toHaveBeenCalledTimes(broadcastVerificationMaxAttempts - 1)
+  })
+
+  it('recovers when a status lookup fails before a known pending result', async () => {
+    const originalError = new Error('broadcast failed')
+    getTxHashMock.mockResolvedValue('0xpending')
+    getTxStatusMock.mockRejectedValueOnce(new Error('rpc down')).mockResolvedValueOnce({
+      status: 'pending',
+      isKnown: true,
+    })
+
+    await expect(verifyBroadcastByHash({ chain, tx, error: originalError })).resolves.toBeUndefined()
+
+    expect(getTxStatusMock).toHaveBeenCalledTimes(2)
+    expect(sleepMock).toHaveBeenCalledOnce()
   })
 
   it("swallows error when status is 'success'", async () => {
@@ -61,14 +113,20 @@ describe('verifyBroadcastByHash', () => {
     getTxStatusMock.mockResolvedValue({ status: 'error' })
 
     await expect(verifyBroadcastByHash({ chain, tx, error: originalError })).rejects.toBe(originalError)
+
+    expect(getTxStatusMock).toHaveBeenCalledTimes(1)
+    expect(sleepMock).not.toHaveBeenCalled()
   })
 
-  it('rethrows original error when getTxStatus throws', async () => {
+  it('retries getTxStatus failures before rethrowing the original error', async () => {
     const originalError = new Error('broadcast failed')
     getTxHashMock.mockResolvedValue('0xabc')
     getTxStatusMock.mockRejectedValue(new Error('rpc down'))
 
     await expect(verifyBroadcastByHash({ chain, tx, error: originalError })).rejects.toBe(originalError)
+
+    expect(getTxStatusMock).toHaveBeenCalledTimes(broadcastVerificationMaxAttempts)
+    expect(sleepMock).toHaveBeenCalledTimes(broadcastVerificationMaxAttempts - 1)
   })
 
   it('rethrows original error when getTxHash throws', async () => {
@@ -78,6 +136,7 @@ describe('verifyBroadcastByHash', () => {
     await expect(verifyBroadcastByHash({ chain, tx, error: originalError })).rejects.toBe(originalError)
 
     expect(getTxStatusMock).not.toHaveBeenCalled()
+    expect(sleepMock).not.toHaveBeenCalled()
   })
 
   it('supports non-Error error values', async () => {

--- a/packages/core/chain/tx/broadcast/verifyBroadcastByHash.ts
+++ b/packages/core/chain/tx/broadcast/verifyBroadcastByHash.ts
@@ -1,3 +1,5 @@
+import { sleep } from '@vultisig/lib-utils/sleep'
+
 import { Chain } from '../../Chain'
 import { SigningOutput } from '../../tw/signingOutput'
 import { getTxHash } from '../hash'
@@ -9,6 +11,9 @@ type VerifyInput<T extends Chain> = {
   error: unknown
 }
 
+export const broadcastVerificationMaxAttempts = 4
+export const broadcastVerificationBaseDelayMs = 500
+
 /**
  * Hash-verification safety net for broadcast resolvers.
  *
@@ -19,26 +24,51 @@ type VerifyInput<T extends Chain> = {
  * string matching is fragile across RPC providers and versions; the
  * deterministic signal is the tx hash itself.
  *
- * This helper re-runs `getTxHash` + `getTxStatus` on the signed output.
+ * This helper derives the hash once, then retries `getTxStatus` briefly to
+ * allow for RPC propagation and indexing lag.
  * If the status lookup confirms the transaction exists (pending or
  * success), the broadcast error is swallowed. Otherwise the original
  * error is re-thrown so the caller sees the real failure.
  *
- * Any failure inside verification (hash/status RPC down, tx not indexed
- * yet, network error) falls through to re-throwing the original error —
- * verification is a safety net, never a new failure mode.
+ * A terminal failed status rethrows immediately. Unknown/not-found status and
+ * transient status lookup failures exhaust the bounded verification window
+ * before the original error is rethrown. Verification is a safety net, never
+ * a new failure mode.
  */
 export const verifyBroadcastByHash = async <T extends Chain>({ chain, tx, error }: VerifyInput<T>): Promise<void> => {
-  try {
-    const hash = await getTxHash({ chain, tx })
-    const result = await getTxStatus({ chain, hash })
-    const isKnownPending = result.status === 'pending' && result.isKnown !== false
+  let hash: string
 
-    if (result.status === 'success' || isKnownPending) {
-      return
-    }
+  try {
+    hash = await getTxHash({ chain, tx })
   } catch {
-    // fall through — verification unavailable, rethrow the original error
+    throw error
   }
+
+  for (let attempt = 1; attempt <= broadcastVerificationMaxAttempts; attempt++) {
+    let result: Awaited<ReturnType<typeof getTxStatus>> | undefined
+
+    try {
+      result = await getTxStatus({ chain, hash })
+    } catch {
+      // Retry status lookup failures within the same bounded window.
+    }
+
+    if (result) {
+      const isKnownPending = result.status === 'pending' && result.isKnown !== false
+
+      if (result.status === 'success' || isKnownPending) {
+        return
+      }
+
+      if (result.status === 'error') {
+        break
+      }
+    }
+
+    if (attempt < broadcastVerificationMaxAttempts) {
+      await sleep(broadcastVerificationBaseDelayMs * attempt)
+    }
+  }
+
   throw error
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction verification after broadcast errors by retrying transaction status checks briefly while propagation/indexing completes.
  * More reliably recovers from transient RPC/status lookup failures and better handles pending or temporarily unknown states.
  * Stops retrying on definitive error states and preserves the original broadcast error if verification can’t be confirmed within the retry window.
  * Added automated test coverage for retry timing and failure-handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->