### PR TITLE
fix(sdk): export dangerous-address canonicals

### DIFF
--- a/.changeset/sdk-dangerous-address-exports.md
+++ b/.changeset/sdk-dangerous-address-exports.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+Export the canonical dangerous-address helpers and constants from both the root SDK entrypoint and the React Native entrypoint.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -107,6 +107,15 @@ export {
 export type { AddressFamily, AddressRole, ChainPrefixResult } from './utils/addressValidation'
 export { address, validate } from './utils/addressValidation'
 export { checkChainPrefix } from './utils/chainPrefix'
+export {
+  assertSafeDestination,
+  assertSafeEvmDestination,
+  EVM_DANGEROUS_ADDRESSES,
+  getChainDangerousReason,
+  getEvmDangerousReason,
+  isEvmBurnAddress,
+  SOLANA_DANGEROUS_ADDRESSES,
+} from './utils/dangerousAddresses'
 
 // ============================================================================
 // PUBLIC API - Tx Shape Normalization (pure, vault-free)

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -613,6 +613,15 @@ export { chainSchema, parseChain, parseTicker, tickerSchema } from '../../tools/
 export type { NormalizeArgs, NormalizedTx } from '../../tx'
 export { normalizeTx, splitMultiTx, TxNormalizeError } from '../../tx'
 export { computePersonalSignHash, formatEcdsaSignature65 } from '../../utils/eip191'
+export {
+  assertSafeDestination,
+  assertSafeEvmDestination,
+  EVM_DANGEROUS_ADDRESSES,
+  getChainDangerousReason,
+  getEvmDangerousReason,
+  isEvmBurnAddress,
+  SOLANA_DANGEROUS_ADDRESSES,
+} from '../../utils/dangerousAddresses'
 export { normalizeChain, UnknownChainError } from '../../utils/normalizeChain'
 export { resolveChainReference } from '../../utils/resolveChainReference'
 export { ChainAmountParseError, toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -152,3 +152,18 @@ describe('RN entry exposes toChainAmount + ChainAmountParseError', () => {
     expect(() => rn.toChainAmount('   ', 8)).toThrow(rn.ChainAmountParseError)
   })
 })
+
+describe('RN entry exposes the dangerous-address helpers', () => {
+  it('re-exports the canonical dangerous-address helpers and constants from the RN entrypoint', async () => {
+    const rn = await import('../../../../src/platforms/react-native/index')
+    const dangerousAddresses = await import('../../../../src/utils/dangerousAddresses')
+
+    expect(rn.EVM_DANGEROUS_ADDRESSES).toBe(dangerousAddresses.EVM_DANGEROUS_ADDRESSES)
+    expect(rn.SOLANA_DANGEROUS_ADDRESSES).toBe(dangerousAddresses.SOLANA_DANGEROUS_ADDRESSES)
+    expect(rn.getEvmDangerousReason).toBe(dangerousAddresses.getEvmDangerousReason)
+    expect(rn.isEvmBurnAddress).toBe(dangerousAddresses.isEvmBurnAddress)
+    expect(rn.getChainDangerousReason).toBe(dangerousAddresses.getChainDangerousReason)
+    expect(rn.assertSafeEvmDestination).toBe(dangerousAddresses.assertSafeEvmDestination)
+    expect(rn.assertSafeDestination).toBe(dangerousAddresses.assertSafeDestination)
+  })
+})

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import * as sdk from '../../../src/index'
+import * as dangerousAddresses from '../../../src/utils/dangerousAddresses'
 
 describe('@vultisig/sdk public exports', () => {
   it('exports fiatToAmount, toChainAmount, and chain-reference normalization utilities', () => {
@@ -43,6 +44,16 @@ describe('@vultisig/sdk public exports', () => {
     expect(typeof sdk.isCanonicalTronContract).toBe('function')
     expect(sdk.canonicalEvmContracts instanceof Set).toBe(true)
     expect(typeof sdk.knownContracts.isKnownContract).toBe('function')
+  })
+
+  it('exports the canonical dangerous-address helpers and constants', () => {
+    expect(sdk.EVM_DANGEROUS_ADDRESSES).toBe(dangerousAddresses.EVM_DANGEROUS_ADDRESSES)
+    expect(sdk.SOLANA_DANGEROUS_ADDRESSES).toBe(dangerousAddresses.SOLANA_DANGEROUS_ADDRESSES)
+    expect(sdk.getEvmDangerousReason).toBe(dangerousAddresses.getEvmDangerousReason)
+    expect(sdk.isEvmBurnAddress).toBe(dangerousAddresses.isEvmBurnAddress)
+    expect(sdk.getChainDangerousReason).toBe(dangerousAddresses.getChainDangerousReason)
+    expect(sdk.assertSafeEvmDestination).toBe(dangerousAddresses.assertSafeEvmDestination)
+    expect(sdk.assertSafeDestination).toBe(dangerousAddresses.assertSafeDestination)
   })
 
   it('exports findSwapQuote, abiEncode, evmCheckAllowance (already consumed by mcp-ts)', () => {


### PR DESCRIPTION
## Summary
- export the canonical dangerous-address helpers/constants from root `@vultisig/sdk`
- export the same helpers/constants from `@vultisig/sdk/react-native`
- add root + RN regression coverage so future public-surface omissions fail loudly

## Why
Round 47 `/improve` found that `packages/sdk/src/utils/dangerousAddresses.ts` already owns the canonical burn/dangerous-address helpers, but first-party consumers still cannot import them from the public SDK surfaces they actually use. That keeps app/backend code on the duplicated-not-imported path.

## Test plan
- `corepack yarn build:shared`
- `corepack yarn vitest run --config packages/sdk/tests/unit/vitest.config.ts packages/sdk/tests/unit/utils/publicExports.test.ts packages/sdk/tests/unit/platforms/react-native/entry.test.ts`
- `corepack yarn build:sdk`
- `corepack yarn cli:build`
- `node --input-type=module -e "import * as sdk from './packages/sdk/dist/index.node.esm.js'; console.log(JSON.stringify({hasEvmDangerous:sdk.EVM_DANGEROUS_ADDRESSES['0x000000000000000000000000000000000000dead'], hasFn: typeof sdk.assertSafeDestination, burnCheck: sdk.isEvmBurnAddress('0x000000000000000000000000000000000000dEaD')}))"`
- inspect `packages/sdk/dist/index.react-native.d.ts` for the RN export surface
- `corepack yarn workspace @vultisig/sdk pack --out /tmp/vultisig-sdk-r47/.artifacts/vultisig-sdk-r47.tgz`

Closes #1476
