### PR TITLE
fix(sdk): normalize IBC destination discovery aliases

### DIFF
--- a/.changeset/sdk-ibc-destination-alias-r58.md
+++ b/.changeset/sdk-ibc-destination-alias-r58.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/sdk": patch
+---
+
+Align `supportedIbcDestinationsFrom()` with `prepareIbcTransfer()` by accepting the same Vultisig canonical chain aliases (for example `Osmosis` and `Cosmos`) before route discovery.

--- a/packages/sdk/src/tools/prep/ibcTransfer.ts
+++ b/packages/sdk/src/tools/prep/ibcTransfer.ts
@@ -130,8 +130,9 @@ function resolveSourceChannelByDestChain(fromChain: string, toChainId: string): 
 
 /** Supported destination chain-IDs reachable FROM the given source chain. */
 export function supportedIbcDestinationsFrom(fromChain: string): string[] {
+  const canonicalFromChain = normaliseIbcChainId(fromChain)
   return Array.from(IBC_CHANNEL_BY_ROUTE.keys())
-    .filter(routeKey => routeKey.startsWith(`${fromChain}→`))
+    .filter(routeKey => routeKey.startsWith(`${canonicalFromChain}→`))
     .map(routeKey => routeKey.split('→')[1]!)
     .sort()
 }

--- a/packages/sdk/tests/unit/cosmos/ibcTransfer.test.ts
+++ b/packages/sdk/tests/unit/cosmos/ibcTransfer.test.ts
@@ -101,6 +101,11 @@ describe('prepareIbcTransfer', () => {
     expect(normaliseIbcChainId('not-a-chain')).toBe('not-a-chain')
   })
 
+  it('lets supportedIbcDestinationsFrom accept Vultisig canonical chain names too', () => {
+    expect(supportedIbcDestinationsFrom('osmosis-1')).toEqual(supportedIbcDestinationsFrom('Osmosis'))
+    expect(supportedIbcDestinationsFrom('Osmosis')).toContain('cosmoshub-4')
+  })
+
   it('resolves destination from sourceChannel alone', () => {
     const r = prepareIbcTransfer({
       fromChain: 'phoenix-1',


### PR DESCRIPTION
## Summary
- normalize `supportedIbcDestinationsFrom()` through `normaliseIbcChainId()` before route discovery
- add a regression proving canonical alias parity (`Osmosis` == `osmosis-1`)
- document the round-58 receipts and report mirror

Closes #1522

## Receipts
- `corepack yarn vitest run --config packages/sdk/tests/unit/vitest.config.ts packages/sdk/tests/unit/cosmos/ibcTransfer.test.ts`
- `corepack yarn build:shared`
- `corepack yarn build:sdk`
- built-dist runtime proof: `{"same":true,"includesCosmos":true,"count":12}`

## Report
- https://gist.github.com/gomesalexandre/4508de07dabd8e40384f1eecdd89c2ca

## Notes
- `corepack yarn build:sdk` completed with the repo's existing Rollup warnings/noise (same class as current mainline), but the build finished successfully.
