### PR TITLE
Harden React Native crypto forward compatibility

### DIFF
--- a/.changeset/rn-forward-compat-hardening.md
+++ b/.changeset/rn-forward-compat-hardening.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Use the noble Point API in React Native derivation and reject malformed Solana or EVM signature hex.

--- a/packages/sdk/src/platforms/react-native/chains/evm/tx.ts
+++ b/packages/sdk/src/platforms/react-native/chains/evm/tx.ts
@@ -222,9 +222,15 @@ export function buildEvmContractCallTx(opts: BuildEvmContractCallOptions): EvmTx
     if (clean.length !== 130) {
       throw new Error(`expected 65-byte signature (130 hex chars, r||s||recoveryId), got ${clean.length}`)
     }
+    if (!/^[0-9a-fA-F]+$/.test(clean)) {
+      throw new Error('invalid signature: non-hex characters in input')
+    }
     const r = `0x${clean.substring(0, 64)}` as `0x${string}`
     const s = `0x${clean.substring(64, 128)}` as `0x${string}`
     const recoveryId = parseInt(clean.substring(128, 130), 16)
+    if (recoveryId !== 0 && recoveryId !== 1) {
+      throw new Error(`invalid signature: recoveryId must be 0 or 1, got ${recoveryId}`)
+    }
 
     const rawTxHex = isLegacy
       ? serializeTransaction(

--- a/packages/sdk/src/platforms/react-native/chains/solana/tx.ts
+++ b/packages/sdk/src/platforms/react-native/chains/solana/tx.ts
@@ -140,6 +140,9 @@ function hexToBytes(hex: string): Uint8Array {
   if (clean.length % 2 !== 0) {
     throw new Error(`invalid hex length: ${clean.length}`)
   }
+  if (!/^[0-9a-fA-F]+$/.test(clean)) {
+    throw new Error('invalid hex: non-hex characters in input')
+  }
   const out = new Uint8Array(clean.length / 2)
   for (let i = 0; i < out.length; i++) {
     out[i] = parseInt(clean.substring(i * 2, i * 2 + 2), 16)

--- a/packages/sdk/src/platforms/react-native/shims/tiny-secp256k1.ts
+++ b/packages/sdk/src/platforms/react-native/shims/tiny-secp256k1.ts
@@ -3,13 +3,14 @@
  * The real tiny-secp256k1 uses WASM bindings that don't work in Hermes.
  * This provides the subset of the API used by bip32 (BIP32Factory).
  */
-import { secp256k1 } from '@noble/curves/secp256k1'
+import { secp256k1 } from '@noble/curves/secp256k1.js'
 
-const GE = secp256k1.ProjectivePoint
+const GE = secp256k1.Point
+const CURVE_N = GE.CURVE().n
 
 function isPoint(p: Uint8Array): boolean {
   try {
-    GE.fromHex(p)
+    GE.fromBytes(p)
     return true
   } catch {
     return false
@@ -19,14 +20,15 @@ function isPoint(p: Uint8Array): boolean {
 function isPrivate(d: Uint8Array): boolean {
   if (d.length !== 32) return false
   const n = BigInt('0x' + Buffer.from(d).toString('hex'))
-  return n > 0n && n < secp256k1.CURVE.n
+  return n > 0n && n < CURVE_N
 }
 
 function pointFromScalar(d: Uint8Array, compressed = true): Uint8Array | null {
   try {
+    if (!isPrivate(d)) return null
     const n = BigInt('0x' + Buffer.from(d).toString('hex'))
     const pt = GE.BASE.multiply(n)
-    return pt.toRawBytes(compressed)
+    return pt.toBytes(compressed)
   } catch {
     return null
   }
@@ -34,11 +36,14 @@ function pointFromScalar(d: Uint8Array, compressed = true): Uint8Array | null {
 
 function pointAddScalar(p: Uint8Array, tweak: Uint8Array, compressed = true): Uint8Array | null {
   try {
-    const pt = GE.fromHex(p)
+    const pt = GE.fromBytes(p)
+    if (tweak.length !== 32) return null
     const t = BigInt('0x' + Buffer.from(tweak).toString('hex'))
+    if (t >= CURVE_N) return null
+    if (t === 0n) return pt.toBytes(compressed)
     const tweakPt = GE.BASE.multiply(t)
     const result = pt.add(tweakPt)
-    return result.toRawBytes(compressed)
+    return result.toBytes(compressed)
   } catch {
     return null
   }
@@ -46,13 +51,15 @@ function pointAddScalar(p: Uint8Array, tweak: Uint8Array, compressed = true): Ui
 
 function privateAdd(d: Uint8Array, tweak: Uint8Array): Uint8Array | null {
   try {
+    if (!isPrivate(d) || tweak.length !== 32) return null
     const dN = BigInt('0x' + Buffer.from(d).toString('hex'))
     const tN = BigInt('0x' + Buffer.from(tweak).toString('hex'))
+    if (tN >= CURVE_N) return null
     // Both dN and tN are read as unsigned 256-bit integers. For secp256k1 scalar
     // addition, tweak values representing negative scalars (> n/2) work correctly
     // because (dN + tN) % n produces the same result as modular addition with
     // signed interpretation — BigInt handles arbitrary precision without overflow.
-    const sum = (dN + tN) % secp256k1.CURVE.n
+    const sum = (dN + tN) % CURVE_N
     if (sum === 0n) return null
     const hex = sum.toString(16).padStart(64, '0')
     return Buffer.from(hex, 'hex')
@@ -61,14 +68,23 @@ function privateAdd(d: Uint8Array, tweak: Uint8Array): Uint8Array | null {
   }
 }
 
-function sign(h: Uint8Array, d: Uint8Array): Uint8Array {
-  const sig = secp256k1.sign(h, d)
-  return sig.toCompactRawBytes()
+function sign(h: Uint8Array, d: Uint8Array, extraData?: Uint8Array): Uint8Array {
+  const signature = secp256k1.sign(h, d, {
+    prehash: false,
+    format: 'compact',
+    ...(extraData ? { extraEntropy: extraData } : {}),
+  }) as unknown
+  if (signature instanceof Uint8Array) return signature
+  const legacySignature = signature as { toCompactRawBytes?: () => Uint8Array }
+  if (typeof legacySignature.toCompactRawBytes === 'function') {
+    return legacySignature.toCompactRawBytes()
+  }
+  throw new Error('unsupported @noble/curves signature result')
 }
 
 function verify(h: Uint8Array, Q: Uint8Array, signature: Uint8Array): boolean {
   try {
-    return secp256k1.verify(signature, h, Q)
+    return secp256k1.verify(signature, h, Q, { prehash: false, format: 'compact' })
   } catch {
     return false
   }

--- a/packages/sdk/tests/unit/platforms/react-native/tiny-secp256k1.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/tiny-secp256k1.test.ts
@@ -1,0 +1,60 @@
+import { secp256k1 } from '@noble/curves/secp256k1.js'
+import { describe, expect, it } from 'vitest'
+
+import ecc from '@/platforms/react-native/shims/tiny-secp256k1'
+
+const scalar = (value: bigint) => Buffer.from(value.toString(16).padStart(64, '0'), 'hex')
+const EXPECTED_SIGNATURE =
+  'd5ebc88d029956fde425fcd18bcd79824ca3d8b1fde30743ec8add79f07abf331d0cbe5f24aac4c3366d72c8f717ff8815fc0074060f168401d7967bbae7a808'
+const EXPECTED_HEDGED_SIGNATURE =
+  'fef7e4a6eb3deb021586587bb471437913d2de4011c8363a8aad4ad630a7b5837d4fda4f291acae5f7348e8856a2c48d692d6a611a2c7afba65bf2047efb104c'
+
+describe('React Native tiny-secp256k1 shim', () => {
+  const privateKey = scalar(1n)
+  const tweak = scalar(2n)
+  const hash = Uint8Array.from({ length: 32 }, (_, index) => index + 1)
+
+  it('derives and validates compressed and uncompressed points through the Point API', () => {
+    const compressed = ecc.pointFromScalar(privateKey, true)
+    const uncompressed = ecc.pointFromScalar(privateKey, false)
+
+    expect(compressed).toEqual(secp256k1.Point.BASE.toBytes(true))
+    expect(uncompressed).toEqual(secp256k1.Point.BASE.toBytes(false))
+    expect(ecc.isPoint(compressed!)).toBe(true)
+    expect(ecc.isPoint(Uint8Array.from([1, 2, 3]))).toBe(false)
+  })
+
+  it('adds public and private tweaks with the noble curve order', () => {
+    const point = ecc.pointFromScalar(privateKey, true)!
+    expect(ecc.pointAddScalar(point, tweak, true)).toEqual(
+      secp256k1.Point.BASE.add(secp256k1.Point.BASE.multiply(2n)).toBytes(true)
+    )
+    expect(ecc.privateAdd(privateKey, tweak)).toEqual(scalar(3n))
+    expect(ecc.pointAddScalar(point, new Uint8Array(32), true)).toEqual(point)
+    expect(ecc.pointFromScalar(Uint8Array.of(1), true)).toBeNull()
+    expect(ecc.privateAdd(privateKey, Uint8Array.of(1))).toBeNull()
+    expect(ecc.privateAdd(privateKey, scalar(secp256k1.Point.CURVE().n))).toBeNull()
+    expect(ecc.isPrivate(privateKey)).toBe(true)
+    expect(ecc.isPrivate(new Uint8Array(32))).toBe(false)
+  })
+
+  it('returns a compact signature and verifies it', () => {
+    const signature = ecc.sign(hash, privateKey)
+    const extraData = Uint8Array.from({ length: 32 }, (_, index) => 255 - index)
+    const hedgedSignature = ecc.sign(hash, privateKey, extraData)
+    const publicKey = ecc.pointFromScalar(privateKey, true)!
+
+    expect(signature).toHaveLength(64)
+    expect(Buffer.from(signature).toString('hex')).toBe(EXPECTED_SIGNATURE)
+    expect(Buffer.from(hedgedSignature).toString('hex')).toBe(EXPECTED_HEDGED_SIGNATURE)
+    expect(hedgedSignature).not.toEqual(signature)
+    expect(ecc.verify(hash, publicKey, signature)).toBe(true)
+    expect(
+      ecc.verify(
+        hash,
+        publicKey,
+        Uint8Array.from(signature, byte => byte ^ 0xff)
+      )
+    ).toBe(false)
+  })
+})

--- a/packages/sdk/tests/unit/platforms/react-native/tx-builder-golden-vectors.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/tx-builder-golden-vectors.test.ts
@@ -204,6 +204,7 @@ describe('React Native transaction builder golden vectors', () => {
         rawTxBase64: SOLANA_SEND_RAW_BASE64,
         signature: SOLANA_SIGNATURE_BASE58,
       })
+      expect(() => tx.finalize(`${SOLANA_SIG_HEX.slice(0, -1)}g`)).toThrow(/non-hex/)
     })
 
     it('dedupes the sender account for self-transfers like @solana/web3.js', async () => {
@@ -263,6 +264,9 @@ describe('React Native transaction builder golden vectors', () => {
       expect(parsed.type).toBe('eip1559')
       expect(parsed.yParity).toBe(1)
       expect(parsed.v).toBe(28n)
+      expect(() => tx.finalize(`${EVM_SIG_HEX.slice(0, -1)}g`)).toThrow(/non-hex/)
+      expect(() => tx.finalize(`${EVM_SIG_HEX.slice(0, -2)}02`)).toThrow(/recoveryId must be 0 or 1/)
+      expect(() => tx.finalize(`${EVM_SIG_HEX.slice(0, -2)}ff`)).toThrow(/recoveryId must be 0 or 1/)
     })
 
     it('pins ERC-20 transfer calldata and legacy unsigned transaction bytes', () => {


### PR DESCRIPTION
Closes #1251
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened React Native signature finalization by rejecting malformed/non-hex Solana and EVM signatures.
  * Added stricter EVM recovery-id validation (must be 0 or 1) during transaction finalization.
  * Strengthened secp256k1 point/tweak/scalar handling in the React Native shim, with improved range checks and safer key derivation.
  * Added optional `extraData` support for deterministic/hedged signing.
* **Tests**
  * Extended React Native unit and golden-vector tests to cover key/point operations and invalid signature inputs during transaction finalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->