### PR TITLE
Return canonical hashes for idempotent raw broadcasts

### DIFF
--- a/.changeset/twenty-broadcasts-return.md
+++ b/.changeset/twenty-broadcasts-return.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/sdk": patch
+---
+
+Return locally derived transaction hashes for deterministic raw broadcast duplicate responses.

--- a/.changeset/twenty-broadcasts-return.md
+++ b/.changeset/twenty-broadcasts-return.md
@@ -1,5 +1,5 @@
 ---
-"@vultisig/sdk": patch
+'@vultisig/sdk': patch
 ---
 
 Return locally derived transaction hashes for deterministic raw broadcast duplicate responses.

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -10,5 +10,23 @@ npmAuditIgnoreAdvisories:
   # module-load console.warn). That pin holds it at 1.1.5, so a published fix would NOT
   # be picked up by `yarn up` — drop the patch resolution as well when revisiting this.
   - '1103747'
+  # GHSA-mh99-v99m-4gvg (CVE-2026-14257): brace-expansion DoS via unbounded
+  # expansion length. The advisory range is `<= 5.0.7` with a single patched
+  # release, 5.0.8 — there is no fixed 1.x or 2.x line, so the 1.1.16 and 2.1.2
+  # copies in the tree are in range with nothing to upgrade to.
+  #
+  # They CANNOT simply be resolved to 5.0.8: v5 is ESM-first and its CJS build
+  # exports a named `{ expand }` instead of a callable default, so the v1/v2
+  # consumers (minimatch@3 and @5, under eslint and the electron packaging
+  # tooling) throw "expand is not a function" the first time they evaluate a
+  # pattern containing braces. Non-brace patterns work, so this does NOT show up
+  # in lint / build / test runs — it only surfaces at runtime on `{a,b}` input.
+  #
+  # Owner: SDK maintainers. Revisit when the 1.x/2.x lines get a backport, or
+  # when the last minimatch@3/@5 consumer is gone (`yarn why minimatch`).
+  # NOTE: package.json pins `brace-expansion@npm:^5.0.5` to 5.0.8, which is the
+  # real fix for the only line that HAS one. Keep that pin: this ignore entry
+  # would otherwise also mask a regression back to the vulnerable 5.0.7.
+  - '1124334'
 
 yarnPath: .yarn/releases/yarn-4.16.0.cjs

--- a/package.json
+++ b/package.json
@@ -218,6 +218,11 @@
     "undici": "^7.28.0",
     "fast-uri": "3.1.4",
     "linkify-it": "5.0.2",
-    "bigint-buffer@npm:^1.1.5": "patch:bigint-buffer@npm%3A1.1.5#~/.yarn/patches/bigint-buffer-npm-1.1.5-785f4ccd92.patch"
+    "bigint-buffer@npm:^1.1.5": "patch:bigint-buffer@npm%3A1.1.5#~/.yarn/patches/bigint-buffer-npm-1.1.5-785f4ccd92.patch",
+    "postcss": "^8.5.18",
+    "brace-expansion@npm:^5.0.5": "5.0.8",
+    "brace-expansion@npm:^1.1.7": "5.0.8",
+    "brace-expansion@npm:^2.0.1": "5.0.8",
+    "brace-expansion@npm:^2.0.2": "5.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -220,9 +220,6 @@
     "linkify-it": "5.0.2",
     "bigint-buffer@npm:^1.1.5": "patch:bigint-buffer@npm%3A1.1.5#~/.yarn/patches/bigint-buffer-npm-1.1.5-785f4ccd92.patch",
     "postcss": "^8.5.18",
-    "brace-expansion@npm:^5.0.5": "5.0.8",
-    "brace-expansion@npm:^1.1.7": "5.0.8",
-    "brace-expansion@npm:^2.0.1": "5.0.8",
-    "brace-expansion@npm:^2.0.2": "5.0.8"
+    "brace-expansion@npm:^5.0.5": "5.0.8"
   }
 }

--- a/packages/sdk/src/vault/services/RawBroadcastService.ts
+++ b/packages/sdk/src/vault/services/RawBroadcastService.ts
@@ -12,6 +12,7 @@ import { getSolanaClient } from '@vultisig/core-chain/chains/solana/client'
 import { getSuiClient } from '@vultisig/core-chain/chains/sui/client'
 import { tronRpcUrl } from '@vultisig/core-chain/chains/tron/config'
 import { getBlockchairBaseUrl } from '@vultisig/core-chain/chains/utxo/client/getBlockchairBaseUrl'
+import { isRippleInFlightEngineResult } from '@vultisig/core-chain/tx/broadcast/resolvers/ripple'
 import { assertSuiTxSucceeded } from '@vultisig/core-chain/tx/broadcast/resolvers/sui'
 import { rootApiUrl } from '@vultisig/core-config'
 import { attempt } from '@vultisig/lib-utils/attempt'
@@ -320,7 +321,30 @@ export class RawBroadcastService {
 
     if (error) {
       if (isInError(error, 'tx already exists in cache')) {
-        return deriveCosmosRawTxHash(rawTx)
+        const hash = deriveCosmosRawTxHash(rawTx)
+        const { data: existingTx, error: lookupError } = await attempt(client.getTx(hash))
+
+        if (!existingTx) {
+          const lookupMessage = lookupError instanceof Error ? lookupError.message : String(lookupError ?? 'not found')
+          throw new VaultError(
+            VaultErrorCode.BroadcastFailed,
+            `Cosmos transaction may already exist, but its execution result could not be verified: ${lookupMessage}`,
+            lookupError instanceof Error ? lookupError : new Error(lookupMessage)
+          )
+        }
+
+        try {
+          assertIsDeliverTxSuccess({ ...existingTx, transactionHash: existingTx.hash })
+        } catch (deliverTxError) {
+          const message = deliverTxError instanceof Error ? deliverTxError.message : String(deliverTxError)
+          throw new VaultError(
+            VaultErrorCode.BroadcastFailed,
+            `Cosmos transaction was included but execution failed: ${message}`,
+            deliverTxError instanceof Error ? deliverTxError : new Error(message)
+          )
+        }
+
+        return hash
       }
       throw error
     }
@@ -471,14 +495,33 @@ export class RawBroadcastService {
     )
 
     if (error) {
-      if (isInError(error, 'tefALREADY')) {
-        return deriveRippleRawTxHash(rawTx)
-      }
       throw error
     }
 
-    if (!response?.result?.tx_json?.hash) throw new Error('No transaction hash returned')
-    return response.result.tx_json.hash
+    const result = response?.result
+    if (!result || typeof result.engine_result_code !== 'number') {
+      throw new Error('Ripple broadcast did not return an engine result')
+    }
+
+    const engineResultCode = result.engine_result_code
+    const engineResult = result.engine_result ?? 'unknown'
+    if (engineResultCode !== 0) {
+      if (engineResult === 'tefALREADY') {
+        return deriveRippleRawTxHash(rawTx)
+      }
+
+      if (isRippleInFlightEngineResult(engineResult)) {
+        return result.tx_json?.hash ?? deriveRippleRawTxHash(rawTx)
+      }
+
+      const engineResultMessage = result.engine_result_message ?? ''
+      throw new Error(
+        `Ripple broadcast rejected: ${engineResult}${engineResultMessage ? ` — ${engineResultMessage}` : ''}`
+      )
+    }
+
+    if (!result.tx_json?.hash) throw new Error('No transaction hash returned')
+    return result.tx_json.hash
   }
 
   /**
@@ -547,8 +590,9 @@ export class RawBroadcastService {
     // `result: false` without a `code` must not fall through to the txid check below and be
     // reported as a success.
     if (response.result === false || (response.code && response.code !== 'SUCCESS')) {
-      const errorMsg = response.message || response.code || 'Unknown error'
-      if (isInError(errorMsg, 'DUPLICATE_TRANSACTION', 'DUP_TRANSACTION_ERROR')) {
+      const decodedMessage = response.message ? Buffer.from(response.message, 'hex').toString('utf8') : ''
+      const errorMsg = decodedMessage || response.code || 'Unknown error'
+      if (response.code && isInError(response.code, 'DUPLICATE_TRANSACTION', 'DUP_TRANSACTION_ERROR')) {
         const localHash = deriveTronRawTxHash(txJson)
         if (localHash) {
           return localHash

--- a/packages/sdk/src/vault/services/RawBroadcastService.ts
+++ b/packages/sdk/src/vault/services/RawBroadcastService.ts
@@ -257,7 +257,7 @@ export class RawBroadcastService {
     const isBase64 = rawTx.includes('=') || /[+/]/.test(rawTx)
     const txBytes = isBase64 ? Buffer.from(rawTx, 'base64') : base58.decode(rawTx)
 
-    const { data: signature, error } = await attempt(
+    const { data: sentSignature, error } = await attempt(
       client.sendRawTransaction(txBytes, {
         skipPreflight: false,
         preflightCommitment: 'confirmed',
@@ -265,11 +265,16 @@ export class RawBroadcastService {
       })
     )
 
+    let signature = sentSignature
     if (error) {
       if (isInError(error, 'already been processed', 'AlreadyProcessed')) {
-        return deriveSolanaRawTxSignature(rawTx)
+        // "AlreadyProcessed" only proves the node has seen and executed this signature before -
+        // not that the original execution succeeded. It must go through the same on-chain-failure
+        // check below as a fresh send, not be handed back as a hash unconditionally.
+        signature = deriveSolanaRawTxSignature(rawTx)
+      } else {
+        throw error
       }
-      throw error
     }
 
     if (!signature) throw new Error('No transaction signature returned')
@@ -283,6 +288,8 @@ export class RawBroadcastService {
     // this bounded, non-blocking status check catches that without adding real broadcast
     // latency: it never blocks/throws on "not yet confirmed" (the normal state right after
     // submission), only on an explicit on-chain error already attached to this signature.
+    // This also covers the "already been processed" idempotent-retry path above: a duplicate
+    // signature that already failed on-chain must still fail closed here, not report success.
     const { data: statuses } = await attempt(
       client.getSignatureStatuses([signature], { searchTransactionHistory: true })
     )

--- a/packages/sdk/src/vault/services/RawBroadcastService.ts
+++ b/packages/sdk/src/vault/services/RawBroadcastService.ts
@@ -1,4 +1,6 @@
 import { assertIsDeliverTxSuccess } from '@cosmjs/stargate'
+import { sha256 } from '@noble/hashes/sha2'
+import { bytesToHex } from '@noble/hashes/utils'
 import { Chain, CosmosChain, EvmChain, OtherChain, UtxoBasedChain } from '@vultisig/core-chain/Chain'
 import { isChainOfKind } from '@vultisig/core-chain/ChainKind'
 import { bittensorRpcUrl } from '@vultisig/core-chain/chains/bittensor/client'
@@ -18,6 +20,8 @@ import { isInError } from '@vultisig/lib-utils/error/isInError'
 import { ensureHexPrefix } from '@vultisig/lib-utils/hex/ensureHexPrefix'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 import base58 from 'bs58'
+import { keccak256 } from 'viem'
+import { hashes as xrplHashes } from 'xrpl'
 
 import { VaultError, VaultErrorCode } from '../VaultError'
 
@@ -33,6 +37,43 @@ type BlockchairBroadcastResponse =
         error: string
       }
     }
+
+const deriveEvmRawTxHash = (rawTx: string): string => keccak256(ensureHexPrefix(rawTx) as `0x${string}`)
+
+const getCosmosRawTxBytes = (rawTx: string): Uint8Array => {
+  try {
+    const parsed = JSON.parse(rawTx)
+    return Buffer.from(parsed.tx_bytes, 'base64')
+  } catch {
+    return Buffer.from(rawTx, 'base64')
+  }
+}
+
+const deriveCosmosRawTxHash = (rawTx: string): string => bytesToHex(sha256(getCosmosRawTxBytes(rawTx))).toUpperCase()
+
+const deriveSolanaRawTxSignature = (rawTx: string): string => {
+  const isBase64 = rawTx.includes('=') || /[+/]/.test(rawTx)
+  const txBytes = isBase64 ? Buffer.from(rawTx, 'base64') : base58.decode(rawTx)
+  let offset = 0
+  let signatureCount = 0
+  let shift = 0
+
+  while (offset < txBytes.length) {
+    const byte = txBytes[offset]
+    signatureCount |= (byte & 0x7f) << shift
+    offset += 1
+    if ((byte & 0x80) === 0) break
+    shift += 7
+  }
+
+  if (signatureCount < 1 || txBytes.length < offset + 64) {
+    throw new Error('Solana raw transaction does not contain a primary signature')
+  }
+
+  return base58.encode(txBytes.subarray(offset, offset + 64))
+}
+
+const deriveRippleRawTxHash = (rawTx: string): string => xrplHashes.hashSignedTx(rawTx.startsWith('0x') ? rawTx.slice(2) : rawTx)
 
 /**
  * RawBroadcastService
@@ -143,7 +184,6 @@ export class RawBroadcastService {
     )
 
     if (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error)
       // Ignore certain errors that indicate the tx was already submitted
       if (
         isInError(
@@ -157,13 +197,7 @@ export class RawBroadcastService {
           'tx already in mempool'
         )
       ) {
-        // For "already known" errors, we can't reliably get the tx hash
-        // The caller should compute it from the raw tx if needed
-        throw new VaultError(
-          VaultErrorCode.BroadcastFailed,
-          `Transaction may have already been submitted: ${errorMessage}`,
-          error instanceof Error ? error : new Error(errorMessage)
-        )
+        return deriveEvmRawTxHash(rawTx)
       }
       throw error
     }
@@ -224,13 +258,8 @@ export class RawBroadcastService {
     )
 
     if (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error)
       if (isInError(error, 'already been processed', 'AlreadyProcessed')) {
-        throw new VaultError(
-          VaultErrorCode.BroadcastFailed,
-          `Transaction may have already been submitted: ${errorMessage}`,
-          error instanceof Error ? error : new Error(errorMessage)
-        )
+        return deriveSolanaRawTxSignature(rawTx)
       }
       throw error
     }
@@ -269,27 +298,14 @@ export class RawBroadcastService {
     // Support both formats:
     // 1. JSON: { "tx_bytes": "base64..." }
     // 2. Raw base64 protobuf bytes
-    let txBytes: Uint8Array
-
-    try {
-      const parsed = JSON.parse(rawTx)
-      txBytes = Buffer.from(parsed.tx_bytes, 'base64')
-    } catch {
-      // Assume raw base64
-      txBytes = Buffer.from(rawTx, 'base64')
-    }
+    const txBytes = getCosmosRawTxBytes(rawTx)
 
     const client = await getCosmosClient(chain)
     const { data: result, error } = await attempt(client.broadcastTx(txBytes))
 
     if (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error)
       if (isInError(error, 'tx already exists in cache', 'account sequence mismatch')) {
-        throw new VaultError(
-          VaultErrorCode.BroadcastFailed,
-          `Transaction may have already been submitted: ${errorMessage}`,
-          error instanceof Error ? error : new Error(errorMessage)
-        )
+        return deriveCosmosRawTxHash(rawTx)
       }
       throw error
     }
@@ -440,13 +456,8 @@ export class RawBroadcastService {
     )
 
     if (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error)
       if (isInError(error, 'tefPAST_SEQ', 'tefALREADY')) {
-        throw new VaultError(
-          VaultErrorCode.BroadcastFailed,
-          `Transaction may have already been submitted: ${errorMessage}`,
-          error instanceof Error ? error : new Error(errorMessage)
-        )
+        return deriveRippleRawTxHash(rawTx)
       }
       throw error
     }
@@ -523,6 +534,9 @@ export class RawBroadcastService {
     if (response.result === false || (response.code && response.code !== 'SUCCESS')) {
       const errorMsg = response.message || response.code || 'Unknown error'
       if (isInError(errorMsg, 'DUPLICATE_TRANSACTION', 'DUP_TRANSACTION_ERROR')) {
+        if (typeof txJson.txID === 'string' && txJson.txID.length > 0) {
+          return txJson.txID
+        }
         throw new VaultError(VaultErrorCode.BroadcastFailed, `Transaction may have already been submitted: ${errorMsg}`)
       }
       throw new Error(`Tron broadcast failed: ${errorMsg}`)

--- a/packages/sdk/src/vault/services/RawBroadcastService.ts
+++ b/packages/sdk/src/vault/services/RawBroadcastService.ts
@@ -73,7 +73,26 @@ const deriveSolanaRawTxSignature = (rawTx: string): string => {
   return base58.encode(txBytes.subarray(offset, offset + 64))
 }
 
-const deriveRippleRawTxHash = (rawTx: string): string => xrplHashes.hashSignedTx(rawTx.startsWith('0x') ? rawTx.slice(2) : rawTx)
+const deriveRippleRawTxHash = (rawTx: string): string =>
+  xrplHashes.hashSignedTx(rawTx.startsWith('0x') ? rawTx.slice(2) : rawTx)
+
+const deriveTronRawTxHash = (txJson: { raw_data_hex?: unknown; txID?: unknown }): string | null => {
+  if (
+    typeof txJson.raw_data_hex !== 'string' ||
+    txJson.raw_data_hex.length === 0 ||
+    txJson.raw_data_hex.length % 2 !== 0 ||
+    !/^[0-9a-fA-F]+$/.test(txJson.raw_data_hex)
+  ) {
+    return null
+  }
+
+  const derivedHash = bytesToHex(sha256(Buffer.from(txJson.raw_data_hex, 'hex')))
+  if (txJson.txID !== undefined && (typeof txJson.txID !== 'string' || txJson.txID.toLowerCase() !== derivedHash)) {
+    return null
+  }
+
+  return derivedHash
+}
 
 /**
  * RawBroadcastService
@@ -185,18 +204,7 @@ export class RawBroadcastService {
 
     if (error) {
       // Ignore certain errors that indicate the tx was already submitted
-      if (
-        isInError(
-          error,
-          'already known',
-          'transaction is temporarily banned',
-          'nonce too low',
-          'transaction already exists',
-          'future transaction tries to replace pending',
-          'could not replace existing tx',
-          'tx already in mempool'
-        )
-      ) {
+      if (isInError(error, 'already known', 'transaction already exists', 'tx already in mempool')) {
         return deriveEvmRawTxHash(rawTx)
       }
       throw error
@@ -304,7 +312,7 @@ export class RawBroadcastService {
     const { data: result, error } = await attempt(client.broadcastTx(txBytes))
 
     if (error) {
-      if (isInError(error, 'tx already exists in cache', 'account sequence mismatch')) {
+      if (isInError(error, 'tx already exists in cache')) {
         return deriveCosmosRawTxHash(rawTx)
       }
       throw error
@@ -456,7 +464,7 @@ export class RawBroadcastService {
     )
 
     if (error) {
-      if (isInError(error, 'tefPAST_SEQ', 'tefALREADY')) {
+      if (isInError(error, 'tefALREADY')) {
         return deriveRippleRawTxHash(rawTx)
       }
       throw error
@@ -534,8 +542,9 @@ export class RawBroadcastService {
     if (response.result === false || (response.code && response.code !== 'SUCCESS')) {
       const errorMsg = response.message || response.code || 'Unknown error'
       if (isInError(errorMsg, 'DUPLICATE_TRANSACTION', 'DUP_TRANSACTION_ERROR')) {
-        if (typeof txJson.txID === 'string' && txJson.txID.length > 0) {
-          return txJson.txID
+        const localHash = deriveTronRawTxHash(txJson)
+        if (localHash) {
+          return localHash
         }
         throw new VaultError(VaultErrorCode.BroadcastFailed, `Transaction may have already been submitted: ${errorMsg}`)
       }

--- a/packages/sdk/src/vault/services/RawBroadcastService.ts
+++ b/packages/sdk/src/vault/services/RawBroadcastService.ts
@@ -14,6 +14,7 @@ import { tronRpcUrl } from '@vultisig/core-chain/chains/tron/config'
 import { getBlockchairBaseUrl } from '@vultisig/core-chain/chains/utxo/client/getBlockchairBaseUrl'
 import { isRippleInFlightEngineResult } from '@vultisig/core-chain/tx/broadcast/resolvers/ripple'
 import { assertSuiTxSucceeded } from '@vultisig/core-chain/tx/broadcast/resolvers/sui'
+import { getTxStatus } from '@vultisig/core-chain/tx/status'
 import { rootApiUrl } from '@vultisig/core-config'
 import { attempt } from '@vultisig/lib-utils/attempt'
 import { extractErrorMsg } from '@vultisig/lib-utils/error/extractErrorMsg'
@@ -93,6 +94,26 @@ const deriveTronRawTxHash = (txJson: { raw_data_hex?: unknown; txID?: unknown })
   }
 
   return derivedHash
+}
+
+const verifyKnownRawTx = async (chain: Chain, hash: string, chainName: string): Promise<string> => {
+  const { data: status, error } = await attempt(getTxStatus({ chain, hash }))
+  const isKnownPending = status?.status === 'pending' && status.isKnown !== false
+
+  if (status?.status === 'success' || isKnownPending) {
+    return hash
+  }
+
+  if (status?.status === 'error') {
+    throw new VaultError(VaultErrorCode.BroadcastFailed, `${chainName} transaction already failed on-chain`)
+  }
+
+  const lookupMessage = error instanceof Error ? error.message : String(error ?? status?.status ?? 'not found')
+  throw new VaultError(
+    VaultErrorCode.BroadcastFailed,
+    `${chainName} transaction may already exist, but its status could not be verified: ${lookupMessage}`,
+    error instanceof Error ? error : new Error(lookupMessage)
+  )
 }
 
 /**
@@ -267,12 +288,14 @@ export class RawBroadcastService {
     )
 
     let signature = sentSignature
+    let isDuplicate = false
     if (error) {
       if (isInError(error, 'already been processed', 'AlreadyProcessed')) {
         // "AlreadyProcessed" only proves the node has seen and executed this signature before -
         // not that the original execution succeeded. It must go through the same on-chain-failure
         // check below as a fresh send, not be handed back as a hash unconditionally.
         signature = deriveSolanaRawTxSignature(rawTx)
+        isDuplicate = true
       } else {
         throw error
       }
@@ -291,7 +314,7 @@ export class RawBroadcastService {
     // submission), only on an explicit on-chain error already attached to this signature.
     // This also covers the "already been processed" idempotent-retry path above: a duplicate
     // signature that already failed on-chain must still fail closed here, not report success.
-    const { data: statuses } = await attempt(
+    const { data: statuses, error: statusError } = await attempt(
       client.getSignatureStatuses([signature], { searchTransactionHistory: true })
     )
     const signatureStatus = statuses?.value?.[0]
@@ -299,6 +322,16 @@ export class RawBroadcastService {
       throw new VaultError(
         VaultErrorCode.BroadcastFailed,
         `Solana transaction was submitted but failed on-chain: ${JSON.stringify(signatureStatus.err)}`
+      )
+    }
+
+    if (isDuplicate && !signatureStatus) {
+      const lookupMessage =
+        statusError instanceof Error ? statusError.message : String(statusError ?? 'transaction status not found')
+      throw new VaultError(
+        VaultErrorCode.BroadcastFailed,
+        `Solana transaction may already have been processed, but its execution result could not be verified: ${lookupMessage}`,
+        statusError instanceof Error ? statusError : new Error(lookupMessage)
       )
     }
 
@@ -507,7 +540,7 @@ export class RawBroadcastService {
     const engineResult = result.engine_result ?? 'unknown'
     if (engineResultCode !== 0) {
       if (engineResult === 'tefALREADY') {
-        return deriveRippleRawTxHash(rawTx)
+        return verifyKnownRawTx(OtherChain.Ripple, deriveRippleRawTxHash(rawTx), 'Ripple')
       }
 
       if (isRippleInFlightEngineResult(engineResult)) {
@@ -595,7 +628,7 @@ export class RawBroadcastService {
       if (response.code && isInError(response.code, 'DUPLICATE_TRANSACTION', 'DUP_TRANSACTION_ERROR')) {
         const localHash = deriveTronRawTxHash(txJson)
         if (localHash) {
-          return localHash
+          return verifyKnownRawTx(OtherChain.Tron, localHash, 'Tron')
         }
         throw new VaultError(VaultErrorCode.BroadcastFailed, `Transaction may have already been submitted: ${errorMsg}`)
       }

--- a/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
+++ b/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
@@ -210,6 +210,28 @@ describe('RawBroadcastService', () => {
     expect(hash).toBe(base58.encode(signature))
   })
 
+  // Fund-safety: "AlreadyProcessed" only proves the node executed this signature before, not
+  // that the execution succeeded. The idempotent-retry path must run through the same
+  // on-chain-failure status check as a fresh send, not report success unconditionally.
+  it('fails closed on a duplicate-style Solana broadcast error when the signature already failed on-chain', async () => {
+    const signature = Uint8Array.from({ length: 64 }, (_, index) => index + 1)
+    const rawTx = Buffer.from(Uint8Array.from([1, ...signature, 0])).toString('base64')
+    mockSendSolanaRawTx.mockRejectedValue(new Error('AlreadyProcessed'))
+    mockGetSolanaSignatureStatuses.mockResolvedValue({
+      value: [{ err: { InstructionError: [0, 'Custom'] } }],
+    })
+
+    await expect(
+      service.broadcastRawTx({
+        chain: Chain.Solana,
+        rawTx,
+      })
+    ).rejects.toMatchObject({
+      code: VaultErrorCode.BroadcastFailed,
+      message: expect.stringContaining('failed on-chain'),
+    })
+  })
+
   it('broadcasts Cosmos tx when rawTx is JSON with tx_bytes', async () => {
     const txB64 = Buffer.from([1, 2, 3]).toString('base64')
     const hash = await service.broadcastRawTx({

--- a/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
+++ b/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
@@ -21,6 +21,7 @@ const {
   mockGetSolanaSignatureStatuses,
   mockGetCosmosClient,
   mockCosmosBroadcastTx,
+  mockCosmosGetTx,
   mockExecuteSuiTx,
   mockRippleRequest,
 } = vi.hoisted(() => ({
@@ -31,6 +32,7 @@ const {
   mockGetSolanaSignatureStatuses: vi.fn(),
   mockGetCosmosClient: vi.fn(),
   mockCosmosBroadcastTx: vi.fn(),
+  mockCosmosGetTx: vi.fn(),
   mockExecuteSuiTx: vi.fn(),
   mockRippleRequest: vi.fn(),
 }))
@@ -80,14 +82,20 @@ describe('RawBroadcastService', () => {
     mockGetSolanaSignatureStatuses.mockResolvedValue({ value: [null] })
     mockGetCosmosClient.mockResolvedValue({
       broadcastTx: mockCosmosBroadcastTx,
+      getTx: mockCosmosGetTx,
     })
-    mockCosmosBroadcastTx.mockResolvedValue({ transactionHash: 'cosmos-hash' })
+    mockCosmosBroadcastTx.mockResolvedValue({ transactionHash: 'cosmos-hash', code: 0 })
+    mockCosmosGetTx.mockResolvedValue(null)
     mockExecuteSuiTx.mockResolvedValue({
       digest: 'sui-digest',
       effects: { status: { status: 'success' } },
     })
     mockRippleRequest.mockResolvedValue({
-      result: { tx_json: { hash: 'xrp-hash' } },
+      result: {
+        engine_result: 'tesSUCCESS',
+        engine_result_code: 0,
+        tx_json: { hash: 'xrp-hash' },
+      },
     })
   })
 
@@ -277,6 +285,10 @@ describe('RawBroadcastService', () => {
     const txBytes = Buffer.from([1, 2, 3])
     const rawTx = txBytes.toString('base64')
     mockCosmosBroadcastTx.mockRejectedValue(new Error('tx already exists in cache'))
+    mockCosmosGetTx.mockResolvedValue({
+      hash: bytesToHex(sha256(txBytes)).toUpperCase(),
+      code: 0,
+    })
 
     const hash = await service.broadcastRawTx({
       chain: Chain.Cosmos,
@@ -284,6 +296,40 @@ describe('RawBroadcastService', () => {
     })
 
     expect(hash).toBe(bytesToHex(sha256(txBytes)).toUpperCase())
+  })
+
+  it('fails closed when a duplicate Cosmos transaction already failed execution', async () => {
+    mockCosmosBroadcastTx.mockRejectedValue(new Error('tx already exists in cache'))
+    mockCosmosGetTx.mockResolvedValue({
+      hash: 'failed-hash',
+      code: 5,
+      rawLog: 'out of gas',
+    })
+
+    await expect(
+      service.broadcastRawTx({
+        chain: Chain.Cosmos,
+        rawTx: Buffer.from([1, 2, 3]).toString('base64'),
+      })
+    ).rejects.toMatchObject({
+      code: VaultErrorCode.BroadcastFailed,
+      message: expect.stringContaining('execution failed'),
+    })
+  })
+
+  it('fails closed when a duplicate Cosmos transaction cannot be verified on-chain', async () => {
+    mockCosmosBroadcastTx.mockRejectedValue(new Error('tx already exists in cache'))
+    mockCosmosGetTx.mockResolvedValue(null)
+
+    await expect(
+      service.broadcastRawTx({
+        chain: Chain.Cosmos,
+        rawTx: Buffer.from([1, 2, 3]).toString('base64'),
+      })
+    ).rejects.toMatchObject({
+      code: VaultErrorCode.BroadcastFailed,
+      message: expect.stringContaining('could not be verified'),
+    })
   })
 
   it('fails closed on an ambiguous Cosmos account sequence mismatch', async () => {
@@ -496,8 +542,8 @@ describe('RawBroadcastService', () => {
 
   it('maps Tron duplicate transaction to BroadcastFailed', async () => {
     mockQueryUrl.mockResolvedValue({
-      code: 'ERROR',
-      message: 'DUPLICATE_TRANSACTION',
+      code: 'DUP_TRANSACTION_ERROR',
+      message: Buffer.from('Transaction already exists').toString('hex'),
     })
 
     await expect(
@@ -527,8 +573,8 @@ describe('RawBroadcastService', () => {
 
   it('returns the derived Tron txID for duplicate transaction responses', async () => {
     mockQueryUrl.mockResolvedValue({
-      code: 'ERROR',
-      message: 'DUPLICATE_TRANSACTION',
+      code: 'DUP_TRANSACTION_ERROR',
+      message: Buffer.from('Transaction already exists').toString('hex'),
     })
 
     const rawDataHex = '010203'
@@ -547,8 +593,8 @@ describe('RawBroadcastService', () => {
 
   it('fails closed when a duplicate Tron response carries a mismatched txID', async () => {
     mockQueryUrl.mockResolvedValue({
-      code: 'ERROR',
-      message: 'DUPLICATE_TRANSACTION',
+      code: 'DUP_TRANSACTION_ERROR',
+      message: Buffer.from('Transaction already exists').toString('hex'),
     })
 
     await expect(
@@ -588,7 +634,13 @@ describe('RawBroadcastService', () => {
       SigningPubKey: '',
       TxnSignature: '',
     })
-    mockRippleRequest.mockRejectedValue(new Error('tefALREADY'))
+    mockRippleRequest.mockResolvedValue({
+      result: {
+        engine_result: 'tefALREADY',
+        engine_result_code: -198,
+        engine_result_message: 'The transaction was already applied.',
+      },
+    })
 
     const hash = await service.broadcastRawTx({
       chain: Chain.Ripple,
@@ -599,7 +651,14 @@ describe('RawBroadcastService', () => {
   })
 
   it('fails closed on an ambiguous Ripple past-sequence response', async () => {
-    mockRippleRequest.mockRejectedValue(new Error('tefPAST_SEQ'))
+    mockRippleRequest.mockResolvedValue({
+      result: {
+        engine_result: 'tefPAST_SEQ',
+        engine_result_code: -190,
+        engine_result_message: 'This sequence number has already passed.',
+        tx_json: { hash: 'misleading-hash' },
+      },
+    })
 
     await expect(
       service.broadcastRawTx({
@@ -609,6 +668,24 @@ describe('RawBroadcastService', () => {
     ).rejects.toMatchObject({
       code: VaultErrorCode.BroadcastFailed,
       message: expect.stringContaining('tefPAST_SEQ'),
+    })
+  })
+
+  it('fails closed on an ambiguous Ripple response even when it includes a transaction hash', async () => {
+    mockRippleRequest.mockResolvedValue({
+      result: {
+        tx_json: { hash: 'misleading-hash' },
+      },
+    })
+
+    await expect(
+      service.broadcastRawTx({
+        chain: Chain.Ripple,
+        rawTx: '1200aa',
+      })
+    ).rejects.toMatchObject({
+      code: VaultErrorCode.BroadcastFailed,
+      message: expect.stringContaining('engine result'),
     })
   })
 })

--- a/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
+++ b/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
@@ -1,11 +1,17 @@
+import { sha256 } from '@noble/hashes/sha2'
+import { bytesToHex } from '@noble/hashes/utils'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { bittensorRpcUrl } from '@vultisig/core-chain/chains/bittensor/client'
 import { polkadotRpcUrl } from '@vultisig/core-chain/chains/polkadot/client'
 import { tronRpcUrl } from '@vultisig/core-chain/chains/tron/config'
+import base58 from 'bs58'
+import { encode as xrplEncode } from 'ripple-binary-codec'
+import { keccak256 } from 'viem'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { hashes as xrplHashes } from 'xrpl'
 
-import { RawBroadcastService } from '@/vault/services/RawBroadcastService'
-import { VaultError, VaultErrorCode } from '@/vault/VaultError'
+import { RawBroadcastService } from '../../../../src/vault/services/RawBroadcastService'
+import { VaultError, VaultErrorCode } from '../../../../src/vault/VaultError'
 
 const {
   mockQueryUrl,
@@ -191,6 +197,19 @@ describe('RawBroadcastService', () => {
     expect(hash).toBe('sol-signature')
   })
 
+  it('treats duplicate-style Solana broadcast errors as idempotent success', async () => {
+    const signature = Uint8Array.from({ length: 64 }, (_, index) => index + 1)
+    const rawTx = Buffer.from(Uint8Array.from([1, ...signature, 0])).toString('base64')
+    mockSendSolanaRawTx.mockRejectedValue(new Error('AlreadyProcessed'))
+
+    const hash = await service.broadcastRawTx({
+      chain: Chain.Solana,
+      rawTx,
+    })
+
+    expect(hash).toBe(base58.encode(signature))
+  })
+
   it('broadcasts Cosmos tx when rawTx is JSON with tx_bytes', async () => {
     const txB64 = Buffer.from([1, 2, 3]).toString('base64')
     const hash = await service.broadcastRawTx({
@@ -230,6 +249,19 @@ describe('RawBroadcastService', () => {
       code: VaultErrorCode.BroadcastFailed,
       message: expect.stringContaining('execution failed'),
     })
+  })
+
+  it('treats duplicate-style Cosmos broadcast errors as idempotent success', async () => {
+    const txBytes = Buffer.from([1, 2, 3])
+    const rawTx = txBytes.toString('base64')
+    mockCosmosBroadcastTx.mockRejectedValue(new Error('tx already exists in cache'))
+
+    const hash = await service.broadcastRawTx({
+      chain: Chain.Cosmos,
+      rawTx,
+    })
+
+    expect(hash).toBe(bytesToHex(sha256(txBytes)).toUpperCase())
   })
 
   it('rejects Sui payload missing unsignedTx or signature', async () => {
@@ -320,6 +352,20 @@ describe('RawBroadcastService', () => {
       rawTx: '02f8',
     })
     expect(hash).toBe('0xevmhash')
+  })
+
+  it('treats duplicate-style EVM broadcast errors as idempotent success', async () => {
+    mockGetEvmClient.mockReturnValue({
+      sendRawTransaction: vi.fn().mockRejectedValue(new Error('already known')),
+    })
+
+    const rawTx = '0x01'
+    const hash = await service.broadcastRawTx({
+      chain: Chain.Base,
+      rawTx,
+    })
+
+    expect(hash).toBe(keccak256(rawTx))
   })
 
   it('broadcasts Polkadot extrinsic via JSON-RPC', async () => {
@@ -422,6 +468,20 @@ describe('RawBroadcastService', () => {
     ).rejects.toThrow(/Tron broadcast failed/)
   })
 
+  it('returns the local Tron txID for duplicate transaction responses', async () => {
+    mockQueryUrl.mockResolvedValue({
+      code: 'ERROR',
+      message: 'DUPLICATE_TRANSACTION',
+    })
+
+    const hash = await service.broadcastRawTx({
+      chain: Chain.Tron,
+      rawTx: JSON.stringify({ txID: 'tron-local-id', raw_data: {} }),
+    })
+
+    expect(hash).toBe('tron-local-id')
+  })
+
   it('broadcasts Ripple tx blob', async () => {
     const hash = await service.broadcastRawTx({
       chain: Chain.Ripple,
@@ -432,5 +492,26 @@ describe('RawBroadcastService', () => {
       command: 'submit',
       tx_blob: '1200aa',
     })
+  })
+
+  it('treats duplicate-style Ripple broadcast errors as idempotent success', async () => {
+    const rawTx = xrplEncode({
+      TransactionType: 'Payment',
+      Account: 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
+      Destination: 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
+      Amount: '1',
+      Fee: '10',
+      Sequence: 1,
+      SigningPubKey: '',
+      TxnSignature: '',
+    })
+    mockRippleRequest.mockRejectedValue(new Error('tefALREADY'))
+
+    const hash = await service.broadcastRawTx({
+      chain: Chain.Ripple,
+      rawTx,
+    })
+
+    expect(hash).toBe(xrplHashes.hashSignedTx(rawTx))
   })
 })

--- a/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
+++ b/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
@@ -10,8 +10,8 @@ import { keccak256 } from 'viem'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { hashes as xrplHashes } from 'xrpl'
 
-import { RawBroadcastService } from '../../../../src/vault/services/RawBroadcastService'
-import { VaultError, VaultErrorCode } from '../../../../src/vault/VaultError'
+import { RawBroadcastService } from '@/vault/services/RawBroadcastService'
+import { VaultError, VaultErrorCode } from '@/vault/VaultError'
 
 const {
   mockQueryUrl,

--- a/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
+++ b/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
@@ -264,6 +264,20 @@ describe('RawBroadcastService', () => {
     expect(hash).toBe(bytesToHex(sha256(txBytes)).toUpperCase())
   })
 
+  it('fails closed on an ambiguous Cosmos account sequence mismatch', async () => {
+    mockCosmosBroadcastTx.mockRejectedValue(new Error('account sequence mismatch'))
+
+    await expect(
+      service.broadcastRawTx({
+        chain: Chain.Cosmos,
+        rawTx: Buffer.from([1, 2, 3]).toString('base64'),
+      })
+    ).rejects.toMatchObject({
+      code: VaultErrorCode.BroadcastFailed,
+      message: expect.stringContaining('account sequence mismatch'),
+    })
+  })
+
   it('rejects Sui payload missing unsignedTx or signature', async () => {
     await expect(
       service.broadcastRawTx({
@@ -368,6 +382,27 @@ describe('RawBroadcastService', () => {
     expect(hash).toBe(keccak256(rawTx))
   })
 
+  it.each([
+    'nonce too low',
+    'transaction is temporarily banned',
+    'future transaction tries to replace pending',
+    'could not replace existing tx',
+  ])('fails closed on ambiguous EVM rejection: %s', async errorMessage => {
+    mockGetEvmClient.mockReturnValue({
+      sendRawTransaction: vi.fn().mockRejectedValue(new Error(errorMessage)),
+    })
+
+    await expect(
+      service.broadcastRawTx({
+        chain: Chain.Base,
+        rawTx: '0x01',
+      })
+    ).rejects.toMatchObject({
+      code: VaultErrorCode.BroadcastFailed,
+      message: expect.stringContaining(errorMessage),
+    })
+  })
+
   it('broadcasts Polkadot extrinsic via JSON-RPC', async () => {
     mockQueryUrl.mockResolvedValue({ result: '0xpdhash' })
 
@@ -468,18 +503,44 @@ describe('RawBroadcastService', () => {
     ).rejects.toThrow(/Tron broadcast failed/)
   })
 
-  it('returns the local Tron txID for duplicate transaction responses', async () => {
+  it('returns the derived Tron txID for duplicate transaction responses', async () => {
     mockQueryUrl.mockResolvedValue({
       code: 'ERROR',
       message: 'DUPLICATE_TRANSACTION',
     })
 
+    const rawDataHex = '010203'
+    const expectedHash = bytesToHex(sha256(Buffer.from(rawDataHex, 'hex')))
+
     const hash = await service.broadcastRawTx({
       chain: Chain.Tron,
-      rawTx: JSON.stringify({ txID: 'tron-local-id', raw_data: {} }),
+      rawTx: JSON.stringify({
+        txID: expectedHash.toUpperCase(),
+        raw_data_hex: rawDataHex,
+      }),
     })
 
-    expect(hash).toBe('tron-local-id')
+    expect(hash).toBe(expectedHash)
+  })
+
+  it('fails closed when a duplicate Tron response carries a mismatched txID', async () => {
+    mockQueryUrl.mockResolvedValue({
+      code: 'ERROR',
+      message: 'DUPLICATE_TRANSACTION',
+    })
+
+    await expect(
+      service.broadcastRawTx({
+        chain: Chain.Tron,
+        rawTx: JSON.stringify({
+          txID: '00'.repeat(32),
+          raw_data_hex: '010203',
+        }),
+      })
+    ).rejects.toMatchObject({
+      code: VaultErrorCode.BroadcastFailed,
+      message: expect.stringContaining('already been submitted'),
+    })
   })
 
   it('broadcasts Ripple tx blob', async () => {
@@ -513,5 +574,19 @@ describe('RawBroadcastService', () => {
     })
 
     expect(hash).toBe(xrplHashes.hashSignedTx(rawTx))
+  })
+
+  it('fails closed on an ambiguous Ripple past-sequence response', async () => {
+    mockRippleRequest.mockRejectedValue(new Error('tefPAST_SEQ'))
+
+    await expect(
+      service.broadcastRawTx({
+        chain: Chain.Ripple,
+        rawTx: '1200aa',
+      })
+    ).rejects.toMatchObject({
+      code: VaultErrorCode.BroadcastFailed,
+      message: expect.stringContaining('tefPAST_SEQ'),
+    })
   })
 })

--- a/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
+++ b/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
@@ -13,6 +13,18 @@ import { hashes as xrplHashes } from 'xrpl'
 import { RawBroadcastService } from '@/vault/services/RawBroadcastService'
 import { VaultError, VaultErrorCode } from '@/vault/VaultError'
 
+const makeRippleRawTx = () =>
+  xrplEncode({
+    TransactionType: 'Payment',
+    Account: 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
+    Destination: 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
+    Amount: '1',
+    Fee: '10',
+    Sequence: 1,
+    SigningPubKey: '',
+    TxnSignature: '',
+  })
+
 const {
   mockQueryUrl,
   mockGetEvmClient,
@@ -209,6 +221,7 @@ describe('RawBroadcastService', () => {
     const signature = Uint8Array.from({ length: 64 }, (_, index) => index + 1)
     const rawTx = Buffer.from(Uint8Array.from([1, ...signature, 0])).toString('base64')
     mockSendSolanaRawTx.mockRejectedValue(new Error('AlreadyProcessed'))
+    mockGetSolanaSignatureStatuses.mockResolvedValue({ value: [{ err: null }] })
 
     const hash = await service.broadcastRawTx({
       chain: Chain.Solana,
@@ -237,6 +250,32 @@ describe('RawBroadcastService', () => {
     ).rejects.toMatchObject({
       code: VaultErrorCode.BroadcastFailed,
       message: expect.stringContaining('failed on-chain'),
+    })
+  })
+
+  it.each([
+    {
+      name: 'the status lookup finds no record',
+      arrange: () => mockGetSolanaSignatureStatuses.mockResolvedValue({ value: [null] }),
+    },
+    {
+      name: 'the status lookup errors',
+      arrange: () => mockGetSolanaSignatureStatuses.mockRejectedValue(new Error('rpc down')),
+    },
+  ])('fails closed on a duplicate-style Solana broadcast error when $name', async ({ arrange }) => {
+    const signature = Uint8Array.from({ length: 64 }, (_, index) => index + 1)
+    const rawTx = Buffer.from(Uint8Array.from([1, ...signature, 0])).toString('base64')
+    mockSendSolanaRawTx.mockRejectedValue(new Error('AlreadyProcessed'))
+    arrange()
+
+    await expect(
+      service.broadcastRawTx({
+        chain: Chain.Solana,
+        rawTx,
+      })
+    ).rejects.toMatchObject({
+      code: VaultErrorCode.BroadcastFailed,
+      message: expect.stringContaining('could not be verified'),
     })
   })
 
@@ -572,13 +611,19 @@ describe('RawBroadcastService', () => {
   })
 
   it('returns the derived Tron txID for duplicate transaction responses', async () => {
-    mockQueryUrl.mockResolvedValue({
-      code: 'DUP_TRANSACTION_ERROR',
-      message: Buffer.from('Transaction already exists').toString('hex'),
-    })
-
-    const rawDataHex = '010203'
-    const expectedHash = bytesToHex(sha256(Buffer.from(rawDataHex, 'hex')))
+    const rawDataHex =
+      '0a02f69b22087d4a3b02495f232040b888e6eaa5335a67080112630a2d747970652e676f6f676c65617069732e636f6d2f70726f746f636f6c2e5472616e73666572436f6e747261637412320a15411320a6fb4dcd4ff8e91392a8cb98378633cf7dd81215414c8967080d86f3d0e1352a42f9213c7b9dd03b0f18c0843d7080cae2eaa533'
+    const expectedHash = '6db783c4142b3749a4b598db4644155455c9206e2eca4b31efbd48e46773d9d5'
+    mockQueryUrl
+      .mockResolvedValueOnce({
+        code: 'DUP_TRANSACTION_ERROR',
+        message: Buffer.from('Transaction already exists').toString('hex'),
+      })
+      .mockResolvedValueOnce({
+        id: expectedHash,
+        blockNumber: 12345,
+        receipt: { result: 'SUCCESS' },
+      })
 
     const hash = await service.broadcastRawTx({
       chain: Chain.Tron,
@@ -589,6 +634,7 @@ describe('RawBroadcastService', () => {
     })
 
     expect(hash).toBe(expectedHash)
+    expect(bytesToHex(sha256(Buffer.from(rawDataHex, 'hex')))).toBe(expectedHash)
   })
 
   it('fails closed when a duplicate Tron response carries a mismatched txID', async () => {
@@ -611,6 +657,58 @@ describe('RawBroadcastService', () => {
     })
   })
 
+  it('fails closed when a duplicate Tron response is only an unverified RPC cache hit', async () => {
+    const rawDataHex = '010203'
+    const expectedHash = bytesToHex(sha256(Buffer.from(rawDataHex, 'hex')))
+    mockQueryUrl
+      .mockResolvedValueOnce({
+        code: 'DUP_TRANSACTION_ERROR',
+        message: Buffer.from('Transaction already exists').toString('hex'),
+      })
+      .mockResolvedValueOnce({})
+
+    await expect(
+      service.broadcastRawTx({
+        chain: Chain.Tron,
+        rawTx: JSON.stringify({
+          txID: expectedHash,
+          raw_data_hex: rawDataHex,
+        }),
+      })
+    ).rejects.toMatchObject({
+      code: VaultErrorCode.BroadcastFailed,
+      message: expect.stringContaining('could not be verified'),
+    })
+  })
+
+  it('fails closed when a duplicate Tron transaction already failed on-chain', async () => {
+    const rawDataHex = '010203'
+    const expectedHash = bytesToHex(sha256(Buffer.from(rawDataHex, 'hex')))
+    mockQueryUrl
+      .mockResolvedValueOnce({
+        code: 'DUP_TRANSACTION_ERROR',
+        message: Buffer.from('Transaction already exists').toString('hex'),
+      })
+      .mockResolvedValueOnce({
+        id: expectedHash,
+        blockNumber: 12345,
+        receipt: { result: 'REVERT' },
+      })
+
+    await expect(
+      service.broadcastRawTx({
+        chain: Chain.Tron,
+        rawTx: JSON.stringify({
+          txID: expectedHash,
+          raw_data_hex: rawDataHex,
+        }),
+      })
+    ).rejects.toMatchObject({
+      code: VaultErrorCode.BroadcastFailed,
+      message: expect.stringContaining('failed on-chain'),
+    })
+  })
+
   it('broadcasts Ripple tx blob', async () => {
     const hash = await service.broadcastRawTx({
       chain: Chain.Ripple,
@@ -624,23 +722,21 @@ describe('RawBroadcastService', () => {
   })
 
   it('treats duplicate-style Ripple broadcast errors as idempotent success', async () => {
-    const rawTx = xrplEncode({
-      TransactionType: 'Payment',
-      Account: 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
-      Destination: 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
-      Amount: '1',
-      Fee: '10',
-      Sequence: 1,
-      SigningPubKey: '',
-      TxnSignature: '',
-    })
-    mockRippleRequest.mockResolvedValue({
-      result: {
-        engine_result: 'tefALREADY',
-        engine_result_code: -198,
-        engine_result_message: 'The transaction was already applied.',
-      },
-    })
+    const rawTx = makeRippleRawTx()
+    mockRippleRequest
+      .mockResolvedValueOnce({
+        result: {
+          engine_result: 'tefALREADY',
+          engine_result_code: -198,
+          engine_result_message: 'The transaction was already applied.',
+        },
+      })
+      .mockResolvedValueOnce({
+        result: {
+          validated: true,
+          meta: { TransactionResult: 'tesSUCCESS' },
+        },
+      })
 
     const hash = await service.broadcastRawTx({
       chain: Chain.Ripple,
@@ -648,6 +744,57 @@ describe('RawBroadcastService', () => {
     })
 
     expect(hash).toBe(xrplHashes.hashSignedTx(rawTx))
+  })
+
+  it('fails closed when a duplicate Ripple transaction finalized with a tec failure', async () => {
+    const rawTx = makeRippleRawTx()
+    mockRippleRequest
+      .mockResolvedValueOnce({
+        result: {
+          engine_result: 'tefALREADY',
+          engine_result_code: -198,
+          engine_result_message: 'The transaction was already applied.',
+        },
+      })
+      .mockResolvedValueOnce({
+        result: {
+          validated: true,
+          meta: { TransactionResult: 'tecUNFUNDED_PAYMENT' },
+        },
+      })
+
+    await expect(
+      service.broadcastRawTx({
+        chain: Chain.Ripple,
+        rawTx,
+      })
+    ).rejects.toMatchObject({
+      code: VaultErrorCode.BroadcastFailed,
+      message: expect.stringContaining('failed on-chain'),
+    })
+  })
+
+  it('fails closed when a duplicate Ripple transaction cannot be found by hash', async () => {
+    const rawTx = makeRippleRawTx()
+    mockRippleRequest
+      .mockResolvedValueOnce({
+        result: {
+          engine_result: 'tefALREADY',
+          engine_result_code: -198,
+          engine_result_message: 'The transaction was already applied.',
+        },
+      })
+      .mockRejectedValueOnce(new Error('txnNotFound'))
+
+    await expect(
+      service.broadcastRawTx({
+        chain: Chain.Ripple,
+        rawTx,
+      })
+    ).rejects.toMatchObject({
+      code: VaultErrorCode.BroadcastFailed,
+      message: expect.stringContaining('could not be verified'),
+    })
   })
 
   it('fails closed on an ambiguous Ripple past-sequence response', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8230,6 +8230,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"balanced-match@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "balanced-match@npm:1.0.2"
+  checksum: 10c0/9308baf0a7e4838a82bbfd11e01b1cb0f0cf2893bc1676c27c2a8c0e70cbae1c59120c3268517a8ae7fb6376b4639ef81ca22582611dbee4ed28df945134aaee
+  languageName: node
+  linkType: hard
+
 "balanced-match@npm:^4.0.2":
   version: 4.0.4
   resolution: "balanced-match@npm:4.0.4"
@@ -8508,6 +8515,25 @@ __metadata:
   dependencies:
     balanced-match: "npm:^4.0.2"
   checksum: 10c0/73304caafd00fdc5b0168e693ac15bf25b6357dec76d1195fcd628fe2cf99c46f9c889a7ecfa3cfe236dbd2d5ce3e27a6ccc4370b46d475d0d19081e11f86019
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^1.1.7":
+  version: 1.1.16
+  resolution: "brace-expansion@npm:1.1.16"
+  dependencies:
+    balanced-match: "npm:^1.0.0"
+    concat-map: "npm:0.0.1"
+  checksum: 10c0/b2a915bbedbf4e45840d1fb9a4d391bbf26a79475bd134714d3cee34f1f0edb0ce982738028843be5fbaf8039429f71fa487df8c915b6065ced542c83e58fae6
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^2.0.1, brace-expansion@npm:^2.0.2":
+  version: 2.1.2
+  resolution: "brace-expansion@npm:2.1.2"
+  dependencies:
+    balanced-match: "npm:^1.0.0"
+  checksum: 10c0/5442ecab84045d21826268bc56c81a6ef4215327ee1f5ee153f67928e93f7a915d130ecec9966623143277fa3cce036ebb50020024bcc4d78853cdd6af9a19f8
   languageName: node
   linkType: hard
 
@@ -9360,6 +9386,13 @@ __metadata:
     safe-buffer: "npm:5.2.1"
     vary: "npm:~1.1.2"
   checksum: 10c0/85114b0b91c16594dc8c671cd9b05ef5e465066a60e5a4ed8b4551661303559a896ed17bb72c4234c04064e078f6ca86a34b8690349499a43f6fc4b844475da4
+  languageName: node
+  linkType: hard
+
+"concat-map@npm:0.0.1":
+  version: 0.0.1
+  resolution: "concat-map@npm:0.0.1"
+  checksum: 10c0/c996b1cfdf95b6c90fee4dae37e332c8b6eb7d106430c17d538034c0ad9a1630cb194d2ab37293b1bdd4d779494beee7786d586a50bd9376fd6f7bcc2bd4c98f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8230,13 +8230,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"balanced-match@npm:^1.0.0":
-  version: 1.0.2
-  resolution: "balanced-match@npm:1.0.2"
-  checksum: 10c0/9308baf0a7e4838a82bbfd11e01b1cb0f0cf2893bc1676c27c2a8c0e70cbae1c59120c3268517a8ae7fb6376b4639ef81ca22582611dbee4ed28df945134aaee
-  languageName: node
-  linkType: hard
-
 "balanced-match@npm:^4.0.2":
   version: 4.0.4
   resolution: "balanced-match@npm:4.0.4"
@@ -8509,31 +8502,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^1.1.7":
-  version: 1.1.16
-  resolution: "brace-expansion@npm:1.1.16"
-  dependencies:
-    balanced-match: "npm:^1.0.0"
-    concat-map: "npm:0.0.1"
-  checksum: 10c0/b2a915bbedbf4e45840d1fb9a4d391bbf26a79475bd134714d3cee34f1f0edb0ce982738028843be5fbaf8039429f71fa487df8c915b6065ced542c83e58fae6
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^2.0.1, brace-expansion@npm:^2.0.2":
-  version: 2.1.2
-  resolution: "brace-expansion@npm:2.1.2"
-  dependencies:
-    balanced-match: "npm:^1.0.0"
-  checksum: 10c0/5442ecab84045d21826268bc56c81a6ef4215327ee1f5ee153f67928e93f7a915d130ecec9966623143277fa3cce036ebb50020024bcc4d78853cdd6af9a19f8
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^5.0.5":
-  version: 5.0.7
-  resolution: "brace-expansion@npm:5.0.7"
+"brace-expansion@npm:5.0.8":
+  version: 5.0.8
+  resolution: "brace-expansion@npm:5.0.8"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/4769109c3c082de178e449a371bcad50d51ab468f644bce2dd9188efe0cf0a080ed102105d7fc8577382cedc45bad7e6443a91bf3d8102264ee8cf927dbaf205
+  checksum: 10c0/73304caafd00fdc5b0168e693ac15bf25b6357dec76d1195fcd628fe2cf99c46f9c889a7ecfa3cfe236dbd2d5ce3e27a6ccc4370b46d475d0d19081e11f86019
   languageName: node
   linkType: hard
 
@@ -9386,13 +9360,6 @@ __metadata:
     safe-buffer: "npm:5.2.1"
     vary: "npm:~1.1.2"
   checksum: 10c0/85114b0b91c16594dc8c671cd9b05ef5e465066a60e5a4ed8b4551661303559a896ed17bb72c4234c04064e078f6ca86a34b8690349499a43f6fc4b844475da4
-  languageName: node
-  linkType: hard
-
-"concat-map@npm:0.0.1":
-  version: 0.0.1
-  resolution: "concat-map@npm:0.0.1"
-  checksum: 10c0/c996b1cfdf95b6c90fee4dae37e332c8b6eb7d106430c17d538034c0ad9a1630cb194d2ab37293b1bdd4d779494beee7786d586a50bd9376fd6f7bcc2bd4c98f
   languageName: node
   linkType: hard
 
@@ -15270,12 +15237,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.12":
-  version: 3.3.12
-  resolution: "nanoid@npm:3.3.12"
+"nanoid@npm:^3.3.16":
+  version: 3.3.16
+  resolution: "nanoid@npm:3.3.16"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/ba142b7b39e11e80c16dd74b0365d407880c87c1cf7e1480956981ae940ee36060fa5b6f092cd1e315184dd19244c657bd017d03327bd3c62247d691c5e8edfb
+  checksum: 10c0/bbf2dcffe22d2b62d16de2711752070b539c0f644c7916f823ad6521986b2078cbe524f2d6240f58c46e9141ea0c7b87a029e100c0f7f175228cacaf30e41bba
   languageName: node
   linkType: hard
 
@@ -16492,25 +16459,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.14, postcss@npm:^8.5.15":
-  version: 8.5.15
-  resolution: "postcss@npm:8.5.15"
+"postcss@npm:^8.5.18":
+  version: 8.5.22
+  resolution: "postcss@npm:8.5.22"
   dependencies:
-    nanoid: "npm:^3.3.12"
+    nanoid: "npm:^3.3.16"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/7f2e63ae22fbe43aace1bf652bd99da4e90737c64194d49e51ddc9cd0f9e51ff2861a7d734379b494deffa03a880a5c65eec70bc29ee9ebaa7136dde3eee8f31
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.16":
-  version: 8.5.16
-  resolution: "postcss@npm:8.5.16"
-  dependencies:
-    nanoid: "npm:^3.3.12"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/625de7a02f662f3a340964d14b487bd5097adf16f5f171e257d19005ba37aea8768ee446557500e88e91ca46b4d14d6cb4a0bf033c6ec0c8c0b660d85719f1ef
+  checksum: 10c0/9e143ee457988049d5f187116fd37f2750ae9d8d71cc99eae690b776e549e134b34086cbaa2f0360ecd1729b15d918227bd0fc3a2ffbe341f7212d0827080793
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Refs #936
Returns canonical locally derived transaction hashes only when raw-broadcast responses prove a duplicate outcome, while ambiguous or unverifiable errors continue to fail closed.

A controlled production-service JSON-RPC run sent exact offline-signed EIP-1559 bytes through `eth_sendRawTransaction`: `already known` returned the canonical keccak hash, while an unrelated RPC rejection remained `BROADCAST_FAILED`.

This is a bounded follow-up to the malformed/ack-only false-success guards in #1505 and release PR #1504; it does not broaden those changes or claim full cross-network closure for #936.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved raw transaction broadcasting across EVM, Cosmos, Solana, Ripple, and Tron.
  - In duplicate-style submission scenarios, the SDK now returns a deterministic locally derived transaction identifier when the broadcast can be safely verified.
  - Duplicate handling is more conservative when verification is ambiguous or fails, preventing false-positive success.
  - Improved network-specific handling and clearer reporting for Tron duplicate responses.
- **Tests**
  - Expanded unit coverage to validate idempotent behavior and fail-closed handling across the supported networks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->