### PR TITLE
fix(cli): sign yield_enter/yield_exit deposits (bead 6rg2)

### DIFF
--- a/clients/cli/src/agent/__tests__/toolOutputSigning.allowlist.test.ts
+++ b/clients/cli/src/agent/__tests__/toolOutputSigning.allowlist.test.ts
@@ -21,6 +21,7 @@ import { describe, expect, it } from 'vitest'
 import {
   CLI_SIGNABLE_FLAT_TOOLS,
   CLI_SIGNABLE_PREP_TOOLS,
+  CLI_SIGNABLE_YIELD_TOOLS,
   DIVERGENT_FIELD_TOOLS,
   POLYMARKET_DEPOSIT_TOOL,
   POLYMARKET_SETUP_TRADING_TOOL,
@@ -85,6 +86,19 @@ describe('CLI_SIGNABLE_FLAT_TOOLS — independent anchor vs the mcp-ts source of
 describe('CLI_SIGNABLE_PREP_TOOLS', () => {
   it('contains exactly the execute_* signer-ready prep tools', () => {
     expect([...CLI_SIGNABLE_PREP_TOOLS].sort()).toEqual(['execute_contract_call', 'execute_send', 'execute_swap'])
+  })
+})
+
+describe('CLI_SIGNABLE_YIELD_TOOLS (bead vultisig-6rg2 — yield deposit/withdraw signing gap)', () => {
+  it('contains exactly yield_enter + yield_exit', () => {
+    expect([...CLI_SIGNABLE_YIELD_TOOLS].sort()).toEqual(['yield_enter', 'yield_exit'])
+  })
+
+  it('is disjoint from the flat and prep allowlists (a tool lives in ONE bucket)', () => {
+    for (const t of CLI_SIGNABLE_YIELD_TOOLS) {
+      expect(CLI_SIGNABLE_FLAT_TOOLS.has(t)).toBe(false)
+      expect(CLI_SIGNABLE_PREP_TOOLS.has(t)).toBe(false)
+    }
   })
 })
 

--- a/clients/cli/src/agent/__tests__/toolOutputSigning.test.ts
+++ b/clients/cli/src/agent/__tests__/toolOutputSigning.test.ts
@@ -18,6 +18,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   buildTxReadyFromToolOutput,
+  buildTxReadyFromYieldOutput,
   CLI_SIGNABLE_FLAT_TOOLS,
   deriveToolOutputCandidate,
   POLYMARKET_DEPOSIT_TOOL,
@@ -541,5 +542,179 @@ describe('deriveToolOutputCandidate — flat vs prep, and the phantom-card guard
     }
     const c = deriveToolOutputCandidate('execute_send', cosmos)
     expect(c?.source).toBe('prep')
+  })
+})
+
+// ============================================================================
+// yield_enter / yield_exit — the top-level transactions[] (Pattern 2) shape.
+// Bead vultisig-6rg2: these were in NEITHER allowlist, so deriveToolOutputCandidate
+// returned null → no synthetic sign_tx → keysign never fired on yield deposits.
+// ============================================================================
+
+const AAVE_POOL = '0x794a61358d6845594f94dc1db02a252b5b4814ad'
+const YIELD_DEPOSIT_DATA = '0x617ba037' + '0'.repeat(248)
+
+/** A realistic EVM yield_enter output: approve USDC → deposit into Aave Pool.
+ *  Mirrors mcp-lunc-hop yield-tools.ts parseActionDisplay EVM canonical steps. */
+function yieldEnterApproveDeposit() {
+  return {
+    scan_request: { kind: 'evm', chain: 'polygon' },
+    intent: 'enter',
+    type: 'lending',
+    yieldId: 'polygon-usdc-aave-v3-lending',
+    amount: '0.4',
+    amountUsd: '0.4',
+    chain: 'Polygon',
+    provider: 'yield_xyz',
+    transactions: [
+      { to: USDC_E, value: '0x0', data: APPROVE_DATA, action: 'approval', description: 'Approve USDC' },
+      { to: AAVE_POOL, value: '0x0', data: YIELD_DEPOSIT_DATA, action: 'deposit', description: 'Deposit into Aave v3' },
+    ],
+  }
+}
+
+/** A single-step EVM yield action (e.g. a withdraw, or a deposit whose allowance
+ *  is already sufficient). */
+function yieldSingleStep() {
+  return {
+    scan_request: { kind: 'evm', chain: 'polygon' },
+    intent: 'exit',
+    type: 'lending',
+    yieldId: 'polygon-usdc-aave-v3-lending',
+    amount: '0.4',
+    chain: 'Polygon',
+    provider: 'yield_xyz',
+    transactions: [
+      { to: AAVE_POOL, value: '0x0', data: YIELD_DEPOSIT_DATA, action: 'withdraw', description: 'Withdraw from Aave v3' },
+    ],
+  }
+}
+
+describe('buildTxReadyFromYieldOutput — allowlist gate', () => {
+  it('returns null for a non-yield tool (never enriches an unlisted tool)', () => {
+    expect(buildTxReadyFromYieldOutput('execute_send', yieldEnterApproveDeposit())).toBeNull()
+    expect(buildTxReadyFromYieldOutput(POLYMARKET_DEPOSIT_TOOL, yieldEnterApproveDeposit())).toBeNull()
+  })
+})
+
+describe('buildTxReadyFromYieldOutput — 2-step approve+deposit → multi-leg', () => {
+  it('maps transactions[approve,deposit] onto approvalTxArgs/txArgs with nested tx', () => {
+    const out = buildTxReadyFromYieldOutput('yield_enter', yieldEnterApproveDeposit())
+    expect(out).not.toBeNull()
+    expect(out).toMatchObject({
+      chain: 'Polygon',
+      approvalTxArgs: { chain: 'Polygon', tx: { to: USDC_E, value: '0x0', data: APPROVE_DATA } },
+      txArgs: { chain: 'Polygon', tx: { to: AAVE_POOL, value: '0x0', data: YIELD_DEPOSIT_DATA } },
+    })
+    // approve leg is FIRST (signed + receipt-confirmed before the deposit).
+    expect(out?.approvalTxArgs).toBeDefined()
+    // a multi-leg envelope must NOT also carry a single-leg `tx`.
+    expect(out?.tx).toBeUndefined()
+  })
+
+  it('faithfully copies the backend-built calldata verbatim (never fabricates)', () => {
+    const out = buildTxReadyFromYieldOutput('yield_enter', yieldEnterApproveDeposit())
+    // the deposit selector (0x617ba037 = Aave supply) survives untouched.
+    expect((out?.txArgs as { tx: { data: string } }).tx.data).toBe(YIELD_DEPOSIT_DATA)
+    expect((out?.approvalTxArgs as { tx: { data: string } }).tx.data).toBe(APPROVE_DATA)
+  })
+})
+
+describe('buildTxReadyFromYieldOutput — single-step → single-leg', () => {
+  it('maps a lone transactions[action] onto {chain,tx}', () => {
+    const out = buildTxReadyFromYieldOutput('yield_exit', yieldSingleStep())
+    expect(out).toMatchObject({ chain: 'Polygon', tx: { to: AAVE_POOL, value: '0x0', data: YIELD_DEPOSIT_DATA } })
+    expect(out?.approvalTxArgs).toBeUndefined()
+  })
+})
+
+describe('buildTxReadyFromYieldOutput — fail-closed guards (never sign a bad shape)', () => {
+  it('null when transactions[] is absent', () => {
+    const { transactions: _drop, ...noTxs } = yieldEnterApproveDeposit()
+    void _drop
+    expect(buildTxReadyFromYieldOutput('yield_enter', noTxs)).toBeNull()
+  })
+
+  it('null when transactions[] is empty', () => {
+    expect(buildTxReadyFromYieldOutput('yield_enter', { ...yieldEnterApproveDeposit(), transactions: [] })).toBeNull()
+  })
+
+  it('null when the envelope is an error', () => {
+    expect(
+      buildTxReadyFromYieldOutput('yield_enter', { ...yieldEnterApproveDeposit(), status: 'error' }),
+    ).toBeNull()
+    expect(buildTxReadyFromYieldOutput('yield_enter', { error: 'yield.xyz rejected' })).toBeNull()
+  })
+
+  it('null when chain is missing (would default to Ethereum at sign time)', () => {
+    const { chain: _drop, ...noChain } = yieldEnterApproveDeposit()
+    void _drop
+    expect(buildTxReadyFromYieldOutput('yield_enter', noChain)).toBeNull()
+  })
+
+  it('null for a non-EVM chain (yield multi-step signing is EVM-only here)', () => {
+    // A Solana yield envelope (its steps carry tx_encoding: solana-tx and a raw
+    // data string, not flat to/data) must NOT be forced through the EVM legs.
+    const solana = {
+      ...yieldEnterApproveDeposit(),
+      chain: 'Solana',
+      transactions: [{ tx_encoding: 'solana-tx', chain: 'Solana', data: 'base64blob', action: 'deposit' }],
+    }
+    expect(buildTxReadyFromYieldOutput('yield_enter', solana)).toBeNull()
+  })
+
+  it('null when ANY leg is un-liftable (all-or-nothing: never a partial sequence)', () => {
+    const badDeposit = {
+      ...yieldEnterApproveDeposit(),
+      transactions: [
+        { to: USDC_E, value: '0x0', data: APPROVE_DATA, action: 'approval' },
+        { to: AAVE_POOL, value: '0x0', action: 'deposit' }, // no calldata
+      ],
+    }
+    expect(buildTxReadyFromYieldOutput('yield_enter', badDeposit)).toBeNull()
+  })
+
+  it('null when a leg carries an error marker', () => {
+    const errLeg = {
+      ...yieldEnterApproveDeposit(),
+      transactions: [
+        { to: USDC_E, value: '0x0', data: APPROVE_DATA, action: 'approval' },
+        { to: AAVE_POOL, value: '0x0', data: YIELD_DEPOSIT_DATA, action: 'deposit', error: 'sim failed' },
+      ],
+    }
+    expect(buildTxReadyFromYieldOutput('yield_enter', errLeg)).toBeNull()
+  })
+
+  it('null for a >2-leg envelope (executor 2-leg sequencer cannot represent it — fail closed)', () => {
+    const threeLegs = {
+      ...yieldEnterApproveDeposit(),
+      transactions: [
+        { to: USDC_E, value: '0x0', data: APPROVE_DATA, action: 'approval' },
+        { to: AAVE_POOL, value: '0x0', data: YIELD_DEPOSIT_DATA, action: 'deposit' },
+        { to: AAVE_POOL, value: '0x0', data: YIELD_DEPOSIT_DATA, action: 'stake' },
+      ],
+    }
+    expect(buildTxReadyFromYieldOutput('yield_enter', threeLegs)).toBeNull()
+  })
+})
+
+describe('deriveToolOutputCandidate — yield tools (bead vultisig-6rg2, the regression)', () => {
+  it('yield_enter approve+deposit → candidate tagged source:yield (WAS null pre-fix)', () => {
+    const c = deriveToolOutputCandidate('yield_enter', yieldEnterApproveDeposit())
+    expect(c?.source).toBe('yield')
+    expect(c?.payload).toMatchObject({
+      approvalTxArgs: { tx: { to: USDC_E, data: APPROVE_DATA } },
+      txArgs: { tx: { to: AAVE_POOL, data: YIELD_DEPOSIT_DATA } },
+    })
+  })
+
+  it('yield_exit single-step → candidate tagged source:yield', () => {
+    const c = deriveToolOutputCandidate('yield_exit', yieldSingleStep())
+    expect(c?.source).toBe('yield')
+    expect(c?.payload).toMatchObject({ tx: { to: AAVE_POOL, data: YIELD_DEPOSIT_DATA } })
+  })
+
+  it('CONTROL: a yield tool with no signable tx → null (nothing signs)', () => {
+    expect(deriveToolOutputCandidate('yield_enter', { chain: 'Polygon', transactions: [] })).toBeNull()
   })
 })

--- a/clients/cli/src/agent/__tests__/toolOutputSigning.test.ts
+++ b/clients/cli/src/agent/__tests__/toolOutputSigning.test.ts
@@ -585,7 +585,13 @@ function yieldSingleStep() {
     chain: 'Polygon',
     provider: 'yield_xyz',
     transactions: [
-      { to: AAVE_POOL, value: '0x0', data: YIELD_DEPOSIT_DATA, action: 'withdraw', description: 'Withdraw from Aave v3' },
+      {
+        to: AAVE_POOL,
+        value: '0x0',
+        data: YIELD_DEPOSIT_DATA,
+        action: 'withdraw',
+        description: 'Withdraw from Aave v3',
+      },
     ],
   }
 }
@@ -640,9 +646,7 @@ describe('buildTxReadyFromYieldOutput — fail-closed guards (never sign a bad s
   })
 
   it('null when the envelope is an error', () => {
-    expect(
-      buildTxReadyFromYieldOutput('yield_enter', { ...yieldEnterApproveDeposit(), status: 'error' }),
-    ).toBeNull()
+    expect(buildTxReadyFromYieldOutput('yield_enter', { ...yieldEnterApproveDeposit(), status: 'error' })).toBeNull()
     expect(buildTxReadyFromYieldOutput('yield_enter', { error: 'yield.xyz rejected' })).toBeNull()
   })
 

--- a/clients/cli/src/agent/client.ts
+++ b/clients/cli/src/agent/client.ts
@@ -9,7 +9,13 @@ import { randomUUID } from 'node:crypto'
 import { IdempotencyKeyReusedError, IdempotentTurnDuplicateError } from '../core/errors'
 import { AgentErrorCode, inferAgentErrorCodeFromMessage, isAgentErrorCode } from './agentErrors'
 import { parseTurnOutcome, type TurnOutcome } from './cards'
-import { CLI_SIGNABLE_FLAT_TOOLS, CLI_SIGNABLE_PREP_TOOLS, deriveToolOutputCandidate } from './toolOutputSigning'
+import {
+  CLI_SIGNABLE_FLAT_TOOLS,
+  CLI_SIGNABLE_PREP_TOOLS,
+  CLI_SIGNABLE_YIELD_TOOLS,
+  deriveToolOutputCandidate,
+  type ToolOutputCandidate,
+} from './toolOutputSigning'
 import type {
   AuthTokenRequest,
   AuthTokenResponse,
@@ -121,7 +127,7 @@ type StreamCallbacks = {
   // the CLI doesn't consume). `source` distinguishes a flat enrichment
   // (polymarket / build_custom_* / erc20_approve) from an `execute_*` prep
   // passthrough; both sign. The session buffers it into the executor.
-  onToolOutputTx?: (payload: TxReadyPayload, toolName: string, source: 'flat' | 'prep') => void
+  onToolOutputTx?: (payload: TxReadyPayload, toolName: string, source: ToolOutputCandidate['source']) => void
   // Fired for the `data-balance_summary` SSE part the backend emits when the
   // client advertised "balance_summary" in supported_surfaces. Carries the raw
   // card envelope; the consumer validates + renders it. Replaces the legacy
@@ -894,7 +900,12 @@ export class AgentClient {
     // resting on a null-check three calls away.
     if (v1Type === 'tool-output-error') return
     if (status !== 'done' || !toolName || !callbacks.onToolOutputTx) return
-    if (!CLI_SIGNABLE_FLAT_TOOLS.has(toolName) && !CLI_SIGNABLE_PREP_TOOLS.has(toolName)) return
+    if (
+      !CLI_SIGNABLE_FLAT_TOOLS.has(toolName) &&
+      !CLI_SIGNABLE_PREP_TOOLS.has(toolName) &&
+      !CLI_SIGNABLE_YIELD_TOOLS.has(toolName)
+    )
+      return
     const candidate = deriveToolOutputCandidate(toolName, output)
     if (!candidate) return
     if (this.verbose)

--- a/clients/cli/src/agent/session.ts
+++ b/clients/cli/src/agent/session.ts
@@ -27,7 +27,12 @@ import {
   loadCachedToken,
   saveCachedToken,
 } from './tokenCache'
-import { CLI_SIGNABLE_FLAT_TOOLS, CLI_SIGNABLE_PREP_TOOLS, payloadLooksSignable } from './toolOutputSigning'
+import {
+  CLI_SIGNABLE_FLAT_TOOLS,
+  CLI_SIGNABLE_PREP_TOOLS,
+  payloadLooksSignable,
+  type ToolOutputCandidate,
+} from './toolOutputSigning'
 import type {
   AgentConfig,
   ConversationMessage,
@@ -578,7 +583,7 @@ export class AgentSession {
     let toolOutputCandidate: {
       payload: TxReadyPayload
       toolName: string
-      source: 'flat' | 'prep'
+      source: ToolOutputCandidate['source']
     } | null = null
     // Whether a balance_summary card was rendered from the SSE data part this
     // turn. When true, the message-content fallback still runs to STRIP any
@@ -624,7 +629,7 @@ export class AgentSession {
       onSuggestions: (suggestions: any[]) => {
         ui.onSuggestions(suggestions)
       },
-      onToolOutputTx: (payload: TxReadyPayload, toolName: string, source: 'flat' | 'prep') => {
+      onToolOutputTx: (payload: TxReadyPayload, toolName: string, source: ToolOutputCandidate['source']) => {
         // Client-enriched candidate from a `tool-output-available` frame — the sole
         // sign source (buffered after the stream by `selectAndBufferSignable`).
         // First-wins per turn: a SECOND signable frame is deferred (the executor
@@ -814,7 +819,7 @@ export class AgentSession {
     toolOutputCandidate: {
       payload: TxReadyPayload
       toolName: string
-      source: 'flat' | 'prep'
+      source: ToolOutputCandidate['source']
     } | null
   ): boolean {
     if (!toolOutputCandidate) return false

--- a/clients/cli/src/agent/toolOutputSigning.ts
+++ b/clients/cli/src/agent/toolOutputSigning.ts
@@ -105,6 +105,38 @@ export const CLI_SIGNABLE_PREP_TOOLS: ReadonlySet<string> = new Set([
   'execute_contract_call',
 ])
 
+/**
+ * `yield_enter` / `yield_exit` (yield.xyz deposit/withdraw). Their output is a
+ * THIRD shape, distinct from both flat and prep tools: a top-level
+ * `transactions[]` array of already-built flat EVM legs
+ * (`{to, value, data, action, description}`) — the `splitMultiTx` Pattern 2 /
+ * `build_cctp_bridge_usdc` envelope (mcp-lunc-hop `yield-tools.ts:435-457`).
+ * A well-formed EVM deposit is a 2-step approve→deposit sequence; some actions
+ * (a pure withdraw, or a deposit whose allowance is already sufficient) are a
+ * single step.
+ *
+ * Neither existing derivation covers this: the FLAT path reads a single flat
+ * leg off the envelope root (`extractLeg(env)`) and never walks `transactions[]`;
+ * the PREP path requires `txArgs.tx_encoding`, which yield's EVM envelope
+ * deliberately omits (yield-tools.ts:205-210). So `yield_enter`/`yield_exit`
+ * fell through `deriveToolOutputCandidate` → no candidate → the CLI never
+ * synthesized a `sign_tx` → keysign never fired (bead vultisig-6rg2, found via
+ * live real-fund dogfood: the turn ended at the backend's "Transaction prepared"
+ * with no txHash).
+ *
+ * `deriveYieldCandidate` maps the `transactions[]` legs onto the executor's
+ * EXISTING two-leg (`{approvalTxArgs, txArgs}`) / single-leg (`{tx}`) machinery,
+ * reusing `extractLeg` (faithful to/value/data lift — never fabricates calldata)
+ * and `resolveStrictEvmChain` (fail-closed EVM chain guard). EVM-only, matching
+ * both the executor's `signMultiLeg` EVM-only constraint AND yield's EVM
+ * canonical-envelope path; non-EVM yields (Solana/Sui/Ton/Tron prebuilt) carry
+ * a per-step `tx_encoding` and are left for a follow-up.
+ */
+export const CLI_SIGNABLE_YIELD_TOOLS: ReadonlySet<string> = new Set([
+  'yield_enter',
+  'yield_exit',
+])
+
 // ============================================================================
 // Small structural helpers (carried from #922 polymarketTxOutput.ts)
 // ============================================================================
@@ -317,11 +349,96 @@ export function buildTxReadyFromToolOutput(toolName: string, output: unknown): T
   return { __buildTx: true, chain: chainStr, chain_id: chainIdStr, ...(action ? { action } : {}), tx: main }
 }
 
-/** Marker: the candidate came from a flat enrichment (`build*`/polymarket/…) vs
- *  an `execute_*` prep passthrough. Drives selection logging only. */
+/**
+ * Turn a `yield_enter`/`yield_exit` output into a signable candidate, or null
+ * when it carries no signable EVM transaction / fails a guard.
+ *
+ * The yield EVM envelope is `{ chain, provider:'yield_xyz', transactions:[…] }`
+ * where each `transactions[]` entry is a flat leg `{to, value, data, action,
+ * description}` (yield-tools.ts:435-457). We:
+ *   - require a known, self-consistent EVM chain via the same fail-closed guard
+ *     the flat path uses. yield emits a top-level `chain` (PascalCase) but no
+ *     `chain_id`, so we resolve `chain` alone (strict name→EVM) rather than
+ *     demanding the chain⇄chain_id pair `resolveStrictEvmChain` wants;
+ *   - lift EACH leg through `extractLeg` (the SAME faithful to/value/data reader
+ *     the flat/polymarket path uses — it copies the backend-built calldata
+ *     verbatim and NEVER fabricates or mutates it), rejecting any leg that isn't
+ *     a real tx (missing to/data);
+ *   - map a 2-leg approve→action sequence onto the executor's `{approvalTxArgs,
+ *     txArgs}` two-leg machinery (approve is signed + receipt-confirmed BEFORE
+ *     the action leg — same sequencing swap-with-approval uses), and a 1-leg
+ *     action onto the single-leg `{tx}` shape.
+ *
+ * Returns null (→ nothing signs) when: not a yield tool; error/no-op envelope;
+ * chain missing / non-EVM; `transactions[]` absent/empty; ANY leg fails
+ * `extractLeg`; more than 2 legs (yield.xyz EVM actions are approve+action; a
+ * >2-leg envelope is unexpected and we refuse rather than sign a shape the
+ * executor's 2-leg sequencer can't represent — fail closed, leave it beaded).
+ *
+ * The scan_request the yield tool emits (`env.scan_request`) is inert to signing
+ * and is NOT consumed here — L4/the backend runs the Blockaid scan before the
+ * tool output reaches the CLI; this path does not bypass it.
+ */
+export function buildTxReadyFromYieldOutput(toolName: string, output: unknown): TxReadyPayload | null {
+  if (!CLI_SIGNABLE_YIELD_TOOLS.has(toolName)) return null
+
+  const env = asRecord(output)
+  if (!env) return null
+  if (env.status === 'error' || 'error' in env) return null
+
+  // yield emits a top-level PascalCase `chain` (Ethereum, Polygon, …) and no
+  // `chain_id`. Resolve strictly by name and require EVM (the executor's
+  // multi-leg sequencer + yield's canonical multi-step envelope are EVM-only).
+  const chain = asChainString(env.chain)
+  if (!chain) return null
+  const resolved = resolveChain(chain)
+  if (!resolved || getChainKind(resolved) !== 'evm') return null
+  const chainStr = chain
+
+  const rawTxs = env.transactions
+  if (!Array.isArray(rawTxs) || rawTxs.length === 0) return null
+
+  // Lift every leg faithfully. A single un-liftable leg fails the whole action
+  // closed — never sign a partial sequence (mirrors yield-tools' all-or-nothing
+  // canonicalization: an approve that signs while its deposit is dropped would
+  // leave funds approved-but-not-deposited).
+  const legs: FlatLeg[] = []
+  for (const raw of rawTxs) {
+    const legObj = asRecord(raw)
+    if (!legObj) return null
+    if (legObj.status === 'error' || 'error' in legObj) return null
+    const leg = extractLeg(legObj)
+    if (!leg) return null
+    legs.push(leg)
+  }
+
+  // The executor's two-leg sequencer represents exactly approve→main. yield.xyz
+  // EVM actions are 1 leg (action only) or 2 legs (approve + action). Refuse a
+  // >2-leg envelope rather than silently drop legs.
+  if (legs.length > 2) return null
+
+  const action = typeof env.action === 'string' && env.action !== '' ? env.action : undefined
+
+  if (legs.length === 2) {
+    const [approveLeg, mainLeg] = legs
+    return {
+      __buildTx: true,
+      chain: chainStr,
+      ...(action ? { action } : {}),
+      approvalTxArgs: { chain: chainStr, tx: approveLeg },
+      txArgs: { chain: chainStr, tx: mainLeg },
+    }
+  }
+
+  return { __buildTx: true, chain: chainStr, ...(action ? { action } : {}), tx: legs[0] }
+}
+
+/** Marker: the candidate came from a flat enrichment (`build*`/polymarket/…), an
+ *  `execute_*` prep passthrough, or a `yield_*` multi-step envelope. Drives
+ *  selection logging only. */
 export type ToolOutputCandidate = {
   payload: TxReadyPayload
-  source: 'flat' | 'prep'
+  source: 'flat' | 'prep' | 'yield'
   toolName: string
 }
 
@@ -331,11 +448,18 @@ export type ToolOutputCandidate = {
  *  - FLAT tools → `buildTxReadyFromToolOutput` (the port).
  *  - `execute_*` PREP tools → passthrough of the already-signer-ready envelope
  *    (must carry `txArgs` with a `tx_encoding` discriminator).
+ *  - `yield_enter`/`yield_exit` → `buildTxReadyFromYieldOutput` maps the
+ *    top-level `transactions[]` (approve + action) EVM legs onto the executor's
+ *    two-leg / single-leg machinery (bead vultisig-6rg2).
  */
 export function deriveToolOutputCandidate(toolName: string, output: unknown): ToolOutputCandidate | null {
   if (CLI_SIGNABLE_FLAT_TOOLS.has(toolName)) {
     const payload = buildTxReadyFromToolOutput(toolName, output)
     return payload ? { payload, source: 'flat', toolName } : null
+  }
+  if (CLI_SIGNABLE_YIELD_TOOLS.has(toolName)) {
+    const payload = buildTxReadyFromYieldOutput(toolName, output)
+    return payload ? { payload, source: 'yield', toolName } : null
   }
   if (CLI_SIGNABLE_PREP_TOOLS.has(toolName)) {
     const env = asRecord(output)

--- a/clients/cli/src/agent/toolOutputSigning.ts
+++ b/clients/cli/src/agent/toolOutputSigning.ts
@@ -132,10 +132,7 @@ export const CLI_SIGNABLE_PREP_TOOLS: ReadonlySet<string> = new Set([
  * canonical-envelope path; non-EVM yields (Solana/Sui/Ton/Tron prebuilt) carry
  * a per-step `tx_encoding` and are left for a follow-up.
  */
-export const CLI_SIGNABLE_YIELD_TOOLS: ReadonlySet<string> = new Set([
-  'yield_enter',
-  'yield_exit',
-])
+export const CLI_SIGNABLE_YIELD_TOOLS: ReadonlySet<string> = new Set(['yield_enter', 'yield_exit'])
 
 // ============================================================================
 // Small structural helpers (carried from #922 polymarketTxOutput.ts)


### PR DESCRIPTION
## Problem (bead vultisig-6rg2, P0 — found via live real-fund dogfood)

Yield deposit/withdraw **never signed** via the CLI agent path. `clients/cli/src/agent/toolOutputSigning.ts` is the sole client-side signing source. `deriveToolOutputCandidate(toolName, output)` returned a signable candidate ONLY when `toolName` was in `CLI_SIGNABLE_FLAT_TOOLS` or `CLI_SIGNABLE_PREP_TOOLS`. `yield_enter` and `yield_exit` were in **neither**, so a well-formed yield tool-output produced **no candidate** → no synthetic `sign_tx` → keysign never fired. The turn ended at the backend's "Transaction prepared" with `transactions:[]` and no txHash.

## Root cause

The yield output is a **third shape**, distinct from both existing derivations:

```jsonc
{ "chain": "Polygon", "provider": "yield_xyz",
  "transactions": [ {"to","value","data","action":"approval"},
                    {"to","value","data","action":"deposit"} ] }
```

a top-level `transactions[]` array of already-built flat EVM legs — the `splitMultiTx` Pattern 2 / `build_cctp_bridge_usdc` envelope (`mcp-lunc-hop` `yield-tools.ts`). It has **no `tx_encoding`** (the EVM path deliberately omits it) and **no root-level `to`/`data`** — so the PREP path (`txArgs.tx_encoding` required) and the FLAT path (reads a single leg off the envelope root) both skip it.

## Fix

- Add `CLI_SIGNABLE_YIELD_TOOLS = {yield_enter, yield_exit}` and `buildTxReadyFromYieldOutput`, wired into `deriveToolOutputCandidate` (`source: 'yield'`).
- Map the `transactions[]` legs onto the executor's **existing** two-leg (`{approvalTxArgs, txArgs}`) / single-leg (`{tx}`) machinery — reusing `extractLeg` (faithful to/value/data lift, **never fabricates or mutates calldata**) and an EVM chain guard.
- A 2-leg approve→deposit sequence signs + broadcasts **in order** (approve receipt-confirmed before the deposit) via the executor's `signMultiLeg`, matching swap-with-approval. EVM-only — matching both `signMultiLeg`'s EVM-only constraint and yield's EVM canonical-envelope path.
- **Fail-closed**: null on error/no-op envelope, missing/non-EVM chain, absent/empty `transactions[]`, any un-liftable leg (all-or-nothing — never a partial sequence), or >2 legs. The `scan_request` the yield tool emits is **not** bypassed (L4/backend scans upstream before the CLI sees the output).

The three `source` consumers (`client.ts` callback type + fast-path gate, `session.ts` handler) are widened `'flat' | 'prep'` → `ToolOutputCandidate['source']`; `source` is log-only, never branched on.

## Tests

- `toolOutputSigning.test.ts`: yield 2-step→multi-leg, 1-step→single-leg, calldata-verbatim, and the fail-closed guards (no/empty transactions, error envelope, missing/non-EVM chain, un-liftable leg, error-leg, >2 legs) + `deriveToolOutputCandidate` yield cases.
- `toolOutputSigning.allowlist.test.ts`: pins `CLI_SIGNABLE_YIELD_TOOLS` and its disjointness from the flat/prep buckets.
- **Control-mutation verified**: emptying `CLI_SIGNABLE_YIELD_TOOLS` turns 5 derivation tests red.
- Full agent suite green (581 tests), typecheck + lint clean.

## Live on-chain proof

Rebuilt CLI + Testwallet2, real Aave v3 USDC deposit on Polygon (`polygon-usdc-aave-v3-lending`, 0.4 USDC). Verbose trace showed the exact previously-broken path now succeeding: `yield_enter → onToolOutputTx (yield candidate) → stored multi-leg envelope (approve, main) → signMultiLeg: approve confirmed, broadcasting main leg → confirmed`.

- Approval tx: `0x8d59e993aec920ca12ccec9c225b109be6c923c0b4aeb2fb54191fa3da0fd100`
- Deposit tx: [`0x9dc5cd037205b5e96b739ebcd8955dc0fe2152a45bec58e4f7f2f0a87919b5fd`](https://polygonscan.com/tx/0x9dc5cd037205b5e96b739ebcd8955dc0fe2152a45bec58e4f7f2f0a87919b5fd) — **confirmed** (independently re-verified via `tx-status`).

## Out of scope (left beaded separately)

`--session-id` resume minting a new conversation_id / losing pending-tx context is a distinct issue, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for signing transactions generated by yield actions.
  * Supports both single-step and approval-plus-action yield transactions.
  * Extended tool-output candidate generation to include yield-sourced results.

* **Bug Fixes**
  * Improved yield tool signing eligibility and allowlist gating.
  * Fail-safe handling for incomplete, malformed, error-marked, or non-EVM yield responses to avoid producing signable transactions.

* **Tests**
  * Expanded CLI signing tests to cover yield enter/exit behavior and regression cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->