### PR TITLE
test(evm): pin the signed chain-id source, not just the viem registry

### DIFF
--- a/packages/sdk/tests/unit/chains/evmChainId.test.ts
+++ b/packages/sdk/tests/unit/chains/evmChainId.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it } from 'vitest'
+import { initWasm, type WalletCore } from '@trustwallet/wallet-core'
+import { getTwChainId } from '@vultisig/core-chain/chains/evm/tx/tw/getTwChainId'
+import { beforeAll, describe, expect, it } from 'vitest'
 
 import type { EvmChain } from '../../../src'
 import { Chain, getEvmChainByChainId, getEvmChainId } from '../../../src'
+import { getEvmNumericChainId } from '../../../src/platforms/react-native/chains/evm/tx'
 
 // Canonical EVM chainIds (numeric), the single source of truth the app and
 // agent-backend-ts previously hand-maintained as their own copies. Pinning
@@ -48,5 +51,47 @@ describe('EVM chainId public API', () => {
 
   it('pins the Hyperliquid mainnet chainId to 999 (not testnet 998)', () => {
     expect(parseInt(getEvmChainId(Chain.Hyperliquid), 16)).toBe(999)
+  })
+})
+
+// The block above only pins the viem chain registry, i.e. the DISPLAY
+// source. It says nothing about the chainId that actually lands in the
+// SIGNED preimage on the wallet-core path
+// (`CoinTypeExt.chainId(getCoinType(chain))`, wired through `getTwChainId`),
+// or the hand-mirrored copy the React Native tx builder keeps at
+// `platforms/react-native/chains/evm/tx.ts`. Both were previously unpinned:
+// a wrong `getCoinType` mapping, or a typo'd RN table entry, could silently
+// sign a transaction against the WRONG chainId (a replay/misdirection bug -
+// the signed tx would be valid on a DIFFERENT chain) while every display
+// surface kept showing the right value, and the suite above stayed green.
+//
+// Both loops below iterate `CANONICAL_EVM_CHAIN_IDS`, which `satisfies
+// Record<EvmChain, number>` keeps exhaustive against the `EvmChain` enum at
+// compile time - a newly added EVM chain is automatically exercised by both
+// assertions the moment its canonical id is added above (and the build
+// fails if it isn't).
+//
+// Hyperliquid and Sei aren't wallet-core-native coin types (`getCoinType`
+// maps both to `CoinType.ethereum`), so `getTwChainId` special-cases them by
+// returning the same viem chain objects' `.id` used to build the registry.
+// No skip/carve-out needed here: pinning against `CANONICAL_EVM_CHAIN_IDS`
+// exercises that special case exactly like every other chain.
+describe('EVM chainId signed-preimage sources', () => {
+  let walletCore: WalletCore
+
+  beforeAll(async () => {
+    walletCore = await initWasm()
+  })
+
+  it('pins the wallet-core signed chainId (CoinTypeExt.chainId via getTwChainId) for every EVM chain', () => {
+    for (const [chain, numericId] of Object.entries(CANONICAL_EVM_CHAIN_IDS)) {
+      expect(getTwChainId({ walletCore, chain: chain as EvmChain })).toBe(String(numericId))
+    }
+  })
+
+  it('pins the React Native hand-mirrored evmChainIds table (platforms/react-native/chains/evm/tx.ts) for every EVM chain', () => {
+    for (const [chain, numericId] of Object.entries(CANONICAL_EVM_CHAIN_IDS)) {
+      expect(getEvmNumericChainId(chain as EvmChain)).toBe(numericId)
+    }
   })
 })


### PR DESCRIPTION
Extends `packages/sdk/tests/unit/chains/evmChainId.test.ts` so it pins the chain id that actually reaches wallet-core's SIGNED preimage, not just the display registry it already covered.

## what's actually being pinned

The existing block in this file pins `getEvmChainId`/`getEvmChainByChainId`, which read the viem chain registry - the DISPLAY source (what shows up in explorers, UI, etc). It never touched the chain id that lands in the SIGNED preimage on the wallet-core path: `CoinTypeExt.chainId(getCoinType(chain))`, wired through `getTwChainId` (`packages/core/chain/chains/evm/tx/tw/getTwChainId.ts:29`). It also never touched the hand-mirrored copy the React Native tx builder keeps at `packages/sdk/src/platforms/react-native/chains/evm/tx.ts:53`.

A wrong `getCoinType` mapping, or a typo'd entry in the RN table, could silently sign a transaction against the WRONG chain id while every display surface kept showing the right value. That's a replay/misdirection class of bug - the signed tx would be valid on a *different* chain - and the existing suite would stay green the whole time.

## how I found it

Working PR #1541 (Robinhood Chain), two mutations proved the gap with the full suites staying green (2133 core + 2989 sdk tests both times):

- `getCoinType(Robinhood) -> CoinType.smartChain`: wallet-core would sign chain id 56 while every display surface showed 4663.
- The hand-mirrored `evmChainIds` table entry for Robinhood, `4663 -> 4636`: the RN builder's legacy and 1559 preimages would carry the wrong chain id while core reported the right one.

This gap is pre-existing across all 13 EVM chains already on `main` - it has nothing to do with #1541 specifically, Robinhood just tripped over it first, and I'd committed to carrying this fix so a new contributor wouldn't have to.

## the fix

Two new assertions, both driven off the existing `CANONICAL_EVM_CHAIN_IDS` table, which `satisfies Record<EvmChain, number>` already keeps exhaustive against the `EvmChain` enum at compile time - add a 14th EVM chain without pinning its id and the build fails. So a newly added chain is automatically covered by every assertion in the file the moment its id lands in that table:

- `getTwChainId({walletCore, chain}) === String(CANONICAL_EVM_CHAIN_IDS[chain])` - pins the wallet-core signed source.
- `getEvmNumericChainId(chain) === CANONICAL_EVM_CHAIN_IDS[chain]` - pins the RN hand-mirror.

Hyperliquid and Sei aren't wallet-core-native coin types (`getCoinType` maps both to `CoinType.ethereum`), so `getTwChainId` special-cases them by returning the same viem chain objects' `.id` used to build the registry. No skip/carve-out needed - pinning against the canonical table exercises that special case exactly like every other chain.

`getTwChainId` needs a real `walletCore` instance, so this follows the same `initWasm()` pattern already used elsewhere in `packages/sdk/tests` (e.g. `tests/unit/chains/tron-tx.test.ts`) rather than mocking wallet-core - mocking the thing under test would just be another fake-green guard.

## mutation-verified (reverted before commit)

- Mutated BSC's `getCoinType` mapping to the wrong `CoinType` -> the new wallet-core-signed assertion failed (`expected '56', got '42161'`); the original 4 tests and the RN-table assertion stayed green.
- Typo'd the RN table's Ethereum entry (`1 -> 2`) -> the new RN-table assertion failed (`expected 1, got 2`); the wallet-core-signed assertion and the original 4 tests stayed green.

## test plan

- [x] `yarn test:unit` - 201 files, 2988 passed
- [x] `yarn test:core` - 221 files, 2133 passed, 1 pre-existing skip
- [x] `yarn workspace @vultisig/sdk typecheck` - clean
- [x] lint on the touched file - clean
- [x] both mutations reproduced the intended failing assertion, then reverted

Co-Authored-By: Claude <noreply@anthropic.com>