### PR TITLE
Expose canonical token IDs

### DIFF
--- a/.changeset/canonical-token-identifiers.md
+++ b/.changeset/canonical-token-identifiers.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': minor
+---
+
+Expose chain-neutral `tokenId` fields across public token registry and discovery surfaces while retaining `contractAddress` as a deprecated compatibility alias.

--- a/docs/SDK-USERS-GUIDE.md
+++ b/docs/SDK-USERS-GUIDE.md
@@ -1856,10 +1856,12 @@ import { Vultisig, Chain } from '@vultisig/sdk'
 // Get all known tokens for a chain
 const tokens = Vultisig.getKnownTokens(Chain.Ethereum)
 for (const token of tokens) {
-  console.log(`${token.ticker}: ${token.contractAddress}`)
+  console.log(`${token.ticker}: ${token.tokenId}`)
 }
 
-// Look up a specific token by contract address (case-insensitive)
+// contractAddress remains as a deprecated alias for existing consumers
+
+// Look up a specific token by its canonical chain-specific token ID
 const usdc = Vultisig.getKnownToken(Chain.Ethereum, '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48')
 if (usdc) {
   console.log(`${usdc.ticker} - ${usdc.decimals} decimals`)
@@ -1893,7 +1895,7 @@ const solTokens = await vault.discoverTokens(Chain.Solana)
 
 ### Resolving Token Metadata
 
-Resolve token metadata by contract address. Checks the built-in registry first (fast, no network), then falls back to chain APIs:
+Resolve token metadata by canonical chain-specific token ID. Checks the built-in registry first (fast, no network), then falls back to chain APIs:
 
 ```typescript
 // Known token → instant, no network call
@@ -2639,7 +2641,7 @@ class Vultisig {
 
   // Token registry (static, no vault needed)
   static getKnownTokens(chain: Chain): TokenInfo[]
-  static getKnownToken(chain: Chain, contractAddress: string): TokenInfo | null
+  static getKnownToken(chain: Chain, tokenId: string): TokenInfo | null
   static getFeeCoin(chain: Chain): FeeCoinInfo
   static getBanxaSupportedChains(): Chain[]
 
@@ -2782,7 +2784,7 @@ class VaultBase {
 
   // Token Discovery & Metadata
   discoverTokens(chain: Chain): Promise<DiscoveredToken[]>
-  resolveToken(chain: Chain, contractAddress: string): Promise<TokenInfo>
+  resolveToken(chain: Chain, tokenId: string): Promise<TokenInfo>
 
   // Fiat On-Ramp
   getBuyUrl(chain: Chain, ticker?: string): Promise<string | null>

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -863,11 +863,13 @@ Sign arbitrary bytes (not a blockchain transaction).
 
 #### `Vultisig.getKnownTokens(chain): TokenInfo[]`
 
-Get all known tokens for a chain from the built-in registry.
+Get all known tokens for a chain from the built-in registry. Each token exposes
+its canonical chain-specific `tokenId`; `contractAddress` remains as a
+deprecated compatibility alias.
 
-#### `Vultisig.getKnownToken(chain, contractAddress): TokenInfo | null`
+#### `Vultisig.getKnownToken(chain, tokenId): TokenInfo | null`
 
-Look up a specific token by contract address (case-insensitive). Returns null if not found.
+Look up a specific token by its canonical chain-specific ID (case-insensitive). Returns null if not found. `TokenInfo.contractAddress` remains as a deprecated alias for `tokenId`.
 
 #### `Vultisig.getFeeCoin(chain): FeeCoinInfo`
 
@@ -901,9 +903,9 @@ Scan a website URL for malicious content via Blockaid.
 
 Discover tokens with non-zero balances at this vault's address. Supported: EVM (via 1inch), Solana (via Jupiter), Cosmos (via RPC).
 
-#### `vault.resolveToken(chain, contractAddress): Promise<TokenInfo>`
+#### `vault.resolveToken(chain, tokenId): Promise<TokenInfo>`
 
-Resolve token metadata by contract address. Checks known tokens registry first, then resolves from chain APIs.
+Resolve token metadata by canonical chain-specific token ID. Checks known tokens registry first, then resolves from chain APIs.
 
 #### `vault.getBuyUrl(chain, ticker?): Promise<string | null>`
 

--- a/packages/sdk/src/Vultisig.ts
+++ b/packages/sdk/src/Vultisig.ts
@@ -1280,13 +1280,18 @@ export class Vultisig extends UniversalEventEmitter<SdkEvents> {
       address: params.address,
       chain: params.chain,
     })
-    return coins.map(coin => ({
-      chain: coin.chain,
-      contractAddress: coin.id ?? '',
-      ticker: coin.ticker,
-      decimals: coin.decimals,
-      logo: coin.logo,
-    }))
+    return coins.map(coin => {
+      const tokenId = coin.id ?? ''
+
+      return {
+        chain: coin.chain,
+        tokenId,
+        contractAddress: tokenId,
+        ticker: coin.ticker,
+        decimals: coin.decimals,
+        logo: coin.logo,
+      }
+    })
   }
 
   /**
@@ -1297,6 +1302,7 @@ export class Vultisig extends UniversalEventEmitter<SdkEvents> {
   static getKnownTokens(chain: Chain): TokenInfo[] {
     return (knownTokens[chain] ?? []).map(coin => ({
       chain: coin.chain,
+      tokenId: coin.id,
       contractAddress: coin.id,
       ticker: coin.ticker,
       decimals: coin.decimals,
@@ -1306,16 +1312,17 @@ export class Vultisig extends UniversalEventEmitter<SdkEvents> {
   }
 
   /**
-   * Look up a specific token by contract address in the known tokens registry.
+   * Look up a specific token by its canonical chain-specific token ID.
    * @param chain - The blockchain chain
-   * @param contractAddress - The token's contract address
+   * @param tokenId - The token's canonical chain-specific identifier
    * @returns Token metadata or null if not found
    */
-  static getKnownToken(chain: Chain, contractAddress: string): TokenInfo | null {
-    const coin = knownTokensIndex[chain]?.[contractAddress.toLowerCase()]
+  static getKnownToken(chain: Chain, tokenId: string): TokenInfo | null {
+    const coin = knownTokensIndex[chain]?.[tokenId.toLowerCase()]
     if (!coin) return null
     return {
       chain,
+      tokenId: coin.id,
       contractAddress: coin.id,
       ticker: coin.ticker,
       decimals: coin.decimals,

--- a/packages/sdk/src/Vultisig.ts
+++ b/packages/sdk/src/Vultisig.ts
@@ -1290,6 +1290,7 @@ export class Vultisig extends UniversalEventEmitter<SdkEvents> {
         ticker: coin.ticker,
         decimals: coin.decimals,
         logo: coin.logo,
+        ...(coin.isHidden === undefined ? {} : { isHidden: coin.isHidden }),
       }
     })
   }

--- a/packages/sdk/src/types/tokens.ts
+++ b/packages/sdk/src/types/tokens.ts
@@ -3,6 +3,9 @@ import type { Chain } from '@vultisig/core-chain/Chain'
 /** Token metadata (SDK-owned, decoupled from core's KnownCoin) */
 export type TokenInfo = {
   chain: Chain
+  /** Canonical chain-specific token identifier. */
+  tokenId?: string
+  /** @deprecated Use `tokenId`; retained as a compatibility alias. */
   contractAddress?: string
   ticker: string
   decimals: number
@@ -22,6 +25,9 @@ export type FeeCoinInfo = {
 /** Token discovered at an address (from on-chain scan) */
 export type DiscoveredToken = {
   chain: Chain
+  /** Canonical chain-specific token identifier. */
+  tokenId?: string
+  /** @deprecated Use `tokenId`; retained as a compatibility alias. */
   contractAddress: string
   ticker: string
   decimals: number

--- a/packages/sdk/src/vault/VaultBase.ts
+++ b/packages/sdk/src/vault/VaultBase.ts
@@ -1654,16 +1654,16 @@ export abstract class VaultBase extends UniversalEventEmitter<VaultEvents> {
   }
 
   /**
-   * Resolve token metadata by contract address.
+   * Resolve token metadata by canonical chain-specific token ID.
    * Checks known tokens registry first, then resolves from chain APIs.
    * Supported: EVM, Solana, Cosmos, TRON.
    *
    * @param chain - The chain the token is on
-   * @param contractAddress - The token's contract address
+   * @param tokenId - The token's canonical chain-specific identifier
    * @returns Token metadata (ticker, decimals, logo, priceProviderId)
    */
-  async resolveToken(chain: Chain, contractAddress: string): Promise<TokenInfo> {
-    return this.tokenDiscoveryService.resolveToken(chain, contractAddress)
+  async resolveToken(chain: Chain, tokenId: string): Promise<TokenInfo> {
+    return this.tokenDiscoveryService.resolveToken(chain, tokenId)
   }
 
   // ===== SECURITY SCANNING =====

--- a/packages/sdk/src/vault/services/TokenDiscoveryService.ts
+++ b/packages/sdk/src/vault/services/TokenDiscoveryService.ts
@@ -14,14 +14,19 @@ export class TokenDiscoveryService {
     try {
       const address = await this.getAddress(chain)
       const coins = await findCoins({ address, chain })
-      return coins.map(coin => ({
-        chain: coin.chain,
-        contractAddress: coin.id ?? '',
-        ticker: coin.ticker,
-        decimals: coin.decimals,
-        logo: coin.logo,
-        ...(coin.isHidden === undefined ? {} : { isHidden: coin.isHidden }),
-      }))
+      return coins.map(coin => {
+        const tokenId = coin.id ?? ''
+
+        return {
+          chain: coin.chain,
+          tokenId,
+          contractAddress: tokenId,
+          ticker: coin.ticker,
+          decimals: coin.decimals,
+          logo: coin.logo,
+          ...(coin.isHidden === undefined ? {} : { isHidden: coin.isHidden }),
+        }
+      })
     } catch (error) {
       throw new VaultError(
         VaultErrorCode.BalanceFetchFailed,
@@ -31,12 +36,13 @@ export class TokenDiscoveryService {
     }
   }
 
-  async resolveToken(chain: Chain, contractAddress: string): Promise<TokenInfo> {
+  async resolveToken(chain: Chain, tokenId: string): Promise<TokenInfo> {
     // Check known tokens first (fast, no network)
-    const known = knownTokensIndex[chain]?.[contractAddress.toLowerCase()]
+    const known = knownTokensIndex[chain]?.[tokenId.toLowerCase()]
     if (known) {
       return {
         chain,
+        tokenId: known.id,
         contractAddress: known.id,
         ticker: known.ticker,
         decimals: known.decimals,
@@ -47,10 +53,11 @@ export class TokenDiscoveryService {
 
     // Fall back to chain-specific resolver
     try {
-      const meta = await coreGetTokenMetadata({ chain: chain as ChainWithTokenMetadataDiscovery, id: contractAddress })
+      const meta = await coreGetTokenMetadata({ chain: chain as ChainWithTokenMetadataDiscovery, id: tokenId })
       return {
         chain,
-        contractAddress,
+        tokenId,
+        contractAddress: tokenId,
         ticker: meta.ticker,
         decimals: meta.decimals,
         logo: meta.logo,
@@ -59,7 +66,7 @@ export class TokenDiscoveryService {
     } catch (error) {
       throw new VaultError(
         VaultErrorCode.UnsupportedChain,
-        `Cannot resolve token ${contractAddress} on ${chain}: ${error instanceof Error ? error.message : String(error)}`,
+        `Cannot resolve token ${tokenId} on ${chain}: ${error instanceof Error ? error.message : String(error)}`,
         error as Error
       )
     }

--- a/packages/sdk/tests/unit/Vultisig.static-methods.test.ts
+++ b/packages/sdk/tests/unit/Vultisig.static-methods.test.ts
@@ -20,6 +20,7 @@ import { findCoins } from '@vultisig/core-chain/coin/find'
 import { getCoinPrices } from '@vultisig/core-chain/coin/price/getCoinPrices'
 import { scanSiteWithBlockaid } from '@vultisig/core-chain/security/blockaid/site'
 
+import type { DiscoveredToken } from '../../src/types/tokens'
 import { Vultisig } from '../../src/Vultisig'
 
 describe('Vultisig static methods', () => {
@@ -35,16 +36,18 @@ describe('Vultisig static methods', () => {
       expect(tokens.length).toBeGreaterThan(0)
     })
 
-    it('should return SDK-owned TokenInfo shape (contractAddress not id)', () => {
+    it('returns a canonical tokenId and the deprecated contractAddress alias', () => {
       const tokens = Vultisig.getKnownTokens(Chain.Ethereum)
 
       const token = tokens[0]
+      expect(token).toHaveProperty('tokenId')
       expect(token).toHaveProperty('contractAddress')
       expect(token).toHaveProperty('chain')
       expect(token).toHaveProperty('ticker')
       expect(token).toHaveProperty('decimals')
       // Should NOT have core's `id` field
       expect(token).not.toHaveProperty('id')
+      expect(token?.contractAddress).toBe(token?.tokenId)
     })
 
     it('should return empty array for chain with no known tokens', () => {
@@ -85,6 +88,15 @@ describe('Vultisig static methods', () => {
       const token = Vultisig.getKnownToken(Chain.Bitcoin, '0x123')
 
       expect(token).toBeNull()
+    })
+
+    it('uses a non-address XRPL issued-currency token ID canonically', () => {
+      const [rlusd] = Vultisig.getKnownTokens(Chain.Ripple)
+
+      expect(rlusd?.ticker).toBe('RLUSD')
+      expect(rlusd?.tokenId).toMatch(/^[A-F0-9]{40}\.r/u)
+      expect(rlusd?.contractAddress).toBe(rlusd?.tokenId)
+      expect(Vultisig.getKnownToken(Chain.Ripple, rlusd!.tokenId!)).toEqual(rlusd)
     })
   })
 
@@ -171,6 +183,17 @@ describe('Vultisig static methods', () => {
   })
 
   describe('discoverTokens (vault-free)', () => {
+    it('keeps the legacy contractAddress-only object shape assignable', () => {
+      const legacyToken: DiscoveredToken = {
+        chain: Chain.Ethereum,
+        contractAddress: '0xlegacy',
+        ticker: 'LEGACY',
+        decimals: 18,
+      }
+
+      expect(legacyToken.tokenId).toBeUndefined()
+    })
+
     it('maps findCoins AccountCoin[] to DiscoveredToken[]', async () => {
       vi.mocked(findCoins).mockResolvedValue([
         {
@@ -200,6 +223,7 @@ describe('Vultisig static methods', () => {
       expect(result).toEqual([
         {
           chain: Chain.Ethereum,
+          tokenId: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
           contractAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
           ticker: 'USDC',
           decimals: 6,
@@ -207,6 +231,7 @@ describe('Vultisig static methods', () => {
         },
         {
           chain: Chain.Ethereum,
+          tokenId: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
           contractAddress: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
           ticker: 'USDT',
           decimals: 6,
@@ -215,7 +240,7 @@ describe('Vultisig static methods', () => {
       ])
     })
 
-    it('coerces a missing coin id to an empty contractAddress', async () => {
+    it('coerces a missing coin id to empty canonical and compatibility fields', async () => {
       vi.mocked(findCoins).mockResolvedValue([{ chain: Chain.Solana, ticker: 'SOL', decimals: 9 }] as never)
 
       const result = await Vultisig.discoverTokens({
@@ -223,6 +248,7 @@ describe('Vultisig static methods', () => {
         address: 'soL111',
       })
 
+      expect(result[0]?.tokenId).toBe('')
       expect(result[0]?.contractAddress).toBe('')
     })
 

--- a/packages/sdk/tests/unit/Vultisig.static-methods.test.ts
+++ b/packages/sdk/tests/unit/Vultisig.static-methods.test.ts
@@ -94,7 +94,7 @@ describe('Vultisig static methods', () => {
       const rlusd = Vultisig.getKnownTokens(Chain.Ripple).find(token => token.ticker === 'RLUSD')
 
       expect(rlusd).toBeDefined()
-      expect(rlusd?.tokenId).toMatch(/^[A-F0-9]{40}\.r/u)
+      expect(rlusd?.tokenId).toMatch(/^[A-F0-9]{40}\.r.+$/u)
       expect(rlusd?.contractAddress).toBe(rlusd?.tokenId)
       expect(Vultisig.getKnownToken(Chain.Ripple, rlusd!.tokenId!)).toEqual(rlusd)
     })

--- a/packages/sdk/tests/unit/Vultisig.static-methods.test.ts
+++ b/packages/sdk/tests/unit/Vultisig.static-methods.test.ts
@@ -91,9 +91,9 @@ describe('Vultisig static methods', () => {
     })
 
     it('uses a non-address XRPL issued-currency token ID canonically', () => {
-      const [rlusd] = Vultisig.getKnownTokens(Chain.Ripple)
+      const rlusd = Vultisig.getKnownTokens(Chain.Ripple).find(token => token.ticker === 'RLUSD')
 
-      expect(rlusd?.ticker).toBe('RLUSD')
+      expect(rlusd).toBeDefined()
       expect(rlusd?.tokenId).toMatch(/^[A-F0-9]{40}\.r/u)
       expect(rlusd?.contractAddress).toBe(rlusd?.tokenId)
       expect(Vultisig.getKnownToken(Chain.Ripple, rlusd!.tokenId!)).toEqual(rlusd)
@@ -202,6 +202,7 @@ describe('Vultisig static methods', () => {
           ticker: 'USDC',
           decimals: 6,
           logo: 'usdc.png',
+          isHidden: true,
         },
         {
           chain: Chain.Ethereum,
@@ -228,6 +229,7 @@ describe('Vultisig static methods', () => {
           ticker: 'USDC',
           decimals: 6,
           logo: 'usdc.png',
+          isHidden: true,
         },
         {
           chain: Chain.Ethereum,

--- a/packages/sdk/tests/unit/vault/services/TokenDiscoveryService.test.ts
+++ b/packages/sdk/tests/unit/vault/services/TokenDiscoveryService.test.ts
@@ -67,6 +67,7 @@ describe('TokenDiscoveryService', () => {
       expect(tokens).toHaveLength(2)
       expect(tokens[0]).toEqual({
         chain: Chain.Ethereum,
+        tokenId: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
         contractAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
         ticker: 'USDC',
         decimals: 6,
@@ -107,6 +108,7 @@ describe('TokenDiscoveryService', () => {
 
       const tokens = await service.discoverTokens(Chain.Ethereum)
 
+      expect(tokens[0].tokenId).toBe('')
       expect(tokens[0].contractAddress).toBe('')
     })
 
@@ -132,6 +134,7 @@ describe('TokenDiscoveryService', () => {
 
       expect(token).toEqual({
         chain: Chain.Ethereum,
+        tokenId: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
         contractAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
         ticker: 'USDC',
         decimals: 6,
@@ -162,6 +165,7 @@ describe('TokenDiscoveryService', () => {
 
       expect(token).toEqual({
         chain: Chain.Ethereum,
+        tokenId: '0x6982508145454Ce325dDbE47a25d4ec3d2311933',
         contractAddress: '0x6982508145454Ce325dDbE47a25d4ec3d2311933',
         ticker: 'PEPE',
         decimals: 18,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed a canonical, chain-specific `tokenId` across token discovery and known-token registry results, with `contractAddress` retained as a deprecated compatibility alias.
  * Token lookup and metadata resolution now use `tokenId` (case-insensitive), including non-address token identifiers.
* **Documentation**
  * Updated the SDK Users Guide and API reference to treat `tokenId` as the primary input/identifier, clarifying `contractAddress` as deprecated.
* **Tests**
  * Updated unit tests to assert `tokenId` presence/derivation, verify resolution behavior (including fallbacks), and confirm backward compatibility for the deprecated alias.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->