### PR TITLE
fix(sdk): export token-id validation

### DIFF
--- a/.changeset/sdk-token-id-validator-export-r53.md
+++ b/.changeset/sdk-token-id-validator-export-r53.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+Export `isValidTokenId` from the root and React Native SDK entrypoints so consumers can validate Sui struct-tag and XRPL issued-currency token ids without reimplementing chain-specific rules.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -112,6 +112,7 @@ export { address, validate } from './utils/addressValidation'
 export { checkChainPrefix } from './utils/chainPrefix'
 export type { ParsedThorSwapMemo } from './utils/thorSwapMemo'
 export { parseThorSwapMemo } from './utils/thorSwapMemo'
+export { isValidTokenId } from '@vultisig/core-chain/utils/isValidTokenId'
 
 // Canonical UTXO wrong-chain guard. Consumers should import this instead of
 // maintaining local bech32 HRP / Base58Check version / CashAddr matrices.

--- a/packages/sdk/src/platforms/react-native/chainHelpers.ts
+++ b/packages/sdk/src/platforms/react-native/chainHelpers.ts
@@ -13,6 +13,7 @@ import { deriveAddress as coreDeriveAddress } from '@vultisig/core-chain/publicK
 import { getPublicKey as coreGetPublicKey } from '@vultisig/core-chain/publicKey/getPublicKey'
 import type { PublicKeys } from '@vultisig/core-chain/publicKey/PublicKeys'
 import { isValidAddress as coreIsValidAddress } from '@vultisig/core-chain/utils/isValidAddress'
+import { isValidTokenId as coreIsValidTokenId } from '@vultisig/core-chain/utils/isValidTokenId'
 import type { WalletCoreLike } from '@vultisig/walletcore-native'
 
 /**
@@ -53,6 +54,16 @@ type IsValidAddressInput = {
 /** Validate a chain address. Accepts WalletCoreLike. */
 export const isValidAddress = ({ walletCore, ...rest }: IsValidAddressInput) =>
   coreIsValidAddress({ ...rest, walletCore: toTwWalletCore(walletCore) })
+
+type IsValidTokenIdInput = {
+  chain: Chain
+  id: string
+  walletCore: WalletCoreLike
+}
+
+/** Validate a chain-specific token identifier. Accepts WalletCoreLike. */
+export const isValidTokenId = ({ walletCore, ...rest }: IsValidTokenIdInput) =>
+  coreIsValidTokenId({ ...rest, walletCore: toTwWalletCore(walletCore) })
 
 type GetCoinTypeInput = {
   walletCore: WalletCoreLike

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -128,7 +128,7 @@ export type { WalletCoreLike } from '@vultisig/walletcore-native'
 // Address derivation and chain utilities
 // RN wrappers accept WalletCoreLike from @vultisig/walletcore-native
 // so consumers don't need to cast to @trustwallet/wallet-core's WalletCore.
-export { deriveAddress, getCoinType, getPublicKey, isValidAddress } from './chainHelpers'
+export { deriveAddress, getCoinType, getPublicKey, isValidAddress, isValidTokenId } from './chainHelpers'
 
 // MPC keysign (uses MpcEngine — no direct WASM imports)
 export { keysign } from '@vultisig/core-mpc/keysign'

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -398,4 +398,12 @@ describe('RN entry exposes canonical EIP-712 helpers', () => {
     expect(rn.computeEip712Hash).toBe(eip712.computeEip712Hash)
     expect(rn.toCanonicalEvmSignature).toBe(eip712.toCanonicalEvmSignature)
   })
+
+  it('exports token-id validation from the RN entry', async () => {
+    const rn = await import('../../../../src/platforms/react-native/index')
+
+    expect(typeof rn.isValidTokenId).toBe('function')
+    expect(rn.isValidTokenId({ chain: rn.Chain.Sui, id: '0x2::sui::SUI', walletCore: {} as never })).toBe(true)
+    expect(rn.isValidTokenId({ chain: rn.Chain.Sui, id: 'not-a-struct-tag', walletCore: {} as never })).toBe(false)
+  })
 })

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -297,6 +297,12 @@ describe('@vultisig/sdk public exports', () => {
     ])
   })
 
+  it('exports canonical token-id validation for non-address token families', () => {
+    expect(typeof sdk.isValidTokenId).toBe('function')
+    expect(sdk.isValidTokenId({ chain: sdk.Chain.Sui, id: '0x2::sui::SUI', walletCore: {} as never })).toBe(true)
+    expect(sdk.isValidTokenId({ chain: sdk.Chain.Sui, id: 'not-a-struct-tag', walletCore: {} as never })).toBe(false)
+  })
+
   it('exports generic CosmWasm amino and protobuf execute builders', () => {
     expect(typeof sdk.buildCosmosWasmExecuteMsg).toBe('function')
     expect(typeof sdk.buildCosmosWasmExecuteTx).toBe('function')


### PR DESCRIPTION
## Summary
- export `isValidTokenId` from the root `@vultisig/sdk` surface
- add a React Native wrapper so RN consumers can validate Sui/XRPL token ids via `WalletCoreLike`
- add root + RN regression coverage and a changeset

## Test plan
- `corepack yarn build:shared`
- `corepack yarn vitest run --config packages/sdk/tests/unit/vitest.config.ts packages/sdk/tests/unit/utils/publicExports.test.ts packages/sdk/tests/unit/platforms/react-native/entry.test.ts`
- `corepack yarn build:sdk`
- `corepack yarn lint`
- `corepack yarn build:all`
- `corepack yarn test` ⚠️ pre-existing mainline/browser-example failure: `command not found: vite`
- built-dist runtime proof: `node --input-type=module` import of `packages/sdk/dist/index.node.esm.js` returned `{"hasIsValidTokenId":true,"suiTrue":true,"suiFalse":false}`
- RN surface proof: `packages/sdk/dist/index.react-native.d.ts` contains `isValidTokenId`
- packed tarball proof: `corepack yarn workspace @vultisig/sdk pack --out /tmp/vultisig-sdk-r53/.artifacts/vultisig-sdk-r53.tgz`
- verification blocker (pre-existing mainline): `corepack yarn cli:build` still fails on unresolved `@vultisig/core-chain/chains/ripple/address` from `clients/cli/src/commands/transaction.ts`

Closes https://github.com/vultisig/vultisig-sdk/issues/1502


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `isValidTokenId` to the SDK’s main and React Native public APIs.
  * Token identifiers can now be validated consistently across supported chains and platforms.

* **Bug Fixes**
  * Improved access to token ID validation for applications using the SDK entry points.

* **Tests**
  * Added coverage for valid and invalid Sui token identifiers through both public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->