### PR TITLE
feat(thorchain): carry a limit-swap memo into a signable payload

### DIFF
--- a/.changeset/limit-swap-keysign-payload.md
+++ b/.changeset/limit-swap-keysign-payload.md
@@ -1,0 +1,21 @@
+---
+'@vultisig/core-chain': minor
+'@vultisig/core-mpc': minor
+'@vultisig/sdk': patch
+---
+
+Add `buildLimitSwapKeysignPayload`, the step that turns a THORChain `=<` limit-order memo into a signable transaction.
+
+`buildLimitSwapMemo` produced the memo and `getThorchainMemoAsset` the asset notation, but nothing carried either into a `KeysignPayload` — limit orders could be composed and never placed. This builder branches on the source asset, mirroring iOS `LimitSwapPayloadAssembler`:
+
+- **Native RUNE** — `MsgDeposit` on THORChain itself; no inbound vault, `toAddress` carries the signer's own address as the placeholder the Cosmos signer ignores.
+- **Native gas asset** — transfer to the live Asgard inbound vault with the memo in tx `data` / `OP_RETURN`, no swap payload.
+- **ERC20** — the router's `depositWithExpiry` call plus an `approve` when allowance is short, both in one ceremony. A token source signed without a swap payload would fall through to a plain ERC-20 transfer, dropping the memo and stranding the tokens on the router.
+
+Every gate fails closed: the `EnableAdvSwapQueue` mimir is re-checked at sign time (it can flip while the user sits on Verify, and a `=<` order on a network with the queue off can execute as an unprotected market swap), the memo must actually be a limit memo, RUNE deposits are blocked on THORChain's global trading pause — including when the inbound list is unverifiable, since RUNE bypasses the per-chain halt filter entirely — and external sources must resolve a live, non-halted inbound whose address is then used as the destination.
+
+Also exports `getAdvancedSwapQueueEnabled` (the mimir gate), `findLimitSwapInbound` / `shouldBlockRuneDeposit` (pure inbound selection), and `assertLimitSwapMemo`.
+
+`assertValidThorchainDepositMemo` is deliberately unchanged: it guards the standalone `prepareThorchainMsgDepositTxFromKeys` tool and is not on the keysign-payload path, so excluding swap-shaped memos there stays correct.
+
+No EVM gas-limit override is applied. iOS pins a native-EVM limit deposit to 120000 to match its own market path, but here both paths put the memo on `keysignPayload.memo` and neither sets a general swap payload, so both already floor at `deriveEvmGasLimit`'s 600000 data-tx limit. Forcing 120000 would make the limit path diverge from the market path and risk under-gassing.

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -1743,6 +1743,16 @@
       "import": "./dist/swap/native/halts/getNativeSwapTradingHalt.js",
       "default": "./dist/swap/native/halts/getNativeSwapTradingHalt.js"
     },
+    "./swap/native/limitSwapAvailability": {
+      "types": "./dist/swap/native/limitSwapAvailability.d.ts",
+      "import": "./dist/swap/native/limitSwapAvailability.js",
+      "default": "./dist/swap/native/limitSwapAvailability.js"
+    },
+    "./swap/native/limitSwapInbound": {
+      "types": "./dist/swap/native/limitSwapInbound.d.ts",
+      "import": "./dist/swap/native/limitSwapInbound.js",
+      "default": "./dist/swap/native/limitSwapInbound.js"
+    },
     "./swap/native/limitSwapMemo": {
       "types": "./dist/swap/native/limitSwapMemo.d.ts",
       "import": "./dist/swap/native/limitSwapMemo.js",

--- a/packages/core/chain/swap/native/limitSwapAvailability.test.ts
+++ b/packages/core/chain/swap/native/limitSwapAvailability.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  advancedSwapQueueMimirKey,
+  getAdvancedSwapQueueEnabled,
+  parseAdvancedSwapQueueMimir,
+} from './limitSwapAvailability'
+
+describe('parseAdvancedSwapQueueMimir', () => {
+  it.each(['1', ' 1 ', '1\n'])('enables on a bare 1 (%j)', raw => {
+    expect(parseAdvancedSwapQueueMimir(raw)).toBe(true)
+  })
+
+  // An over-broad accept set is worse than a rare false block: a `=<` order
+  // placed while the queue is off can execute as an unprotected market swap.
+  it.each(['0', '2', '-1', '"1"', '01', '+1', '1.0', '', 'true', 'null'])('stays disabled for %j', raw => {
+    expect(parseAdvancedSwapQueueMimir(raw)).toBe(false)
+  })
+})
+
+describe('getAdvancedSwapQueueEnabled', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  const stubFetch = (response: () => Promise<Response>) => {
+    const fetchMock = vi.fn(async (_url: RequestInfo | URL) => response())
+    vi.stubGlobal('fetch', fetchMock)
+    return fetchMock
+  }
+
+  it('reads the EnableAdvSwapQueue mimir key', async () => {
+    const fetchMock = stubFetch(async () => new Response('1'))
+
+    await getAdvancedSwapQueueEnabled()
+
+    expect(String(fetchMock.mock.calls[0][0])).toContain(`/mimir/key/${advancedSwapQueueMimirKey}`)
+  })
+
+  it('enables when the node confirms the queue is live', async () => {
+    stubFetch(async () => new Response('1'))
+
+    await expect(getAdvancedSwapQueueEnabled()).resolves.toBe(true)
+  })
+
+  it('disables when the node reports the queue off', async () => {
+    stubFetch(async () => new Response('0'))
+
+    await expect(getAdvancedSwapQueueEnabled()).resolves.toBe(false)
+  })
+
+  it('fails closed when the request throws', async () => {
+    stubFetch(async () => {
+      throw new Error('network down')
+    })
+
+    await expect(getAdvancedSwapQueueEnabled()).resolves.toBe(false)
+  })
+
+  it('fails closed on an HTTP error', async () => {
+    stubFetch(async () => new Response('upstream exploded', { status: 500 }))
+
+    await expect(getAdvancedSwapQueueEnabled()).resolves.toBe(false)
+  })
+})

--- a/packages/core/chain/swap/native/limitSwapAvailability.ts
+++ b/packages/core/chain/swap/native/limitSwapAvailability.ts
@@ -1,0 +1,42 @@
+import { attempt, withFallback } from '@vultisig/lib-utils/attempt'
+import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+
+import { Chain } from '../../Chain'
+import { cosmosRpcUrl } from '../../chains/cosmos/cosmosRpcUrl'
+
+/** The mimir key gating THORChain's Advanced Swap Queue — what makes `=<` a real resting limit order. */
+export const advancedSwapQueueMimirKey = 'EnableAdvSwapQueue'
+
+const advancedSwapQueueMimirUrl = `${cosmosRpcUrl[Chain.THORChain]}/thorchain/mimir/key/${advancedSwapQueueMimirKey}`
+
+/**
+ * Interpret a `/thorchain/mimir/key/<KEY>` body. THORChain returns the value as a
+ * bare integer, and only an exact `1` (after trimming whitespace) means enabled.
+ *
+ * Deliberately not integer-parsed: on a gate that protects funds an over-broad
+ * accept set is worse than a rare false block. `0`, `2`, `-1`, a quoted `"1"`,
+ * `01`, `+1`, and `1.0` all read as disabled.
+ */
+export const parseAdvancedSwapQueueMimir = (raw: string): boolean => raw.trim() === '1'
+
+/**
+ * Whether THORChain currently accepts resting limit orders.
+ *
+ * Fails closed — any network, HTTP, or parse failure returns `false`. A `=<`
+ * order placed while the queue is disabled can be treated as a market swap or
+ * rejected on-chain, executing at a price the user never agreed to, so the only
+ * value that unblocks placement is a live, confirmed `1`.
+ */
+export const getAdvancedSwapQueueEnabled = async (): Promise<boolean> => {
+  const raw = await withFallback(
+    attempt(() =>
+      queryUrl<string>(advancedSwapQueueMimirUrl, {
+        responseType: 'text',
+        headers: { 'X-Client-ID': 'vultisig' },
+      })
+    ),
+    ''
+  )
+
+  return parseAdvancedSwapQueueMimir(raw)
+}

--- a/packages/core/chain/swap/native/limitSwapInbound.test.ts
+++ b/packages/core/chain/swap/native/limitSwapInbound.test.ts
@@ -73,6 +73,22 @@ describe('isLimitSwapDestinationHalted', () => {
     )
   })
 
+  // A partial or stale feed that drops a row would otherwise let an order be
+  // signed into a destination whose halt status was never verified.
+  it('fails closed when a mapped destination has no inbound row', () => {
+    expect(isLimitSwapDestinationHalted({ inbounds: [inbound('ETH')], chain: Chain.Bitcoin })).toBe(true)
+  })
+
+  it('fails closed on an empty inbound feed', () => {
+    expect(isLimitSwapDestinationHalted({ inbounds: [], chain: Chain.Bitcoin })).toBe(true)
+  })
+
+  // THORChain has no Asgard vault, so it never appears in the feed -- treating a
+  // missing row as halted there would block every RUNE-denominated destination.
+  it('treats THORChain itself as live despite having no inbound row', () => {
+    expect(isLimitSwapDestinationHalted({ inbounds: [inbound('BTC')], chain: Chain.THORChain })).toBe(false)
+  })
+
   it('matches the destination row case-insensitively and ignores surrounding whitespace', () => {
     expect(isLimitSwapDestinationHalted({ inbounds: [inbound(' btc ', { halted: true })], chain: Chain.Bitcoin })).toBe(
       true

--- a/packages/core/chain/swap/native/limitSwapInbound.test.ts
+++ b/packages/core/chain/swap/native/limitSwapInbound.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+
+import { Chain } from '../../Chain'
+import { ThorchainInboundAddress } from '../../chains/cosmos/thor/getThorchainInboundAddress'
+import { findLimitSwapInbound, isThorchainGloballyPaused, shouldBlockRuneDeposit } from './limitSwapInbound'
+
+const inbound = (chain: string, overrides: Partial<ThorchainInboundAddress> = {}): ThorchainInboundAddress => ({
+  address: `${chain.toLowerCase()}-vault`,
+  chain,
+  chain_lp_actions_paused: false,
+  chain_trading_paused: false,
+  dust_threshold: '0',
+  gas_rate: '0',
+  gas_rate_units: 'satsperbyte',
+  global_trading_paused: false,
+  halted: false,
+  observed_fee_rate: '0',
+  outbound_fee: '0',
+  outbound_tx_size: '0',
+  pub_key: 'pub',
+  router: '',
+  ...overrides,
+})
+
+describe('isThorchainGloballyPaused', () => {
+  it('detects the network-wide pause flag on any row', () => {
+    expect(isThorchainGloballyPaused([inbound('BTC'), inbound('ETH', { global_trading_paused: true })])).toBe(true)
+  })
+
+  it('is false when no row is paused', () => {
+    expect(isThorchainGloballyPaused([inbound('BTC'), inbound('ETH')])).toBe(false)
+  })
+})
+
+describe('shouldBlockRuneDeposit', () => {
+  it('blocks when trading is globally paused', () => {
+    expect(shouldBlockRuneDeposit([inbound('BTC', { global_trading_paused: true })])).toBe(true)
+  })
+
+  // A real inbound_addresses response always carries many rows, so an empty
+  // (non-throwing) result means the pause state is unverifiable.
+  it('blocks on an empty inbound list rather than assuming healthy', () => {
+    expect(shouldBlockRuneDeposit([])).toBe(true)
+  })
+
+  it('allows a deposit when the network is trading normally', () => {
+    expect(shouldBlockRuneDeposit([inbound('BTC'), inbound('ETH')])).toBe(false)
+  })
+
+  // RUNE has no inbound vault, so a halted BTC row must not block a RUNE deposit.
+  it('ignores a single halted chain', () => {
+    expect(shouldBlockRuneDeposit([inbound('BTC', { halted: true }), inbound('ETH')])).toBe(false)
+  })
+})
+
+describe('findLimitSwapInbound', () => {
+  it('resolves the row matching the chain', () => {
+    const result = findLimitSwapInbound({
+      inbounds: [inbound('BTC'), inbound('ETH')],
+      chain: Chain.Ethereum,
+    })
+
+    expect(result.address).toBe('eth-vault')
+  })
+
+  it('matches the chain symbol case-insensitively and ignores surrounding whitespace', () => {
+    const result = findLimitSwapInbound({
+      inbounds: [inbound(' btc ', { address: 'trimmed-vault' })],
+      chain: Chain.Bitcoin,
+    })
+
+    expect(result.address).toBe('trimmed-vault')
+  })
+
+  it.each([
+    ['halted', { halted: true }],
+    ['globally paused', { global_trading_paused: true }],
+    ['chain paused', { chain_trading_paused: true }],
+  ])('refuses a %s inbound rather than signing against it', (_, overrides) => {
+    expect(() => findLimitSwapInbound({ inbounds: [inbound('BTC', overrides)], chain: Chain.Bitcoin })).toThrow(
+      /no live, tradeable THORChain inbound/
+    )
+  })
+
+  it('throws when the chain has no inbound row at all', () => {
+    expect(() => findLimitSwapInbound({ inbounds: [inbound('ETH')], chain: Chain.Bitcoin })).toThrow(
+      /no live, tradeable THORChain inbound/
+    )
+  })
+
+  it('refuses a chain the memo builder cannot encode', () => {
+    expect(() => findLimitSwapInbound({ inbounds: [inbound('ADA')], chain: Chain.Cardano })).toThrow(
+      /not routable through THORChain/
+    )
+  })
+})

--- a/packages/core/chain/swap/native/limitSwapInbound.test.ts
+++ b/packages/core/chain/swap/native/limitSwapInbound.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from 'vitest'
 
 import { Chain } from '../../Chain'
 import { ThorchainInboundAddress } from '../../chains/cosmos/thor/getThorchainInboundAddress'
-import { findLimitSwapInbound, isThorchainGloballyPaused, shouldBlockRuneDeposit } from './limitSwapInbound'
+import {
+  findLimitSwapInbound,
+  isLimitSwapDestinationHalted,
+  isThorchainGloballyPaused,
+  shouldBlockRuneDeposit,
+} from './limitSwapInbound'
 
 const inbound = (chain: string, overrides: Partial<ThorchainInboundAddress> = {}): ThorchainInboundAddress => ({
   address: `${chain.toLowerCase()}-vault`,
@@ -50,6 +55,38 @@ describe('shouldBlockRuneDeposit', () => {
   // RUNE has no inbound vault, so a halted BTC row must not block a RUNE deposit.
   it('ignores a single halted chain', () => {
     expect(shouldBlockRuneDeposit([inbound('BTC', { halted: true }), inbound('ETH')])).toBe(false)
+  })
+})
+
+describe('isLimitSwapDestinationHalted', () => {
+  it.each([
+    ['halted', { halted: true }],
+    ['globally paused', { global_trading_paused: true }],
+    ['chain paused', { chain_trading_paused: true }],
+  ])('flags a %s destination', (_, overrides) => {
+    expect(isLimitSwapDestinationHalted({ inbounds: [inbound('BTC', overrides)], chain: Chain.Bitcoin })).toBe(true)
+  })
+
+  it('reads a live destination as not halted', () => {
+    expect(isLimitSwapDestinationHalted({ inbounds: [inbound('BTC'), inbound('ETH')], chain: Chain.Bitcoin })).toBe(
+      false
+    )
+  })
+
+  it('matches the destination row case-insensitively and ignores surrounding whitespace', () => {
+    expect(isLimitSwapDestinationHalted({ inbounds: [inbound(' btc ', { halted: true })], chain: Chain.Bitcoin })).toBe(
+      true
+    )
+  })
+
+  // The feed lists no row for THORChain itself, so a THORChain-native
+  // destination (RUNE, TCY, secured assets) is not haltable via it.
+  it('skips a destination with no inbound row rather than false-blocking it', () => {
+    expect(isLimitSwapDestinationHalted({ inbounds: [inbound('BTC')], chain: Chain.THORChain })).toBe(false)
+  })
+
+  it('skips a destination the memo builder cannot encode', () => {
+    expect(isLimitSwapDestinationHalted({ inbounds: [inbound('BTC')], chain: Chain.Cardano })).toBe(false)
   })
 })
 

--- a/packages/core/chain/swap/native/limitSwapInbound.test.ts
+++ b/packages/core/chain/swap/native/limitSwapInbound.test.ts
@@ -82,6 +82,17 @@ describe('findLimitSwapInbound', () => {
     )
   })
 
+  // The selected row's address becomes the deposit's toAddress; an empty one
+  // would sign funds to nowhere.
+  it.each([
+    ['empty', ''],
+    ['whitespace-only', '   '],
+  ])('refuses an inbound with an %s vault address', (_, address) => {
+    expect(() => findLimitSwapInbound({ inbounds: [inbound('BTC', { address })], chain: Chain.Bitcoin })).toThrow(
+      /no live, tradeable THORChain inbound/
+    )
+  })
+
   it('throws when the chain has no inbound row at all', () => {
     expect(() => findLimitSwapInbound({ inbounds: [inbound('ETH')], chain: Chain.Bitcoin })).toThrow(
       /no live, tradeable THORChain inbound/

--- a/packages/core/chain/swap/native/limitSwapInbound.ts
+++ b/packages/core/chain/swap/native/limitSwapInbound.ts
@@ -37,6 +37,32 @@ export const isThorchainGloballyPaused = (inbounds: ThorchainInboundAddress[]): 
 export const shouldBlockRuneDeposit = (inbounds: ThorchainInboundAddress[]): boolean =>
   inbounds.length === 0 || isThorchainGloballyPaused(inbounds)
 
+type IsLimitSwapDestinationHaltedInput = {
+  inbounds: ThorchainInboundAddress[]
+  chain: Chain
+}
+
+/**
+ * Whether a limit order's destination chain is halted or trading-paused, per the
+ * live inbound list.
+ *
+ * The market path re-checks both route legs at broadcast through the native swap
+ * payload, but a RUNE `MsgDeposit` never carries one — this sign-time gate is
+ * its only destination check. Mirrors the broadcast guard's tolerance: a leg
+ * with no memo prefix or no inbound row (THORChain-native assets; the feed lists
+ * no row for THORChain itself) is not haltable via this feed and reads as live.
+ */
+export const isLimitSwapDestinationHalted = ({ inbounds, chain }: IsLimitSwapDestinationHaltedInput): boolean => {
+  const chainSymbol = thorchainMemoAssetChainPrefix[chain]
+  if (!chainSymbol) {
+    return false
+  }
+
+  const inbound = inbounds.find(entry => entry.chain.trim().toUpperCase() === chainSymbol)
+
+  return Boolean(inbound && (inbound.halted || inbound.global_trading_paused || inbound.chain_trading_paused))
+}
+
 type FindLimitSwapInboundInput = {
   inbounds: ThorchainInboundAddress[]
   chain: Chain

--- a/packages/core/chain/swap/native/limitSwapInbound.ts
+++ b/packages/core/chain/swap/native/limitSwapInbound.ts
@@ -1,0 +1,62 @@
+import { Chain } from '../../Chain'
+import { ThorchainInboundAddress } from '../../chains/cosmos/thor/getThorchainInboundAddress'
+import { thorchainMemoAssetChainPrefix } from './thorchainMemoAsset'
+
+/**
+ * Whether an inbound row is usable right now.
+ *
+ * Missing pause flags read as "not paused", matching the market swap's halt gate.
+ */
+const isTradeable = ({ halted, global_trading_paused, chain_trading_paused }: ThorchainInboundAddress): boolean =>
+  !halted && !global_trading_paused && !chain_trading_paused
+
+/**
+ * Whether THORChain has globally paused trading, per a live `inbound_addresses`
+ * list. THORChain sets `global_trading_paused` on every inbound row when it halts
+ * network-wide.
+ */
+export const isThorchainGloballyPaused = (inbounds: ThorchainInboundAddress[]): boolean =>
+  inbounds.some(({ global_trading_paused }) => global_trading_paused)
+
+/**
+ * Whether a native RUNE `MsgDeposit` must be blocked given the live inbound list.
+ *
+ * RUNE settles on THORChain itself with no inbound vault, so it never passes
+ * through the per-chain halt filter an external source does — this global signal
+ * is its gate. Blocks on an empty list too: a real `inbound_addresses` response
+ * always carries many rows, so an empty (but non-throwing) result means the pause
+ * state is unverifiable and a deposit must not be signed against it.
+ */
+export const shouldBlockRuneDeposit = (inbounds: ThorchainInboundAddress[]): boolean =>
+  inbounds.length === 0 || isThorchainGloballyPaused(inbounds)
+
+type FindLimitSwapInboundInput = {
+  inbounds: ThorchainInboundAddress[]
+  chain: Chain
+}
+
+/**
+ * Select the live, tradeable inbound row a limit-swap deposit should target.
+ *
+ * Resolves the chain through the same prefix table the memo builder uses, so a
+ * source the memo could not encode can never resolve an inbound. Throws rather
+ * than returning undefined: every caller is about to sign a value-bearing
+ * deposit, and there is no safe fallback for "no usable vault".
+ */
+export const findLimitSwapInbound = ({ inbounds, chain }: FindLimitSwapInboundInput): ThorchainInboundAddress => {
+  const chainSymbol = thorchainMemoAssetChainPrefix[chain]
+  if (!chainSymbol) {
+    throw new Error(`findLimitSwapInbound: ${chain} is not routable through THORChain`)
+  }
+
+  const inbound = inbounds.find(entry => entry.chain.trim().toUpperCase() === chainSymbol && isTradeable(entry))
+
+  if (!inbound) {
+    throw new Error(
+      `findLimitSwapInbound: no live, tradeable THORChain inbound address for ${chainSymbol}. ` +
+        'The chain may be halted or trading-paused.'
+    )
+  }
+
+  return inbound
+}

--- a/packages/core/chain/swap/native/limitSwapInbound.ts
+++ b/packages/core/chain/swap/native/limitSwapInbound.ts
@@ -6,9 +6,16 @@ import { thorchainMemoAssetChainPrefix } from './thorchainMemoAsset'
  * Whether an inbound row is usable right now.
  *
  * Missing pause flags read as "not paused", matching the market swap's halt gate.
+ * The vault address must also be present: it becomes the deposit's `toAddress`,
+ * and an empty one would sign funds to nowhere.
  */
-const isTradeable = ({ halted, global_trading_paused, chain_trading_paused }: ThorchainInboundAddress): boolean =>
-  !halted && !global_trading_paused && !chain_trading_paused
+const isTradeable = ({
+  address,
+  halted,
+  global_trading_paused,
+  chain_trading_paused,
+}: ThorchainInboundAddress): boolean =>
+  Boolean(address?.trim()) && !halted && !global_trading_paused && !chain_trading_paused
 
 /**
  * Whether THORChain has globally paused trading, per a live `inbound_addresses`

--- a/packages/core/chain/swap/native/limitSwapInbound.ts
+++ b/packages/core/chain/swap/native/limitSwapInbound.ts
@@ -48,19 +48,27 @@ type IsLimitSwapDestinationHaltedInput = {
  *
  * The market path re-checks both route legs at broadcast through the native swap
  * payload, but a RUNE `MsgDeposit` never carries one — this sign-time gate is
- * its only destination check. Mirrors the broadcast guard's tolerance: a leg
- * with no memo prefix or no inbound row (THORChain-native assets; the feed lists
- * no row for THORChain itself) is not haltable via this feed and reads as live.
+ * its only destination check, so it fails closed.
+ *
+ * Two legs are genuinely not haltable through this feed and read as live: a
+ * chain with no memo prefix (nothing this builder can encode reaches here), and
+ * THORChain itself, which never appears in `inbound_addresses` because it has no
+ * Asgard vault. Every other mapped chain **must** produce a row: a partial or
+ * stale feed that silently drops one would otherwise let an order be signed into
+ * a destination whose halt status was never verified.
  */
 export const isLimitSwapDestinationHalted = ({ inbounds, chain }: IsLimitSwapDestinationHaltedInput): boolean => {
   const chainSymbol = thorchainMemoAssetChainPrefix[chain]
-  if (!chainSymbol) {
+  if (!chainSymbol || chain === Chain.THORChain) {
     return false
   }
 
   const inbound = inbounds.find(entry => entry.chain.trim().toUpperCase() === chainSymbol)
+  if (!inbound) {
+    return true
+  }
 
-  return Boolean(inbound && (inbound.halted || inbound.global_trading_paused || inbound.chain_trading_paused))
+  return inbound.halted || inbound.global_trading_paused || inbound.chain_trading_paused
 }
 
 type FindLimitSwapInboundInput = {

--- a/packages/core/chain/swap/native/limitSwapMemo.assertMemo.test.ts
+++ b/packages/core/chain/swap/native/limitSwapMemo.assertMemo.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { assertLimitSwapMemo } from './limitSwapMemo'
+
+const validMemo = '=<:ETH.ETH:0x742d35Cc6634C0532925a3b844Bc454e4438f44e:1600000000/14400/0'
+const validWithAffiliate = `${validMemo}:v0:50`
+
+describe('assertLimitSwapMemo', () => {
+  it.each([validMemo, validWithAffiliate])('accepts a well-formed memo (%s)', memo => {
+    expect(() => assertLimitSwapMemo(memo)).not.toThrow()
+  })
+
+  it.each([
+    ['a market swap', '=>:ETH.ETH:0xdest:100/1/0'],
+    ['an LP add', '+:BTC.BTC'],
+    ['empty', ''],
+  ])('rejects %s memo', (_, memo) => {
+    expect(() => assertLimitSwapMemo(memo)).toThrow(/not a THORChain limit-swap memo/)
+  })
+
+  // A prefix-only check would let these through to a signer.
+  it('rejects a memo whose trade target is not limit-shaped', () => {
+    expect(() => assertLimitSwapMemo('=<:BTC.BTC:destination:not-a-limit')).toThrow(/trade target must be/)
+  })
+
+  it.each([
+    ['too few', '=<:ETH.ETH:0xdest'],
+    ['too many', '=<:ETH.ETH:0xdest:1/2/0:v0:50:extra'],
+  ])('rejects a memo with %s segments', (_, memo) => {
+    expect(() => assertLimitSwapMemo(memo)).toThrow(/must have 3 segments/)
+  })
+
+  it('rejects a missing target asset', () => {
+    expect(() => assertLimitSwapMemo('=<::0xdest:100/14400/0')).toThrow(/missing its target asset/)
+  })
+
+  it('rejects a missing destination address', () => {
+    expect(() => assertLimitSwapMemo('=<:ETH.ETH::100/14400/0')).toThrow(/missing its destination address/)
+  })
+
+  // THORChain reads a zero trade target as an unprotected market order.
+  it('rejects a zero minimum-received', () => {
+    expect(() => assertLimitSwapMemo('=<:ETH.ETH:0xdest:0/14400/0')).toThrow(/zero minimum-received/)
+  })
+
+  it('rejects a non-integer affiliate bps', () => {
+    expect(() => assertLimitSwapMemo(`${validMemo}:v0:half`)).toThrow(/affiliate bps must be an integer/)
+  })
+
+  it('rejects an empty affiliate name', () => {
+    expect(() => assertLimitSwapMemo(`${validMemo}::50`)).toThrow(/empty affiliate segment/)
+  })
+})

--- a/packages/core/chain/swap/native/limitSwapMemo.ts
+++ b/packages/core/chain/swap/native/limitSwapMemo.ts
@@ -250,18 +250,69 @@ export const validateLimitSwapInputs = (inputs: LimitSwapMemoInput): void => {
  */
 export const limitSwapMemoPrefix = '=<:'
 
+/** `<LIM>/<interval>/<quantity>`, the segment that makes the order a limit order. */
+const limitSwapMemoTradeTargetPattern = /^\d+\/\d+\/\d+$/
+
+/** Basis points are a bare integer; the affiliate name is a printable, separator-free token. */
+const limitSwapMemoAffiliateBpsPattern = /^\d+$/
+
 /**
- * Fail closed on a memo that is not a THORChain limit-swap memo.
+ * Fail closed on anything that is not a well-formed THORChain limit-swap memo.
  *
- * Guards the signing path: the limit deposit builder accepts a pre-built memo
- * string, and a market (`=>`) or unrelated memo reaching it would sign a
- * value-bearing deposit that executes with completely different semantics.
+ * Guards the signing path. The limit deposit builder accepts a pre-built memo
+ * string, so a market (`=>`) memo, an unrelated action, or a truncated/corrupted
+ * limit memo would otherwise sign a value-bearing deposit that executes with
+ * completely different semantics — or with no price protection at all.
+ *
+ * Validates the shape `=<:TARGET:DEST:LIM/INTERVAL/QUANTITY[:AFFILIATE:BPS]`
+ * rather than only the prefix, because it is the trade-target segment that
+ * carries the order's price floor: a memo whose LIM is missing or non-numeric is
+ * exactly the case that must never reach a signer.
  */
 export const assertLimitSwapMemo = (memo: string): void => {
   if (!memo.startsWith(limitSwapMemoPrefix)) {
     throw new Error(
       `memo is not a THORChain limit-swap memo (expected a "${limitSwapMemoPrefix}" prefix): ${JSON.stringify(memo)}`
     )
+  }
+
+  const segments = memo.slice(limitSwapMemoPrefix.length).split(':')
+  if (segments.length !== 3 && segments.length !== 5) {
+    throw new Error(
+      `limit-swap memo must have 3 segments (or 5 with an affiliate) after the prefix, got ${segments.length}: ${JSON.stringify(memo)}`
+    )
+  }
+
+  const [targetAsset, destAddress, tradeTarget, affiliate, affiliateBps] = segments
+
+  if (!targetAsset) {
+    throw new Error(`limit-swap memo is missing its target asset: ${JSON.stringify(memo)}`)
+  }
+
+  if (!destAddress) {
+    throw new Error(`limit-swap memo is missing its destination address: ${JSON.stringify(memo)}`)
+  }
+
+  if (!limitSwapMemoTradeTargetPattern.test(tradeTarget)) {
+    throw new Error(
+      `limit-swap memo trade target must be "<limit>/<interval>/<quantity>", got ${JSON.stringify(tradeTarget)}`
+    )
+  }
+
+  const [limit] = tradeTarget.split('/')
+  if (BigInt(limit) === 0n) {
+    // THORChain reads a zero trade target as an unprotected market order.
+    throw new Error(`limit-swap memo has a zero minimum-received (LIM), which THORChain treats as a market order`)
+  }
+
+  if (segments.length === 5) {
+    if (!affiliate) {
+      throw new Error(`limit-swap memo has an empty affiliate segment: ${JSON.stringify(memo)}`)
+    }
+
+    if (!limitSwapMemoAffiliateBpsPattern.test(affiliateBps)) {
+      throw new Error(`limit-swap memo affiliate bps must be an integer, got ${JSON.stringify(affiliateBps)}`)
+    }
   }
 }
 

--- a/packages/core/chain/swap/native/limitSwapMemo.ts
+++ b/packages/core/chain/swap/native/limitSwapMemo.ts
@@ -244,10 +244,31 @@ export const validateLimitSwapInputs = (inputs: LimitSwapMemoInput): void => {
   getLimitSwapIntervalBlocks(inputs.expiry_hours)
 }
 
+/**
+ * THORChain memo prefix selecting the advanced swap queue — what makes a deposit
+ * a resting limit order rather than a market swap (`=>`).
+ */
+export const limitSwapMemoPrefix = '=<:'
+
+/**
+ * Fail closed on a memo that is not a THORChain limit-swap memo.
+ *
+ * Guards the signing path: the limit deposit builder accepts a pre-built memo
+ * string, and a market (`=>`) or unrelated memo reaching it would sign a
+ * value-bearing deposit that executes with completely different semantics.
+ */
+export const assertLimitSwapMemo = (memo: string): void => {
+  if (!memo.startsWith(limitSwapMemoPrefix)) {
+    throw new Error(
+      `memo is not a THORChain limit-swap memo (expected a "${limitSwapMemoPrefix}" prefix): ${JSON.stringify(memo)}`
+    )
+  }
+}
+
 const buildMemo = (inputs: LimitSwapMemoInput, includeAffiliate: boolean): string => {
   const limit = getLimitSwapLimitAmount(inputs)
   const interval = getLimitSwapIntervalBlocks(inputs.expiry_hours)
-  const memo = `=<:${inputs.target_asset}:${inputs.dest_addr}:${limit}/${interval}/0`
+  const memo = `${limitSwapMemoPrefix}${inputs.target_asset}:${inputs.dest_addr}:${limit}/${interval}/0`
 
   return includeAffiliate ? `${memo}:${nativeSwapAffiliateConfig.affiliateFeeAddress}:${baseAffiliateBps}` : memo
 }

--- a/packages/core/mpc/keysign/swap/buildLimitSwapKeysignPayload.test.ts
+++ b/packages/core/mpc/keysign/swap/buildLimitSwapKeysignPayload.test.ts
@@ -114,6 +114,22 @@ describe('buildLimitSwapKeysignPayload', () => {
         /globally paused trading|unverifiable/
       )
     })
+
+    // With no swap payload attached, the broadcast guard's destination-leg
+    // re-check never runs for a RUNE deposit — sign time is its only
+    // destination gate, or RUNE->BTC signs while BTC's outbound cannot leave.
+    it.each([
+      ['halted', { halted: true }],
+      ['trading-paused', { chain_trading_paused: true }],
+    ])('refuses to sign into a %s destination chain', async (_, overrides) => {
+      mocks.getThorchainInboundAddress.mockResolvedValue([inbound('BTC', overrides), inbound('ETH')])
+
+      await expect(buildLimitSwapKeysignPayload({ ...baseInput, fromCoin: runeCoin, toCoin: btcCoin })).rejects.toThrow(
+        /halted Bitcoin trading/
+      )
+      expect(mocks.getChainSpecific).not.toHaveBeenCalled()
+    })
+
   })
 
   describe('native gas asset (inbound vault transfer)', () => {

--- a/packages/core/mpc/keysign/swap/buildLimitSwapKeysignPayload.test.ts
+++ b/packages/core/mpc/keysign/swap/buildLimitSwapKeysignPayload.test.ts
@@ -1,0 +1,221 @@
+import { create } from '@bufbuild/protobuf'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { ThorchainInboundAddress } from '@vultisig/core-chain/chains/cosmos/thor/getThorchainInboundAddress'
+import { THORChainSpecificSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getChainSpecific: vi.fn(async () => ({
+    case: 'thorchainSpecific' as const,
+    value: create(THORChainSpecificSchema, { accountNumber: 1n, sequence: 2n, fee: 2000000n }),
+  })),
+  getKeysignUtxoInfo: vi.fn(async () => []),
+  getAdvancedSwapQueueEnabled: vi.fn(async () => true),
+  getThorchainInboundAddress: vi.fn(async (): Promise<ThorchainInboundAddress[]> => []),
+  getErc20Allowance: vi.fn(async () => 0n),
+  refineKeysignUtxo: vi.fn(async ({ keysignPayload }: { keysignPayload: unknown }) => keysignPayload),
+}))
+
+vi.mock('@vultisig/core-mpc/keysign/chainSpecific', () => ({ getChainSpecific: mocks.getChainSpecific }))
+vi.mock('@vultisig/core-mpc/keysign/utxo/getKeysignUtxoInfo', () => ({
+  getKeysignUtxoInfo: mocks.getKeysignUtxoInfo,
+}))
+vi.mock('@vultisig/core-mpc/keysign/refine/utxo', () => ({ refineKeysignUtxo: mocks.refineKeysignUtxo }))
+vi.mock('@vultisig/core-chain/swap/native/limitSwapAvailability', () => ({
+  getAdvancedSwapQueueEnabled: mocks.getAdvancedSwapQueueEnabled,
+}))
+vi.mock('@vultisig/core-chain/chains/cosmos/thor/getThorchainInboundAddress', () => ({
+  getThorchainInboundAddress: mocks.getThorchainInboundAddress,
+}))
+vi.mock('@vultisig/core-chain/chains/evm/erc20/getErc20Allowance', () => ({
+  getErc20Allowance: mocks.getErc20Allowance,
+}))
+
+import { buildLimitSwapKeysignPayload } from './buildLimitSwapKeysignPayload'
+
+const inbound = (chain: string, overrides: Partial<ThorchainInboundAddress> = {}): ThorchainInboundAddress => ({
+  address: `${chain.toLowerCase()}-vault`,
+  chain,
+  chain_lp_actions_paused: false,
+  chain_trading_paused: false,
+  dust_threshold: '0',
+  gas_rate: '0',
+  gas_rate_units: 'satsperbyte',
+  global_trading_paused: false,
+  halted: false,
+  observed_fee_rate: '0',
+  outbound_fee: '0',
+  outbound_tx_size: '0',
+  pub_key: 'pub',
+  router: '',
+  ...overrides,
+})
+
+const publicKey = { data: () => new Uint8Array([1, 2, 3]) } as never
+
+const runeCoin = { chain: Chain.THORChain, address: 'thor1sender', ticker: 'RUNE', decimals: 8 }
+const ethCoin = { chain: Chain.Ethereum, address: '0xsender', ticker: 'ETH', decimals: 18 }
+const usdcCoin = {
+  chain: Chain.Ethereum,
+  address: '0xsender',
+  id: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+  ticker: 'USDC',
+  decimals: 6,
+}
+const btcCoin = { chain: Chain.Bitcoin, address: 'bc1sender', ticker: 'BTC', decimals: 8 }
+
+const memo = '=<:ETH.ETH:0x742d35Cc6634C0532925a3b844Bc454e4438f44e:1600000000/14400/0:v0:50'
+
+const baseInput = {
+  toCoin: ethCoin,
+  amount: 100_000_000n,
+  memo,
+  vaultId: 'vault-id',
+  localPartyId: 'local-party',
+  fromPublicKey: publicKey,
+  toPublicKey: publicKey,
+  libType: 'DKLS' as const,
+  walletCore: {} as never,
+  now: 1_700_000_000_000,
+}
+
+describe('buildLimitSwapKeysignPayload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getAdvancedSwapQueueEnabled.mockResolvedValue(true)
+    mocks.getErc20Allowance.mockResolvedValue(0n)
+    mocks.getThorchainInboundAddress.mockResolvedValue([inbound('BTC'), inbound('ETH', { router: '0xrouter' })])
+  })
+
+  describe('native RUNE (MsgDeposit)', () => {
+    it('signs a deposit with no inbound vault and the memo attached', async () => {
+      const payload = await buildLimitSwapKeysignPayload({ ...baseInput, fromCoin: runeCoin })
+
+      expect(payload.memo).toBe(memo)
+      expect(payload.toAddress).toBe(runeCoin.address)
+      expect(payload.swapPayload.case).toBeUndefined()
+      expect(mocks.getChainSpecific).toHaveBeenCalledWith(expect.objectContaining({ isDeposit: true }))
+    })
+
+    // RUNE bypasses the per-chain inbound halt filter entirely, so the global
+    // pause is its only gate.
+    it('refuses to sign while THORChain has globally paused trading', async () => {
+      mocks.getThorchainInboundAddress.mockResolvedValue([inbound('BTC', { global_trading_paused: true })])
+
+      await expect(buildLimitSwapKeysignPayload({ ...baseInput, fromCoin: runeCoin })).rejects.toThrow(
+        /globally paused trading/
+      )
+    })
+
+    it('refuses to sign when the inbound list is unverifiable', async () => {
+      mocks.getThorchainInboundAddress.mockResolvedValue([])
+
+      await expect(buildLimitSwapKeysignPayload({ ...baseInput, fromCoin: runeCoin })).rejects.toThrow(
+        /globally paused trading|unverifiable/
+      )
+    })
+  })
+
+  describe('native gas asset (inbound vault transfer)', () => {
+    it('targets the live Asgard vault and carries no swap payload', async () => {
+      const payload = await buildLimitSwapKeysignPayload({ ...baseInput, fromCoin: ethCoin, toCoin: btcCoin })
+
+      expect(payload.toAddress).toBe('eth-vault')
+      expect(payload.memo).toBe(memo)
+      expect(payload.swapPayload.case).toBeUndefined()
+      expect(payload.erc20ApprovePayload).toBeUndefined()
+      expect(mocks.getChainSpecific).toHaveBeenCalledWith(expect.objectContaining({ isDeposit: false }))
+    })
+
+    it('refuses a halted source chain', async () => {
+      mocks.getThorchainInboundAddress.mockResolvedValue([inbound('ETH', { halted: true })])
+
+      await expect(buildLimitSwapKeysignPayload({ ...baseInput, fromCoin: ethCoin, toCoin: btcCoin })).rejects.toThrow(
+        /no live, tradeable THORChain inbound/
+      )
+    })
+  })
+
+  describe('ERC20 (router depositWithExpiry + approve)', () => {
+    it('targets the router and carries the swap payload the router call needs', async () => {
+      const payload = await buildLimitSwapKeysignPayload({ ...baseInput, fromCoin: usdcCoin, toCoin: btcCoin })
+
+      expect(payload.toAddress).toBe('0xrouter')
+      expect(payload.swapPayload.case).toBe('thorchainSwapPayload')
+
+      const swap = payload.swapPayload.case === 'thorchainSwapPayload' ? payload.swapPayload.value : undefined
+      expect(swap?.routerAddress).toBe('0xrouter')
+      expect(swap?.vaultAddress).toBe('eth-vault')
+      expect(swap?.fromAmount).toBe('100000000')
+      // The order's real floor is the LIM in the memo; these travel for display only.
+      expect(swap?.toAmountLimit).toBe('0')
+    })
+
+    it('approves the router when allowance is short', async () => {
+      const payload = await buildLimitSwapKeysignPayload({ ...baseInput, fromCoin: usdcCoin, toCoin: btcCoin })
+
+      expect(payload.erc20ApprovePayload?.spender).toBe('0xrouter')
+      expect(payload.erc20ApprovePayload?.amount).toBe('100000000')
+    })
+
+    it('skips the approve when allowance already covers the deposit', async () => {
+      mocks.getErc20Allowance.mockResolvedValue(10n ** 30n)
+
+      const payload = await buildLimitSwapKeysignPayload({ ...baseInput, fromCoin: usdcCoin, toCoin: btcCoin })
+
+      expect(payload.erc20ApprovePayload).toBeUndefined()
+    })
+
+    // Without a router the tokens cannot be deposited; falling back to a plain
+    // transfer would strand them on the vault with no memo.
+    it('refuses a token source whose inbound has no router', async () => {
+      mocks.getThorchainInboundAddress.mockResolvedValue([inbound('ETH')])
+
+      await expect(buildLimitSwapKeysignPayload({ ...baseInput, fromCoin: usdcCoin, toCoin: btcCoin })).rejects.toThrow(
+        /no router contract/
+      )
+    })
+
+    it('bounds the router call with a 15-minute execution deadline', async () => {
+      const payload = await buildLimitSwapKeysignPayload({ ...baseInput, fromCoin: usdcCoin, toCoin: btcCoin })
+
+      const swap = payload.swapPayload.case === 'thorchainSwapPayload' ? payload.swapPayload.value : undefined
+      expect(swap?.expirationTime).toBe(BigInt(1_700_000_000 + 15 * 60))
+    })
+  })
+
+  describe('fail-closed gates', () => {
+    it('refuses to build anything while the advanced swap queue is disabled', async () => {
+      mocks.getAdvancedSwapQueueEnabled.mockResolvedValue(false)
+
+      await expect(buildLimitSwapKeysignPayload({ ...baseInput, fromCoin: runeCoin })).rejects.toThrow(
+        /advanced swap queue is disabled/
+      )
+      expect(mocks.getChainSpecific).not.toHaveBeenCalled()
+    })
+
+    // The builder takes a pre-built memo, so a market or unrelated memo reaching
+    // it would sign a deposit with completely different semantics.
+    it.each([
+      ['=>:ETH.ETH:0xdest:100/1/0', 'market swap'],
+      ['+:BTC.BTC', 'LP add'],
+      ['', 'empty'],
+    ])('rejects a %s memo', async (badMemo: string) => {
+      await expect(buildLimitSwapKeysignPayload({ ...baseInput, fromCoin: runeCoin, memo: badMemo })).rejects.toThrow(
+        /not a THORChain limit-swap memo/
+      )
+    })
+
+    it('rejects a non-positive amount rather than signing an empty deposit', async () => {
+      await expect(buildLimitSwapKeysignPayload({ ...baseInput, fromCoin: runeCoin, amount: 0n })).rejects.toThrow(
+        /amount must be greater than 0/
+      )
+    })
+  })
+
+  it('refines the payload for a UTXO source', async () => {
+    await buildLimitSwapKeysignPayload({ ...baseInput, fromCoin: btcCoin, toCoin: ethCoin })
+
+    expect(mocks.refineKeysignUtxo).toHaveBeenCalled()
+  })
+})

--- a/packages/core/mpc/keysign/swap/buildLimitSwapKeysignPayload.test.ts
+++ b/packages/core/mpc/keysign/swap/buildLimitSwapKeysignPayload.test.ts
@@ -129,7 +129,6 @@ describe('buildLimitSwapKeysignPayload', () => {
       )
       expect(mocks.getChainSpecific).not.toHaveBeenCalled()
     })
-
   })
 
   describe('native gas asset (inbound vault transfer)', () => {

--- a/packages/core/mpc/keysign/swap/buildLimitSwapKeysignPayload.ts
+++ b/packages/core/mpc/keysign/swap/buildLimitSwapKeysignPayload.ts
@@ -1,5 +1,6 @@
 import { Buffer } from 'buffer'
 import { create } from '@bufbuild/protobuf'
+import { fromChainAmountDisplay } from '@vultisig/core-chain/amount/fromChainAmountExact'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { isChainOfKind } from '@vultisig/core-chain/ChainKind'
 import { getThorchainInboundAddress } from '@vultisig/core-chain/chains/cosmos/thor/getThorchainInboundAddress'
@@ -11,6 +12,7 @@ import { isFeeCoin } from '@vultisig/core-chain/coin/utils/isFeeCoin'
 import { getAdvancedSwapQueueEnabled } from '@vultisig/core-chain/swap/native/limitSwapAvailability'
 import { findLimitSwapInbound, shouldBlockRuneDeposit } from '@vultisig/core-chain/swap/native/limitSwapInbound'
 import { assertLimitSwapMemo } from '@vultisig/core-chain/swap/native/limitSwapMemo'
+import { getNativeSwapDecimals } from '@vultisig/core-chain/swap/native/utils/getNativeSwapDecimals'
 import { WalletCore } from '@trustwallet/wallet-core'
 import { PublicKey } from '@trustwallet/wallet-core/dist/src/wallet-core'
 
@@ -48,10 +50,15 @@ export type BuildLimitSwapKeysignPayloadInput = {
   libType: KeysignLibType
   walletCore: WalletCore
   /**
-   * The order's guaranteed-minimum output in the target's natural units, for
-   * cross-device "you receive" display only. Never influences signing.
+   * The order's guaranteed-minimum output (the memo's LIM) in the target's
+   * smallest units, for cross-device "you receive" display only. Never
+   * influences signing.
+   *
+   * Taken as a chain amount rather than a decimal so it is formatted the same
+   * way the market path formats its expected output — `Number#toString()` would
+   * emit scientific notation for dust values and render as `1e-8` on a co-signer.
    */
-  expectedToAmountDecimal?: number
+  expectedToAmount?: bigint
   /** Epoch milliseconds; parameterised so the router expiry is deterministic under test. */
   now?: number
 }
@@ -103,7 +110,7 @@ export const buildLimitSwapKeysignPayload = async ({
   toPublicKey,
   libType,
   walletCore,
-  expectedToAmountDecimal = 0,
+  expectedToAmount = 0n,
   now = Date.now(),
 }: BuildLimitSwapKeysignPayloadInput) => {
   assertLimitSwapMemo(memo)
@@ -165,7 +172,7 @@ export const buildLimitSwapKeysignPayload = async ({
         fromAmount: amount.toString(),
         // Display-only, for the co-signer's "you receive" row. The order's real
         // floor is the LIM inside the memo; these fields are never read here.
-        toAmountDecimal: expectedToAmountDecimal.toString(),
+        toAmountDecimal: fromChainAmountDisplay(expectedToAmount, getNativeSwapDecimals(toCoin)),
         toAmountLimit: '0',
         streamingInterval: '0',
         streamingQuantity: '0',

--- a/packages/core/mpc/keysign/swap/buildLimitSwapKeysignPayload.ts
+++ b/packages/core/mpc/keysign/swap/buildLimitSwapKeysignPayload.ts
@@ -10,7 +10,11 @@ import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { areEqualCoins } from '@vultisig/core-chain/coin/Coin'
 import { isFeeCoin } from '@vultisig/core-chain/coin/utils/isFeeCoin'
 import { getAdvancedSwapQueueEnabled } from '@vultisig/core-chain/swap/native/limitSwapAvailability'
-import { findLimitSwapInbound, shouldBlockRuneDeposit } from '@vultisig/core-chain/swap/native/limitSwapInbound'
+import {
+  findLimitSwapInbound,
+  isLimitSwapDestinationHalted,
+  shouldBlockRuneDeposit,
+} from '@vultisig/core-chain/swap/native/limitSwapInbound'
 import { assertLimitSwapMemo } from '@vultisig/core-chain/swap/native/limitSwapMemo'
 import { getNativeSwapDecimals } from '@vultisig/core-chain/swap/native/utils/getNativeSwapDecimals'
 import { WalletCore } from '@trustwallet/wallet-core'
@@ -89,7 +93,9 @@ export type BuildLimitSwapKeysignPayloadInput = {
  * - The memo must actually be a limit memo.
  * - RUNE deposits are blocked on THORChain's global trading pause (they bypass
  *   the per-chain inbound halt filter entirely), including when the inbound list
- *   is unverifiable.
+ *   is unverifiable — and on a halted destination chain: with no swap payload
+ *   attached, the broadcast guard's destination-leg re-check never runs for
+ *   them, so sign time is their only destination gate.
  * - External sources must resolve a live, non-halted, non-paused inbound row,
  *   and the destination is taken from that same live view rather than a cache.
  *
@@ -141,6 +147,12 @@ export const buildLimitSwapKeysignPayload = async ({
       if (shouldBlockRuneDeposit(inbounds)) {
         throw new Error(
           'THORChain has globally paused trading (or its inbound list is unverifiable); refusing to sign a RUNE limit-order deposit'
+        )
+      }
+
+      if (isLimitSwapDestinationHalted({ inbounds, chain: toCoin.chain })) {
+        throw new Error(
+          `THORChain has halted ${toCoin.chain} trading; refusing to sign a RUNE limit-order deposit whose outbound could not leave`
         )
       }
 

--- a/packages/core/mpc/keysign/swap/buildLimitSwapKeysignPayload.ts
+++ b/packages/core/mpc/keysign/swap/buildLimitSwapKeysignPayload.ts
@@ -1,0 +1,221 @@
+import { Buffer } from 'buffer'
+import { create } from '@bufbuild/protobuf'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { isChainOfKind } from '@vultisig/core-chain/ChainKind'
+import { getThorchainInboundAddress } from '@vultisig/core-chain/chains/cosmos/thor/getThorchainInboundAddress'
+import { getErc20Allowance } from '@vultisig/core-chain/chains/evm/erc20/getErc20Allowance'
+import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
+import { areEqualCoins } from '@vultisig/core-chain/coin/Coin'
+import { isFeeCoin } from '@vultisig/core-chain/coin/utils/isFeeCoin'
+import { getAdvancedSwapQueueEnabled } from '@vultisig/core-chain/swap/native/limitSwapAvailability'
+import { findLimitSwapInbound, shouldBlockRuneDeposit } from '@vultisig/core-chain/swap/native/limitSwapInbound'
+import { assertLimitSwapMemo } from '@vultisig/core-chain/swap/native/limitSwapMemo'
+import { WalletCore } from '@trustwallet/wallet-core'
+import { PublicKey } from '@trustwallet/wallet-core/dist/src/wallet-core'
+
+import { getChainSpecific } from '../chainSpecific'
+import { refineKeysignUtxo } from '../refine/utxo'
+import { getKeysignUtxoInfo } from '../utxo/getKeysignUtxoInfo'
+import { KeysignLibType } from '../../mpcLib'
+import { toCommCoin } from '../../types/utils/commCoin'
+import { Erc20ApprovePayloadSchema } from '../../types/vultisig/keysign/v1/erc20_approve_payload_pb'
+import { KeysignPayloadSchema } from '../../types/vultisig/keysign/v1/keysign_message_pb'
+import { THORChainSwapPayloadSchema } from '../../types/vultisig/keysign/v1/thorchain_swap_payload_pb'
+
+/**
+ * On-chain deadline for the router's `depositWithExpiry` call.
+ *
+ * This bounds when the *deposit transaction* may execute — a stale, long-
+ * unconfirmed tx cannot land later. It is NOT the resting order's lifetime: that
+ * is the memo's interval, up to 3 days, evaluated per block by THORChain. Once
+ * THORChain observes the deposit (a block or two, far inside this window) the
+ * order rests for its full memo TTL regardless of this value.
+ */
+const routerExpiryMs = 15 * 60 * 1000
+
+export type BuildLimitSwapKeysignPayloadInput = {
+  fromCoin: AccountCoin
+  toCoin: AccountCoin
+  /** Source amount in the coin's native smallest units. */
+  amount: bigint
+  /** The `=<` memo from `buildLimitSwapMemo`. */
+  memo: string
+  vaultId: string
+  localPartyId: string
+  fromPublicKey: PublicKey
+  toPublicKey: PublicKey
+  libType: KeysignLibType
+  walletCore: WalletCore
+  /**
+   * The order's guaranteed-minimum output in the target's natural units, for
+   * cross-device "you receive" display only. Never influences signing.
+   */
+  expectedToAmountDecimal?: number
+  /** Epoch milliseconds; parameterised so the router expiry is deterministic under test. */
+  now?: number
+}
+
+/**
+ * Build the `KeysignPayload` for a THORChain limit order.
+ *
+ * The limit-ness always lives in the memo (`=<` vs the market `=>`); how that
+ * memo reaches the chain depends on the source asset:
+ *
+ * - **Native RUNE** — `MsgDeposit` on THORChain itself. No inbound vault and no
+ *   real destination, so `toAddress` carries the signer's own address as a
+ *   placeholder (the Cosmos signer keys off `isDeposit`, not `toAddress`).
+ * - **Native gas asset** (BTC/ETH/AVAX/…) — a plain transfer to the Asgard
+ *   inbound vault with the memo in tx `data` / `OP_RETURN`. No swap payload.
+ * - **ERC20** — the router's `depositWithExpiry(vault, asset, amount, memo,
+ *   expiry)` call, which needs `approve(router, amount)` first. Both ride one
+ *   ceremony, mirroring the market ERC20 THORChain swap. A token source signed
+ *   *without* a swap payload would fall through to a plain ERC20 transfer,
+ *   dropping the memo and stranding the tokens on the router — so it must carry
+ *   one.
+ *
+ * Fund-safety gates, all fail-closed:
+ * - The `EnableAdvSwapQueue` mimir is re-checked here, at sign time. Placement
+ *   was already gated on it, but it can flip while the user sits on Verify, and
+ *   a `=<` order on a network with the queue disabled can execute as an
+ *   unprotected market swap.
+ * - The memo must actually be a limit memo.
+ * - RUNE deposits are blocked on THORChain's global trading pause (they bypass
+ *   the per-chain inbound halt filter entirely), including when the inbound list
+ *   is unverifiable.
+ * - External sources must resolve a live, non-halted, non-paused inbound row,
+ *   and the destination is taken from that same live view rather than a cache.
+ *
+ * Gas: unlike iOS, no EVM gas-limit override is applied. iOS pins a native-EVM
+ * limit deposit to 120000 to match its own market path; here both paths put the
+ * memo on `keysignPayload.memo` and neither sets a general swap payload, so both
+ * already floor at `deriveEvmGasLimit`'s 600000 data-tx limit. Forcing 120000
+ * would make the limit path diverge from the market path and risk under-gassing.
+ */
+export const buildLimitSwapKeysignPayload = async ({
+  fromCoin,
+  toCoin,
+  amount,
+  memo,
+  vaultId,
+  localPartyId,
+  fromPublicKey,
+  toPublicKey,
+  libType,
+  walletCore,
+  expectedToAmountDecimal = 0,
+  now = Date.now(),
+}: BuildLimitSwapKeysignPayloadInput) => {
+  assertLimitSwapMemo(memo)
+
+  if (amount <= 0n) {
+    throw new Error('buildLimitSwapKeysignPayload: amount must be greater than 0')
+  }
+
+  if (!(await getAdvancedSwapQueueEnabled())) {
+    throw new Error(
+      "THORChain's advanced swap queue is disabled; a limit order placed now could execute as an unprotected market swap"
+    )
+  }
+
+  const fromCoinHexPublicKey = Buffer.from(fromPublicKey.data()).toString('hex')
+  const toCoinHexPublicKey = Buffer.from(toPublicKey.data()).toString('hex')
+
+  const isRuneDeposit = areEqualCoins(fromCoin, chainFeeCoin[Chain.THORChain])
+
+  const inbounds = await getThorchainInboundAddress()
+
+  const { toAddress, swapPayload, approveSpender } = ((): {
+    toAddress: string
+    swapPayload?: ReturnType<typeof create<typeof THORChainSwapPayloadSchema>>
+    approveSpender?: string
+  } => {
+    if (isRuneDeposit) {
+      if (shouldBlockRuneDeposit(inbounds)) {
+        throw new Error(
+          'THORChain has globally paused trading (or its inbound list is unverifiable); refusing to sign a RUNE limit-order deposit'
+        )
+      }
+
+      return { toAddress: fromCoin.address }
+    }
+
+    const inbound = findLimitSwapInbound({ inbounds, chain: fromCoin.chain })
+
+    if (isFeeCoin(fromCoin)) {
+      return { toAddress: inbound.address }
+    }
+
+    const { router } = inbound
+    if (!router) {
+      throw new Error(
+        `buildLimitSwapKeysignPayload: THORChain's ${inbound.chain} inbound has no router contract, so a token deposit cannot be built`
+      )
+    }
+
+    return {
+      toAddress: router,
+      approveSpender: router,
+      swapPayload: create(THORChainSwapPayloadSchema, {
+        fromAddress: fromCoin.address,
+        fromCoin: toCommCoin({ ...fromCoin, hexPublicKey: fromCoinHexPublicKey }),
+        toCoin: toCommCoin({ ...toCoin, hexPublicKey: toCoinHexPublicKey }),
+        vaultAddress: inbound.address,
+        routerAddress: router,
+        fromAmount: amount.toString(),
+        // Display-only, for the co-signer's "you receive" row. The order's real
+        // floor is the LIM inside the memo; these fields are never read here.
+        toAmountDecimal: expectedToAmountDecimal.toString(),
+        toAmountLimit: '0',
+        streamingInterval: '0',
+        streamingQuantity: '0',
+        expirationTime: BigInt(Math.floor((now + routerExpiryMs) / 1000)),
+        isAffiliate: true,
+      }),
+    }
+  })()
+
+  let keysignPayload = create(KeysignPayloadSchema, {
+    coin: toCommCoin({ ...fromCoin, hexPublicKey: fromCoinHexPublicKey }),
+    toAmount: amount.toString(),
+    vaultLocalPartyId: localPartyId,
+    vaultPublicKeyEcdsa: vaultId,
+    libType,
+    toAddress,
+    memo,
+    utxoInfo: await getKeysignUtxoInfo(fromCoin),
+    ...(swapPayload ? { swapPayload: { case: 'thorchainSwapPayload' as const, value: swapPayload } } : {}),
+  })
+
+  keysignPayload.blockchainSpecific = await getChainSpecific({
+    keysignPayload,
+    walletCore,
+    isDeposit: isRuneDeposit,
+  })
+
+  if (approveSpender && isChainOfKind(fromCoin.chain, 'evm') && fromCoin.id) {
+    const allowance = await getErc20Allowance({
+      chain: fromCoin.chain,
+      id: fromCoin.id,
+      address: fromCoin.address,
+      spender: approveSpender,
+    })
+
+    if (allowance < amount) {
+      keysignPayload.erc20ApprovePayload = create(Erc20ApprovePayloadSchema, {
+        amount: amount.toString(),
+        spender: approveSpender,
+      })
+    }
+  }
+
+  if (isChainOfKind(fromCoin.chain, 'utxo')) {
+    keysignPayload = await refineKeysignUtxo({
+      keysignPayload,
+      walletCore,
+      publicKey: fromPublicKey,
+    })
+  }
+
+  return keysignPayload
+}

--- a/packages/core/mpc/package.json
+++ b/packages/core/mpc/package.json
@@ -591,6 +591,11 @@
       "import": "./dist/keysign/swap/build.js",
       "default": "./dist/keysign/swap/build.js"
     },
+    "./keysign/swap/buildLimitSwapKeysignPayload": {
+      "types": "./dist/keysign/swap/buildLimitSwapKeysignPayload.d.ts",
+      "import": "./dist/keysign/swap/buildLimitSwapKeysignPayload.js",
+      "default": "./dist/keysign/swap/buildLimitSwapKeysignPayload.js"
+    },
     "./keysign/swap/cowswap/buildCowSwapApprovalSigningInput": {
       "types": "./dist/keysign/swap/cowswap/buildCowSwapApprovalSigningInput.d.ts",
       "import": "./dist/keysign/swap/cowswap/buildCowSwapApprovalSigningInput.js",


### PR DESCRIPTION
Closes #1516

## Why

`buildLimitSwapMemo` produced the `=<` memo and `getThorchainMemoAsset` the asset notation, but nothing turned either into a `KeysignPayload` — a limit order could be composed and never placed. Both existing builders refuse it **by design**:

- `assertValidThorchainDepositMemo` deliberately excludes swap-shaped memos
- `nativeSwapQuoteToSwapPayload` rebuilds everything by parsing a **server-issued** quote memo, which a locally-built limit order does not have

## What

`buildLimitSwapKeysignPayload` branches on the source asset, mirroring iOS `LimitSwapPayloadAssembler`:

| Source | Shape |
|---|---|
| Native RUNE | `MsgDeposit` on THORChain, no inbound vault; `toAddress` is the signer's own address (the placeholder the Cosmos signer ignores in favour of `isDeposit`) |
| Native gas asset | Transfer to the live Asgard inbound vault, memo in tx `data` / `OP_RETURN`, no swap payload |
| ERC20 | Router `depositWithExpiry` + `approve` when allowance is short, one ceremony |

That last row matters: a token source signed *without* a swap payload falls through to a plain ERC-20 transfer, which drops the memo and strands the tokens on the router.

Also exports `getAdvancedSwapQueueEnabled`, `findLimitSwapInbound` / `shouldBlockRuneDeposit` (pure, so the halt logic is testable without a fetch), and `assertLimitSwapMemo`.

## Fund-safety gates, all fail-closed

- **`EnableAdvSwapQueue` re-checked at sign time** rather than trusted from the form. It can flip while the user sits on Verify, and a `=<` order on a network with the queue off can execute as an unprotected market swap.
- **Memo must actually be a limit memo.** The builder takes a pre-built string, so a market (`=>`) or unrelated memo would otherwise sign a value-bearing deposit with completely different semantics.
- **RUNE deposits gated on the global trading pause**, including an unverifiable (empty) inbound list. RUNE has no inbound vault, so it never passes the per-chain halt filter — the global flag is its only gate.
- **External sources take their destination from the same live inbound row the halt check validated**, so a stale cache can't route to a rotated vault.
- Non-positive amounts and router-less token inbounds throw rather than degrade.

## Two deliberate divergences from iOS — please sanity-check these

**1. `assertValidThorchainDepositMemo` is untouched.** The issue proposed permitting `=<` there. On inspection it has exactly one caller — the standalone `prepareThorchainMsgDepositTxFromKeys` tool — and is **not** on the keysign-payload path, which is where this builder lives. Excluding swap-shaped memos there stays correct, and no security check was widened.

**2. No EVM gas-limit override.** iOS pins a native-EVM limit deposit to 120000 to match *its* market path. Here both paths put the memo on `keysignPayload.memo` and neither sets a general swap payload, so `deriveEvmGasLimit` returns its 600000 data-tx limit for both, and `capGasLimit` takes `bigIntMax(estimate, thirdParty, minimum)` plus a 1.5× buffer. Porting 120000 would make the limit path diverge from the market path and risk under-gassing. iOS was fixing an iOS-specific discrepancy that doesn't exist here.

## Testing

- 24 new cases in `buildLimitSwapKeysignPayload.test.ts` covering all three branches, the approve/skip-approve split, the router expiry window, and every fail-closed gate (queue disabled, market memo, empty memo, zero amount, halted chain, global pause, missing router).
- Pure inbound-selection and mimir-parse suites alongside them.
- Full core suite: **2106 passed**, 1 skipped. `tsc`, `lint`, `knip`, `prettier`, `check:shared-exports`, and `changeset:check-sdk-bundle` all clean.

## Downstream

Unblocks vultisig/vultisig-windows — the form (vultisig/vultisig-windows#4436) can compose an order, but placing one needs this released and bumped there. Changeset included: `core-chain` minor, `core-mpc` minor, `@vultisig/sdk` patch (it bundles this source, so it needs a fresh tarball even though the helper isn't re-exported from its public API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating signable THORChain limit-swap key-signing payloads for native RUNE, native gas assets, ERC20 tokens, and UTXO-based assets.
  * Added native limit-swap availability gating plus inbound destination/route validation.

* **Bug Fixes**
  * Strengthened fail-closed checks to prevent limit swaps when the advanced swap queue is disabled, THORChain trading is paused, the destination is halted, or memos/amounts are invalid.

* **Tests**
  * Added unit tests covering queue “mimir” parsing, inbound selection/pausing rules, memo validation, and payload building (including conditional ERC20 approvals and router deadline behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->