### PR TITLE
Fix Bittensor broadcast error handling

### DIFF
--- a/.changeset/fuzzy-taxis-broadcast.md
+++ b/.changeset/fuzzy-taxis-broadcast.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/core-chain': patch
+---
+
+Align Bittensor broadcast error handling with the shared Substrate safeguards.

--- a/package.json
+++ b/package.json
@@ -216,7 +216,8 @@
     "form-data@npm:^4.0.5": "^4.0.6",
     "hono@npm:^4.11.4": "4.12.25",
     "undici": "^7.28.0",
-    "linkify-it": "5.0.1",
+    "fast-uri": "3.1.4",
+    "linkify-it": "5.0.2",
     "bigint-buffer@npm:^1.1.5": "patch:bigint-buffer@npm%3A1.1.5#~/.yarn/patches/bigint-buffer-npm-1.1.5-785f4ccd92.patch"
   }
 }

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -1883,6 +1883,11 @@
       "import": "./dist/tx/broadcast/resolvers/solana.js",
       "default": "./dist/tx/broadcast/resolvers/solana.js"
     },
+    "./tx/broadcast/resolvers/substrate": {
+      "types": "./dist/tx/broadcast/resolvers/substrate.d.ts",
+      "import": "./dist/tx/broadcast/resolvers/substrate.js",
+      "default": "./dist/tx/broadcast/resolvers/substrate.js"
+    },
     "./tx/broadcast/resolvers/sui": {
       "types": "./dist/tx/broadcast/resolvers/sui.d.ts",
       "import": "./dist/tx/broadcast/resolvers/sui.js",

--- a/packages/core/chain/tx/broadcast/resolvers/bittensor.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/bittensor.test.ts
@@ -19,44 +19,94 @@ describe('broadcastBittensorTx', () => {
 
   beforeEach(() => vi.clearAllMocks())
 
-  it('returns silently when the node accepts the extrinsic (result present)', async () => {
-    mocks.queryUrl.mockResolvedValue({ result: '0xhash' })
+  it('returns silently when the node accepts the extrinsic', async () => {
+    mocks.queryUrl.mockResolvedValue({ result: '0xdeadbeef' })
+
     await expect(broadcastBittensorTx({ chain, tx })).resolves.toBeUndefined()
     expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
   })
 
-  it('swallows the idempotent "Already Imported" peer-race error', async () => {
-    mocks.queryUrl.mockResolvedValue({ error: { code: 1013, message: 'Transaction Already Imported' } })
+  it('accepts case-variant duplicate import errors', async () => {
+    mocks.queryUrl.mockResolvedValue({
+      error: { code: 1013, message: 'TRANSACTION ALREADY IMPORTED' },
+    })
+
     await expect(broadcastBittensorTx({ chain, tx })).resolves.toBeUndefined()
     expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
   })
 
-  it('verifies by hash on a genuine error', async () => {
-    mocks.queryUrl.mockResolvedValue({ error: { code: 1010, message: 'Invalid Transaction' } })
-    await broadcastBittensorTx({ chain, tx })
-    expect(mocks.verifyBroadcastByHash).toHaveBeenCalledOnce()
+  it('recognizes an idempotent signal carried in error data', async () => {
+    mocks.queryUrl.mockResolvedValue({
+      error: { code: 1010, message: 'Invalid Transaction', data: 'Already known' },
+    })
+
+    await expect(broadcastBittensorTx({ chain, tx })).resolves.toBeUndefined()
+    expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
   })
 
-  // The gap: a malformed/truncated body with neither error nor result used to return undefined = success.
-  it('does NOT assume success on a malformed response (neither error nor result) — verifies by hash', async () => {
-    mocks.queryUrl.mockResolvedValue({})
+  it('hash-verifies ambiguous temporarily-banned responses', async () => {
+    mocks.queryUrl.mockResolvedValue({
+      error: { code: 1010, message: 'Transaction is temporarily banned' },
+    })
+    mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+
     await broadcastBittensorTx({ chain, tx })
+
     expect(mocks.verifyBroadcastByHash).toHaveBeenCalledOnce()
+    expect((mocks.verifyBroadcastByHash.mock.calls[0]![0].error as Error).message).toBe(
+      'Bittensor broadcast failed: Transaction is temporarily banned'
+    )
   })
 
-  // #1430-class retry-interlock: bittensor runs inside `withTransientBroadcastRetry`
-  // (index.ts hasResolverOwnedRetry = evm|solana only). When hash verification
-  // cannot confirm the tx, verifyBroadcastByHash rethrows the original error and
-  // it escapes to the retry wrapper. That error MUST be classified non-transient
-  // so a genuinely-failed/unconfirmed broadcast is not silently re-sent up to 3×.
-  it('surfaces the malformed-response failure as a NON-transient error (must not be re-broadcast)', async () => {
+  it('preserves error data when routing a genuine rejection through verification', async () => {
+    mocks.queryUrl.mockResolvedValue({
+      error: {
+        code: 1010,
+        message: 'Invalid Transaction',
+        data: 'Transaction has a bad signature',
+      },
+    })
+    mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+
+    await broadcastBittensorTx({ chain, tx })
+
+    expect(mocks.verifyBroadcastByHash).toHaveBeenCalledOnce()
+    expect((mocks.verifyBroadcastByHash.mock.calls[0]![0].error as Error).message).toBe(
+      'Bittensor broadcast failed: Invalid Transaction: Transaction has a bad signature'
+    )
+  })
+
+  it('routes a response without a result or error through verification', async () => {
     mocks.queryUrl.mockResolvedValue({})
-    // Simulate verification unable to confirm the tx on-chain → rethrow.
+    mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+
+    await broadcastBittensorTx({ chain, tx })
+
+    expect(mocks.verifyBroadcastByHash).toHaveBeenCalledOnce()
+    expect((mocks.verifyBroadcastByHash.mock.calls[0]![0].error as Error).message).toContain('missing extrinsic hash')
+  })
+
+  it('surfaces an unconfirmed malformed response as non-transient', async () => {
+    mocks.queryUrl.mockResolvedValue({})
     mocks.verifyBroadcastByHash.mockImplementation(async ({ error }) => {
       throw error
     })
-    await expect(broadcastBittensorTx({ chain, tx })).rejects.toThrow(/missing extrinsic hash/)
-    const err = await broadcastBittensorTx({ chain, tx }).catch(e => e)
-    expect(isTransientBroadcastError(err)).toBe(false)
+
+    const error = await broadcastBittensorTx({ chain, tx }).catch(caught => caught)
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toHaveProperty('message', 'Bittensor broadcast failed: missing extrinsic hash in RPC response')
+    expect(isTransientBroadcastError(error)).toBe(false)
+  })
+
+  it('routes transport failures through verification', async () => {
+    const error = new Error('ECONNRESET')
+    mocks.queryUrl.mockRejectedValue(error)
+    mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+
+    await broadcastBittensorTx({ chain, tx })
+
+    expect(mocks.verifyBroadcastByHash).toHaveBeenCalledOnce()
+    expect(mocks.verifyBroadcastByHash.mock.calls[0]![0].error).toBe(error)
   })
 })

--- a/packages/core/chain/tx/broadcast/resolvers/bittensor.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/bittensor.ts
@@ -5,40 +5,37 @@ import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
 import { BroadcastTxResolver } from '../resolver'
 import { verifyBroadcastByHash } from '../verifyBroadcastByHash'
+import { formatSubstrateRpcError, isIdempotentSubstrateBroadcastError, SubstrateRpcError } from './substrate'
 
 type RpcResponse = {
   result?: string
-  error?: { code: number; message: string }
+  error?: SubstrateRpcError
 }
 
 export const broadcastBittensorTx: BroadcastTxResolver<OtherChain.Bittensor> = async ({ chain, tx }) => {
   const hexWithPrefix = ensureHexPrefix(Buffer.from(tx.encoded).toString('hex'))
 
-  const response = await queryUrl<RpcResponse>(bittensorRpcUrl, {
-    body: {
-      jsonrpc: '2.0',
-      method: 'author_submitExtrinsic',
-      params: [hexWithPrefix],
-      id: 1,
-    },
-  })
+  try {
+    const response = await queryUrl<RpcResponse>(bittensorRpcUrl, {
+      body: {
+        jsonrpc: '2.0',
+        method: 'author_submitExtrinsic',
+        params: [hexWithPrefix],
+        id: 1,
+      },
+    })
 
-  if (response.error) {
-    const message = response.error.message ?? ''
-    // "Already Imported" means another device already broadcast this tx — not an error
-    if (message.includes('Already Imported')) {
-      return
+    if (response.error) {
+      if (isIdempotentSubstrateBroadcastError(response.error)) {
+        return
+      }
+      throw new Error(`Bittensor broadcast failed: ${formatSubstrateRpcError(response.error)}`)
     }
-    const err = new Error(`Bittensor broadcast failed: ${message || `code ${response.error.code}`}`)
-    await verifyBroadcastByHash({ chain, tx, error: err })
-    return
-  }
 
-  // Per JSON-RPC 2.0 a valid response carries exactly one of `result` / `error`. Neither present
-  // (malformed / truncated gateway body) must NOT be assumed a success — force hash verification.
-  // Mirrors the polkadot resolver's guard; without it a truncated body returned `undefined` = success.
-  if (!response.result) {
-    const err = new Error('Bittensor broadcast failed: missing extrinsic hash in RPC response')
-    await verifyBroadcastByHash({ chain, tx, error: err })
+    if (!response.result) {
+      throw new Error('Bittensor broadcast failed: missing extrinsic hash in RPC response')
+    }
+  } catch (error) {
+    await verifyBroadcastByHash({ chain, tx, error })
   }
 }

--- a/packages/core/chain/tx/broadcast/resolvers/polkadot.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/polkadot.test.ts
@@ -46,15 +46,6 @@ describe('broadcastPolkadotTx', () => {
       expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
     })
 
-    it('swallows "Transaction is temporarily banned"', async () => {
-      mocks.queryUrl.mockResolvedValue({
-        error: { code: 1010, message: 'Transaction is temporarily banned' },
-      })
-
-      await expect(broadcastPolkadotTx({ chain, tx })).resolves.toBeUndefined()
-      expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
-    })
-
     it('swallows generic "Already known" Pool error variants', async () => {
       mocks.queryUrl.mockResolvedValue({
         error: { code: 1013, message: 'Already known' },
@@ -74,6 +65,20 @@ describe('broadcastPolkadotTx', () => {
   })
 
   describe('genuine broadcast failures (MUST surface)', () => {
+    it('hash-verifies ambiguous temporarily-banned responses', async () => {
+      mocks.queryUrl.mockResolvedValue({
+        error: { code: 1010, message: 'Transaction is temporarily banned' },
+      })
+      mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+
+      await broadcastPolkadotTx({ chain, tx })
+
+      expect(mocks.verifyBroadcastByHash).toHaveBeenCalledOnce()
+      expect((mocks.verifyBroadcastByHash.mock.calls[0]![0].error as Error).message).toBe(
+        'Polkadot broadcast failed: Transaction is temporarily banned'
+      )
+    })
+
     it('forwards BadProof to verifyBroadcastByHash and includes the data field', async () => {
       mocks.queryUrl.mockResolvedValue({
         error: {

--- a/packages/core/chain/tx/broadcast/resolvers/polkadot.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/polkadot.ts
@@ -5,47 +5,11 @@ import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 import { polkadotRpcUrl } from '../../../chains/polkadot/client'
 import { BroadcastTxResolver } from '../resolver'
 import { verifyBroadcastByHash } from '../verifyBroadcastByHash'
+import { formatSubstrateRpcError, isIdempotentSubstrateBroadcastError, SubstrateRpcError } from './substrate'
 
 type RpcResponse = {
   result?: string
-  error?: { code: number; message: string; data?: string }
-}
-
-/**
- * Substrate Pool errors that mean "this extrinsic is already in the pool /
- * imported / banned because a peer just submitted it." In an MPC ceremony,
- * the initiator and the joiner both broadcast the same signed extrinsic; the
- * slower device hits exactly these messages while the tx is in fact already
- * on chain. Treat them as idempotent successes — the alternative is showing
- * the slower device a "Signing Error" screen for a transaction that did
- * confirm. Fast path so we don't rely on `verifyBroadcastByHash`, which can't
- * help on Polkadot until tx-status polling moves off the gated Subscan API.
- *
- * Substrate sources for the exact strings:
- *   substrate/client/transaction-pool/api/src/error.rs (AlreadyImported,
- *   TemporarilyBanned, NoTagsProvided, ImmediatelyDropped) and
- *   primitives/runtime/src/transaction_validity.rs (Stale).
- */
-const idempotentBroadcastErrorPatterns: readonly RegExp[] = [
-  /already imported/i,
-  /already known/i,
-  /temporarily banned/i,
-]
-
-const isIdempotentBroadcastError = (text: string): boolean =>
-  idempotentBroadcastErrorPatterns.some(pattern => pattern.test(text))
-
-/**
- * Substrate's JSON-RPC error shape is `{ code, message, data? }`. For
- * `InvalidTransaction::*` rejections (code 1010) the `message` is the
- * generic `"Invalid Transaction"` and the specific reason ("Transaction has
- * a bad signature", "Transaction is outdated", "Inability to pay some fees",
- * etc.) lives in `data`. Surfacing only `message` makes every failure look
- * identical in the UI and strips the information we need to triage.
- */
-const formatRpcError = ({ code, message, data }: { code: number; message: string; data?: string }): string => {
-  const head = message ?? `code ${code}`
-  return data ? `${head}: ${data}` : head
+  error?: SubstrateRpcError
 }
 
 export const broadcastPolkadotTx: BroadcastTxResolver<OtherChain.Polkadot> = async ({ chain, tx }) => {
@@ -66,11 +30,10 @@ export const broadcastPolkadotTx: BroadcastTxResolver<OtherChain.Polkadot> = asy
       // already submitted this exact tx; the node tells us with a Pool error
       // (string usually in `message`) or, less commonly, an Invalid
       // Transaction variant whose duplicate signal lives in `data`.
-      const errorText = `${response.error.message ?? ''} ${response.error.data ?? ''}`
-      if (isIdempotentBroadcastError(errorText)) {
+      if (isIdempotentSubstrateBroadcastError(response.error)) {
         return
       }
-      throw new Error(`Polkadot broadcast failed: ${formatRpcError(response.error)}`)
+      throw new Error(`Polkadot broadcast failed: ${formatSubstrateRpcError(response.error)}`)
     }
 
     // Per JSON-RPC 2.0 a valid response must have exactly one of `result` /

--- a/packages/core/chain/tx/broadcast/resolvers/substrate.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/substrate.ts
@@ -1,0 +1,24 @@
+export type SubstrateRpcError = {
+  code: number
+  message?: string
+  data?: string
+}
+
+// These pool errors mean another MPC peer has already submitted the same
+// deterministic extrinsic. Treat them as idempotent success so the slower peer
+// does not show a signing failure for a transaction that is already in flight.
+const idempotentBroadcastErrorPatterns: readonly RegExp[] = [/already imported/i, /already known/i]
+
+// `TemporarilyBanned` is deliberately not a fast success. Substrate bans
+// hashes after known block imports, but it can also ban transactions removed
+// as invalid or dropped. Only hash verification can disambiguate those cases.
+
+export const isIdempotentSubstrateBroadcastError = ({ message, data }: SubstrateRpcError): boolean =>
+  idempotentBroadcastErrorPatterns.some(pattern => pattern.test(`${message ?? ''} ${data ?? ''}`))
+
+// Substrate often carries the actionable InvalidTransaction reason in `data`
+// while `message` contains only the generic "Invalid Transaction" label.
+export const formatSubstrateRpcError = ({ code, message, data }: SubstrateRpcError): string => {
+  const head = message ?? `code ${code}`
+  return data ? `${head}: ${data}` : head
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11445,10 +11445,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.0.1":
-  version: 3.1.2
-  resolution: "fast-uri@npm:3.1.2"
-  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
+"fast-uri@npm:3.1.4":
+  version: 3.1.4
+  resolution: "fast-uri@npm:3.1.4"
+  checksum: 10c0/f90948821ceb49980f64f89b8216ba498f5957f26035be813526a55b6145d26cbd63ef5618d5205a3292b31edc9c08589749350cd72bd86c7095eb434dceb757
   languageName: node
   linkType: hard
 
@@ -13990,12 +13990,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"linkify-it@npm:5.0.1":
-  version: 5.0.1
-  resolution: "linkify-it@npm:5.0.1"
+"linkify-it@npm:5.0.2":
+  version: 5.0.2
+  resolution: "linkify-it@npm:5.0.2"
   dependencies:
     uc.micro: "npm:^2.0.0"
-  checksum: 10c0/d06d04f1ed03be131740fc900a5e74ea1f49886b052213599e306d469d5ffe2303db76dd8f771de9f28e2b0b38852de22ec46ae597d245f8b66439b0ceb19b10
+  checksum: 10c0/dd70b1735a13d41a2cff0a058ac3771166038f23f6aff004dd53873cf985c64b107902fe0b544a5b3d1ff6e63249cf9c648fb3ae9f285481db48f56887adb0d6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bittensor and Polkadot transaction broadcast error handling with shared Substrate safeguards.
  * Idempotent “already imported/known” failures are treated as success, while ambiguous “temporarily banned” cases are verified before reporting failure.
  * Added explicit handling for missing extrinsic hash scenarios with clearer non-transient error behavior.

* **New Features**
  * Added a new public export for shared Substrate broadcast error utilities.

* **Tests**
  * Expanded broadcast resolver coverage to validate verification and error-message behavior across success and failure paths.

* **Chores**
  * Updated select root dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->