### PR TITLE
fix(tron): encode the memo into protobuf field 10 (data) not 12 (scripts)

### DIFF
--- a/.changeset/tron-memo-field-10.md
+++ b/.changeset/tron-memo-field-10.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Fix the hand-rolled RN Tron transaction builder writing the transfer memo into protobuf field 12 (`scripts`, deprecated) instead of field 10 (`data`, the real Tron memo field). A TRC-20/TRX send carrying an exchange deposit tag or a THORChain swap memo previously broadcast with an empty `data` field on-chain. `buildTronSendTx`/`buildTrc20TransferTx` now write the memo to field 10 (and re-order `raw_data` field emission to match Tron's canonical ascending field order), matching the WalletCore keysign path exactly. Added a WalletCore cross-check test so the RN builder can never silently diverge from WalletCore's own encoding again.

--- a/packages/sdk/src/chains/tron/tx.ts
+++ b/packages/sdk/src/chains/tron/tx.ts
@@ -16,6 +16,8 @@
  *       ref_block_bytes:  bytes  (field 1, last 2 bytes of block number, BE)
  *       ref_block_hash:   bytes  (field 4, bytes 8..16 of block id hash)
  *       expiration:       int64  (field 8, unix ms)
+ *       data:             bytes  (field 10, optional memo — exchange deposit tags,
+ *                                 THORChain swap memos)
  *       contract:         Contract[] (field 11)
  *       timestamp:        int64  (field 14, unix ms)
  *       fee_limit:        int64  (field 18, optional, only for TRC-20)
@@ -87,13 +89,13 @@ export type BuildTronSendOptions = {
   /** Transaction timestamp (ms). Required — typically `BigInt(Date.now())`. */
   timestamp: bigint
   /**
-   * Optional memo / data bytes encoded into raw_data.data (proto field 12).
+   * Optional memo / data bytes encoded into raw_data.data (proto field 10).
    *
    * IMPORTANT: this is the *Transaction-level* memo on `raw_data.data`, NOT
    * any contract-call data. For native TRX sends the memo is the free-form
    * payload most exchanges and THORChain expect.
    *
-   * Empty Uint8Array is treated as absent — no field 12 is emitted.
+   * Empty Uint8Array is treated as absent — no field 10 is emitted.
    *
    * Used by:
    *   - THORChain swap memos (`SWAP:CHAIN.ASSET:dest:limit`)
@@ -101,8 +103,10 @@ export type BuildTronSendOptions = {
    *   - Any flow that needs to attach an arbitrary identifier to a transfer
    *
    * Parity: iOS sets `TronTransaction.memo = memoString` which WalletCore
-   * encodes identically as field 12; the legacy keysign resolver wires
-   * `memo: keysignPayload.memo` on the TW proto for the same effect.
+   * encodes to the same `raw_data.data` field 10; the legacy keysign
+   * resolver wires `memo: keysignPayload.memo` on the TW proto for the same
+   * effect. Cross-checked byte-for-byte against WalletCore's own output in
+   * `tron-tx.test.ts` ("WalletCore cross-check").
    */
   data?: Uint8Array
 }
@@ -132,14 +136,14 @@ export type BuildTrc20TransferOptions = {
   /** Timestamp (ms). Required — see `BuildTronSendOptions`. */
   timestamp: bigint
   /**
-   * Optional memo / data bytes encoded into raw_data.data (proto field 12).
+   * Optional memo / data bytes encoded into raw_data.data (proto field 10).
    *
    * IMPORTANT: this is the *Transaction-level* memo on the WRAPPING
    * Transaction, NOT the TRC-20 contract call data. The contract call data
    * (4-byte selector + 32-byte recipient + 32-byte amount) is built
    * separately and lives on the inner `TriggerSmartContract.data` field.
    *
-   * Empty Uint8Array is treated as absent — no field 12 is emitted.
+   * Empty Uint8Array is treated as absent — no field 10 is emitted.
    *
    * Used by:
    *   - Exchange deposit memos for TRC-20 USDT / USDC user-tag identifiers
@@ -148,8 +152,9 @@ export type BuildTrc20TransferOptions = {
    *     transfer
    *
    * Parity: iOS sets `TronTransaction.memo = memoString` for both native
-   * and TRC-20 paths; WalletCore encodes it as field 12 on the wrapping
-   * Transaction in both cases.
+   * and TRC-20 paths; WalletCore encodes it as field 10 on the wrapping
+   * Transaction in both cases. Cross-checked byte-for-byte against
+   * WalletCore's own output in `tron-tx.test.ts` ("WalletCore cross-check").
    */
   data?: Uint8Array
 }
@@ -278,21 +283,31 @@ function buildRawData(opts: {
 
   // Raw: we write the fields in ascending field-number order as Tron does.
   // The spec allows any order, but tronweb/core emit this exact ordering, so
-  // matching it helps byte parity checks against external signers.
+  // matching it helps byte parity checks against external signers — and is
+  // required for byte-identical output vs WalletCore (verified in
+  // tron-tx.test.ts's "WalletCore cross-check").
   let raw = concatProtoBytes(
     fieldBytes(1, opts.refBlockBytes),
     fieldBytes(4, opts.refBlockHash),
-    fieldInt64(8, opts.expiration),
-    fieldBytes(11, contract)
+    fieldInt64(8, opts.expiration)
   )
 
-  // Field 12: data (proto field 12, wire type 2 = length-delimited bytes).
-  // Encodes swap memos, exchange deposit memos, etc. Matches the behaviour of
-  // WalletCore's TronTransaction.memo field and the legacy keysign resolver.
+  // Field 10: data (proto field 10, wire type 2 = length-delimited bytes).
+  // This is the REAL Tron memo field — encodes swap memos, exchange deposit
+  // memos, etc. Matches WalletCore's TronTransaction.memo field and the
+  // legacy keysign resolver. Field 10 sorts BEFORE field 11 (contract), so it
+  // must be written here to match Tron's canonical ascending field order.
+  //
+  // Field 12 (`scripts`) is a different, deprecated field entirely (legacy
+  // VM scripts, unrelated to memos) — writing the memo there means it never
+  // reaches `raw_data.data`, and the memo is silently dropped on broadcast.
+  //
   // Empty arrays are treated as absent — Tron nodes reject zero-length data.
   if (opts.data != null && opts.data.length > 0) {
-    raw = concatProtoBytes(raw, fieldBytes(12, opts.data))
+    raw = concatProtoBytes(raw, fieldBytes(10, opts.data))
   }
+
+  raw = concatProtoBytes(raw, fieldBytes(11, contract))
 
   raw = concatProtoBytes(raw, fieldInt64(14, opts.timestamp))
 

--- a/packages/sdk/tests/unit/chains/tron-tx.test.ts
+++ b/packages/sdk/tests/unit/chains/tron-tx.test.ts
@@ -5,7 +5,10 @@
  *  - `encodeInt64Varint` for negative values (MUST be 10 bytes, two's-complement)
  *  - `buildTronSendTx` / `buildTrc20TransferTx` byte-level shape
  */
-import { describe, expect, it } from 'vitest'
+import { initWasm, TW, type WalletCore } from '@trustwallet/wallet-core'
+import { Buffer } from 'buffer'
+import Long from 'long'
+import { beforeAll, describe, expect, it } from 'vitest'
 
 import { encodeInt64Varint, encodeVarint } from '../../../src/chains/tron/proto'
 import {
@@ -27,6 +30,17 @@ function bytesToHex(b: Uint8Array): string {
   let s = ''
   for (let i = 0; i < b.length; i++) s += b[i]!.toString(16).padStart(2, '0')
   return s
+}
+
+// A plain `hex.includes(needle)` can false-positive on a needle that
+// straddles a byte boundary (e.g. '52' matching the tail of one byte and the
+// head of the next) even though no actual 0x52 byte is present at a tag
+// position. Only match at even (byte-aligned) offsets.
+function containsAlignedHex(hex: string, needle: string): boolean {
+  for (let i = 0; i <= hex.length - needle.length; i += 2) {
+    if (hex.slice(i, i + needle.length) === needle) return true
+  }
+  return false
 }
 
 describe('tron / encodeVarint', () => {
@@ -182,9 +196,9 @@ describe('tron / buildTrc20TransferTx', () => {
   })
 })
 
-describe('tron / buildTronSendTx memo / data field (proto field 12)', () => {
-  // Baseline: no memo → field 12 must be absent (back-compat guarantee).
-  it('no memo → field 12 tag 0x62 is absent from raw_data bytes', () => {
+describe('tron / buildTronSendTx memo / data field (proto field 10)', () => {
+  // Baseline: no memo → field 10 must be absent (back-compat guarantee).
+  it('no memo → field 10 tag 0x52 is absent from raw_data bytes', () => {
     const tx = buildTronSendTx({
       from: FROM,
       to: TO,
@@ -194,11 +208,13 @@ describe('tron / buildTronSendTx memo / data field (proto field 12)', () => {
       expiration: 1_700_000_000_000n,
       timestamp: 1_699_999_940_000n,
     })
-    // 0x62 is the tag for field 12 wire type 2; must be absent when no memo.
-    expect(tx.unsignedRawHex).not.toContain('62')
+    // 0x52 is the tag for field 10 wire type 2; must be absent when no memo.
+    // Byte-aligned check — a plain substring search can false-positive on a
+    // '52' that straddles two unrelated bytes (see `containsAlignedHex`).
+    expect(containsAlignedHex(tx.unsignedRawHex, '52')).toBe(false)
   })
 
-  it('empty Uint8Array memo → treated as absent, no field 12', () => {
+  it('empty Uint8Array memo → treated as absent, no field 10', () => {
     const tx = buildTronSendTx({
       from: FROM,
       to: TO,
@@ -209,10 +225,10 @@ describe('tron / buildTronSendTx memo / data field (proto field 12)', () => {
       timestamp: 1_699_999_940_000n,
       data: new Uint8Array(0),
     })
-    expect(tx.unsignedRawHex).not.toContain('62')
+    expect(containsAlignedHex(tx.unsignedRawHex, '52')).toBe(false)
   })
 
-  it('THORChain swap memo → field 12 present with UTF-8 encoded bytes', () => {
+  it('THORChain swap memo → field 10 (the real Tron memo field) present with UTF-8 encoded bytes', () => {
     const memo = 'SWAP:BTC.BTC:bc1qabcdef1234567890:1000000'
     const memoBytes = new TextEncoder().encode(memo)
     const tx = buildTronSendTx({
@@ -225,10 +241,10 @@ describe('tron / buildTronSendTx memo / data field (proto field 12)', () => {
       timestamp: 1_699_999_940_000n,
       data: memoBytes,
     })
-    // field 12 tag = 0x62, length varint = memo.length (< 128 so 1 byte), then data.
+    // field 10 tag = 0x52, length varint = memo.length (< 128 so 1 byte), then data.
     const expectedLen = memoBytes.length.toString(16).padStart(2, '0')
     const expectedMemoHex = bytesToHex(memoBytes)
-    expect(tx.unsignedRawHex).toContain('62' + expectedLen + expectedMemoHex)
+    expect(tx.unsignedRawHex).toContain('52' + expectedLen + expectedMemoHex)
   })
 
   it('memo changes the signing hash (pre-signing hash stability check)', () => {
@@ -268,8 +284,8 @@ describe('tron / buildTronSendTx memo / data field (proto field 12)', () => {
     // canonical value, then it fails on any deviation. The test itself asserts
     // length (64 hex chars = 32 bytes = SHA-256) and stability across runs.
     expect(tx.signingHashHex).toMatch(/^[0-9a-f]{64}$/)
-    // Pinned value established from first correct run:
-    expect(tx.signingHashHex).toBe('5f14bf8b2f6681f04a433beb93084b85f2d003ce337a2d72ea013d307a4e7841')
+    // Pinned value established from first correct run after the field-10 fix:
+    expect(tx.signingHashHex).toBe('e9b2b75390c656f9135f9379bae5a27e14dbfb6e9a2857004bf6d4f51ff30c12')
   })
 
   it('long memo (100+ bytes) is encoded correctly with varint length prefix', () => {
@@ -291,7 +307,7 @@ describe('tron / buildTronSendTx memo / data field (proto field 12)', () => {
     // varint(130) = 0x82 0x01 (two bytes: 130 & 0x7f | 0x80 = 0x82, then 1).
     const expectedVarint = '8201'
     const expectedMemoHex = bytesToHex(memoBytes)
-    expect(tx.unsignedRawHex).toContain('62' + expectedVarint + expectedMemoHex)
+    expect(tx.unsignedRawHex).toContain('52' + expectedVarint + expectedMemoHex)
     expect(tx.signingHashHex).toMatch(/^[0-9a-f]{64}$/)
   })
 
@@ -321,37 +337,38 @@ describe('tron / buildTronSendTx memo / data field (proto field 12)', () => {
 
     it('127-byte memo → 1-byte varint length prefix (0x7f)', () => {
       const memo = memoOf(127)
-      const expected = '62' + '7f' + bytesToHex(memo)
+      const expected = '52' + '7f' + bytesToHex(memo)
       expect(rawHexFor(memo)).toContain(expected)
     })
 
     it('128-byte memo → 2-byte varint length prefix (0x8001)', () => {
       const memo = memoOf(128)
-      const expected = '62' + '8001' + bytesToHex(memo)
+      const expected = '52' + '8001' + bytesToHex(memo)
       expect(rawHexFor(memo)).toContain(expected)
     })
 
     it('16383-byte memo → 2-byte varint length prefix (0xff7f)', () => {
       const memo = memoOf(16383)
-      const expected = '62' + 'ff7f' + bytesToHex(memo)
+      const expected = '52' + 'ff7f' + bytesToHex(memo)
       expect(rawHexFor(memo)).toContain(expected)
     })
 
     it('16384-byte memo → 3-byte varint length prefix (0x808001)', () => {
       const memo = memoOf(16384)
-      const expected = '62' + '808001' + bytesToHex(memo)
+      const expected = '52' + '808001' + bytesToHex(memo)
       expect(rawHexFor(memo)).toContain(expected)
     })
   })
 })
 
-describe('tron / buildTrc20TransferTx memo / data field (proto field 12)', () => {
+describe('tron / buildTrc20TransferTx memo / data field (proto field 10)', () => {
   // TRC-20 path mirrors the native send path: memo goes on the *wrapping*
-  // Transaction's raw_data.data (field 12), NOT the inner contract-call
-  // data (which is the ABI-encoded transfer payload). Exchanges that
-  // require user-tag memos to credit TRC-20 USDT deposits (Binance, OKX,
-  // KuCoin) rely on this field being present and correctly encoded.
-  it('no memo → field 12 tag 0x62 is absent from raw_data bytes', () => {
+  // Transaction's raw_data.data (field 10, the real Tron memo field), NOT
+  // the inner contract-call data (which is the ABI-encoded transfer
+  // payload). Exchanges that require user-tag memos to credit TRC-20 USDT
+  // deposits (Binance, OKX, KuCoin) rely on this field being present and
+  // correctly encoded.
+  it('no memo → field 10 tag 0x52 is absent from raw_data bytes', () => {
     const tx = buildTrc20TransferTx({
       from: FROM,
       to: TO,
@@ -363,29 +380,25 @@ describe('tron / buildTrc20TransferTx memo / data field (proto field 12)', () =>
       expiration: 1_700_000_000_000n,
       timestamp: 1_699_999_940_000n,
     })
-    // 0x62 is the field-12 tag (12<<3|2 = 0x62). When absent it must not
+    // 0x52 is the field-10 tag (10<<3|2 = 0x52). When absent it must not
     // appear in the tail of the raw bytes. The inner contract data lives
     // under a different tag (field 4 of TriggerSmartContract = 0x22)
     // wrapped inside Any(field 2)→Contract(field 2)→Raw(field 11), so
-    // 0x62 is only emitted when field 12 itself is set.
+    // 0x52 is only emitted when field 10 itself is set.
     const rawHex = tx.unsignedRawHex
     // Field 18 (fee_limit) tag = 18<<3|0 = 0x90 0x01. Locate it as a
-    // boundary marker; everything after must be the feeLimit varint, no
-    // stray 0x62 tag.
+    // boundary marker to confirm the tail of the tx is well-formed.
     const feeLimitIdx = rawHex.indexOf('900180c2d72f')
     expect(feeLimitIdx).toBeGreaterThan(-1)
-    // The bytes preceding fee_limit are: timestamp tag (0x70) + varint.
-    // The bytes preceding timestamp would be field 12 if present. Assert
-    // the timestamp tag follows directly after the contract block by
-    // checking no 0x62-tag-prefixed length-delimited block sits between
-    // contract end and timestamp tag — simplest signal is just length.
-    // Match what the native-send "no memo" assertion does: scan for the
-    // 0x62 tag. The contract value never legitimately ends with 0x62
-    // followed by a valid varint length so this is a tight check.
-    expect(rawHex).not.toContain('6204') // any short memo wouldn't appear
+    // Scan for the 0x52 tag anywhere in the raw bytes (byte-aligned — a plain
+    // substring search can false-positive on a '52' straddling two unrelated
+    // bytes, see `containsAlignedHex`). The contract value never legitimately
+    // produces a 0x52-tag-prefixed length-delimited block, so this is a
+    // tight check for field-10 absence.
+    expect(containsAlignedHex(rawHex, '5204')).toBe(false) // any short memo wouldn't appear
   })
 
-  it('empty Uint8Array memo → treated as absent, no field 12 emitted', () => {
+  it('empty Uint8Array memo → treated as absent, no field 10 emitted', () => {
     const tx = buildTrc20TransferTx({
       from: FROM,
       to: TO,
@@ -398,10 +411,10 @@ describe('tron / buildTrc20TransferTx memo / data field (proto field 12)', () =>
       timestamp: 1_699_999_940_000n,
       data: new Uint8Array(0),
     })
-    expect(tx.unsignedRawHex).not.toContain('6204')
+    expect(containsAlignedHex(tx.unsignedRawHex, '5204')).toBe(false)
   })
 
-  it('exchange deposit memo → field 12 present with UTF-8 encoded bytes', () => {
+  it('exchange deposit memo → field 10 (the real Tron memo field) present with UTF-8 encoded bytes', () => {
     // Binance-style TRC-20 USDT deposit memo (numeric user tag).
     const memo = '103456789'
     const memoBytes = new TextEncoder().encode(memo)
@@ -419,7 +432,7 @@ describe('tron / buildTrc20TransferTx memo / data field (proto field 12)', () =>
     })
     const expectedLen = memoBytes.length.toString(16).padStart(2, '0')
     const expectedMemoHex = bytesToHex(memoBytes)
-    expect(tx.unsignedRawHex).toContain('62' + expectedLen + expectedMemoHex)
+    expect(tx.unsignedRawHex).toContain('52' + expectedLen + expectedMemoHex)
   })
 
   it('memo changes the signing hash vs no-memo TRC-20 (pre-signing stability)', () => {
@@ -443,7 +456,7 @@ describe('tron / buildTrc20TransferTx memo / data field (proto field 12)', () =>
     expect(withMemo.unsignedRawHex).not.toBe(noMemo.unsignedRawHex)
   })
 
-  // Same boundary set as the native path — TRC-20 must encode field 12
+  // Same boundary set as the native path — TRC-20 must encode field 10
   // length prefix identically. The two builders share `buildRawData` so
   // the test guards against future divergence (e.g. someone routing TRC-20
   // through a different encoder).
@@ -471,25 +484,25 @@ describe('tron / buildTrc20TransferTx memo / data field (proto field 12)', () =>
 
     it('127-byte memo → 1-byte varint length prefix (0x7f)', () => {
       const memo = memoOf(127)
-      const expected = '62' + '7f' + bytesToHex(memo)
+      const expected = '52' + '7f' + bytesToHex(memo)
       expect(rawHexFor(memo)).toContain(expected)
     })
 
     it('128-byte memo → 2-byte varint length prefix (0x8001)', () => {
       const memo = memoOf(128)
-      const expected = '62' + '8001' + bytesToHex(memo)
+      const expected = '52' + '8001' + bytesToHex(memo)
       expect(rawHexFor(memo)).toContain(expected)
     })
 
     it('16383-byte memo → 2-byte varint length prefix (0xff7f)', () => {
       const memo = memoOf(16383)
-      const expected = '62' + 'ff7f' + bytesToHex(memo)
+      const expected = '52' + 'ff7f' + bytesToHex(memo)
       expect(rawHexFor(memo)).toContain(expected)
     })
 
     it('16384-byte memo → 3-byte varint length prefix (0x808001)', () => {
       const memo = memoOf(16384)
-      const expected = '62' + '808001' + bytesToHex(memo)
+      const expected = '52' + '808001' + bytesToHex(memo)
       expect(rawHexFor(memo)).toContain(expected)
     })
   })
@@ -599,5 +612,120 @@ describe('tron / buildTronTxFromRawData (prebuilt raw_data signing)', () => {
   it('finalize rejects a sig that is not 65 bytes', () => {
     const out = buildTronTxFromRawData('0a024010')
     expect(() => out.finalize('aa'.repeat(64))).toThrow(/65-byte/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// WalletCore cross-check — the durable guard against this class of bug.
+// ---------------------------------------------------------------------------
+//
+// The bug this file fixes (memo written to field 12 instead of field 10) was
+// invisible to the golden-vector suite because that suite hand-transcribed
+// the SAME wrong field number as its "independent" reference. A second
+// encoding of the same wrong assumption catches typos, not wrong assumptions.
+//
+// This block asserts the hand-rolled `raw_data` bytes are BYTE-IDENTICAL to
+// what WalletCore itself produces for an equivalent transaction — WalletCore
+// is a genuinely different implementation (used by the iOS/Android/Windows
+// co-signers), so it cannot silently share this encoder's mistake. If the RN
+// builder ever again diverges from WalletCore on field placement, ordering,
+// or memo encoding, this test fails.
+describe('tron / WalletCore cross-check (fund-safety net)', () => {
+  let walletCore: WalletCore
+
+  beforeAll(async () => {
+    walletCore = await initWasm()
+  })
+
+  const SENDER_PRIVATE_KEY = new Uint8Array(32).fill(7)
+  const RECIPIENT_PRIVATE_KEY = new Uint8Array(32).fill(8)
+  const AMOUNT = 250_000_000n
+  const EXPIRATION = 1_700_000_060_000n
+  const TIMESTAMP = 1_700_000_000_000n
+
+  function buildWalletCoreSignedOutput(memo: string) {
+    const senderPrivateKey = walletCore.PrivateKey.createWithData(SENDER_PRIVATE_KEY)
+    const senderPublicKey = senderPrivateKey.getPublicKeySecp256k1(false)
+    const sender = walletCore.AnyAddress.createWithPublicKey(senderPublicKey, walletCore.CoinType.tron).description()
+
+    const recipientPrivateKey = walletCore.PrivateKey.createWithData(RECIPIENT_PRIVATE_KEY)
+    const recipientPublicKey = recipientPrivateKey.getPublicKeySecp256k1(false)
+    const recipient = walletCore.AnyAddress.createWithPublicKey(
+      recipientPublicKey,
+      walletCore.CoinType.tron
+    ).description()
+
+    const signingInput = TW.Tron.Proto.SigningInput.create({
+      transaction: TW.Tron.Proto.Transaction.create({
+        transfer: TW.Tron.Proto.TransferContract.create({
+          ownerAddress: sender,
+          toAddress: recipient,
+          amount: Long.fromString(AMOUNT.toString()),
+        }),
+        timestamp: Long.fromString(TIMESTAMP.toString()),
+        blockHeader: TW.Tron.Proto.BlockHeader.create({
+          timestamp: Long.fromString(TIMESTAMP.toString()),
+          number: Long.fromNumber(56_000_000),
+          version: 31,
+          txTrieRoot: new Uint8Array(32).fill(0x01),
+          parentHash: new Uint8Array(32).fill(0x02),
+          witnessAddress: new Uint8Array(21).fill(0x03),
+        }),
+        expiration: Long.fromString(EXPIRATION.toString()),
+        memo,
+      }),
+    })
+
+    const output = TW.Tron.Proto.SigningOutput.decode(
+      walletCore.AnySigner.sign(
+        TW.Tron.Proto.SigningInput.encode({
+          ...signingInput,
+          privateKey: senderPrivateKey.data(),
+        }).finish(),
+        walletCore.CoinType.tron
+      )
+    )
+
+    return { output, sender, recipient }
+  }
+
+  it("a THORChain-swap-memo'd native TRX send matches WalletCore's raw_data byte-for-byte", () => {
+    const memo = 'SWAP:THOR.RUNE:thor1zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz:0'
+    const { output, sender, recipient } = buildWalletCoreSignedOutput(memo)
+    const walletCoreRawDataHex = (JSON.parse(output.json) as { raw_data_hex: string }).raw_data_hex
+
+    const ours = buildTronSendTx({
+      from: sender,
+      to: recipient,
+      amount: AMOUNT,
+      refBlockBytes: output.refBlockBytes,
+      refBlockHash: output.refBlockHash,
+      expiration: EXPIRATION,
+      timestamp: TIMESTAMP,
+      data: new TextEncoder().encode(memo),
+    })
+
+    // Sanity: the memo bytes must actually be present in WalletCore's own
+    // output (field 10, `data`) — this is what proves field 10 is correct,
+    // not an assumption baked into both sides.
+    expect(walletCoreRawDataHex).toContain(Buffer.from(memo, 'utf8').toString('hex'))
+    expect(ours.unsignedRawHex).toBe(walletCoreRawDataHex)
+  })
+
+  it("a no-memo native TRX send still matches WalletCore's raw_data byte-for-byte (regression guard)", () => {
+    const { output, sender, recipient } = buildWalletCoreSignedOutput('')
+    const walletCoreRawDataHex = (JSON.parse(output.json) as { raw_data_hex: string }).raw_data_hex
+
+    const ours = buildTronSendTx({
+      from: sender,
+      to: recipient,
+      amount: AMOUNT,
+      refBlockBytes: output.refBlockBytes,
+      refBlockHash: output.refBlockHash,
+      expiration: EXPIRATION,
+      timestamp: TIMESTAMP,
+    })
+
+    expect(ours.unsignedRawHex).toBe(walletCoreRawDataHex)
   })
 })

--- a/packages/sdk/tests/unit/platforms/react-native/tron-golden-vectors.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/tron-golden-vectors.test.ts
@@ -106,10 +106,13 @@ function encodeRawData(opts: {
   w.tag(1, WireType.LengthDelimited).bytes(opts.refBlockBytes)
   w.tag(4, WireType.LengthDelimited).bytes(opts.refBlockHash)
   w.tag(8, WireType.Varint).int64(opts.expiration)
-  w.tag(11, WireType.LengthDelimited).bytes(contractBytes)
+  // Field 10: `raw_data.data`, the real Tron memo field. Sorts before field 11
+  // (contract) in ascending field-number order, matching Tron's own encoder
+  // and WalletCore's output (see the cross-check in tron-tx.test.ts).
   if (opts.data && opts.data.length > 0) {
-    w.tag(12, WireType.LengthDelimited).bytes(opts.data)
+    w.tag(10, WireType.LengthDelimited).bytes(opts.data)
   }
+  w.tag(11, WireType.LengthDelimited).bytes(contractBytes)
   w.tag(14, WireType.Varint).int64(opts.timestamp)
   if (opts.feeLimit != null && opts.feeLimit > 0n) {
     w.tag(18, WireType.Varint).int64(opts.feeLimit)
@@ -151,7 +154,7 @@ describe('Tron / buildTronSendTx — TransferContract golden vectors', () => {
     expect(result.signingHashHex).toBe(bytesToHex(sha256(referenceRawData)))
   })
 
-  it('embeds the transaction-level memo (field 12) identically to the reference encoding', () => {
+  it('embeds the transaction-level memo (field 10) identically to the reference encoding', () => {
     const memo = new TextEncoder().encode('SWAP:THOR.RUNE:thor1abc:0')
     const result = buildTronSendTx({
       from: FX.from,


### PR DESCRIPTION
Closes #1468

## what

The hand-rolled RN Tron tx builder (`buildRawData` in `packages/sdk/src/chains/tron/tx.ts`) wrote the transfer memo (`opts.data`) into `raw_data` field **12** (`scripts`, deprecated) instead of field **10** (`data`, the real Tron memo field). WalletCore's keysign path (`packages/core/mpc/keysign/signingInputs/resolvers/tron.ts`) was already correct - it sets `memo: keysignPayload.memo` on the TW proto, which WalletCore encodes to field 10.

The golden test enshrined the bug instead of catching it: `tron-golden-vectors.test.ts`'s "independent" `@bufbuild/protobuf` reference encoder hand-transcribed the same wrong field number, so both "sides" agreed on the wrong answer and stayed green.

## where

- `packages/sdk/src/chains/tron/tx.ts:289-295` (pre-fix) - `buildRawData` wrote `opts.data` to field 12.
- `packages/sdk/tests/unit/platforms/react-native/tron-golden-vectors.test.ts:154` (pre-fix) - reference encoder re-derived the same field-12 assumption.
- `packages/core/mpc/keysign/signingInputs/resolvers/tron.ts` - confirmed correct (field 10) pre-fix, unchanged by this PR.

## why (fund-loss impact)

Any TRC-20/TRX send **with a memo** was affected:
- Exchange deposits use the memo as the destination tag. An empty `data` field means the exchange credits nothing - frequently unrecoverable.
- A THORChain swap memo landing empty means Bifrost never sees the swap intent - funds sent, swap never happens.

## fix

- `buildRawData` now writes the memo to field 10, and the field is emitted **before** field 11 (`contract`) to match Tron's canonical ascending field order - this also matches WalletCore's actual byte layout, not just the field number (verified byte-for-byte, see below).
- `tron-golden-vectors.test.ts` rebuilt against field 10 with the same reordering.
- `tron-tx.test.ts`: all field-12/tag-`0x62` references moved to field-10/tag-`0x52`; the "field absent" checks were switched from a raw substring search (which can false-positive on a `52` straddling two unrelated bytes) to a byte-aligned check; the pinned signing-hash regression test recomputed for the new encoding.
- **New durable guard** - `tron / WalletCore cross-check (fund-safety net)` in `tron-tx.test.ts`: builds an equivalent `TransferContract` via `@trustwallet/wallet-core` (a genuinely independent implementation, not a second hand-transcription of the same spec) and asserts the hand-rolled `raw_data` is **byte-identical** to WalletCore's own `raw_data_hex`, for both a THORChain-swap-memo'd send and a no-memo regression case. This is what would have caught the original bug and will catch any future drift between the RN builder and WalletCore.

## cross-consumer (shared-SDK caution)

- `packages/sdk` ships to the flagship iOS/Android/Windows apps too. Grepped all consumers of `buildTronSendTx`/`buildTrc20TransferTx`: the only non-test consumer is `packages/sdk/src/platforms/react-native/chains/tron/index.ts`, a thin re-export explicitly documented as the RN/Hermes bridge (`tronweb` is avoided because of a `ws`/`node-fetch` cascade it doesn't want to eval at module init). This is the mobile/Station-agent-only code path.
- The flagship WalletCore signing path (`packages/core/mpc/keysign/signingInputs/resolvers/tron.ts` + `packages/core/mpc/tx/compile/compileTx.ts`) is untouched by this PR and was already correct - confirmed via `packages/core/mpc/tx/compile/compileTx.golden.test.ts`'s existing Tron `TransferContract` golden test, which still passes unmodified.
- Grepped for any test/consumer asserting field-12 behavior outside the two files fixed here - none found. Field 12 was a straight bug; nothing legitimately depended on it.
- **No version bump / republish in this PR.** Added a changeset (`.changeset/tron-memo-field-10.md`, `patch`) so the fix is queued for the next release, but the actual `@vultisig/sdk` version bump only happens when a maintainer merges the separate changesets-bot "Version Packages" PR - not this one. Publish/republish timing is a maintainer decision.
- **Consumers needing a regression pass before this ships**: any RN/mobile Tron memo send (exchange deposit tag) and any THORChain Tron-source swap (memo carries the swap intent) - both currently broken pre-fix, both should be spot-checked post-fix before the version bump lands.

## test receipts

`yarn workspace @vultisig/sdk vitest run --config tests/unit/vitest.config.ts tests/unit/chains/tron-tx.test.ts tests/unit/platforms/react-native/tron-golden-vectors.test.ts`:
```
Test Files  2 passed (2)
     Tests  49 passed (49)
```
Includes the two new WalletCore cross-check tests, both green.

`yarn workspace @vultisig/sdk typecheck`: clean (0 errors after `yarn build:shared`; confirmed identical 29 pre-existing baseline errors on main before `yarn build:shared`, none tron-related, none introduced by this diff).

`yarn workspace @vultisig/sdk test` (full unit suite, post `yarn build:shared`):
```
Test Files  193 passed (193)
     Tests  2929 passed (2929)
```

`yarn test:core` (full core suite, confirms the WalletCore Tron golden test is untouched and still green):
```
Test Files  215 passed | 1 skipped (216)
     Tests  1938 passed | 1 skipped (1939)
```
Tron-specific subset (`-t "Tron"`): 8 files / 45 tests, all passing.

Prettier + eslint clean on all touched files.

🤖 Agent-generated