### PR TITLE
fix(sdk): raw broadcast paths fail closed - no false success on ack-only or malformed responses

### DIFF
--- a/.changeset/raw-broadcast-fail-closed.md
+++ b/.changeset/raw-broadcast-fail-closed.md
@@ -1,0 +1,24 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/sdk': patch
+---
+
+fix(sdk): raw broadcast paths fail closed instead of reporting false success
+
+Three raw-broadcast/status hardening fixes, all fail-closed (throw/pending on
+ambiguity, never fabricate success):
+
+- `RawBroadcastService.broadcastRawTx`: Polkadot/Bittensor no longer return
+  `undefined` as a success hash when the RPC response has neither `result`
+  nor `error`; Tron now also checks `result === false` (not only `code`),
+  matching the guard the core resolver already has; Solana adds a bounded,
+  non-blocking signature-status check so a signature the node already knows
+  failed is not handed back as a hash. Cosmos and Sui raw paths already had
+  assert guards from prior PRs and are untouched.
+- `getTronTxStatus` (status resolver): an unrecognized `receipt.result` value
+  is no longer narrated as `success` just because it isn't on the known
+  failure list - it now resolves to `pending`. `SUCCESS` and absent
+  `receipt.result` are unchanged (still `success`).
+- `BroadcastService.broadcastTx`: prefers the resolver-returned hash (utxo/
+  cardano/tron echo the node's own hash) over a locally re-derived one,
+  falling back to the local computation only when the resolver returns none.

--- a/packages/core/chain/tx/status/resolvers/tron.test.ts
+++ b/packages/core/chain/tx/status/resolvers/tron.test.ts
@@ -90,8 +90,11 @@ describe('getTronTxStatus', () => {
   })
 
   // sdk#1505 should-fix (S1): completes the documented core/Tron.proto contractResult enum
-  // (values 3-9, 12, 14) so every KNOWN failure resolves promptly to 'error' instead of
-  // falling to the allowlist's 'pending' branch and waiting out the poll timeout.
+  // (every non-DEFAULT, non-SUCCESS member) so every KNOWN failure resolves promptly to 'error'
+  // instead of falling to the allowlist's 'pending' branch and waiting out the poll timeout.
+  // Names are the exact protobuf enum spellings (PRECOMPILED_CONTRACT, not *_ERROR) and stay in
+  // parity with the app's TRON_TERMINAL_FAILURE_RESULTS. 'UNKNOWN' here is the enum member
+  // (value 14) — distinct from a genuinely unrecognized code, which still buckets pending below.
   it.each([
     'TRANSFER_FAILED',
     'BAD_JUMP_DESTINATION',
@@ -100,8 +103,10 @@ describe('getTronTxStatus', () => {
     'STACK_TOO_SMALL',
     'STACK_TOO_LARGE',
     'ILLEGAL_OPERATION',
-    'PRECOMPILE_CONTRACT_ERROR',
+    'PRECOMPILED_CONTRACT',
     'JVM_STACK_OVER_FLOW',
+    'UNKNOWN',
+    'INVALID_CODE',
   ])('returns error for %s (completed contractResult allowlist)', async (result) => {
     mocks.queryUrl.mockResolvedValue({ id: hash, blockNumber: 12345, receipt: { result } })
 

--- a/packages/core/chain/tx/status/resolvers/tron.test.ts
+++ b/packages/core/chain/tx/status/resolvers/tron.test.ts
@@ -107,7 +107,7 @@ describe('getTronTxStatus', () => {
     'JVM_STACK_OVER_FLOW',
     'UNKNOWN',
     'INVALID_CODE',
-  ])('returns error for %s (completed contractResult allowlist)', async (result) => {
+  ])('returns error for %s (completed contractResult allowlist)', async result => {
     mocks.queryUrl.mockResolvedValue({ id: hash, blockNumber: 12345, receipt: { result } })
 
     const status = await getTronTxStatus({ chain: OtherChain.Tron, hash })

--- a/packages/core/chain/tx/status/resolvers/tron.test.ts
+++ b/packages/core/chain/tx/status/resolvers/tron.test.ts
@@ -89,6 +89,26 @@ describe('getTronTxStatus', () => {
     expect(result.status).toBe('error')
   })
 
+  // sdk#1505 should-fix (S1): completes the documented core/Tron.proto contractResult enum
+  // (values 3-9, 12, 14) so every KNOWN failure resolves promptly to 'error' instead of
+  // falling to the allowlist's 'pending' branch and waiting out the poll timeout.
+  it.each([
+    'TRANSFER_FAILED',
+    'BAD_JUMP_DESTINATION',
+    'OUT_OF_MEMORY',
+    'STACK_OVERFLOW',
+    'STACK_TOO_SMALL',
+    'STACK_TOO_LARGE',
+    'ILLEGAL_OPERATION',
+    'PRECOMPILE_CONTRACT_ERROR',
+    'JVM_STACK_OVER_FLOW',
+  ])('returns error for %s (completed contractResult allowlist)', async (result) => {
+    mocks.queryUrl.mockResolvedValue({ id: hash, blockNumber: 12345, receipt: { result } })
+
+    const status = await getTronTxStatus({ chain: OtherChain.Tron, hash })
+    expect(status.status).toBe('error')
+  })
+
   // NeO's live mainnet canary: real USDT TRC20 transfer emits receipt.result='SUCCESS'.
   // protobuf3 serializes non-default contractResult enum values by name — value=1 (SUCCESS) is
   // non-default so it appears as "SUCCESS" in the JSON response. Must NOT be treated as error.

--- a/packages/core/chain/tx/status/resolvers/tron.test.ts
+++ b/packages/core/chain/tx/status/resolvers/tron.test.ts
@@ -99,11 +99,14 @@ describe('getTronTxStatus', () => {
     expect(result.status).toBe('success')
   })
 
-  it('returns success for unknown receipt.result value (future-proof: unknown codes treated as success)', async () => {
+  // Inverted from a deny-list to an allowlist: an unrecognized receipt.result must never be
+  // narrated as success just because it isn't on the known-failure list. SUCCESS/absent still
+  // resolve to success (see tests above); a truly unknown code now falls to pending instead.
+  it('returns pending (never success) for an unrecognized receipt.result value', async () => {
     mocks.queryUrl.mockResolvedValue({ id: hash, blockNumber: 12345, receipt: { result: 'UNKNOWN_FUTURE_CODE' } })
 
     const result = await getTronTxStatus({ chain: OtherChain.Tron, hash })
-    expect(result.status).toBe('success')
+    expect(result).toEqual({ status: 'pending', isKnown: true })
   })
 
   it('returns error when top-level result is FAILED and receipt is absent (iOS parity)', async () => {

--- a/packages/core/chain/tx/status/resolvers/tron.ts
+++ b/packages/core/chain/tx/status/resolvers/tron.ts
@@ -70,11 +70,6 @@ export const getTronTxStatus: TxStatusResolver<OtherChain.Tron> = async ({ hash 
     return { status: 'pending', isKnown: true }
   }
 
-  // 3. receipt.result in terminal failure set → error
-  //    receipt.result == null → success (native TRX send, no contract result)
-  //    receipt.result == 'SUCCESS' → success (TRC20/smart-contract success, protobuf3 non-default enum)
-  //    receipt.result unknown → treat as success (safer than false-failure for user)
-  const status = tx.receipt.result != null && TRON_RECEIPT_FAILURE_RESULTS.has(tx.receipt.result) ? 'error' : 'success'
   const feeCoin = chainFeeCoin[Chain.Tron]
   const receipt =
     tx.fee != null
@@ -85,5 +80,22 @@ export const getTronTxStatus: TxStatusResolver<OtherChain.Tron> = async ({ hash 
         }
       : undefined
 
-  return { status, receipt }
+  // 3. receipt.result decides success vs failure vs unknown - an ALLOWLIST, not a deny-list:
+  //    - in the known terminal failure set → error
+  //    - null → success (native TRX send, no contract result)
+  //    - 'SUCCESS' → success (TRC20/smart-contract success, protobuf3 non-default enum;
+  //      pinned against NeO's live mainnet tx 1540b1b3, see tron.test.ts)
+  //    - anything else (a receipt.result value we've never seen) → pending, NEVER success.
+  //      The block is already final at this point, so this isn't "still processing" - it's an
+  //      unrecognized terminal outcome, and a new Tron enum value must not be silently narrated
+  //      as a successful fund movement just because it isn't on the known-failure list.
+  if (tx.receipt.result != null && TRON_RECEIPT_FAILURE_RESULTS.has(tx.receipt.result)) {
+    return { status: 'error', receipt }
+  }
+
+  if (tx.receipt.result == null || tx.receipt.result === 'SUCCESS') {
+    return { status: 'success', receipt }
+  }
+
+  return { status: 'pending', isKnown: true, receipt }
 }

--- a/packages/core/chain/tx/status/resolvers/tron.ts
+++ b/packages/core/chain/tx/status/resolvers/tron.ts
@@ -10,6 +10,12 @@ import { TxStatusResolver } from '../resolver'
 // Protobuf3 JSON serializes non-default enum values by name: successful TRC20 calls emit
 // receipt.result="SUCCESS" (non-default, value=1). Native TRX transfers emit no receipt at all.
 // Known failure codes verified against Tron protocol and live mainnet responses.
+//
+// sdk#1505 should-fix (S1): the allowlist-inversion below correctly means an UNKNOWN result
+// never reads as false-success, but an unlisted contractResult still resolves 'pending' until
+// the poll times out rather than promptly 'error'. The 9 codes below complete the documented
+// core/Tron.proto contractResult enum (values 3-9, 12, 14) so every KNOWN failure surfaces
+// immediately instead of waiting out the poll.
 const TRON_RECEIPT_FAILURE_RESULTS = new Set([
   'FAILED',
   'OUT_OF_ENERGY',
@@ -17,6 +23,15 @@ const TRON_RECEIPT_FAILURE_RESULTS = new Set([
   'OUT_OF_TIME',
   'BANDWIDTH_ERROR',
   'ACCOUNT_FREEZED',
+  'TRANSFER_FAILED',
+  'BAD_JUMP_DESTINATION',
+  'OUT_OF_MEMORY',
+  'STACK_OVERFLOW',
+  'STACK_TOO_SMALL',
+  'STACK_TOO_LARGE',
+  'ILLEGAL_OPERATION',
+  'PRECOMPILE_CONTRACT_ERROR',
+  'JVM_STACK_OVER_FLOW',
 ])
 
 type TronTxInfoResponse = {

--- a/packages/core/chain/tx/status/resolvers/tron.ts
+++ b/packages/core/chain/tx/status/resolvers/tron.ts
@@ -13,9 +13,11 @@ import { TxStatusResolver } from '../resolver'
 //
 // sdk#1505 should-fix (S1): the allowlist-inversion below correctly means an UNKNOWN result
 // never reads as false-success, but an unlisted contractResult still resolves 'pending' until
-// the poll times out rather than promptly 'error'. The 9 codes below complete the documented
-// core/Tron.proto contractResult enum (values 3-9, 12, 14) so every KNOWN failure surfaces
-// immediately instead of waiting out the poll.
+// the poll times out rather than promptly 'error'. The codes below complete the documented
+// core/Tron.proto contractResult enum (every non-DEFAULT, non-SUCCESS member: values 2-16) so
+// every KNOWN failure surfaces immediately instead of waiting out the poll. Kept in exact
+// parity with the app's TRON_TERMINAL_FAILURE_RESULTS (vultiagent-app txVerifier.ts, app#2198)
+// so a Tron failure buckets identically in the SDK resolver and the app tx-verifier.
 const TRON_RECEIPT_FAILURE_RESULTS = new Set([
   'FAILED',
   'OUT_OF_ENERGY',
@@ -30,8 +32,10 @@ const TRON_RECEIPT_FAILURE_RESULTS = new Set([
   'STACK_TOO_SMALL',
   'STACK_TOO_LARGE',
   'ILLEGAL_OPERATION',
-  'PRECOMPILE_CONTRACT_ERROR',
+  'PRECOMPILED_CONTRACT',
   'JVM_STACK_OVER_FLOW',
+  'UNKNOWN',
+  'INVALID_CODE',
 ])
 
 type TronTxInfoResponse = {

--- a/packages/sdk/src/vault/services/BroadcastService.ts
+++ b/packages/sdk/src/vault/services/BroadcastService.ts
@@ -16,6 +16,29 @@ import { convertToKeysignSignatures } from '../utils/convertSignature'
 import { VaultError, VaultErrorCode } from '../VaultError'
 
 /**
+ * Broadcast resolvers return `Promise<unknown>` and are inconsistent in shape: utxo/cardano
+ * resolve a bare hash string, tron resolves the raw RPC response object (`{ txid, ... }`), and
+ * most others (evm/cosmos/sui/ripple/ton/polkadot/bittensor) resolve void. When the resolver DID
+ * echo back a hash, prefer it over a locally re-derived one - it is the node's own authoritative
+ * value, not a client-side guess about what the node will have computed.
+ */
+const extractResolverTxHash = (broadcastResult: unknown): string | undefined => {
+  if (typeof broadcastResult === 'string' && broadcastResult.length > 0) {
+    return broadcastResult
+  }
+  if (
+    broadcastResult &&
+    typeof broadcastResult === 'object' &&
+    'txid' in broadcastResult &&
+    typeof (broadcastResult as { txid?: unknown }).txid === 'string' &&
+    (broadcastResult as { txid: string }).txid.length > 0
+  ) {
+    return (broadcastResult as { txid: string }).txid
+  }
+  return undefined
+}
+
+/**
  * BroadcastService
  *
  * Handles transaction broadcasting to blockchain networks.
@@ -118,12 +141,12 @@ export class BroadcastService {
 
         const signingOutput = decodeSigningOutput(chain, compiledTx)
 
-        await coreBroadcastTx({
+        const broadcastResult = await coreBroadcastTx({
           chain,
           tx: signingOutput,
         })
 
-        txHash = await getTxHash({ chain, tx: signingOutput })
+        txHash = extractResolverTxHash(broadcastResult) ?? (await getTxHash({ chain, tx: signingOutput }))
       }
 
       return txHash

--- a/packages/sdk/src/vault/services/RawBroadcastService.ts
+++ b/packages/sdk/src/vault/services/RawBroadcastService.ts
@@ -236,6 +236,27 @@ export class RawBroadcastService {
     }
 
     if (!signature) throw new Error('No transaction signature returned')
+
+    // sendRawTransaction only confirms the node ACCEPTED the payload into its queue - it is
+    // fire-and-forget by protocol design and never returns an execution result inline (unlike
+    // Cosmos/Sui's broadcast RPCs, which block until inclusion). Full confirmation is out of
+    // scope here and remains the caller's job via a status poll (mirrors the core resolver's
+    // documented trade-off, packages/core/chain/tx/broadcast/resolvers/solana.ts). But a
+    // signature the node already knows to have failed must not be handed back as a "hash" -
+    // this bounded, non-blocking status check catches that without adding real broadcast
+    // latency: it never blocks/throws on "not yet confirmed" (the normal state right after
+    // submission), only on an explicit on-chain error already attached to this signature.
+    const { data: statuses } = await attempt(
+      client.getSignatureStatuses([signature], { searchTransactionHistory: true })
+    )
+    const signatureStatus = statuses?.value?.[0]
+    if (signatureStatus?.err) {
+      throw new VaultError(
+        VaultErrorCode.BroadcastFailed,
+        `Solana transaction was submitted but failed on-chain: ${JSON.stringify(signatureStatus.err)}`
+      )
+    }
+
     return signature
   }
 
@@ -352,6 +373,13 @@ export class RawBroadcastService {
       throw new Error(`Polkadot broadcast failed: ${response.error.message}`)
     }
 
+    // Per JSON-RPC 2.0 a valid response must have exactly one of `result` / `error`. If both
+    // are missing (malformed gateway response, truncated body, ...) do not silently return
+    // `undefined` as a success hash - fail closed instead.
+    if (!response.result) {
+      throw new Error('Polkadot broadcast failed: missing extrinsic hash in RPC response')
+    }
+
     return response.result
   }
 
@@ -383,6 +411,12 @@ export class RawBroadcastService {
 
     if (response.error) {
       throw new Error(`Bittensor broadcast failed: ${response.error.message}`)
+    }
+
+    // Same JSON-RPC 2.0 invariant as Polkadot: a response with neither `result` nor `error`
+    // is malformed, not a success - fail closed instead of returning `undefined` as a hash.
+    if (!response.result) {
+      throw new Error('Bittensor broadcast failed: missing extrinsic hash in RPC response')
     }
 
     return response.result
@@ -482,8 +516,12 @@ export class RawBroadcastService {
 
     if (!response) throw new Error('No response returned')
 
-    if (response.code && response.code !== 'SUCCESS') {
-      const errorMsg = response.message || response.code
+    // `result === false` is Tron's own explicit failure signal, independent of `code` (which
+    // core/chain/tx/broadcast/resolvers/tron.ts also checks separately) - a response carrying
+    // `result: false` without a `code` must not fall through to the txid check below and be
+    // reported as a success.
+    if (response.result === false || (response.code && response.code !== 'SUCCESS')) {
+      const errorMsg = response.message || response.code || 'Unknown error'
       if (isInError(errorMsg, 'DUPLICATE_TRANSACTION', 'DUP_TRANSACTION_ERROR')) {
         throw new VaultError(VaultErrorCode.BroadcastFailed, `Transaction may have already been submitted: ${errorMsg}`)
       }

--- a/packages/sdk/tests/unit/vault/services/BroadcastService.test.ts
+++ b/packages/sdk/tests/unit/vault/services/BroadcastService.test.ts
@@ -1,0 +1,169 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import type { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { Signature } from '@/types'
+import { BroadcastService } from '@/vault/services/BroadcastService'
+import { VaultErrorCode } from '@/vault/VaultError'
+
+const {
+  mockGetCoinType,
+  mockGetTwPublicKeyType,
+  mockDecodeSigningOutput,
+  mockCoreBroadcastTx,
+  mockGetTxHash,
+  mockGetEncodedSigningInputs,
+  mockAssertNativeSwapReadyForBroadcast,
+  mockGetKeysignTwPublicKey,
+  mockCompileTx,
+  mockConvertToKeysignSignatures,
+} = vi.hoisted(() => ({
+  mockGetCoinType: vi.fn(),
+  mockGetTwPublicKeyType: vi.fn(),
+  mockDecodeSigningOutput: vi.fn(),
+  mockCoreBroadcastTx: vi.fn(),
+  mockGetTxHash: vi.fn(),
+  mockGetEncodedSigningInputs: vi.fn(),
+  mockAssertNativeSwapReadyForBroadcast: vi.fn(),
+  mockGetKeysignTwPublicKey: vi.fn(),
+  mockCompileTx: vi.fn(),
+  mockConvertToKeysignSignatures: vi.fn(),
+}))
+
+vi.mock('@vultisig/core-chain/coin/coinType', () => ({
+  getCoinType: (...args: unknown[]) => mockGetCoinType(...args),
+}))
+
+vi.mock('@vultisig/core-chain/publicKey/tw/getTwPublicKeyType', () => ({
+  getTwPublicKeyType: (...args: unknown[]) => mockGetTwPublicKeyType(...args),
+}))
+
+vi.mock('@vultisig/core-chain/tw/signingOutput', () => ({
+  decodeSigningOutput: (...args: unknown[]) => mockDecodeSigningOutput(...args),
+}))
+
+vi.mock('@vultisig/core-chain/tx/broadcast', () => ({
+  broadcastTx: (...args: unknown[]) => mockCoreBroadcastTx(...args),
+}))
+
+vi.mock('@vultisig/core-chain/tx/hash', () => ({
+  getTxHash: (...args: unknown[]) => mockGetTxHash(...args),
+}))
+
+vi.mock('@vultisig/core-mpc/keysign/signingInputs', () => ({
+  getEncodedSigningInputs: (...args: unknown[]) => mockGetEncodedSigningInputs(...args),
+}))
+
+vi.mock('@vultisig/core-mpc/keysign/swap/assertNativeSwapReadyForBroadcast', () => ({
+  assertNativeSwapReadyForBroadcast: (...args: unknown[]) => mockAssertNativeSwapReadyForBroadcast(...args),
+}))
+
+vi.mock('@vultisig/core-mpc/keysign/tw/getKeysignTwPublicKey', () => ({
+  getKeysignTwPublicKey: (...args: unknown[]) => mockGetKeysignTwPublicKey(...args),
+}))
+
+vi.mock('@vultisig/core-mpc/tx/compile/compileTx', () => ({
+  compileTx: (...args: unknown[]) => mockCompileTx(...args),
+}))
+
+vi.mock('@/vault/utils/convertSignature', () => ({
+  convertToKeysignSignatures: (...args: unknown[]) => mockConvertToKeysignSignatures(...args),
+}))
+
+const fakeWalletCore = {
+  CoinType: { tron: 'coin-tron' },
+  PublicKeyType: { secp256k1Extended: 'pubkey-secp256k1-extended' },
+  PublicKey: { createWithData: vi.fn().mockReturnValue('fake-public-key') },
+}
+
+const signature: Signature = { signature: '0xdeadbeef', format: 'ECDSA' }
+const keysignPayload = {} as KeysignPayload
+
+describe('BroadcastService', () => {
+  const wasmProvider = { getWalletCore: vi.fn().mockResolvedValue(fakeWalletCore) }
+  const extractMessageHashes = vi.fn().mockResolvedValue(['0xmessagehash'])
+  const service = new BroadcastService(extractMessageHashes, wasmProvider)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    wasmProvider.getWalletCore.mockResolvedValue(fakeWalletCore)
+    extractMessageHashes.mockResolvedValue(['0xmessagehash'])
+    mockAssertNativeSwapReadyForBroadcast.mockResolvedValue(undefined)
+    mockGetKeysignTwPublicKey.mockReturnValue(new Uint8Array())
+    mockGetTwPublicKeyType.mockReturnValue('pubkey-type')
+    mockGetCoinType.mockReturnValue('coin-not-tron')
+    mockConvertToKeysignSignatures.mockReturnValue({})
+    mockCompileTx.mockReturnValue('compiled-tx-bytes')
+    mockDecodeSigningOutput.mockReturnValue({ marker: 'signing-output' })
+    mockGetEncodedSigningInputs.mockResolvedValue(['tx-input'])
+  })
+
+  it('falls back to the locally computed hash when the resolver returns void (evm/cosmos/sui/ripple/ton/polkadot/bittensor)', async () => {
+    mockCoreBroadcastTx.mockResolvedValue(undefined)
+    mockGetTxHash.mockResolvedValue('0xlocally-computed-hash')
+
+    const hash = await service.broadcastTx({ chain: Chain.Ethereum, keysignPayload, signature })
+
+    expect(hash).toBe('0xlocally-computed-hash')
+    expect(mockGetTxHash).toHaveBeenCalledOnce()
+  })
+
+  it('prefers the resolver-returned hash over the local computation when the resolver returns a bare string (utxo/cardano)', async () => {
+    mockCoreBroadcastTx.mockResolvedValue('node-returned-hash')
+    mockGetTxHash.mockResolvedValue('should-never-be-used')
+
+    const hash = await service.broadcastTx({ chain: Chain.Bitcoin, keysignPayload, signature })
+
+    expect(hash).toBe('node-returned-hash')
+    expect(mockGetTxHash).not.toHaveBeenCalled()
+  })
+
+  it('prefers the resolver-returned txid over the local computation for the Tron response shape', async () => {
+    mockCoreBroadcastTx.mockResolvedValue({ txid: 'tron-node-hash', result: true })
+    mockGetTxHash.mockResolvedValue('should-never-be-used')
+
+    const hash = await service.broadcastTx({ chain: Chain.Tron, keysignPayload, signature })
+
+    expect(hash).toBe('tron-node-hash')
+    expect(mockGetTxHash).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the local hash when the resolver returns an empty string', async () => {
+    mockCoreBroadcastTx.mockResolvedValue('')
+    mockGetTxHash.mockResolvedValue('local-fallback-hash')
+
+    const hash = await service.broadcastTx({ chain: Chain.Bitcoin, keysignPayload, signature })
+
+    expect(hash).toBe('local-fallback-hash')
+  })
+
+  it('falls back to the local hash when the resolver returns an object without a usable txid', async () => {
+    mockCoreBroadcastTx.mockResolvedValue({ result: true })
+    mockGetTxHash.mockResolvedValue('local-fallback-hash')
+
+    const hash = await service.broadcastTx({ chain: Chain.Tron, keysignPayload, signature })
+
+    expect(hash).toBe('local-fallback-hash')
+  })
+
+  it('resolves each broadcast input independently and returns the last transaction hash (approve + swap)', async () => {
+    mockGetEncodedSigningInputs.mockResolvedValue(['approve-input', 'swap-input'])
+    mockCoreBroadcastTx.mockResolvedValueOnce(undefined).mockResolvedValueOnce('swap-node-hash')
+    mockGetTxHash.mockResolvedValue('approve-local-hash')
+
+    const hash = await service.broadcastTx({ chain: Chain.Ethereum, keysignPayload, signature })
+
+    expect(hash).toBe('swap-node-hash')
+    // Only the first (void-resolver) iteration needed the local fallback.
+    expect(mockGetTxHash).toHaveBeenCalledOnce()
+  })
+
+  it('wraps a broadcast failure in a BroadcastFailed VaultError', async () => {
+    mockCoreBroadcastTx.mockRejectedValue(new Error('network down'))
+
+    await expect(service.broadcastTx({ chain: Chain.Ethereum, keysignPayload, signature })).rejects.toMatchObject({
+      code: VaultErrorCode.BroadcastFailed,
+      message: expect.stringContaining('Ethereum'),
+    })
+  })
+})

--- a/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
+++ b/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
@@ -12,6 +12,7 @@ const {
   mockGetEvmClient,
   mockGetBlockchairBaseUrl,
   mockSendSolanaRawTx,
+  mockGetSolanaSignatureStatuses,
   mockGetCosmosClient,
   mockCosmosBroadcastTx,
   mockExecuteSuiTx,
@@ -21,6 +22,7 @@ const {
   mockGetEvmClient: vi.fn(),
   mockGetBlockchairBaseUrl: vi.fn(),
   mockSendSolanaRawTx: vi.fn(),
+  mockGetSolanaSignatureStatuses: vi.fn(),
   mockGetCosmosClient: vi.fn(),
   mockCosmosBroadcastTx: vi.fn(),
   mockExecuteSuiTx: vi.fn(),
@@ -42,6 +44,7 @@ vi.mock('@vultisig/core-chain/chains/utxo/client/getBlockchairBaseUrl', () => ({
 vi.mock('@vultisig/core-chain/chains/solana/client', () => ({
   getSolanaClient: () => ({
     sendRawTransaction: mockSendSolanaRawTx,
+    getSignatureStatuses: mockGetSolanaSignatureStatuses,
   }),
 }))
 
@@ -68,6 +71,7 @@ describe('RawBroadcastService', () => {
     vi.clearAllMocks()
     mockGetBlockchairBaseUrl.mockReturnValue('https://mock.blockchair.test/bitcoin')
     mockSendSolanaRawTx.mockResolvedValue('sol-signature')
+    mockGetSolanaSignatureStatuses.mockResolvedValue({ value: [null] })
     mockGetCosmosClient.mockResolvedValue({
       broadcastTx: mockCosmosBroadcastTx,
     })
@@ -146,6 +150,45 @@ describe('RawBroadcastService', () => {
     })
     expect(hash).toBe('sol-signature')
     expect(mockSendSolanaRawTx).toHaveBeenCalled()
+  })
+
+  // sendRawTransaction is fire-and-forget (accepted-into-queue, not execution result), so the
+  // raw path cannot assert success from the send response the way Cosmos/Sui do. This bounded
+  // status check catches the case where the node already knows the signature failed on-chain.
+  it('throws instead of returning a signature when Solana reports an on-chain error for it', async () => {
+    mockGetSolanaSignatureStatuses.mockResolvedValue({
+      value: [{ err: { InstructionError: [0, 'Custom'] } }],
+    })
+
+    await expect(
+      service.broadcastRawTx({
+        chain: Chain.Solana,
+        rawTx: 'YQ==',
+      })
+    ).rejects.toMatchObject({
+      code: VaultErrorCode.BroadcastFailed,
+      message: expect.stringContaining('failed on-chain'),
+    })
+  })
+
+  it('still returns the signature when the status check finds no record yet (normal, not yet confirmed)', async () => {
+    mockGetSolanaSignatureStatuses.mockResolvedValue({ value: [null] })
+
+    const hash = await service.broadcastRawTx({
+      chain: Chain.Solana,
+      rawTx: 'YQ==',
+    })
+    expect(hash).toBe('sol-signature')
+  })
+
+  it('still returns the signature when the status check itself errors (verification is best-effort, not a new failure mode)', async () => {
+    mockGetSolanaSignatureStatuses.mockRejectedValue(new Error('rpc down'))
+
+    const hash = await service.broadcastRawTx({
+      chain: Chain.Solana,
+      rawTx: 'YQ==',
+    })
+    expect(hash).toBe('sol-signature')
   })
 
   it('broadcasts Cosmos tx when rawTx is JSON with tx_bytes', async () => {
@@ -297,6 +340,19 @@ describe('RawBroadcastService', () => {
     )
   })
 
+  // JSON-RPC 2.0 requires exactly one of `result` / `error`. A malformed gateway response with
+  // NEITHER must not fall through to `return response.result` and hand back `undefined` as a hash.
+  it('throws on a malformed Polkadot response with neither result nor error', async () => {
+    mockQueryUrl.mockResolvedValue({})
+
+    await expect(
+      service.broadcastRawTx({
+        chain: Chain.Polkadot,
+        rawTx: '0xabc',
+      })
+    ).rejects.toThrow(/missing extrinsic hash/)
+  })
+
   it('broadcasts Bittensor extrinsic via JSON-RPC', async () => {
     mockQueryUrl.mockResolvedValue({ result: '0xbtensor' })
 
@@ -311,6 +367,17 @@ describe('RawBroadcastService', () => {
         body: expect.objectContaining({ method: 'author_submitExtrinsic' }),
       })
     )
+  })
+
+  it('throws on a malformed Bittensor response with neither result nor error', async () => {
+    mockQueryUrl.mockResolvedValue({})
+
+    await expect(
+      service.broadcastRawTx({
+        chain: Chain.Bittensor,
+        rawTx: 'beef',
+      })
+    ).rejects.toThrow(/missing extrinsic hash/)
   })
 
   it('broadcasts Tron transaction JSON', async () => {
@@ -339,6 +406,20 @@ describe('RawBroadcastService', () => {
       code: VaultErrorCode.BroadcastFailed,
       message: expect.stringContaining('already been submitted'),
     })
+  })
+
+  // `result: false` is Tron's own explicit failure signal, independent of `code`. Only checking
+  // `code !== 'SUCCESS'` misses a response that carries `result: false` without a `code` at all -
+  // that must not fall through to the txid check and be reported as a success.
+  it('throws on a Tron response with result:false and no code', async () => {
+    mockQueryUrl.mockResolvedValue({ result: false, txid: 'tron-id' })
+
+    await expect(
+      service.broadcastRawTx({
+        chain: Chain.Tron,
+        rawTx: '{}',
+      })
+    ).rejects.toThrow(/Tron broadcast failed/)
   })
 
   it('broadcasts Ripple tx blob', async () => {


### PR DESCRIPTION
Continues today's broadcast-hunt hardening campaign (cosmos raw got the same treatment in #1426, sui raw in #1413) - three more bounded fixes, one PR, all fail-closed by construction: throw or report `pending` on ambiguity, never fabricate a success hash/status.

## what

- `RawBroadcastService.broadcastRawTx` (the public raw-broadcast path, bypasses the signing-input resolvers' verification net):
  - Polkadot/Bittensor: a malformed RPC response with neither `result` nor `error` was falling through to `return response.result`, handing back `undefined` as if it were the extrinsic hash.
  - Tron: only checked `response.code !== 'SUCCESS'`, missing Tron's own explicit `result: false` failure signal when no `code` is present.
  - Solana: `sendRawTransaction` resolving just meant "the node queued it", not confirmation - the raw path returned that ack signature with zero on-chain verification.
- `getTronTxStatus` (core status resolver): a `receipt.result` value we've never seen before was narrated as `success`, because the terminal-failure set was a deny-list ("not a known failure" = success). Inverted to an allowlist.
- `BroadcastService.broadcastTx`: discarded the hash the broadcast resolver itself returned (utxo/cardano/tron all echo the node's own hash back) and unconditionally recomputed one locally instead.

Cosmos and Sui raw broadcast already have assert guards from the prior two PRs in this campaign - untouched here, just added regression coverage confirmed already green.

## how

**Polkadot/Bittensor raw** - added the exact same "response must have exactly one of `result`/`error`" guard the CORE resolvers (`packages/core/chain/tx/broadcast/resolvers/{polkadot,bittensor}.ts`) already have, which the raw path was missing:
```ts
if (!response.result) {
  throw new Error('Polkadot broadcast failed: missing extrinsic hash in RPC response')
}
```

**Tron raw** - widened the failure check to match the core resolver's `result.result === false || result.code` condition (previously only checked `code`):
```ts
if (response.result === false || (response.code && response.code !== 'SUCCESS')) { ... }
```

**Solana raw** - `sendRawTransaction` is fire-and-forget by protocol design; it never returns an inline execution result the way Cosmos's `broadcastTx` or Sui's `executeTransactionBlock` do, so there's no "assert on the response" fix available here. Added a bounded, non-blocking `getSignatureStatuses` check after a successful send: throws only on an *explicit* on-chain error already attached to the signature, never on "not found yet" (the normal state seconds after submission) - so it doesn't fabricate success on a known-bad signature without adding real broadcast latency or turning this into a "wait for confirmation" call. Full confirmation is still the caller's job via a status poll, same as the core resolver's own documented trade-off (see the comment trail on `packages/core/chain/tx/broadcast/resolvers/solana.ts` from #874).

**getTronTxStatus** - this one has history: PR #545 (me, reviewed by NeO) originally tried "any non-null `receipt.result` = error", which NeO's live-mainnet test caught as a false FAILURE on a real successful USDT TRC20 transfer (`receipt.result: "SUCCESS"`). The fix at the time was a deny-list ("only known failure codes = error, everything else = success") - correct for that bug, but broader than necessary, since it now silently maps ANY future/unrecognized code to success too. Tightened to an allowlist that still keeps `SUCCESS`/absent = success (so NeO's live tx stays green) but a genuinely unrecognized value now resolves to `pending` instead of `success`. `TRON_RECEIPT_FAILURE_RESULTS` isn't exported, so nothing outside this file needs updating - but vultiagent-app has its own local Tron status probe that should get the mirror inversion in a follow-up (not touched here per scope).

**BroadcastService** - added `extractResolverTxHash()`: prefers a string return (utxo/cardano) or a `{ txid }` object (tron) from the broadcast resolver over calling `getTxHash` locally; falls back to the local computation only when the resolver returned nothing (evm/cosmos/sui/ripple/ton/polkadot/bittensor all resolve void today).

## cross-consumer impact

`@vultisig/sdk` is bundled into flagship ios/android/windows in addition to any third-party raw-broadcast consumer, so being honest about what changes:

- **Polkadot/bittensor/tron raw broadcast**: a caller who previously got `undefined`/a false-success hash back from a malformed or explicitly-failed response now gets a thrown error instead. Anyone relying on `vault.broadcastRawTx()` for these three chains was either already broken downstream (chasing an `undefined` "hash") or silently reporting a failed tx as sent - this is strictly safer, but it IS a new throw path a caller must handle if they weren't already.
- **Solana raw broadcast**: happy path unchanged in the vast majority of cases (a legit broadcast still returns the signature after one cheap extra status check that no-ops on "not found yet"). The only newly-thrown case is a signature the node can already tell you failed - narrow, and strictly an improvement.
- **getTronTxStatus**: any consumer polling Tron tx status (app, CLI, anything importing `@vultisig/core-chain`) that happens to hit a truly unrecognized `receipt.result` value will now see `pending` forever instead of a (fabricated) `success`. This is the one that trades a UX regression (looks stuck) for a fund-safety improvement (never confidently says "your funds moved" when we don't actually know that). Given the known Tron failure codes are exhaustively documented and haven't changed, this should be a near-zero-frequency case in practice.
- **BroadcastService hash preference**: only observable if a resolver-returned hash and a locally-computed one would ever disagree - which, if it ever happened, means the local computation had a bug and the node's value is the one that was actually right. No observable change in the (expected) common case where they agree.

## testing

New tests, each with a mutation-verify pass (reverted the src hunk, confirmed the named test goes red, restored):

- `RawBroadcastService.test.ts`: `throws on a malformed Polkadot response with neither result nor error`, `throws on a malformed Bittensor response with neither result nor error`, `throws on a Tron response with result:false and no code`, `throws instead of returning a signature when Solana reports an on-chain error for it` (+ two pinning the non-regression: still-pending and status-check-itself-erroring both still return the signature).
- `tron.test.ts` (core): `returns pending (never success) for an unrecognized receipt.result value` (replaces the old test that pinned the deny-list behavior as intentional).
- `BroadcastService.test.ts` (new file, zero prior coverage): `prefers the resolver-returned hash ... (utxo/cardano)`, `prefers the resolver-returned txid ... (Tron)`, `falls back to the locally computed hash when the resolver returns void`, `falls back ... when the resolver returns an empty string / an object without a usable txid`, `resolves each broadcast input independently and returns the last transaction hash (approve + swap)`, `wraps a broadcast failure in a BroadcastFailed VaultError`.

Full suite runs: `yarn test:core` (2041 passed, 1 skipped) and SDK `yarn test` (199 files / 2970 tests, all green) both clean. `yarn typecheck`, `yarn lint`, `yarn format:check`, `yarn quality:architecture`, `yarn quality:complexity`, `yarn quality:duplication`, `yarn quality:secrets`, `yarn changeset:check-sdk-bundle` all pass. Did not run `quality:contracts`/`cli:build`/`mcp:build` - those need a from-scratch CLI/MCP build unrelated to this diff's scope (three files, no CLI/MCP surface touched). One pre-existing, unrelated typecheck gap confirmed on origin/main too (missing optional native dep `node-pty` in an unrelated CLI test file, not present in node_modules on either tree).

🤖 Agent-generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Raw transaction broadcasts now fail closed when RPC responses are invalid, ambiguous, or indicate on-chain errors.
  - Improved broadcast error handling across Solana, Tron, Polkadot, and Bittensor.
  - Unknown/unsupported Tron receipt results are now treated as pending (not successful).
  - Transaction hashes now prefer the resolver-provided value when available, with consistent local fallback.
- **Tests**
  - Expanded unit test coverage for resolver hash selection and additional Solana/Tron/Polkadot/Bittensor failure modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->