### PR TITLE
fix(sui): migrate off JSON-RPC to gRPC (+ GraphQL on React Native)

### DIFF
--- a/.changeset/sui-grpc-graphql-migration.md
+++ b/.changeset/sui-grpc-graphql-migration.md
@@ -1,0 +1,29 @@
+---
+'@vultisig/core-chain': minor
+'@vultisig/core-mpc': minor
+'@vultisig/sdk': minor
+---
+
+Move every Sui read, simulation and broadcast off JSON-RPC.
+
+Sui disabled JSON-RPC on Foundation mainnet full nodes the week of 2026-07-27
+and decommissions it entirely by mid-October 2026, so the previous
+`SuiJsonRpcClient` against `sui-rpc.publicnode.com` was on a dead rail.
+
+- `getSuiClient()` now returns a `SuiGrpcClient` pointed at
+  `https://fullnode.mainnet.sui.io:443` (gRPC-web over HTTPS).
+- React Native uses `SuiGraphQLClient` against
+  `https://graphql.mainnet.sui.io/graphql` instead: grpc-web needs
+  `Response.body` streaming, which Hermes' fetch does not provide. Both clients
+  implement the same unified transport interface, so callsites are identical.
+- Balance, coin metadata, coin listing, tx hash, tx status, broadcast and
+  keysign gas refinement moved to `getBalance` / `getCoinMetadata` / `listCoins`
+  / `simulateTransaction` / `getTransaction` / `executeTransaction`.
+- The dependency-free `@vultisig/sdk` balance tools (`getSuiBalance`,
+  `getSuiTokenBalance`, `getSuiAllBalances`) now POST Sui GraphQL and follow the
+  paginated `balances` connection to completion, returning `tokens_unavailable`
+  rather than a silently truncated portfolio.
+
+Breaking for direct consumers: `assertSuiTxSucceeded` now takes the unified
+client's transaction result (`{ $kind, Transaction | FailedTransaction }`)
+instead of a JSON-RPC effects object.

--- a/.changeset/sui-grpc-graphql-migration.md
+++ b/.changeset/sui-grpc-graphql-migration.md
@@ -7,9 +7,11 @@
 
 Move every Sui read, simulation and broadcast off JSON-RPC.
 
-Sui disabled JSON-RPC on Foundation mainnet full nodes the week of 2026-07-27
-and decommissions it entirely by mid-October 2026, so the previous
-`SuiJsonRpcClient` against `sui-rpc.publicnode.com` was on a dead rail.
+Sui is retiring JSON-RPC: shutdown on Foundation mainnet full nodes began the
+week of 2026-07-27 and full decommission (code removal) lands mid-October 2026,
+after which no provider can serve it. This is a scheduled migration ahead of
+that date, NOT a fix for a live outage — as of 2026-07-27 both
+`sui-rpc.publicnode.com` and `fullnode.mainnet.sui.io` still answer JSON-RPC.
 
 - `getSuiClient()` now returns a `SuiGrpcClient` pointed at
   `https://fullnode.mainnet.sui.io:443` (gRPC-web over HTTPS).

--- a/.changeset/sui-grpc-graphql-migration.md
+++ b/.changeset/sui-grpc-graphql-migration.md
@@ -25,11 +25,17 @@ and decommissions it entirely by mid-October 2026, so the previous
   paginated `balances` connection to completion, returning `tokens_unavailable`
   rather than a silently truncated portfolio.
 
-The CLI's permanent-vs-retryable broadcast classifier follows the transport:
-a Sui rejection now carries the grpc-status name (`INVALID_ARGUMENT`) instead
-of the numeric JSON-RPC `-32002`, and grpc-web percent-encodes the message
-trailer. Left unchanged, that gate would have gone dead and every permanent
-Sui rejection would have been re-broadcast as if transient.
+Broadcast-error classification follows the transport. A gRPC failure carries the
+grpc-status NAME in `code` (not a JSON-RPC number) and a percent-encoded message,
+so both classifiers were re-pointed:
+
+- `isTransientBroadcastError` retries `UNAVAILABLE` / `DEADLINE_EXCEEDED` /
+  `RESOURCE_EXHAUSTED` and decodes the message before pattern-matching. A
+  grpc-web response is HTTP 200 with the real status in the trailer, so the
+  existing 5xx branch never saw a busy or restarting node.
+- The CLI's permanent-vs-retryable gate matches `INVALID_ARGUMENT` instead of
+  the numeric `-32002`. Left unchanged, that gate would have gone dead and every
+  permanent Sui rejection would have been re-broadcast as if transient.
 
 Breaking for direct consumers: `assertSuiTxSucceeded` now takes the unified
 client's transaction result (`{ $kind, Transaction | FailedTransaction }`)

--- a/.changeset/sui-grpc-graphql-migration.md
+++ b/.changeset/sui-grpc-graphql-migration.md
@@ -2,6 +2,7 @@
 '@vultisig/core-chain': minor
 '@vultisig/core-mpc': minor
 '@vultisig/sdk': minor
+'@vultisig/cli': patch
 ---
 
 Move every Sui read, simulation and broadcast off JSON-RPC.
@@ -23,6 +24,12 @@ and decommissions it entirely by mid-October 2026, so the previous
   `getSuiTokenBalance`, `getSuiAllBalances`) now POST Sui GraphQL and follow the
   paginated `balances` connection to completion, returning `tokens_unavailable`
   rather than a silently truncated portfolio.
+
+The CLI's permanent-vs-retryable broadcast classifier follows the transport:
+a Sui rejection now carries the grpc-status name (`INVALID_ARGUMENT`) instead
+of the numeric JSON-RPC `-32002`, and grpc-web percent-encodes the message
+trailer. Left unchanged, that gate would have gone dead and every permanent
+Sui rejection would have been re-broadcast as if transient.
 
 Breaking for direct consumers: `assertSuiTxSucceeded` now takes the unified
 client's transaction result (`{ $kind, Transaction | FailedTransaction }`)

--- a/clients/cli/src/core/errors.test.ts
+++ b/clients/cli/src/core/errors.test.ts
@@ -636,7 +636,7 @@ describe('anticipated CLI taxonomy regressions', () => {
       )
     })
 
-    // Sui retired JSON-RPC: broadcasts go over gRPC, so the rejection carries a
+    // Sui is retiring JSON-RPC: broadcasts go over gRPC, so the rejection carries a
     // grpc-status NAME (string) instead of the old numeric -32002, and grpc-web
     // percent-encodes the message trailer. Both fixtures below are verbatim mainnet
     // captures from `fullnode.mainnet.sui.io`.

--- a/clients/cli/src/core/errors.test.ts
+++ b/clients/cli/src/core/errors.test.ts
@@ -636,11 +636,47 @@ describe('anticipated CLI taxonomy regressions', () => {
       )
     })
 
+    // Sui retired JSON-RPC: broadcasts go over gRPC, so the rejection carries a
+    // grpc-status NAME (string) instead of the old numeric -32002, and grpc-web
+    // percent-encodes the message trailer. Both fixtures below are verbatim mainnet
+    // captures from `fullnode.mainnet.sui.io`.
     it('maps a Sui transaction-execution client rejection to non-retryable input', () => {
-      const rpcError = Object.assign(new Error('Invalid user signature: cryptographic signature verification failed'), {
-        code: -32002,
+      const rpcError = Object.assign(new Error('Invalid user signature: Expect 1 signer signatures but got 0'), {
+        code: 'INVALID_ARGUMENT',
       })
       expectPermanent(
+        new VaultError(
+          VaultErrorCode.BroadcastFailed,
+          `Failed to broadcast transaction on Sui: ${rpcError.message}`,
+          rpcError
+        )
+      )
+    })
+
+    it.each([
+      [
+        'malformed signature',
+        'invalid%20signature:%20error%20converting%20from%20protobuf:%20field:%20bcs%20reason:%20FIELD_INVALID%20description:%20missing%20signature%20scheme%20flag',
+      ],
+      ['no signatures', 'Invalid%20user%20signature:%20Expect%201%20signer%20signatures%20but%20got%200'],
+      [
+        'malformed transaction bytes',
+        'invalid%20transaction:%20error%20converting%20from%20protobuf:%20field:%20bcs%20reason:%20FIELD_INVALID',
+      ],
+    ])('decodes the percent-encoded grpc-message trailer (%s)', (_label, encoded) => {
+      // A regex with literal spaces never matches the raw wire text — without decoding,
+      // every permanent Sui rejection would be misread as retryable and re-broadcast.
+      const rpcError = Object.assign(new Error(encoded), { code: 'INVALID_ARGUMENT' })
+      expectPermanent(
+        new VaultError(VaultErrorCode.BroadcastFailed, `Failed to broadcast transaction on Sui: ${encoded}`, rpcError)
+      )
+    })
+
+    it('keeps a Sui rejection retryable when the grpc status is not INVALID_ARGUMENT', () => {
+      // UNAVAILABLE / NOT_FOUND / DEADLINE_EXCEEDED are node-or-network conditions; the
+      // identical signed bytes can still land on a retry.
+      const rpcError = Object.assign(new Error('invalid%20signature:%20whatever'), { code: 'UNAVAILABLE' })
+      expectTransient(
         new VaultError(
           VaultErrorCode.BroadcastFailed,
           `Failed to broadcast transaction on Sui: ${rpcError.message}`,
@@ -658,8 +694,8 @@ describe('anticipated CLI taxonomy regressions', () => {
       )
     })
 
-    it('keeps a Sui server-busy JSON-RPC failure retryable', () => {
-      const rpcError = Object.assign(new Error('Server busy'), { code: -32604 })
+    it('keeps a Sui server-busy failure retryable', () => {
+      const rpcError = Object.assign(new Error('Server busy'), { code: 'UNAVAILABLE' })
       expectTransient(
         new VaultError(
           VaultErrorCode.BroadcastFailed,
@@ -669,11 +705,12 @@ describe('anticipated CLI taxonomy regressions', () => {
       )
     })
 
-    it('keeps a Sui -32002 rejection retryable when the message is not a recognized permanent signal', () => {
-      // -32002 (TransactionExecutionClientError) is a broad bucket covering more than
-      // signature failures — an unrecognized message under that code must not be
-      // blanket-matched to permanent.
-      const rpcError = Object.assign(new Error('Insufficient gas budget for this transaction'), { code: -32002 })
+    it('keeps a Sui INVALID_ARGUMENT rejection retryable when the message is not a recognized permanent signal', () => {
+      // INVALID_ARGUMENT is still a bucket covering more than signature/decode failures —
+      // an unrecognized message under that status must not be blanket-matched to permanent.
+      const rpcError = Object.assign(new Error('Insufficient gas budget for this transaction'), {
+        code: 'INVALID_ARGUMENT',
+      })
       expectTransient(
         new VaultError(
           VaultErrorCode.BroadcastFailed,

--- a/clients/cli/src/core/errors.ts
+++ b/clients/cli/src/core/errors.ts
@@ -396,7 +396,7 @@ const SOLANA_PERMANENT_BROADCAST_INPUT_RE =
 // it never carries an RPC status, so it's checked independently of the status gate below.
 const SUI_REQUIRED_FIELDS_GUARD_RE = /Sui broadcast requires JSON with "unsignedTx" and "signature" fields/i
 
-// Sui retired JSON-RPC, so broadcasts now go over gRPC and the rejection signal changed
+// Sui is retiring JSON-RPC, so broadcasts now go over gRPC and the rejection signal changed
 // shape twice over:
 //
 //  - `err.code` is the grpc-status NAME (a string) — `@protobuf-ts` surfaces the

--- a/clients/cli/src/core/errors.ts
+++ b/clients/cli/src/core/errors.ts
@@ -393,16 +393,48 @@ const SOLANA_PERMANENT_BROADCAST_INPUT_RE =
   /failed to deserialize(?: transaction)?|failed to sanitize|(?:transaction )?signature verification (?:failed|failure)|non-base58 character|invalid base58/i
 
 // The local required-fields guard (RawBroadcastService) is always permanent —
-// it never carries an RPC code, so it's checked independently of the -32002 gate below.
+// it never carries an RPC status, so it's checked independently of the status gate below.
 const SUI_REQUIRED_FIELDS_GUARD_RE = /Sui broadcast requires JSON with "unsignedTx" and "signature" fields/i
 
-// -32002 ("TransactionExecutionClientError") is a broad Sui JSON-RPC bucket covering
-// many distinct client-caused execution failures, not signature verification alone —
-// pairing the code with a message match keeps a generic/unrecognized -32002 (e.g. an
-// object-version or gas condition we can't positively identify as permanent) retryable
-// instead of a blanket match on the code.
+// Sui retired JSON-RPC, so broadcasts now go over gRPC and the rejection signal changed
+// shape twice over:
+//
+//  - `err.code` is the grpc-status NAME (a string) — `@protobuf-ts` surfaces the
+//    grpc-status/grpc-message trailer pair as an `RpcError`. The old numeric -32002
+//    ("TransactionExecutionClientError") gate can never match again, and a dead gate here
+//    is not fail-safe: it silently reclassifies every permanent rejection as retryable, so
+//    the CLI would re-broadcast bytes that can never land.
+//  - the message arrives PERCENT-ENCODED. grpc-web escapes the trailer, so the wire text
+//    reads `invalid%20signature:%20...` and a regex with literal spaces never matches.
+//
+// INVALID_ARGUMENT is Sui's status for a request the node rejected at (or before)
+// conversion. It is still a bucket, so keep the original discipline: pair the status with
+// a recognized message, leaving anything unidentified retryable. Ambiguity staying
+// retryable is the safe side — a false permanent verdict strands a user.
+const SUI_PERMANENT_GRPC_STATUS = 'INVALID_ARGUMENT'
+
+// Every alternative below is a message this repo has actually captured from mainnet
+// (`fullnode.mainnet.sui.io`), not a guess at the node's wording:
+//   executeTransaction, malformed signature  -> "invalid signature: error converting from
+//                                               protobuf: field: bcs reason: FIELD_INVALID
+//                                               description: missing signature scheme flag"
+//   executeTransaction, no signatures        -> "Invalid user signature: Expect 1 signer
+//                                               signatures but got 0"
+//   executeTransaction, malformed tx bytes   -> "invalid transaction: error converting from
+//                                               protobuf: field: bcs reason: FIELD_INVALID ..."
+// All three are intrinsic to the bytes being sent — no retry or wait makes them valid.
 const SUI_PERMANENT_EXECUTION_MESSAGE_RE =
-  /invalid (?:user )?signature|signature verification (?:failed|failure)|malformed transaction|invalid transaction (?:data|bytes)/i
+  /invalid (?:user )?signature|signature verification (?:failed|failure)|malformed transaction|invalid transaction(?: (?:data|bytes))?\b/i
+
+// grpc-web percent-encodes the grpc-message trailer. Match against BOTH forms so a
+// decodable message is understood and a plain (or malformed-escape) one still works.
+const decodeRpcDetails = (details: string): string => {
+  try {
+    return decodeURIComponent(details)
+  } catch {
+    return details
+  }
+}
 
 // Cosmos SDK RootCodespace error codes (codespace "sdk") whose rejection is intrinsic
 // to THIS signed tx — the fault is in the bytes themselves, so no amount of retrying or
@@ -454,7 +486,11 @@ const permanentBroadcastInputClassifiers: Partial<Record<ChainKind, PermanentBro
   sui: (err, details) => {
     if (SUI_REQUIRED_FIELDS_GUARD_RE.test(details)) return true
     const rpcCode = (err.originalError as (Error & { code?: unknown }) | undefined)?.code
-    return rpcCode === -32002 && SUI_PERMANENT_EXECUTION_MESSAGE_RE.test(details)
+    if (rpcCode !== SUI_PERMANENT_GRPC_STATUS) return false
+    return (
+      SUI_PERMANENT_EXECUTION_MESSAGE_RE.test(details) ||
+      SUI_PERMANENT_EXECUTION_MESSAGE_RE.test(decodeRpcDetails(details))
+    )
   },
   cosmos: (_err, details) => isCosmosPermanentBroadcastInput(details),
 }

--- a/packages/core/chain/chains/sui/client.ts
+++ b/packages/core/chain/chains/sui/client.ts
@@ -1,10 +1,22 @@
-import { SuiJsonRpcClient } from '@mysten/sui/jsonRpc'
+import { SuiGrpcClient } from '@mysten/sui/grpc'
 import { memoize } from '@vultisig/lib-utils/memoize'
 
+import { suiGrpcUrl, suiNetwork } from './config'
+
+/**
+ * The Sui client every callsite programs against.
+ *
+ * `SuiGrpcClient` and `SuiGraphQLClient` both implement
+ * `SuiClientTypes.TransportMethods`, so the React Native override
+ * (`platforms/react-native/overrides/suiClient.ts`) can swap in the GraphQL
+ * client without touching a single caller.
+ */
+export type SuiClient = SuiGrpcClient
+
 export const getSuiClient = memoize(
-  () =>
-    new SuiJsonRpcClient({
-      url: 'https://sui-rpc.publicnode.com',
-      network: 'mainnet',
+  (): SuiClient =>
+    new SuiGrpcClient({
+      network: suiNetwork,
+      baseUrl: suiGrpcUrl,
     })
 )

--- a/packages/core/chain/chains/sui/config.ts
+++ b/packages/core/chain/chains/sui/config.ts
@@ -8,10 +8,12 @@ export const suiNetwork: SuiClientTypes.Network = 'mainnet'
 /**
  * Sui full node gRPC endpoint (grpc-web over HTTPS).
  *
- * Sui is retiring JSON-RPC: it was disabled on Sui Foundation mainnet full
- * nodes the week of 2026-07-27 and is fully decommissioned (code removed)
- * mid-October 2026. gRPC and GraphQL RPC are the supported replacements, so
- * every Sui read/simulate/execute in this repo goes through one of them.
+ * Sui is retiring JSON-RPC: shutdown on Foundation mainnet full nodes began the
+ * week of 2026-07-27 and full decommission (code removal) lands mid-October
+ * 2026, after which no provider can serve it. gRPC and GraphQL RPC are the
+ * supported replacements, so every Sui read/simulate/execute in this repo goes
+ * through one of them. (JSON-RPC still answered on 2026-07-27 — this is a
+ * migration ahead of the deadline, not a response to a live outage.)
  *
  * The previously-used `sui-rpc.publicnode.com` is JSON-RPC only — it answers
  * nothing over gRPC — so the endpoint moves to the Foundation full node.

--- a/packages/core/chain/chains/sui/config.ts
+++ b/packages/core/chain/chains/sui/config.ts
@@ -1,2 +1,32 @@
+import type { SuiClientTypes } from '@mysten/sui/client'
+
 export const suiGasBudget = 3000_000n
 export const suiMinGasBudget = 2000n
+
+export const suiNetwork: SuiClientTypes.Network = 'mainnet'
+
+/**
+ * Sui full node gRPC endpoint (grpc-web over HTTPS).
+ *
+ * Sui is retiring JSON-RPC: it was disabled on Sui Foundation mainnet full
+ * nodes the week of 2026-07-27 and is fully decommissioned (code removed)
+ * mid-October 2026. gRPC and GraphQL RPC are the supported replacements, so
+ * every Sui read/simulate/execute in this repo goes through one of them.
+ *
+ * The previously-used `sui-rpc.publicnode.com` is JSON-RPC only — it answers
+ * nothing over gRPC — so the endpoint moves to the Foundation full node.
+ */
+export const suiGrpcUrl = 'https://fullnode.mainnet.sui.io:443'
+
+/**
+ * Sui GraphQL RPC endpoint.
+ *
+ * Used on React Native: `@mysten/sui`'s gRPC client speaks grpc-web through
+ * `GrpcWebFetchTransport`, which reads `Response.body` as a `ReadableStream`.
+ * Hermes' XHR-backed `fetch` exposes no `Response.body`, so grpc-web throws
+ * "missing response body" there. GraphQL RPC is a plain JSON POST and exposes
+ * the exact same unified client surface (`SuiClientTypes.TransportMethods`),
+ * so RN keeps identical call sites. See
+ * `packages/sdk/src/platforms/react-native/overrides/suiClient.ts`.
+ */
+export const suiGraphqlUrl = 'https://graphql.mainnet.sui.io/graphql'

--- a/packages/core/chain/chains/sui/listAllCoins.test.ts
+++ b/packages/core/chain/chains/sui/listAllCoins.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { listAllSuiCoins, maxSuiCoinPages, unwrapSuiCoinType } from './listAllCoins'
+
+const NATIVE = '0x2::sui::SUI'
+const coinObject = (i: number, balance = '1', type = `0x2::coin::Coin<${NATIVE}>`) => ({
+  objectId: `0xobj${i}`,
+  version: `${i}`,
+  digest: `dig${i}`,
+  type,
+  balance,
+  owner: { $kind: 'AddressOwner' as const, AddressOwner: '0xowner' },
+})
+
+const client = (listCoins: ReturnType<typeof vi.fn>) => ({ listCoins }) as never
+
+describe('unwrapSuiCoinType', () => {
+  it('unwraps the Coin<> object type into the inner coin type', () => {
+    expect(unwrapSuiCoinType('0x2::coin::Coin<0x2::sui::SUI>', 'fallback')).toBe('0x2::sui::SUI')
+  })
+
+  it('unwraps a fully-normalized wrapper type with generic parameters intact', () => {
+    const inner = '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC'
+    expect(
+      unwrapSuiCoinType(`0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<${inner}>`, 'x')
+    ).toBe(inner)
+  })
+
+  it('falls back to the requested coin type when the object type is absent or unexpected', () => {
+    expect(unwrapSuiCoinType(undefined, NATIVE)).toBe(NATIVE)
+    expect(unwrapSuiCoinType('0x2::sui::SUI', NATIVE)).toBe(NATIVE)
+  })
+})
+
+describe('listAllSuiCoins', () => {
+  it('follows the cursor across pages and flattens to the keysign coin shape', async () => {
+    const listCoins = vi
+      .fn()
+      .mockResolvedValueOnce({ objects: [coinObject(0), coinObject(1)], hasNextPage: true, cursor: 'cur1' })
+      .mockResolvedValueOnce({ objects: [coinObject(2)], hasNextPage: false, cursor: null })
+
+    const coins = await listAllSuiCoins({ client: client(listCoins), owner: '0xowner', coinType: NATIVE })
+
+    expect(coins).toEqual([
+      { coinType: NATIVE, coinObjectId: '0xobj0', version: '0', digest: 'dig0', balance: '1' },
+      { coinType: NATIVE, coinObjectId: '0xobj1', version: '1', digest: 'dig1', balance: '1' },
+      { coinType: NATIVE, coinObjectId: '0xobj2', version: '2', digest: 'dig2', balance: '1' },
+    ])
+
+    expect(listCoins).toHaveBeenCalledTimes(2)
+    expect(listCoins.mock.calls[0]?.[0]).toEqual({ owner: '0xowner', coinType: NATIVE, cursor: undefined })
+    // The cursor from each page is threaded into the next request — the whole
+    // point of the loop. `cursor` replaced JSON-RPC's `nextCursor`.
+    expect(listCoins.mock.calls[1]?.[0]).toEqual({ owner: '0xowner', coinType: NATIVE, cursor: 'cur1' })
+  })
+
+  it('terminates on a single page', async () => {
+    const listCoins = vi.fn().mockResolvedValueOnce({ objects: [coinObject(0)], hasNextPage: false, cursor: null })
+
+    await expect(
+      listAllSuiCoins({ client: client(listCoins), owner: '0xowner', coinType: NATIVE })
+    ).resolves.toHaveLength(1)
+    expect(listCoins).toHaveBeenCalledTimes(1)
+  })
+
+  it('fails closed (throws, no infinite loop) when the cursor never advances', async () => {
+    const listCoins = vi.fn().mockResolvedValue({ objects: [coinObject(0)], hasNextPage: true, cursor: 'stuck' })
+
+    await expect(listAllSuiCoins({ client: client(listCoins), owner: '0xowner', coinType: NATIVE })).rejects.toThrow(
+      /exceeded \d+ pages/
+    )
+    // Bounded, not unbounded.
+    expect(listCoins).toHaveBeenCalledTimes(maxSuiCoinPages)
+  })
+
+  it('does not truncate when hasNextPage is true but the cursor is null', async () => {
+    // A page that claims more data yet hands back no cursor cannot be followed;
+    // stopping is correct (and must not loop forever on `undefined`).
+    const listCoins = vi.fn().mockResolvedValue({ objects: [coinObject(0)], hasNextPage: true, cursor: null })
+
+    await expect(
+      listAllSuiCoins({ client: client(listCoins), owner: '0xowner', coinType: NATIVE })
+    ).resolves.toHaveLength(1)
+    expect(listCoins).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/chain/chains/sui/listAllCoins.ts
+++ b/packages/core/chain/chains/sui/listAllCoins.ts
@@ -1,0 +1,78 @@
+import type { SuiClient } from './client'
+
+/**
+ * A coin object flattened into the shape the keysign payload stores.
+ *
+ * The unified client returns coin objects whose `type` is the full wrapper
+ * (`0x2::coin::Coin<0x2::sui::SUI>`) and whose id field is `objectId`; the
+ * retired JSON-RPC `CoinStruct` exposed the inner `coinType` and
+ * `coinObjectId` directly. Normalizing here keeps coin selection, the
+ * `SuiCoin` protobuf and every downstream comparison unchanged.
+ */
+export type SuiCoinObject = {
+  coinType: string
+  coinObjectId: string
+  version: string
+  digest: string
+  balance: string
+}
+
+/**
+ * A misbehaving endpoint that keeps returning `hasNextPage: true` with a
+ * non-advancing cursor would otherwise spin forever. 200 pages is far beyond
+ * any real wallet, so hitting the cap means the cursor is stuck: fail CLOSED
+ * rather than hang or silently truncate the coin set and under-fund a send.
+ */
+export const maxSuiCoinPages = 200
+
+const coinWrapperType = /::coin::Coin<(.+)>$/
+
+/** `0x2::coin::Coin<0x2::sui::SUI>` -> `0x2::sui::SUI`. */
+export const unwrapSuiCoinType = (objectType: string | undefined, fallback: string): string =>
+  objectType?.match(coinWrapperType)?.[1] ?? fallback
+
+type ListAllSuiCoinsInput = {
+  client: Pick<SuiClient, 'listCoins'>
+  owner: string
+  coinType: string
+}
+
+/**
+ * Every coin object of one coin type owned by `owner`.
+ *
+ * `listCoins` is paginated (~50 objects/page). Sui's object-per-coin model
+ * makes >50 coin objects realistic for an active wallet (dust, partial fills,
+ * repeated small transfers, staking rewards), so reading only the first page
+ * silently truncates the coin set and produces a broken send ("insufficient
+ * balance" despite adequate holdings) even though the balance-based display
+ * path shows the correct aggregate total. Follow the cursor to completion.
+ */
+export const listAllSuiCoins = async ({ client, owner, coinType }: ListAllSuiCoinsInput): Promise<SuiCoinObject[]> => {
+  const coins: SuiCoinObject[] = []
+  let cursor: string | null | undefined = undefined
+  let pages = 0
+
+  do {
+    const page = await client.listCoins({ owner, coinType, cursor })
+
+    for (const object of page.objects) {
+      coins.push({
+        coinType: unwrapSuiCoinType(object.type, coinType),
+        coinObjectId: object.objectId,
+        version: object.version,
+        digest: object.digest,
+        balance: object.balance,
+      })
+    }
+
+    cursor = page.hasNextPage ? page.cursor : null
+
+    if (++pages >= maxSuiCoinPages && cursor) {
+      throw new Error(
+        `listAllSuiCoins: exceeded ${maxSuiCoinPages} pages for ${owner} (${coinType}) — refusing to build a send from a possibly-truncated or looping coin set`
+      )
+    }
+  } while (cursor)
+
+  return coins
+}

--- a/packages/core/chain/chains/sui/transactionResult.test.ts
+++ b/packages/core/chain/chains/sui/transactionResult.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+
+import { describeSuiExecutionFailure, getSuiResultTransaction, isSuiExecutionSuccess } from './transactionResult'
+
+const success = {
+  $kind: 'Transaction' as const,
+  Transaction: { digest: '0xok', status: { success: true, error: null }, effects: { transactionDigest: '0xok' } },
+}
+
+const failure = {
+  $kind: 'FailedTransaction' as const,
+  FailedTransaction: {
+    digest: '0xbad',
+    status: { success: false, error: { message: 'MoveAbort(...) in command 0' } },
+    effects: { transactionDigest: '0xbad' },
+  },
+}
+
+describe('getSuiResultTransaction', () => {
+  it('reads the transaction off either arm of the union', () => {
+    expect(getSuiResultTransaction(success)?.digest).toBe('0xok')
+    // A failed transaction still carries effects — gas refinement and broadcast
+    // hash-verification both depend on being able to read them.
+    expect(getSuiResultTransaction(failure)?.effects?.transactionDigest).toBe('0xbad')
+  })
+
+  it('returns undefined for a null/empty result', () => {
+    expect(getSuiResultTransaction(null)).toBeUndefined()
+    expect(getSuiResultTransaction(undefined)).toBeUndefined()
+    expect(getSuiResultTransaction({})).toBeUndefined()
+  })
+})
+
+describe('isSuiExecutionSuccess — fails closed (sdk#1398)', () => {
+  it('is true only for a Transaction arm with an explicit success status', () => {
+    expect(isSuiExecutionSuccess(success)).toBe(true)
+  })
+
+  it.each([
+    ['a failed arm', failure],
+    [
+      'a failed status on the success arm',
+      { $kind: 'Transaction' as const, Transaction: { status: { success: false } } },
+    ],
+    ['a missing status', { $kind: 'Transaction' as const, Transaction: { digest: '0xok' } }],
+    [
+      'a success status on the failed arm',
+      { $kind: 'FailedTransaction' as const, FailedTransaction: { status: { success: true } } },
+    ],
+    ['a result with no discriminant', { Transaction: { status: { success: true } } }],
+    ['an empty result', {}],
+    ['null', null],
+  ])('is false for %s', (_label, result) => {
+    expect(isSuiExecutionSuccess(result)).toBe(false)
+  })
+})
+
+describe('describeSuiExecutionFailure', () => {
+  it('prefers the chain-supplied error message', () => {
+    expect(describeSuiExecutionFailure(failure)).toBe('MoveAbort(...) in command 0')
+  })
+
+  it('describes a failed status with no message', () => {
+    expect(describeSuiExecutionFailure({ $kind: 'Transaction', Transaction: { status: { success: false } } })).toBe(
+      'execution failed'
+    )
+  })
+
+  it('describes a failed arm with no status at all', () => {
+    expect(describeSuiExecutionFailure({ $kind: 'FailedTransaction', FailedTransaction: {} })).toBe(
+      'transaction did not execute'
+    )
+  })
+
+  it('describes a response that carries no status information', () => {
+    expect(describeSuiExecutionFailure({})).toBe('no execution status returned')
+  })
+})

--- a/packages/core/chain/chains/sui/transactionResult.ts
+++ b/packages/core/chain/chains/sui/transactionResult.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared readers for the unified Sui client's transaction result shape.
+ *
+ * Sui's gRPC / GraphQL clients return a discriminated union rather than the
+ * JSON-RPC `{ effects: { status: { status: 'success' | 'failure' } } }` object:
+ *
+ *   { $kind: 'Transaction',       Transaction:       { status, effects, ... } }
+ *   { $kind: 'FailedTransaction', FailedTransaction: { status, effects, ... } }
+ *
+ * and execution status is `{ success: true, error: null }` /
+ * `{ success: false, error: { message, ... } }`.
+ *
+ * The types below are structural on purpose: `SuiGrpcClient` and
+ * `SuiGraphQLClient` produce the same shape but through different generic
+ * instantiations, and every resolver here only ever reads status + effects.
+ */
+
+export type SuiExecutionStatusLike = {
+  success?: boolean
+  error?: { message?: string } | null
+}
+
+export type SuiGasCostSummaryLike = {
+  computationCost?: string
+  storageCost?: string
+  storageRebate?: string
+}
+
+export type SuiTransactionEffectsLike = {
+  transactionDigest?: string
+  gasUsed?: SuiGasCostSummaryLike
+}
+
+export type SuiTransactionLike = {
+  digest?: string
+  status?: SuiExecutionStatusLike
+  effects?: SuiTransactionEffectsLike
+}
+
+export type SuiTransactionResultLike = {
+  $kind?: 'Transaction' | 'FailedTransaction'
+  Transaction?: SuiTransactionLike
+  FailedTransaction?: SuiTransactionLike
+}
+
+/**
+ * The transaction payload of a result, regardless of which arm of the union it
+ * arrived on. A failed transaction still carries effects (gas used, digest),
+ * which broadcast verification and gas refinement both need.
+ */
+export const getSuiResultTransaction = (
+  result: SuiTransactionResultLike | null | undefined
+): SuiTransactionLike | undefined => result?.Transaction ?? result?.FailedTransaction
+
+/**
+ * Execution success — NOT transport success.
+ *
+ * Fails closed: only an explicit `$kind: 'Transaction'` carrying
+ * `status.success === true` counts. A `FailedTransaction`, a `success: false`
+ * status, or a result with no status at all (malformed / unexpected response)
+ * is not proven success and must not be treated as one (sdk#1398).
+ */
+export const isSuiExecutionSuccess = (result: SuiTransactionResultLike | null | undefined): boolean =>
+  result?.$kind === 'Transaction' && getSuiResultTransaction(result)?.status?.success === true
+
+/** Human-readable reason a transaction did not execute successfully. */
+export const describeSuiExecutionFailure = (result: SuiTransactionResultLike | null | undefined): string => {
+  const status = getSuiResultTransaction(result)?.status
+
+  if (status?.error?.message) return status.error.message
+  if (status?.success === false) return 'execution failed'
+  if (result?.$kind === 'FailedTransaction') return 'transaction did not execute'
+
+  return 'no execution status returned'
+}

--- a/packages/core/chain/coin/balance/resolvers/sui.test.ts
+++ b/packages/core/chain/coin/balance/resolvers/sui.test.ts
@@ -1,0 +1,43 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getBalanceMock = vi.fn()
+
+vi.mock('@vultisig/core-chain/chains/sui/client', () => ({
+  getSuiClient: () => ({ getBalance: getBalanceMock }),
+}))
+
+import { getSuiCoinBalance } from './sui'
+
+const address = '0x0000000000000000000000000000000000000000000000000000000000000abc'
+
+describe('getSuiCoinBalance', () => {
+  beforeEach(() => getBalanceMock.mockReset())
+
+  it('reads the total from the nested balance envelope', async () => {
+    // The unified client returns `{ balance: { balance, coinBalance, addressBalance } }`.
+    // `balance.balance` is the total (the retired JSON-RPC `totalBalance`) — reading
+    // `coinBalance` or `addressBalance` would under-report a wallet.
+    getBalanceMock.mockResolvedValueOnce({
+      balance: {
+        coinType: '0x2::sui::SUI',
+        balance: '2227801536832',
+        coinBalance: '2227801536832',
+        addressBalance: '0',
+      },
+    })
+
+    await expect(getSuiCoinBalance({ chain: Chain.Sui, address })).resolves.toBe(2227801536832n)
+    expect(getBalanceMock).toHaveBeenCalledWith({ owner: address })
+  })
+
+  it('scopes the query to a coin type when one is given', async () => {
+    const id = '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC'
+    getBalanceMock.mockResolvedValueOnce({
+      balance: { coinType: id, balance: '42', coinBalance: '42', addressBalance: '0' },
+    })
+
+    await expect(getSuiCoinBalance({ chain: Chain.Sui, address, id })).resolves.toBe(42n)
+    expect(getBalanceMock).toHaveBeenCalledWith({ owner: address, coinType: id })
+  })
+})

--- a/packages/core/chain/coin/balance/resolvers/sui.ts
+++ b/packages/core/chain/coin/balance/resolvers/sui.ts
@@ -3,12 +3,15 @@ import { getSuiClient } from '@vultisig/core-chain/chains/sui/client'
 import { CoinBalanceResolver } from '../resolver'
 
 export const getSuiCoinBalance: CoinBalanceResolver = async input => {
-  const rpcClient = getSuiClient()
+  const client = getSuiClient()
 
-  const { totalBalance } = await rpcClient.getBalance({
+  // The unified client nests the balance: `{ balance: { balance, coinType, ... } }`.
+  // `balance.balance` is the total (the retired JSON-RPC `totalBalance`), NOT
+  // the `coinBalance` / `addressBalance` split.
+  const { balance } = await client.getBalance({
     owner: input.address,
     ...(input.id ? { coinType: input.id } : {}),
   })
 
-  return BigInt(totalBalance)
+  return BigInt(balance.balance)
 }

--- a/packages/core/chain/coin/token/metadata/resolvers/sui.test.ts
+++ b/packages/core/chain/coin/token/metadata/resolvers/sui.test.ts
@@ -16,12 +16,16 @@ describe('getSuiTokenMetadata', () => {
 
   it('maps SUI coin metadata into CoinMetadata', async () => {
     const id = '0x2::sui::SUI'
+    // The unified client nests the result under `coinMetadata`.
     getCoinMetadataMock.mockResolvedValue({
-      decimals: 9,
-      symbol: 'SUI',
-      name: 'Sui',
-      description: 'Sui native coin',
-      iconUrl: 'https://example.com/sui.png',
+      coinMetadata: {
+        id: '0xf256d3fb6a50eaa748d94335b34f2982fbc3b63ceec78cafaa29ebc9ebaf2bbc',
+        decimals: 9,
+        symbol: 'SUI',
+        name: 'Sui',
+        description: 'Sui native coin',
+        iconUrl: 'https://example.com/sui.png',
+      },
     })
 
     await expect(getSuiTokenMetadata({ chain: OtherChain.Sui, id })).resolves.toEqual({
@@ -33,13 +37,16 @@ describe('getSuiTokenMetadata', () => {
     expect(getCoinMetadataMock).toHaveBeenCalledWith({ coinType: id })
   })
 
-  it('omits the logo when iconUrl is missing', async () => {
+  it('omits the logo when iconUrl is null', async () => {
     getCoinMetadataMock.mockResolvedValue({
-      decimals: 6,
-      symbol: 'USDC',
-      name: 'USD Coin',
-      description: '',
-      iconUrl: null,
+      coinMetadata: {
+        id: null,
+        decimals: 6,
+        symbol: 'USDC',
+        name: 'USD Coin',
+        description: '',
+        iconUrl: null,
+      },
     })
 
     await expect(
@@ -54,8 +61,22 @@ describe('getSuiTokenMetadata', () => {
     })
   })
 
+  it('omits the logo when iconUrl is the empty string', async () => {
+    // gRPC and GraphQL both return '' (not null) for an absent icon — mainnet SUI
+    // itself does. `??` would leak that empty string through as a logo URL.
+    getCoinMetadataMock.mockResolvedValue({
+      coinMetadata: { id: null, decimals: 9, symbol: 'SUI', name: 'Sui', description: '', iconUrl: '' },
+    })
+
+    await expect(getSuiTokenMetadata({ chain: OtherChain.Sui, id: '0x2::sui::SUI' })).resolves.toEqual({
+      ticker: 'SUI',
+      decimals: 9,
+      logo: undefined,
+    })
+  })
+
   it('throws when no metadata is returned for the coin type', async () => {
-    getCoinMetadataMock.mockResolvedValue(null)
+    getCoinMetadataMock.mockResolvedValue({ coinMetadata: null })
 
     await expect(getSuiTokenMetadata({ chain: OtherChain.Sui, id: '0x123::foo::BAR' })).rejects.toThrow()
   })

--- a/packages/core/chain/coin/token/metadata/resolvers/sui.ts
+++ b/packages/core/chain/coin/token/metadata/resolvers/sui.ts
@@ -5,17 +5,21 @@ import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { TokenMetadataResolver } from '../resolver'
 
 /**
- * Resolves SUI coin metadata via the `suix_getCoinMetadata` JSON-RPC method.
+ * Resolves SUI coin metadata through the unified client's `getCoinMetadata`.
  * The `id` is the fully-qualified coin type (e.g. `0x...::module::TYPE`).
  */
 export const getSuiTokenMetadata: TokenMetadataResolver<OtherChain.Sui> = async ({ id }) => {
   const client = getSuiClient()
 
-  const metadata = shouldBePresent(await client.getCoinMetadata({ coinType: id }), `SUI coin metadata for ${id}`)
+  const { coinMetadata } = await client.getCoinMetadata({ coinType: id })
+
+  const metadata = shouldBePresent(coinMetadata, `SUI coin metadata for ${id}`)
 
   return {
     ticker: metadata.symbol,
     decimals: metadata.decimals,
-    logo: metadata.iconUrl ?? undefined,
+    // gRPC/GraphQL return an EMPTY STRING for an absent icon where JSON-RPC
+    // returned null, so `??` would leak `''` through as a logo URL.
+    logo: metadata.iconUrl || undefined,
   }
 }

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -820,10 +820,20 @@
       "import": "./dist/chains/sui/config.js",
       "default": "./dist/chains/sui/config.js"
     },
+    "./chains/sui/listAllCoins": {
+      "types": "./dist/chains/sui/listAllCoins.d.ts",
+      "import": "./dist/chains/sui/listAllCoins.js",
+      "default": "./dist/chains/sui/listAllCoins.js"
+    },
     "./chains/sui/sign": {
       "types": "./dist/chains/sui/sign.d.ts",
       "import": "./dist/chains/sui/sign.js",
       "default": "./dist/chains/sui/sign.js"
+    },
+    "./chains/sui/transactionResult": {
+      "types": "./dist/chains/sui/transactionResult.d.ts",
+      "import": "./dist/chains/sui/transactionResult.js",
+      "default": "./dist/chains/sui/transactionResult.js"
     },
     "./chains/thorchain/ruji/services/fetchMergeableTokenBalances": {
       "types": "./dist/chains/thorchain/ruji/services/fetchMergeableTokenBalances.d.ts",

--- a/packages/core/chain/tx/broadcast/resolvers/sui.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/sui.test.ts
@@ -8,36 +8,63 @@ const { mockExecute, mockVerify } = vi.hoisted(() => ({
   mockVerify: vi.fn(async () => {}),
 }))
 vi.mock('@vultisig/core-chain/chains/sui/client', () => ({
-  getSuiClient: () => ({ executeTransactionBlock: mockExecute }),
+  getSuiClient: () => ({ executeTransaction: mockExecute }),
 }))
 vi.mock('../verifyBroadcastByHash', () => ({ verifyBroadcastByHash: mockVerify }))
 
 import { broadcastSuiTx } from './sui'
 
-const tx = { unsignedTx: 'tx-block', signature: 'sig' } as never
+// `unsignedTx` is base64 (TW.Sui.Proto.SigningOutput). The resolver decodes it to BCS bytes for the
+// unified client, so the fixture must be VALID base64 ('tx-block').
+const tx = { unsignedTx: 'dHgtYmxvY2s=', signature: 'sig' } as never
 
-// A real Sui `effects.status.error` renders the aborting package's OWN module/function identifiers,
+// A real Sui execution error renders the aborting package's OWN module/function identifiers,
 // so the string is chain-controlled and can read exactly like a transient network error.
 const moveAbort = 'MoveAbort(MoveLocation { module: 0x2::pool, function_name: Some("aborted") }, 1) in command 0'
+
+const failed = (message: string) => ({
+  $kind: 'FailedTransaction' as const,
+  FailedTransaction: {
+    digest: '0xabc',
+    status: { success: false, error: { message } },
+    effects: { transactionDigest: '0xabc' },
+  },
+})
+
+const succeeded = {
+  $kind: 'Transaction' as const,
+  Transaction: {
+    digest: '0xabc',
+    status: { success: true, error: null },
+    effects: { transactionDigest: '0xabc' },
+  },
+}
 
 describe('broadcastSuiTx — sdk#1398 MoveAbort false-success', () => {
   afterEach(() => vi.clearAllMocks())
 
-  it('requests effects and throws when the tx aborts on-chain (effects.status = failure)', async () => {
-    mockExecute.mockResolvedValueOnce({
-      digest: '0xabc',
-      effects: { status: { status: 'failure', error: 'MoveAbort' } },
-    })
+  it('requests effects and throws when the tx aborts on-chain (FailedTransaction arm)', async () => {
+    mockExecute.mockResolvedValueOnce(failed('MoveAbort'))
     await expect(broadcastSuiTx({ chain: OtherChain.Sui, tx })).rejects.toThrow(/failed on-chain/i)
-    expect(mockExecute).toHaveBeenCalledWith(expect.objectContaining({ options: { showEffects: true } }))
+    expect(mockExecute).toHaveBeenCalledWith(expect.objectContaining({ include: { effects: true } }))
     // A genuinely-failed Move is NOT fed back into verifyBroadcastByHash (it's on-chain, not un-broadcast).
     expect(mockVerify).not.toHaveBeenCalled()
   })
 
-  it('fails closed when effects status is missing/unknown (must not default to success)', async () => {
-    // With showEffects requested a real Sui RPC always returns effects; a response WITHOUT an
-    // explicit 'success' status is not proven execution success and must NOT be reported as one.
-    mockExecute.mockResolvedValueOnce({ digest: '0xabc' })
+  it('throws on a Transaction arm whose execution status says failure', async () => {
+    // The union arm and the status must BOTH say success; a mismatched pair is not proven success.
+    mockExecute.mockResolvedValueOnce({
+      $kind: 'Transaction',
+      Transaction: { digest: '0xabc', status: { success: false, error: { message: 'InsufficientGas' } } },
+    })
+    await expect(broadcastSuiTx({ chain: OtherChain.Sui, tx })).rejects.toThrow(/InsufficientGas/)
+    expect(mockVerify).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when execution status is missing/unknown (must not default to success)', async () => {
+    // With effects requested a real endpoint always returns a status; a response WITHOUT an
+    // explicit success is not proven execution success and must NOT be reported as one.
+    mockExecute.mockResolvedValueOnce({ $kind: 'Transaction', Transaction: { digest: '0xabc' } })
     await expect(broadcastSuiTx({ chain: OtherChain.Sui, tx })).rejects.toThrow()
     expect(mockVerify).not.toHaveBeenCalled()
   })
@@ -50,7 +77,7 @@ describe('broadcastSuiTx — sdk#1398 MoveAbort false-success', () => {
     // short-circuit on the `instanceof` BEFORE that regex ever runs. Keep this fixture
     // regex-matching: with a message that matches nothing, the assertion passes on a bare Error too
     // and the guard goes inert.
-    mockExecute.mockResolvedValueOnce({ digest: '0xabc', effects: { status: { status: 'failure', error: moveAbort } } })
+    mockExecute.mockResolvedValueOnce(failed(moveAbort))
     const err = await broadcastSuiTx({ chain: OtherChain.Sui, tx }).catch((e: unknown) => e)
     expect(isTransientBroadcastError(err)).toBe(false)
     // Red-on-revert anchor: prove the fixture really does trip the message regex, so the assertion
@@ -64,7 +91,7 @@ describe('broadcastSuiTx — sdk#1398 MoveAbort false-success', () => {
   it('does not re-broadcast an on-chain MoveAbort when run through withTransientBroadcastRetry', async () => {
     // Same chain-controlled text as above — a fixture the transient regex does NOT match would let
     // this pass on a bare Error and prove nothing about the wrapper.
-    mockExecute.mockResolvedValue({ digest: '0xabc', effects: { status: { status: 'failure', error: moveAbort } } })
+    mockExecute.mockResolvedValue(failed(moveAbort))
 
     await expect(withTransientBroadcastRetry(() => broadcastSuiTx({ chain: OtherChain.Sui, tx }))).rejects.toThrow(
       /failed on-chain/i
@@ -75,10 +102,20 @@ describe('broadcastSuiTx — sdk#1398 MoveAbort false-success', () => {
   })
 
   it('returns the response when the tx executes successfully', async () => {
-    const response = { digest: '0xabc', effects: { status: { status: 'success' } } }
-    mockExecute.mockResolvedValueOnce(response)
-    await expect(broadcastSuiTx({ chain: OtherChain.Sui, tx })).resolves.toBe(response)
+    mockExecute.mockResolvedValueOnce(succeeded)
+    await expect(broadcastSuiTx({ chain: OtherChain.Sui, tx })).resolves.toBe(succeeded)
     expect(mockVerify).not.toHaveBeenCalled()
+  })
+
+  it('sends decoded BCS bytes and the signature under the unified request shape', async () => {
+    mockExecute.mockResolvedValueOnce(succeeded)
+    await broadcastSuiTx({ chain: OtherChain.Sui, tx })
+
+    const request = mockExecute.mock.calls[0]?.[0]
+    // gRPC/GraphQL take raw bytes + `signatures[]`, NOT a base64 `transactionBlock` + `signature[]`.
+    expect(request.transaction).toBeInstanceOf(Uint8Array)
+    expect(new TextDecoder().decode(request.transaction)).toBe('tx-block')
+    expect(request.signatures).toEqual(['sig'])
   })
 
   it('verifies by hash on an RPC-level error (unchanged behavior)', async () => {

--- a/packages/core/chain/tx/broadcast/resolvers/sui.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/sui.ts
@@ -1,37 +1,32 @@
+import { fromBase64 } from '@mysten/sui/utils'
 import { OtherChain } from '@vultisig/core-chain/Chain'
 import { getSuiClient } from '@vultisig/core-chain/chains/sui/client'
+import {
+  describeSuiExecutionFailure,
+  isSuiExecutionSuccess,
+  SuiTransactionResultLike,
+} from '@vultisig/core-chain/chains/sui/transactionResult'
 import { attempt } from '@vultisig/lib-utils/attempt'
 
 import { BroadcastTxResolver } from '../resolver'
 import { DeliverTxFailedError } from '../transientRetry'
 import { verifyBroadcastByHash } from '../verifyBroadcastByHash'
 
-type SuiExecutionEffects = {
-  status?: {
-    status?: string
-    error?: string | null
-  }
-}
+export const assertSuiTxSucceeded = (result: SuiTransactionResultLike | null | undefined): void => {
+  if (isSuiExecutionSuccess(result)) return
 
-export const assertSuiTxSucceeded = (effects: SuiExecutionEffects | null | undefined): void => {
-  const executionStatus = effects?.status?.status
-
-  if (executionStatus === 'success') return
-
-  throw new DeliverTxFailedError(
-    `Sui transaction failed on-chain: ${effects?.status?.error ?? executionStatus ?? 'no effects status returned'}`
-  )
+  throw new DeliverTxFailedError(`Sui transaction failed on-chain: ${describeSuiExecutionFailure(result)}`)
 }
 
 export const broadcastSuiTx: BroadcastTxResolver<OtherChain.Sui> = async ({ chain, tx }) => {
   const { data: response, error } = await attempt(
-    getSuiClient().executeTransactionBlock({
-      transactionBlock: tx.unsignedTx,
-      signature: [tx.signature],
-      // sdk#1398: without requesting effects, executeTransactionBlock resolves with a digest even
-      // when the tx executed but ABORTED (MoveAbort / InsufficientGas) — an RPC-level success that
-      // is NOT execution success. Ask for effects so we can tell the two apart.
-      options: { showEffects: true },
+    getSuiClient().executeTransaction({
+      transaction: fromBase64(tx.unsignedTx),
+      signatures: [tx.signature],
+      // sdk#1398: without requesting effects, execution resolves with a digest even when the tx
+      // executed but ABORTED (MoveAbort / InsufficientGas) — an RPC-level success that is NOT
+      // execution success. Ask for effects so we can tell the two apart.
+      include: { effects: true },
     })
   )
 
@@ -44,17 +39,17 @@ export const broadcastSuiTx: BroadcastTxResolver<OtherChain.Sui> = async ({ chai
     return
   }
 
-  // Mirror the status resolver (status/resolvers/sui.ts): ONLY an explicit 'success' effects status
-  // is execution success. A 'failure' (MoveAbort / InsufficientGas) — or a missing/unknown status —
-  // must NOT be returned as a digest-carrying successful broadcast (that's the sdk#1398 bug). Thrown
-  // outside the RPC-error path above so it isn't fed back into verifyBroadcastByHash — the tx is
-  // on-chain and failed, not un-broadcast.
+  // Mirror the status resolver (status/resolvers/sui.ts): ONLY an explicit `$kind: 'Transaction'`
+  // with `status.success === true` is execution success. A `FailedTransaction` (MoveAbort /
+  // InsufficientGas) — or a missing/unknown status — must NOT be returned as a digest-carrying
+  // successful broadcast (that's the sdk#1398 bug). Thrown outside the RPC-error path above so it
+  // isn't fed back into verifyBroadcastByHash — the tx is on-chain and failed, not un-broadcast.
   //
   // Throw DeliverTxFailedError (not a bare Error) so isTransientBroadcastError short-circuits on the
   // `instanceof` BEFORE its message-regex runs: a Sui abort error string routinely contains
   // "aborted"/"timed out", which the transient patterns match — a bare Error would be misclassified
   // as transient and the aborted tx re-sent by withTransientBroadcastRetry.
-  assertSuiTxSucceeded(response.effects)
+  assertSuiTxSucceeded(response)
 
   return response
 }

--- a/packages/core/chain/tx/broadcast/transientRetry.grpc.test.ts
+++ b/packages/core/chain/tx/broadcast/transientRetry.grpc.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import { DeliverTxFailedError, isTransientBroadcastError } from './transientRetry'
+
+// Sui retired JSON-RPC, so its broadcasts now fail through gRPC. `@protobuf-ts`
+// surfaces the grpc-status/grpc-message trailer pair as an `RpcError` whose `code`
+// is the status NAME and whose `message` is still PERCENT-ENCODED (grpc-web escapes
+// the trailer). Both fixtures here are verbatim mainnet captures from
+// `fullnode.mainnet.sui.io`.
+const rpcError = (message: string, code: string) => Object.assign(new Error(message), { code })
+
+describe('isTransientBroadcastError — gRPC transport', () => {
+  it.each(['UNAVAILABLE', 'DEADLINE_EXCEEDED', 'RESOURCE_EXHAUSTED'])(
+    'retries the %s grpc status (a busy/restarting node used to arrive as an HTTP 5xx)',
+    status => {
+      // A grpc-web response is HTTP 200 with the real status in the trailer, so the
+      // existing 5xx branch never sees these.
+      expect(isTransientBroadcastError(rpcError('node%20restarting', status))).toBe(true)
+    }
+  )
+
+  it.each([
+    ['INVALID_ARGUMENT', 'invalid%20signature:%20missing%20signature%20scheme%20flag'],
+    ['NOT_FOUND', 'Transaction%2011111111111111111111111111111111%20not%20found'],
+    ['FAILED_PRECONDITION', 'object%20version%20unavailable'],
+  ])('does not retry the %s grpc status (a verdict about the request, not the connection)', (status, message) => {
+    expect(isTransientBroadcastError(rpcError(message, status))).toBe(false)
+  })
+
+  it('decodes the percent-encoded grpc-message so genuinely transient text still matches', () => {
+    // Without decoding, a space-bearing pattern (`connection reset`) can never match
+    // the raw wire text and a retryable failure is misread as permanent.
+    expect(isTransientBroadcastError(new Error('connection%20reset%20by%20peer'))).toBe(true)
+    expect(isTransientBroadcastError(new Error('request%20timed%20out'))).toBe(true)
+    // Red-on-revert anchor: the same text undecoded matches nothing.
+    expect(/\bconnection (?:reset|refused|closed)\b/i.test('connection%20reset%20by%20peer')).toBe(false)
+  })
+
+  it('leaves a malformed percent-escape alone instead of throwing', () => {
+    // decodeURIComponent throws on a stray '%'; classification must survive it.
+    expect(() => isTransientBroadcastError(new Error('100% failure, no retry signal'))).not.toThrow()
+    expect(isTransientBroadcastError(new Error('100% failure, no retry signal'))).toBe(false)
+    // A stray '%' must not mask a real transient signal either.
+    expect(isTransientBroadcastError(new Error('100% packet loss: socket hang up'))).toBe(true)
+  })
+
+  it('still refuses to retry an on-chain execution failure even under a transient-looking status', () => {
+    // The DeliverTxFailedError marker short-circuits BEFORE any code/message test —
+    // a Sui MoveAbort's chain-controlled text routinely contains "aborted".
+    const aborted = Object.assign(new DeliverTxFailedError('Sui transaction failed on-chain: MoveAbort ... aborted'), {
+      code: 'UNAVAILABLE',
+    })
+    expect(isTransientBroadcastError(aborted)).toBe(false)
+  })
+})

--- a/packages/core/chain/tx/broadcast/transientRetry.grpc.test.ts
+++ b/packages/core/chain/tx/broadcast/transientRetry.grpc.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { DeliverTxFailedError, isTransientBroadcastError } from './transientRetry'
 
-// Sui retired JSON-RPC, so its broadcasts now fail through gRPC. `@protobuf-ts`
+// Sui is retiring JSON-RPC, so its broadcasts now go over gRPC. `@protobuf-ts`
 // surfaces the grpc-status/grpc-message trailer pair as an `RpcError` whose `code`
 // is the status NAME and whose `message` is still PERCENT-ENCODED (grpc-web escapes
 // the trailer). Both fixtures here are verbatim mainnet captures from

--- a/packages/core/chain/tx/broadcast/transientRetry.ts
+++ b/packages/core/chain/tx/broadcast/transientRetry.ts
@@ -38,6 +38,33 @@ const transientErrorCodes = new Set([
   'EAI_AGAIN',
 ])
 
+// gRPC statuses (Sui, since it retired JSON-RPC). `@protobuf-ts` surfaces the
+// grpc-status trailer as `RpcError.code`, holding the status NAME — so these land
+// in the same `code` slot as the errno strings above.
+//
+// Deliberately only the three the gRPC project itself calls safe to retry. Under
+// JSON-RPC a busy or restarting node surfaced as an HTTP 5xx and was retried by the
+// status branch below; without this set that coverage silently disappears, because a
+// grpc-web response is HTTP 200 with the real status in the trailer.
+//
+// Excluded on purpose: INVALID_ARGUMENT / NOT_FOUND / FAILED_PRECONDITION are verdicts
+// about the request itself, and ABORTED / INTERNAL are ambiguous enough that retrying
+// could re-send bytes the chain already rejected.
+const transientGrpcStatuses = new Set(['UNAVAILABLE', 'DEADLINE_EXCEEDED', 'RESOURCE_EXHAUSTED'])
+
+// grpc-web percent-encodes the grpc-message trailer, so a server-produced message
+// arrives as `connection%20reset` and none of the space-bearing patterns below can
+// match it. Decode before testing (falling back to the raw text on a malformed escape)
+// so gRPC errors are classified on the same footing as every other transport's.
+const decodeTransportMessage = (message: string): string => {
+  if (!message.includes('%')) return message
+  try {
+    return decodeURIComponent(message)
+  } catch {
+    return message
+  }
+}
+
 const transientMessagePatterns = [
   /\bfetch failed\b/i,
   /\bfailed to fetch\b/i,
@@ -82,7 +109,7 @@ export const isTransientBroadcastError = (error: unknown): boolean => {
 
     if (typeof current === 'object') {
       const code = (current as { code?: unknown }).code
-      if (typeof code === 'string' && transientErrorCodes.has(code)) {
+      if (typeof code === 'string' && (transientErrorCodes.has(code) || transientGrpcStatuses.has(code))) {
         return true
       }
 
@@ -92,7 +119,8 @@ export const isTransientBroadcastError = (error: unknown): boolean => {
       }
     }
 
-    const message = current instanceof Error ? current.message : typeof current === 'string' ? current : undefined
+    const rawMessage = current instanceof Error ? current.message : typeof current === 'string' ? current : undefined
+    const message = rawMessage === undefined ? undefined : decodeTransportMessage(rawMessage)
     if (message && transientMessagePatterns.some(pattern => pattern.test(message))) {
       return true
     }

--- a/packages/core/chain/tx/hash/resolvers/sui.test.ts
+++ b/packages/core/chain/tx/hash/resolvers/sui.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({ simulateTransaction: vi.fn() }))
+
+vi.mock('@vultisig/core-chain/chains/sui/client', () => ({
+  getSuiClient: () => ({ simulateTransaction: mocks.simulateTransaction }),
+}))
+
+import { getSuiTxHash } from './sui'
+
+const digest = 'BWWMRhDrfnMWiLCsGqcvJZGDLGGkTKAyLQMJVGqZ4Vzq'
+// base64 of 'tx-block'
+const unsignedTx = 'dHgtYmxvY2s='
+const tx = { unsignedTx } as never
+
+describe('getSuiTxHash — simulateTransaction replaces dryRunTransactionBlock', () => {
+  beforeEach(() => mocks.simulateTransaction.mockReset())
+
+  it('simulates with decoded BCS bytes and returns the effects digest', async () => {
+    mocks.simulateTransaction.mockResolvedValueOnce({
+      $kind: 'Transaction',
+      Transaction: { status: { success: true, error: null }, effects: { transactionDigest: digest } },
+    })
+
+    await expect(getSuiTxHash(tx)).resolves.toBe(digest)
+
+    const request = mocks.simulateTransaction.mock.calls[0]?.[0]
+    // The unified API takes raw bytes, not the base64 string JSON-RPC accepted.
+    expect(request.transaction).toBeInstanceOf(Uint8Array)
+    expect(new TextDecoder().decode(request.transaction)).toBe('tx-block')
+    expect(request.include).toEqual({ effects: true })
+  })
+
+  it('still returns the digest when the simulation itself fails execution', async () => {
+    // A simulated MoveAbort still produces effects with a digest — and broadcast
+    // hash-verification needs exactly that digest to look the tx up on-chain.
+    mocks.simulateTransaction.mockResolvedValueOnce({
+      $kind: 'FailedTransaction',
+      FailedTransaction: {
+        status: { success: false, error: { message: 'MoveAbort' } },
+        effects: { transactionDigest: digest },
+      },
+    })
+
+    await expect(getSuiTxHash(tx)).resolves.toBe(digest)
+  })
+
+  it('throws rather than returning an empty hash when no digest comes back', async () => {
+    // `digest` (top level) is NOT populated for a simulation — only the effects
+    // carry it. Reading the wrong field must fail loudly, not yield undefined.
+    mocks.simulateTransaction.mockResolvedValueOnce({
+      $kind: 'Transaction',
+      Transaction: { digest, status: { success: true, error: null } },
+    })
+
+    await expect(getSuiTxHash(tx)).rejects.toThrow()
+  })
+})

--- a/packages/core/chain/tx/hash/resolvers/sui.ts
+++ b/packages/core/chain/tx/hash/resolvers/sui.ts
@@ -1,16 +1,27 @@
+import { fromBase64 } from '@mysten/sui/utils'
 import { OtherChain } from '@vultisig/core-chain/Chain'
 import { getSuiClient } from '@vultisig/core-chain/chains/sui/client'
+import { getSuiResultTransaction } from '@vultisig/core-chain/chains/sui/transactionResult'
+import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 
 import { TxHashResolver } from '../resolver'
 
 export const getSuiTxHash: TxHashResolver<OtherChain.Sui> = async ({ unsignedTx }) => {
   const client = getSuiClient()
 
-  const {
-    effects: { transactionDigest },
-  } = await client.dryRunTransactionBlock({
-    transactionBlock: unsignedTx,
+  // `simulateTransaction` replaces the retired `dryRunTransactionBlock`. It
+  // takes raw BCS bytes rather than a base64 string, and the digest lives on
+  // the EFFECTS — the top-level `digest` is not populated for a simulation.
+  // A simulation whose execution fails still returns effects carrying the
+  // digest, which is exactly what broadcast hash-verification needs, so read
+  // it off whichever arm of the result union came back.
+  const result = await client.simulateTransaction({
+    transaction: fromBase64(unsignedTx),
+    include: { effects: true },
   })
 
-  return transactionDigest
+  return shouldBePresent(
+    getSuiResultTransaction(result)?.effects?.transactionDigest,
+    'Sui simulated transaction digest'
+  )
 }

--- a/packages/core/chain/tx/status/resolvers/isknown-contract.test.ts
+++ b/packages/core/chain/tx/status/resolvers/isknown-contract.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   getSuiClient: vi.fn(),
-  getTransactionBlock: vi.fn(),
+  getTransaction: vi.fn(),
   queryUrl: vi.fn(),
 }))
 
@@ -28,18 +28,27 @@ describe('status resolver isKnown contract', () => {
     vi.clearAllMocks()
     vi.unstubAllGlobals()
     mocks.getSuiClient.mockReturnValue({
-      getTransactionBlock: mocks.getTransactionBlock,
+      getTransaction: mocks.getTransaction,
     })
   })
 
   it('marks Sui lookup failures and unknown hashes as not known', async () => {
-    mocks.getTransactionBlock.mockRejectedValueOnce(new Error('not found'))
+    // The unified client REJECTS on an unknown digest ("missing digest") rather
+    // than resolving to null — both must land in the not-known branch.
+    mocks.getTransaction.mockRejectedValueOnce(new Error('missing digest'))
     await expect(getSuiTxStatus({ chain: OtherChain.Sui, hash })).resolves.toEqual({
       status: 'pending',
       isKnown: false,
     })
 
-    mocks.getTransactionBlock.mockResolvedValueOnce(null)
+    mocks.getTransaction.mockResolvedValueOnce(null)
+    await expect(getSuiTxStatus({ chain: OtherChain.Sui, hash })).resolves.toEqual({
+      status: 'pending',
+      isKnown: false,
+    })
+
+    // A result union with neither arm populated carries no transaction at all.
+    mocks.getTransaction.mockResolvedValueOnce({})
     await expect(getSuiTxStatus({ chain: OtherChain.Sui, hash })).resolves.toEqual({
       status: 'pending',
       isKnown: false,
@@ -47,7 +56,8 @@ describe('status resolver isKnown contract', () => {
   })
 
   it('marks non-terminal Sui responses as known pending', async () => {
-    mocks.getTransactionBlock.mockResolvedValueOnce({ effects: { status: { status: 'pending' } } })
+    // Indexed, but no terminal execution status yet.
+    mocks.getTransaction.mockResolvedValueOnce({ $kind: 'Transaction', Transaction: { digest: hash } })
 
     await expect(getSuiTxStatus({ chain: OtherChain.Sui, hash })).resolves.toEqual({
       status: 'pending',

--- a/packages/core/chain/tx/status/resolvers/sui.test.ts
+++ b/packages/core/chain/tx/status/resolvers/sui.test.ts
@@ -1,0 +1,95 @@
+import { OtherChain } from '@vultisig/core-chain/Chain'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({ getTransaction: vi.fn() }))
+
+vi.mock('@vultisig/core-chain/chains/sui/client', () => ({
+  getSuiClient: () => ({ getTransaction: mocks.getTransaction }),
+}))
+
+import { getSuiTxStatus } from './sui'
+
+const hash = 'BWWMRhDrfnMWiLCsGqcvJZGDLGGkTKAyLQMJVGqZ4Vzq'
+
+describe('getSuiTxStatus — unified client result union', () => {
+  beforeEach(() => mocks.getTransaction.mockReset())
+
+  it('asks for effects by digest', async () => {
+    mocks.getTransaction.mockResolvedValueOnce({ $kind: 'Transaction', Transaction: {} })
+    await getSuiTxStatus({ chain: OtherChain.Sui, hash })
+
+    expect(mocks.getTransaction).toHaveBeenCalledWith({ digest: hash, include: { effects: true } })
+  })
+
+  it('reports success with a fee receipt derived from gasUsed', async () => {
+    mocks.getTransaction.mockResolvedValueOnce({
+      $kind: 'Transaction',
+      Transaction: {
+        status: { success: true, error: null },
+        effects: {
+          transactionDigest: hash,
+          gasUsed: {
+            computationCost: '1000000',
+            storageCost: '2000000',
+            storageRebate: '500000',
+            nonRefundableStorageFee: '20000',
+          },
+        },
+      },
+    })
+
+    await expect(getSuiTxStatus({ chain: OtherChain.Sui, hash })).resolves.toEqual({
+      status: 'success',
+      receipt: {
+        // computation + storage - rebate; nonRefundableStorageFee is NOT part of the charge.
+        feeAmount: 2_500_000n,
+        feeDecimals: 9,
+        feeTicker: 'SUI',
+      },
+    })
+  })
+
+  it('omits the receipt when the success response carries no gas breakdown', async () => {
+    mocks.getTransaction.mockResolvedValueOnce({
+      $kind: 'Transaction',
+      Transaction: { status: { success: true, error: null }, effects: { transactionDigest: hash } },
+    })
+
+    await expect(getSuiTxStatus({ chain: OtherChain.Sui, hash })).resolves.toEqual({
+      status: 'success',
+      receipt: undefined,
+    })
+  })
+
+  it('reports a finalized on-chain failure as error (sdk#1398)', async () => {
+    mocks.getTransaction.mockResolvedValueOnce({
+      $kind: 'FailedTransaction',
+      FailedTransaction: {
+        status: { success: false, error: { message: 'MoveAbort' } },
+        effects: { transactionDigest: hash },
+      },
+    })
+
+    await expect(getSuiTxStatus({ chain: OtherChain.Sui, hash })).resolves.toEqual({ status: 'error' })
+  })
+
+  it('reports error when the Transaction arm itself carries a failed status', async () => {
+    mocks.getTransaction.mockResolvedValueOnce({
+      $kind: 'Transaction',
+      Transaction: { status: { success: false, error: { message: 'InsufficientGas' } } },
+    })
+
+    await expect(getSuiTxStatus({ chain: OtherChain.Sui, hash })).resolves.toEqual({ status: 'error' })
+  })
+
+  it('does not report success on a FailedTransaction arm that claims success', async () => {
+    // Defense in depth: the arm is the authoritative signal, so a contradictory
+    // status must never be upgraded to a success + fee receipt.
+    mocks.getTransaction.mockResolvedValueOnce({
+      $kind: 'FailedTransaction',
+      FailedTransaction: { status: { success: true, error: null } },
+    })
+
+    await expect(getSuiTxStatus({ chain: OtherChain.Sui, hash })).resolves.toEqual({ status: 'error' })
+  })
+})

--- a/packages/core/chain/tx/status/resolvers/sui.ts
+++ b/packages/core/chain/tx/status/resolvers/sui.ts
@@ -1,5 +1,6 @@
 import { Chain, OtherChain } from '@vultisig/core-chain/Chain'
 import { getSuiClient } from '@vultisig/core-chain/chains/sui/client'
+import { getSuiResultTransaction, isSuiExecutionSuccess } from '@vultisig/core-chain/chains/sui/transactionResult'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { attempt } from '@vultisig/lib-utils/attempt'
 
@@ -8,10 +9,13 @@ import { TxStatusResolver } from '../resolver'
 export const getSuiTxStatus: TxStatusResolver<OtherChain.Sui> = async ({ hash }) => {
   const client = getSuiClient()
 
+  // `getTransaction` replaces the retired `getTransactionBlock`. An unknown
+  // digest REJECTS ("missing digest") rather than resolving to null, which the
+  // attempt() wrapper already funnels into the not-known branch below.
   const { data, error } = await attempt(
-    client.getTransactionBlock({
+    client.getTransaction({
       digest: hash,
-      options: { showEffects: true },
+      include: { effects: true },
     })
   )
 
@@ -19,10 +23,14 @@ export const getSuiTxStatus: TxStatusResolver<OtherChain.Sui> = async ({ hash })
     return { status: 'pending', isKnown: false }
   }
 
-  const effectsStatus = data.effects?.status?.status
+  const transaction = getSuiResultTransaction(data)
 
-  if (effectsStatus === 'success') {
-    const gasUsed = data.effects?.gasUsed
+  if (!transaction) {
+    return { status: 'pending', isKnown: false }
+  }
+
+  if (isSuiExecutionSuccess(data)) {
+    const gasUsed = transaction.effects?.gasUsed
     const feeCoin = chainFeeCoin[Chain.Sui]
     const receipt =
       gasUsed != null &&
@@ -43,7 +51,9 @@ export const getSuiTxStatus: TxStatusResolver<OtherChain.Sui> = async ({ hash })
     return { status: 'success', receipt }
   }
 
-  if (effectsStatus === 'failure') {
+  // A `FailedTransaction` arm, or an explicit `status.success === false`, is a
+  // finalized on-chain failure (MoveAbort / InsufficientGas).
+  if (data.$kind === 'FailedTransaction' || transaction.status?.success === false) {
     return { status: 'error' }
   }
 

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/sui/index.test.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/sui/index.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockListCoins, mockGetReferenceGasPrice } = vi.hoisted(() => ({
+const { mockListCoins, mockGetReferenceGasPrice, mockGetKeysignCoin } = vi.hoisted(() => ({
   mockListCoins: vi.fn(),
   mockGetReferenceGasPrice: vi.fn(async () => ({ referenceGasPrice: '1000' })),
+  mockGetKeysignCoin: vi.fn(() => ({ address: '0xsender', id: undefined }) as { address: string; id?: string }),
 }))
 
 vi.mock('@vultisig/core-chain/chains/sui/client', () => ({
@@ -15,7 +16,7 @@ vi.mock('@vultisig/core-chain/chains/sui/config', () => ({
   suiGasBudget: 3_000_000n,
 }))
 vi.mock('../../../utils/getKeysignCoin', () => ({
-  getKeysignCoin: () => ({ address: '0xsender', id: undefined }),
+  getKeysignCoin: mockGetKeysignCoin,
 }))
 // Force the fallback branch so the resolver returns the raw chainSpecific
 // (with every paginated coin) rather than a walletCore-refined payload.
@@ -30,11 +31,11 @@ import { getSuiChainSpecific } from './index'
 const suiType = '0x2::sui::SUI'
 // The unified client returns coin OBJECTS: `objectId` plus the full `Coin<...>`
 // wrapper type, not JSON-RPC's `coinObjectId` plus the inner `coinType`.
-const makeCoin = (i: number, balance = '1') => ({
+const makeCoin = (i: number, balance = '1', coinType = suiType) => ({
   objectId: `0xobj${i}`,
   version: `${i}`,
   digest: `dig${i}`,
-  type: `0x2::coin::Coin<${suiType}>`,
+  type: `0x2::coin::Coin<${coinType}>`,
   balance,
   owner: { $kind: 'AddressOwner', AddressOwner: '0xsender' },
 })
@@ -46,6 +47,8 @@ const payload = {
 } as unknown as Parameters<typeof getSuiChainSpecific>[0]['keysignPayload']
 
 describe('getSuiChainSpecific — listCoins pagination', () => {
+  beforeEach(() => mockGetKeysignCoin.mockReturnValue({ address: '0xsender', id: undefined }))
+
   it('follows the cursor across pages so the full coin set feeds gas/input selection', async () => {
     // Three pages of 50, 50, 7 — a single-page read silently truncates the set.
     mockListCoins
@@ -156,5 +159,68 @@ describe('getSuiChainSpecific — listCoins pagination', () => {
     })
 
     expect(res.coins.map(c => c.coinObjectId)).toEqual(['0xobj0'])
+  })
+})
+
+// `listCoins` is scoped to ONE coin type, unlike the retired `getAllCoins` sweep, so a
+// token send has to ask for two sets. Getting this wrong is not a visible error: it
+// yields an empty `inputCoins` (nothing to send) or a missing gas object.
+describe('getSuiChainSpecific — non-native token sends need two coin listings', () => {
+  const tokenType = '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC'
+
+  const pageFor = (coinType: string) => {
+    if (coinType === suiType) {
+      return { objects: [makeCoin(0, '3000001')], hasNextPage: false, cursor: null }
+    }
+    return { objects: [makeCoin(1, '5000000', tokenType)], hasNextPage: false, cursor: null }
+  }
+
+  it('lists the native SUI objects (for gas) AND the sent token type', async () => {
+    mockGetKeysignCoin.mockReturnValue({ address: '0xsender', id: tokenType })
+    mockListCoins.mockReset().mockImplementation(async ({ coinType }: { coinType: string }) => pageFor(coinType))
+
+    const res = await getSuiChainSpecific({ keysignPayload: payload, walletCore: {} as never })
+
+    expect(mockListCoins).toHaveBeenCalledTimes(2)
+    expect(mockListCoins.mock.calls.map(([req]) => req.coinType).sort()).toEqual([tokenType, suiType].sort())
+
+    // The token object funds the transfer; the native object is carried as the gas
+    // candidate. Both must survive into the payload.
+    const byType = res.coins.map(c => c.coinType)
+    expect(byType).toContain(tokenType)
+    expect(byType).toContain(suiType)
+  })
+
+  it('does not list SUI twice when the payload names SUI as its token id', async () => {
+    // A second listing would put every native object into the selection pool twice.
+    //
+    // Scope note: `selectSuiPayloadCoins` ALREADY emits this object twice for this
+    // payload shape (once as the selected "token", once as a gas candidate) because
+    // `isNativeToken` is `!coin.id` while the coin-type filter resolves to SUI. That
+    // is pre-existing selection behaviour, unchanged by this transport migration and
+    // not reachable from `getKeysignCoin` in practice (it leaves `id` empty for
+    // native sends), so it is deliberately not touched here. What this test pins is
+    // the part this change owns: exactly ONE network listing.
+    mockGetKeysignCoin.mockReturnValue({ address: '0xsender', id: suiType })
+    mockListCoins.mockReset().mockResolvedValue(pageFor(suiType))
+
+    const res = await getSuiChainSpecific({ keysignPayload: payload, walletCore: {} as never })
+
+    expect(mockListCoins).toHaveBeenCalledTimes(1)
+    expect(mockListCoins.mock.calls[0]?.[0]).toMatchObject({ coinType: suiType })
+    // Only the one object that was actually listed appears — no phantom second fetch.
+    expect(new Set(res.coins.map(c => c.coinObjectId))).toEqual(new Set(['0xobj0']))
+  })
+
+  it('does not list SUI twice for a non-canonical spelling of the native type', async () => {
+    // `0x2::sui::SUI` and its zero-padded form are the same coin type; comparison must
+    // normalize, or the padded spelling silently duplicates the native set.
+    const padded = '0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI'
+    mockGetKeysignCoin.mockReturnValue({ address: '0xsender', id: padded })
+    mockListCoins.mockReset().mockResolvedValue(pageFor(suiType))
+
+    await getSuiChainSpecific({ keysignPayload: payload, walletCore: {} as never })
+
+    expect(mockListCoins).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/sui/index.test.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/sui/index.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it, vi } from 'vitest'
 
-const { mockGetAllCoins, mockGetReferenceGasPrice } = vi.hoisted(() => ({
-  mockGetAllCoins: vi.fn(),
-  mockGetReferenceGasPrice: vi.fn(async () => 1000n),
+const { mockListCoins, mockGetReferenceGasPrice } = vi.hoisted(() => ({
+  mockListCoins: vi.fn(),
+  mockGetReferenceGasPrice: vi.fn(async () => ({ referenceGasPrice: '1000' })),
 }))
 
 vi.mock('@vultisig/core-chain/chains/sui/client', () => ({
   getSuiClient: () => ({
-    getAllCoins: mockGetAllCoins,
+    listCoins: mockListCoins,
     getReferenceGasPrice: mockGetReferenceGasPrice,
   }),
 }))
@@ -28,13 +28,15 @@ vi.mock('./refine', () => ({
 import { getSuiChainSpecific } from './index'
 
 const suiType = '0x2::sui::SUI'
+// The unified client returns coin OBJECTS: `objectId` plus the full `Coin<...>`
+// wrapper type, not JSON-RPC's `coinObjectId` plus the inner `coinType`.
 const makeCoin = (i: number, balance = '1') => ({
-  coinType: suiType,
-  coinObjectId: `0xobj${i}`,
+  objectId: `0xobj${i}`,
   version: `${i}`,
   digest: `dig${i}`,
+  type: `0x2::coin::Coin<${suiType}>`,
   balance,
-  previousTransaction: `tx${i}`,
+  owner: { $kind: 'AddressOwner', AddressOwner: '0xsender' },
 })
 
 const payload = {
@@ -43,24 +45,25 @@ const payload = {
   toAmount: '1',
 } as unknown as Parameters<typeof getSuiChainSpecific>[0]['keysignPayload']
 
-describe('getSuiChainSpecific — getAllCoins pagination', () => {
-  it('follows nextCursor across pages so the full coin set feeds gas/input selection', async () => {
-    // Three pages of 50, 50, 7 — the pre-fix code read only the first page.
-    mockGetAllCoins
+describe('getSuiChainSpecific — listCoins pagination', () => {
+  it('follows the cursor across pages so the full coin set feeds gas/input selection', async () => {
+    // Three pages of 50, 50, 7 — a single-page read silently truncates the set.
+    mockListCoins
+      .mockReset()
       .mockResolvedValueOnce({
-        data: Array.from({ length: 50 }, (_, i) => makeCoin(i)),
+        objects: Array.from({ length: 50 }, (_, i) => makeCoin(i)),
         hasNextPage: true,
-        nextCursor: 'cur1',
+        cursor: 'cur1',
       })
       .mockResolvedValueOnce({
-        data: Array.from({ length: 50 }, (_, i) => makeCoin(50 + i)),
+        objects: Array.from({ length: 50 }, (_, i) => makeCoin(50 + i)),
         hasNextPage: true,
-        nextCursor: 'cur2',
+        cursor: 'cur2',
       })
       .mockResolvedValueOnce({
-        data: [makeCoin(100, '3000001'), ...Array.from({ length: 6 }, (_, i) => makeCoin(101 + i))],
+        objects: [makeCoin(100, '3000001'), ...Array.from({ length: 6 }, (_, i) => makeCoin(101 + i))],
         hasNextPage: false,
-        nextCursor: null,
+        cursor: null,
       })
 
     const res = await getSuiChainSpecific({
@@ -68,40 +71,66 @@ describe('getSuiChainSpecific — getAllCoins pagination', () => {
       walletCore: {} as never,
     })
 
-    expect(mockGetAllCoins).toHaveBeenCalledTimes(3)
+    expect(mockListCoins).toHaveBeenCalledTimes(3)
     expect(res.coins.map(coin => coin.coinObjectId)).toEqual(['0xobj100'])
+    // The wrapper type is unwrapped back to the inner coin type the payload stores,
+    // which is what every downstream coin-type comparison matches against.
+    expect(res.coins.map(coin => coin.coinType)).toEqual([suiType])
     // Cursor from each page is threaded into the next request.
-    expect(mockGetAllCoins.mock.calls[1]?.[0]).toMatchObject({
-      cursor: 'cur1',
-    })
-    expect(mockGetAllCoins.mock.calls[2]?.[0]).toMatchObject({
-      cursor: 'cur2',
-    })
+    expect(mockListCoins.mock.calls[1]?.[0]).toMatchObject({ cursor: 'cur1' })
+    expect(mockListCoins.mock.calls[2]?.[0]).toMatchObject({ cursor: 'cur2' })
   })
 
-  it('fails closed (throws, no infinite loop) when the RPC cursor never advances', async () => {
-    // A misbehaving RPC that keeps claiming hasNextPage=true with a stuck cursor
-    // must not spin forever — the resolver caps the loop and throws.
-    mockGetAllCoins.mockReset()
-    mockGetAllCoins.mockResolvedValue({
-      data: [makeCoin(0)],
+  it('scopes the native listing to the SUI coin type', async () => {
+    // `listCoins` returns ONE coin type per call (SUI by default) where JSON-RPC's
+    // getAllCoins returned every type — the request must name the type explicitly.
+    mockListCoins.mockReset().mockResolvedValueOnce({
+      objects: [makeCoin(0, '3000001')],
+      hasNextPage: false,
+      cursor: null,
+    })
+
+    await getSuiChainSpecific({ keysignPayload: payload, walletCore: {} as never })
+
+    expect(mockListCoins).toHaveBeenCalledTimes(1)
+    expect(mockListCoins.mock.calls[0]?.[0]).toMatchObject({ owner: '0xsender', coinType: suiType })
+  })
+
+  it('reads the reference gas price out of its response envelope', async () => {
+    mockListCoins.mockReset().mockResolvedValueOnce({
+      objects: [makeCoin(0, '3000001')],
+      hasNextPage: false,
+      cursor: null,
+    })
+
+    const res = await getSuiChainSpecific({ keysignPayload: payload, walletCore: {} as never })
+
+    // `{ referenceGasPrice }`, not a bare bigint — stringifying the envelope
+    // itself would put '[object Object]' into the signed payload.
+    expect(res.referenceGasPrice).toBe('1000')
+  })
+
+  it('fails closed (throws, no infinite loop) when the cursor never advances', async () => {
+    mockListCoins.mockReset()
+    mockListCoins.mockResolvedValue({
+      objects: [makeCoin(0)],
       hasNextPage: true,
-      nextCursor: 'stuck-cursor',
+      cursor: 'stuck-cursor',
     })
 
     await expect(getSuiChainSpecific({ keysignPayload: payload, walletCore: {} as never })).rejects.toThrow(
       /exceeded \d+ pages/
     )
     // Bounded, not unbounded: called exactly the cap number of times.
-    expect(mockGetAllCoins).toHaveBeenCalledTimes(200)
+    expect(mockListCoins).toHaveBeenCalledTimes(200)
   })
 
   it('terminates on a single page (hasNextPage false)', async () => {
-    mockGetAllCoins.mockReset()
-    mockGetAllCoins.mockResolvedValueOnce({
-      data: [makeCoin(0, '3000001'), makeCoin(1)],
+    mockListCoins.mockReset()
+    mockListCoins.mockResolvedValueOnce({
+      objects: [makeCoin(0, '3000001'), makeCoin(1)],
       hasNextPage: false,
-      nextCursor: null,
+      cursor: null,
     })
 
     const res = await getSuiChainSpecific({
@@ -109,16 +138,16 @@ describe('getSuiChainSpecific — getAllCoins pagination', () => {
       walletCore: {} as never,
     })
 
-    expect(mockGetAllCoins).toHaveBeenCalledTimes(1)
+    expect(mockListCoins).toHaveBeenCalledTimes(1)
     expect(res.coins.map(coin => coin.coinObjectId)).toEqual(['0xobj0'])
   })
 
   it('bounds a dusty native wallet payload to the largest covering object', async () => {
-    mockGetAllCoins.mockReset()
-    mockGetAllCoins.mockResolvedValueOnce({
-      data: [makeCoin(0, '3000001'), ...Array.from({ length: 799 }, (_, i) => makeCoin(i + 1, '1'))],
+    mockListCoins.mockReset()
+    mockListCoins.mockResolvedValueOnce({
+      objects: [makeCoin(0, '3000001'), ...Array.from({ length: 799 }, (_, i) => makeCoin(i + 1, '1'))],
       hasNextPage: false,
-      nextCursor: null,
+      cursor: null,
     })
 
     const res = await getSuiChainSpecific({

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/sui/index.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/sui/index.ts
@@ -1,12 +1,12 @@
 import { create } from '@bufbuild/protobuf'
 import { getSuiClient } from '@vultisig/core-chain/chains/sui/client'
 import { suiGasBudget } from '@vultisig/core-chain/chains/sui/config'
+import { listAllSuiCoins } from '@vultisig/core-chain/chains/sui/listAllCoins'
 import { SuiCoinSchema, SuiSpecificSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
 import { attempt } from '@vultisig/lib-utils/attempt'
-import type { CoinStruct } from '@mysten/sui/jsonRpc'
 
 import { getKeysignCoin } from '../../../utils/getKeysignCoin'
-import { selectSuiPayloadCoins } from '../../../suiCoinSelection'
+import { isSameSuiCoinType, selectSuiPayloadCoins, suiNativeCoinType } from '../../../suiCoinSelection'
 import { GetChainSpecificResolver } from '../../resolver'
 import { refineSuiChainSpecific } from './refine'
 
@@ -28,41 +28,26 @@ export const getSuiChainSpecific: GetChainSpecificResolver<'suicheSpecific'> = a
   const { address } = coin
   const client = getSuiClient()
 
-  // `getAllCoins` is paginated (~50 objects/page). Sui's object-per-coin model
-  // makes >50 coin objects realistic for an active wallet (dust, partial fills,
-  // repeated small transfers, staking rewards), so reading only the first page
-  // silently truncates the coin set. That set feeds both `gasCoins` (native SUI
-  // objects for the Pay/PaySui gas payment) and `inputCoins` (the coinType being
-  // sent) downstream, so a truncated page produces a broken send ("insufficient
-  // balance" despite adequate holdings, or an empty inputCoins array if none of
-  // the sent coinType's objects land on page 1) even though the getBalance-based
-  // display path shows the correct aggregate total. Follow the cursor to
-  // completion, mirroring the Solana SPL pagination fix (sdk#962).
-  // Bound the cursor loop: a buggy/misbehaving RPC that keeps returning
-  // hasNextPage=true with a non-advancing cursor would otherwise spin forever.
-  // 200 pages ≈ 10k coin objects — far beyond any real wallet — so hitting the
-  // cap means the cursor is stuck; fail CLOSED (throw) rather than hang or
-  // silently truncate the coin set and under-fund the send.
-  const MAX_COIN_PAGES = 200
-  const rawCoins: CoinStruct[] = []
-  let cursor: string | null | undefined = undefined
-  let pages = 0
-  do {
-    const page = await client.getAllCoins({ owner: address, cursor })
-    rawCoins.push(...page.data)
-    cursor = page.hasNextPage ? page.nextCursor : null
-    if (++pages >= MAX_COIN_PAGES && cursor) {
-      throw new Error(
-        `getSuiChainSpecific: getAllCoins exceeded ${MAX_COIN_PAGES} pages for ${address} — refusing to build a send from a possibly-truncated or looping coin set`
-      )
-    }
-  } while (cursor)
-
-  const coins = rawCoins.map((coin: CoinStruct) => create(SuiCoinSchema, coin))
-
-  const referenceGasPrice = await client.getReferenceGasPrice()
-  const amount = BigInt(keysignPayload.toAmount || '0')
+  // The retired JSON-RPC `getAllCoins` returned every coin type in one paginated
+  // sweep. The unified client's `listCoins` is scoped to ONE coin type (SUI by
+  // default), so fetch exactly the two sets the payload needs and nothing more:
+  //   - native SUI objects, always — they pay gas for both Pay and PaySui;
+  //   - the sent coin type's objects, when sending a non-native token.
+  // `listAllSuiCoins` follows the cursor to completion (see its comment on why
+  // a single page silently under-funds a send) and is bounded so a stuck cursor
+  // fails closed instead of spinning.
   const isNativeToken = !coin.id
+  const sendsNonNativeToken = !!coin.id && !isSameSuiCoinType(coin.id, suiNativeCoinType)
+
+  const nativeCoins = await listAllSuiCoins({ client, owner: address, coinType: suiNativeCoinType })
+  const tokenCoins = sendsNonNativeToken
+    ? await listAllSuiCoins({ client, owner: address, coinType: coin.id as string })
+    : []
+
+  const coins = [...nativeCoins, ...tokenCoins].map(rawCoin => create(SuiCoinSchema, rawCoin))
+
+  const { referenceGasPrice } = await client.getReferenceGasPrice()
+  const amount = BigInt(keysignPayload.toAmount || '0')
   const selectCoins = (gasBudget: bigint) =>
     selectSuiPayloadCoins({
       coins,

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/sui/index.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/sui/index.ts
@@ -37,12 +37,14 @@ export const getSuiChainSpecific: GetChainSpecificResolver<'suicheSpecific'> = a
   // a single page silently under-funds a send) and is bounded so a stuck cursor
   // fails closed instead of spinning.
   const isNativeToken = !coin.id
-  const sendsNonNativeToken = !!coin.id && !isSameSuiCoinType(coin.id, suiNativeCoinType)
+  // A payload can name SUI as its "token" id; listing it twice would duplicate every
+  // native object in the selection pool, so only a genuinely distinct type is fetched.
+  const tokenCoinType = coin.id && !isSameSuiCoinType(coin.id, suiNativeCoinType) ? coin.id : undefined
 
-  const nativeCoins = await listAllSuiCoins({ client, owner: address, coinType: suiNativeCoinType })
-  const tokenCoins = sendsNonNativeToken
-    ? await listAllSuiCoins({ client, owner: address, coinType: coin.id as string })
-    : []
+  const [nativeCoins, tokenCoins] = await Promise.all([
+    listAllSuiCoins({ client, owner: address, coinType: suiNativeCoinType }),
+    tokenCoinType ? listAllSuiCoins({ client, owner: address, coinType: tokenCoinType }) : Promise.resolve([]),
+  ])
 
   const coins = [...nativeCoins, ...tokenCoins].map(rawCoin => create(SuiCoinSchema, rawCoin))
 

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/sui/refine.test.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/sui/refine.test.ts
@@ -3,17 +3,17 @@ import { Chain } from '@vultisig/core-chain/Chain'
 import { initWasm, TW, WalletCore } from '@trustwallet/wallet-core'
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 
-const { mockGetAllCoins, mockGetReferenceGasPrice, mockDryRunTransactionBlock } = vi.hoisted(() => ({
-  mockGetAllCoins: vi.fn(),
-  mockGetReferenceGasPrice: vi.fn(async () => 1000n),
-  mockDryRunTransactionBlock: vi.fn(),
+const { mockListCoins, mockGetReferenceGasPrice, mockSimulateTransaction } = vi.hoisted(() => ({
+  mockListCoins: vi.fn(),
+  mockGetReferenceGasPrice: vi.fn(async () => ({ referenceGasPrice: '1000' })),
+  mockSimulateTransaction: vi.fn(),
 }))
 
 vi.mock('@vultisig/core-chain/chains/sui/client', () => ({
   getSuiClient: () => ({
-    getAllCoins: mockGetAllCoins,
+    listCoins: mockListCoins,
     getReferenceGasPrice: mockGetReferenceGasPrice,
-    dryRunTransactionBlock: mockDryRunTransactionBlock,
+    simulateTransaction: mockSimulateTransaction,
   }),
 }))
 
@@ -27,13 +27,14 @@ const NATIVE_TYPE = '0x2::sui::SUI'
 const SENDER = '0x0000000000000000000000000000000000000000000000000000000000000abc'
 const RECIPIENT = '0x51d5b8e2f3d2f0aef0aefdc4e6c0f4f3d2b1a09788c7e6f5d4c3b2a190817263'
 
+// Unified-client coin object shape: `objectId` + the full `Coin<...>` wrapper type.
 const makeRpcCoin = (i: number, balance: string) => ({
-  coinType: NATIVE_TYPE,
-  coinObjectId: `0x${(1000 + i).toString(16).padStart(64, '0')}`,
+  objectId: `0x${(1000 + i).toString(16).padStart(64, '0')}`,
   version: `${i + 1}`,
   digest: '5PLj4rE6ZP1AXwT9CkyzX1zNvfSFVAKUB7T5uf5RCXvY',
+  type: `0x2::coin::Coin<${NATIVE_TYPE}>`,
   balance,
-  previousTransaction: `0x${(2000 + i).toString(16).padStart(64, '0')}`,
+  owner: { $kind: 'AddressOwner', AddressOwner: SENDER },
 })
 
 let walletCore: WalletCore
@@ -61,31 +62,34 @@ const buildPayload = (amount: bigint) =>
 // baseline (pre-refine) payload selection has ZERO slack against the static
 // `suiGasBudget` default.
 const wallet = Array.from({ length: 300 }, (_, i) => makeRpcCoin(i, '50000'))
-// computationCost + storageCost = 3_000_000 -> gasBudgetMultiplier (*1.15) =
-// 3_450_000, above the 3_000_000 static baseline used to size the initial
-// (dry-run) payload selection.
-const dryRunResponse = {
-  effects: {
-    gasUsed: {
-      computationCost: '2000000',
-      storageCost: '1000000',
-      storageRebate: '0',
+
+// Simulation result union carrying the priced gas breakdown.
+const simulation = (computationCost: string, storageCost: string) => ({
+  $kind: 'Transaction' as const,
+  Transaction: {
+    status: { success: true, error: null },
+    effects: {
+      transactionDigest: '5PLj4rE6ZP1AXwT9CkyzX1zNvfSFVAKUB7T5uf5RCXvY',
+      gasUsed: { computationCost, storageCost, storageRebate: '0', nonRefundableStorageFee: '0' },
     },
   },
-}
+})
+
+// computationCost + storageCost = 3_000_000 -> gasBudgetMultiplier (*1.15) =
+// 3_450_000, above the 3_000_000 static baseline used to size the initial
+// (simulated) payload selection.
+const dryRunResponse = simulation('2000000', '1000000')
+
+const singlePage = (objects: unknown[]) => ({ objects, hasNextPage: false, cursor: null })
 
 describe('getSuiChainSpecific -> refine -> getSuiSigningInputs (full pipeline, refine NOT stubbed)', () => {
   it('re-selects payload coins against the REFINED budget so the final signing input covers the budget it declares', async () => {
-    mockGetAllCoins.mockReset().mockResolvedValueOnce({
-      data: wallet,
-      hasNextPage: false,
-      nextCursor: null,
-    })
+    mockListCoins.mockReset().mockResolvedValueOnce(singlePage(wallet))
     // Selection grows 140 -> 149 (see below), so refine's converge loop fires
-    // ONE re-price round. The re-price reports the SAME cost as the first dry
-    // run, so it converges immediately without growing further — the "typical
-    // path converges in one round" case the loop bound's comment describes.
-    mockDryRunTransactionBlock.mockReset().mockResolvedValueOnce(dryRunResponse).mockResolvedValueOnce(dryRunResponse)
+    // ONE re-price round. The re-price reports the SAME cost as the first
+    // simulation, so it converges immediately without growing further — the
+    // "typical path converges in one round" case the loop bound's comment describes.
+    mockSimulateTransaction.mockReset().mockResolvedValueOnce(dryRunResponse).mockResolvedValueOnce(dryRunResponse)
 
     const amount = 4_000_000n
     const keysignPayload = buildPayload(amount)
@@ -97,7 +101,7 @@ describe('getSuiChainSpecific -> refine -> getSuiSigningInputs (full pipeline, r
 
     // Refine actually landed (not the attempt/withFallback error path).
     expect(chainSpecific.gasBudget).toBe('3450000')
-    expect(mockDryRunTransactionBlock).toHaveBeenCalledTimes(2)
+    expect(mockSimulateTransaction).toHaveBeenCalledTimes(2)
 
     const target = amount + BigInt(chainSpecific.gasBudget)
     const payloadTotal = chainSpecific.coins.reduce((sum, c) => sum + BigInt(c.balance), 0n)
@@ -126,14 +130,10 @@ describe('getSuiChainSpecific -> refine -> getSuiSigningInputs (full pipeline, r
     expect(inputTotal).toBeGreaterThanOrEqual(target)
     expect(inputCoins.length).toBeLessThanOrEqual(maxSuiInputCoinObjects)
 
-    // Deterministic: an identical wallet + dry-run responses select the
+    // Deterministic: an identical wallet + simulation responses select the
     // identical object set on a second run.
-    mockGetAllCoins.mockReset().mockResolvedValueOnce({
-      data: wallet,
-      hasNextPage: false,
-      nextCursor: null,
-    })
-    mockDryRunTransactionBlock.mockReset().mockResolvedValueOnce(dryRunResponse).mockResolvedValueOnce(dryRunResponse)
+    mockListCoins.mockReset().mockResolvedValueOnce(singlePage(wallet))
+    mockSimulateTransaction.mockReset().mockResolvedValueOnce(dryRunResponse).mockResolvedValueOnce(dryRunResponse)
     const again = await getSuiChainSpecific({
       keysignPayload: buildPayload(amount),
       walletCore,
@@ -141,49 +141,51 @@ describe('getSuiChainSpecific -> refine -> getSuiSigningInputs (full pipeline, r
     expect(again.coins.map(c => c.coinObjectId)).toEqual(chainSpecific.coins.map(c => c.coinObjectId))
   })
 
-  it('fails closed after 2 re-price rounds when the dry-run cost keeps climbing', async () => {
+  it('simulates the raw BCS bytes with the intent prefix stripped', async () => {
+    mockListCoins.mockReset().mockResolvedValueOnce(singlePage(wallet))
+    mockSimulateTransaction.mockReset().mockResolvedValueOnce(dryRunResponse).mockResolvedValueOnce(dryRunResponse)
+
+    await getSuiChainSpecific({ keysignPayload: buildPayload(4_000_000n), walletCore })
+
+    const request = mockSimulateTransaction.mock.calls[0]?.[0]
+    // Raw bytes, NOT the base64 string the retired dryRunTransactionBlock took.
+    expect(request.transaction).toBeInstanceOf(Uint8Array)
+    expect(request.include).toEqual({ effects: true })
+    // WalletCore's 3-byte intent prefix (0x00 0x00 0x00 for a Sui TransactionData)
+    // must be stripped — the chain wants bare TransactionData BCS.
+    expect(Array.from(request.transaction.slice(0, 3))).not.toEqual([0, 0, 0])
+  })
+
+  it('fails closed when a simulation returns no gas breakdown at all', async () => {
+    mockListCoins.mockReset().mockResolvedValueOnce(singlePage(wallet))
+    // A response with effects but no gasUsed cannot price the budget; refine must
+    // throw rather than silently price the send at 0.
+    mockSimulateTransaction.mockReset().mockResolvedValue({
+      $kind: 'Transaction',
+      Transaction: { status: { success: true, error: null }, effects: { transactionDigest: 'x' } },
+    })
+
+    // The initial refinement failure is caught by design and falls back to the
+    // static baseline, so assert on the baseline rather than a throw.
+    const res = await getSuiChainSpecific({ keysignPayload: buildPayload(4_000_000n), walletCore })
+    expect(res.gasBudget).toBe('3000000')
+  })
+
+  it('fails closed after 2 re-price rounds when the simulated cost keeps climbing', async () => {
     // Each round's re-price reports a HIGHER cost than the last, so the
     // selection keeps growing (140 -> 149 -> 154 -> 159) and would keep
     // triggering further rounds forever if unbounded. The loop must stop
-    // after exactly 2 extra rounds (3 dry runs total) and reject the unpriced
+    // after exactly 2 extra rounds (3 simulations total) and reject the unpriced
     // final selection rather than returning it.
-    mockGetAllCoins.mockReset().mockResolvedValueOnce({
-      data: wallet,
-      hasNextPage: false,
-      nextCursor: null,
-    })
-    mockDryRunTransactionBlock
+    mockListCoins.mockReset().mockResolvedValueOnce(singlePage(wallet))
+    mockSimulateTransaction
       .mockReset()
       // Round 0 (baseline, 140 objects): 3_000_000 -> budget 3_450_000, grows to 149.
-      .mockResolvedValueOnce({
-        effects: {
-          gasUsed: {
-            computationCost: '2000000',
-            storageCost: '1000000',
-            storageRebate: '0',
-          },
-        },
-      })
+      .mockResolvedValueOnce(simulation('2000000', '1000000'))
       // Round 1 (re-price on 149 objects): 3_200_000 -> budget 3_680_000, grows to 154.
-      .mockResolvedValueOnce({
-        effects: {
-          gasUsed: {
-            computationCost: '2100000',
-            storageCost: '1100000',
-            storageRebate: '0',
-          },
-        },
-      })
+      .mockResolvedValueOnce(simulation('2100000', '1100000'))
       // Round 2 (re-price on 154 objects): 3_400_000 -> budget 3_910_000, grows to 159.
-      .mockResolvedValueOnce({
-        effects: {
-          gasUsed: {
-            computationCost: '2200000',
-            storageCost: '1200000',
-            storageRebate: '0',
-          },
-        },
-      })
+      .mockResolvedValueOnce(simulation('2200000', '1200000'))
 
     const amount = 4_000_000n
     const keysignPayload = buildPayload(amount)
@@ -192,18 +194,14 @@ describe('getSuiChainSpecific -> refine -> getSuiSigningInputs (full pipeline, r
       'Sui gas budget did not converge after 2 re-price rounds'
     )
 
-    // Exactly 1 (baseline) + 2 (the bound) dry runs — never a 4th, even though
+    // Exactly 1 (baseline) + 2 (the bound) simulations — never a 4th, even though
     // the round-2 selection (159 objects) still grew past round-1's (154).
-    expect(mockDryRunTransactionBlock).toHaveBeenCalledTimes(3)
+    expect(mockSimulateTransaction).toHaveBeenCalledTimes(3)
   })
 
   it('fails closed when re-pricing errors after the initial selection grows', async () => {
-    mockGetAllCoins.mockReset().mockResolvedValueOnce({
-      data: wallet,
-      hasNextPage: false,
-      nextCursor: null,
-    })
-    mockDryRunTransactionBlock
+    mockListCoins.mockReset().mockResolvedValueOnce(singlePage(wallet))
+    mockSimulateTransaction
       .mockReset()
       .mockResolvedValueOnce(dryRunResponse)
       .mockRejectedValueOnce(new Error('Sui re-price RPC unavailable'))
@@ -215,24 +213,12 @@ describe('getSuiChainSpecific -> refine -> getSuiSigningInputs (full pipeline, r
       })
     ).rejects.toThrow('Sui re-price RPC unavailable')
 
-    expect(mockDryRunTransactionBlock).toHaveBeenCalledTimes(2)
+    expect(mockSimulateTransaction).toHaveBeenCalledTimes(2)
   })
 
   it('fails closed when a refined budget exceeds the available wallet balance', async () => {
-    mockGetAllCoins.mockReset().mockResolvedValueOnce({
-      data: wallet,
-      hasNextPage: false,
-      nextCursor: null,
-    })
-    mockDryRunTransactionBlock.mockReset().mockResolvedValueOnce({
-      effects: {
-        gasUsed: {
-          computationCost: '10000000',
-          storageCost: '4000000',
-          storageRebate: '0',
-        },
-      },
-    })
+    mockListCoins.mockReset().mockResolvedValueOnce(singlePage(wallet))
+    mockSimulateTransaction.mockReset().mockResolvedValueOnce(simulation('10000000', '4000000'))
 
     await expect(
       getSuiChainSpecific({
@@ -241,6 +227,6 @@ describe('getSuiChainSpecific -> refine -> getSuiSigningInputs (full pipeline, r
       })
     ).rejects.toThrow('Insufficient Sui coin balance to cover 20100000')
 
-    expect(mockDryRunTransactionBlock).toHaveBeenCalledTimes(1)
+    expect(mockSimulateTransaction).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/sui/refine.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/sui/refine.ts
@@ -3,6 +3,8 @@ import { create } from '@bufbuild/protobuf'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { getSuiClient } from '@vultisig/core-chain/chains/sui/client'
 import { suiMinGasBudget } from '@vultisig/core-chain/chains/sui/config'
+import { getSuiResultTransaction } from '@vultisig/core-chain/chains/sui/transactionResult'
+import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { SuiSpecific } from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
 import { KeysignPayload, KeysignPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
 import { maxBigInt } from '@vultisig/lib-utils/math/maxBigInt'
@@ -43,17 +45,22 @@ export const refineSuiChainSpecific = async ({
     chain: Chain.Sui,
   })
 
-  const txBytes = Buffer.from(data).subarray(3).toString('base64')
+  // Strip WalletCore's 3-byte intent prefix — the chain wants the raw
+  // TransactionData BCS bytes. `simulateTransaction` (the replacement for the
+  // retired `dryRunTransactionBlock`) takes those bytes directly rather than a
+  // base64 string.
+  const txBytes = new Uint8Array(Buffer.from(data).subarray(3))
 
-  const {
-    effects: {
-      gasUsed: { computationCost, storageCost },
-    },
-  } = await client.dryRunTransactionBlock({
-    transactionBlock: txBytes,
+  const simulation = await client.simulateTransaction({
+    transaction: txBytes,
+    include: { effects: true },
   })
 
-  const gasBudget = BigInt(computationCost) + BigInt(storageCost)
+  // A simulation that reports no gas at all cannot price the budget; fail
+  // closed rather than fall through to a 0 budget the send can't pay for.
+  const gasUsed = shouldBePresent(getSuiResultTransaction(simulation)?.effects?.gasUsed, 'Sui simulated gas usage')
+
+  const gasBudget = BigInt(gasUsed.computationCost ?? '0') + BigInt(gasUsed.storageCost ?? '0')
 
   return {
     ...chainSpecific,

--- a/packages/sdk/rollup.platforms.config.js
+++ b/packages/sdk/rollup.platforms.config.js
@@ -103,9 +103,11 @@ const onwarn = (warning, warn) => {
 // eventually resolves to the same file. One mapping, all callsites covered.
 //
 // The overrides exist because the real modules would evaluate Hermes-hostile
-// deps (`@solana/web3.js`, `@mysten/sui/jsonRpc`, `@lifi/sdk`) at module-init
+// deps (`@solana/web3.js`, `@mysten/sui/grpc`, `@lifi/sdk`) at module-init
 // time. The RN-specific versions defer those imports to inside async function
-// bodies so the module graph stays cold until the first real call.
+// bodies so the module graph stays cold until the first real call. The Sui
+// override additionally swaps gRPC for GraphQL RPC: grpc-web needs
+// `Response.body` streaming, which Hermes' fetch does not provide.
 const rnOverrideMap = {
   'packages/core/chain/chains/solana/client.ts': 'src/platforms/react-native/overrides/solanaClient.ts',
   'packages/core/chain/chains/sui/client.ts': 'src/platforms/react-native/overrides/suiClient.ts',

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -31,7 +31,7 @@ if (typeof globalThis !== 'undefined' && !(globalThis as { Buffer?: unknown }).B
 // full cascade in dependency order: getCanonicalLocales → Locale →
 // NumberFormat → PluralRules.
 //
-// Without these, even lazy `import('@mysten/sui/jsonRpc')` /
+// Without these, even lazy `import('@mysten/sui/graphql')` /
 // `import('@lifi/sdk')` crashes the first time the module is evaluated.
 import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
@@ -173,7 +173,7 @@ export type {
 //
 // These helpers work on RN because heavy chain clients (viem, xrpl,
 // @solana/web3.js, @ton/*, @polkadot/util-crypto, bitcoinjs-lib, @cosmjs/*,
-// @mysten/sui/jsonRpc, @lifi/sdk, @bufbuild/protobuf, cbor-x, i18next)
+// @mysten/sui/graphql, @lifi/sdk, @bufbuild/protobuf, cbor-x, i18next)
 // are externalized in rollup.platforms.config.js. Consumers must install
 // those they actually reach (or metro-stub the rest). `bip32` is inlined
 // from its real (pure-JS) npm package, and `tiny-secp256k1` is inlined

--- a/packages/sdk/src/platforms/react-native/overrides/suiClient.ts
+++ b/packages/sdk/src/platforms/react-native/overrides/suiClient.ts
@@ -1,27 +1,39 @@
 // RN override for `@vultisig/core-chain/chains/sui/client`.
 //
-// `@mysten/sui` evaluates `new Intl.PluralRules(...)` at module top-level
-// (see `@mysten/sui/dist/client/utils.mjs`). Hermes ships without
-// `Intl.PluralRules`, so importing eagerly crashes `sdk.initialize()`.
+// Two RN-specific problems, one proxy:
 //
-// We expose `getSuiClient` with the same sync signature as the core
-// module (`() => SuiJsonRpcClient`) so callsites that do
-// `const client = getSuiClient(); await client.getBalance(...)` work
-// unchanged on both platforms. On RN we return a Proxy that lazy-imports
-// `@mysten/sui/jsonRpc` only when a real method is invoked. Every
-// SuiJsonRpcClient method is async, so the extra `await` for the
-// deferred import flattens naturally.
-import type { SuiJsonRpcClient } from '@mysten/sui/jsonRpc'
+// 1. `@mysten/sui` evaluates `new Intl.PluralRules(...)` at module top-level
+//    (see `@mysten/sui/dist/client/utils.mjs`). Hermes ships without
+//    `Intl.PluralRules`, so importing eagerly crashes `sdk.initialize()`.
+//    The Proxy below lazy-imports the client only when a method is invoked.
+//
+// 2. Core now talks gRPC (Sui retired JSON-RPC), but `SuiGrpcClient` speaks
+//    grpc-web through `GrpcWebFetchTransport`, which reads `Response.body` as
+//    a `ReadableStream`. Hermes' XHR-backed `fetch` exposes no `Response.body`,
+//    so every grpc-web call would throw "missing response body". Sui's other
+//    supported replacement, GraphQL RPC, is a plain JSON POST — and
+//    `SuiGraphQLClient` implements the SAME unified surface
+//    (`SuiClientTypes.TransportMethods`) as `SuiGrpcClient`, so RN swaps the
+//    transport without changing a single callsite.
+//
+// `getSuiClient` therefore keeps the core module's sync signature
+// (`() => SuiClient`) so callsites that do
+// `const client = getSuiClient(); await client.getBalance(...)` work unchanged
+// on both platforms. Every method on the unified client is async, so the extra
+// `await` for the deferred import flattens naturally.
+import type { SuiGraphQLClient } from '@mysten/sui/graphql'
+import type { SuiClient } from '@vultisig/core-chain/chains/sui/client'
+import { suiGraphqlUrl, suiNetwork } from '@vultisig/core-chain/chains/sui/config'
 import { memoize } from '@vultisig/lib-utils/memoize'
 
-let clientPromise: Promise<SuiJsonRpcClient> | undefined
-const loadClient = (): Promise<SuiJsonRpcClient> => {
+let clientPromise: Promise<SuiGraphQLClient> | undefined
+const loadClient = (): Promise<SuiGraphQLClient> => {
   if (!clientPromise) {
-    clientPromise = import('@mysten/sui/jsonRpc').then(
-      ({ SuiJsonRpcClient }) =>
-        new SuiJsonRpcClient({
-          url: 'https://sui-rpc.publicnode.com',
-          network: 'mainnet',
+    clientPromise = import('@mysten/sui/graphql').then(
+      ({ SuiGraphQLClient }) =>
+        new SuiGraphQLClient({
+          url: suiGraphqlUrl,
+          network: suiNetwork,
         })
     )
   }
@@ -44,7 +56,7 @@ const NON_METHOD_PROPS = new Set<string | symbol>([
   Symbol.asyncIterator,
 ])
 
-const suiClientProxy = new Proxy({} as SuiJsonRpcClient, {
+const suiClientProxy = new Proxy({} as SuiGraphQLClient, {
   get(_target, prop) {
     if (typeof prop === 'symbol' || NON_METHOD_PROPS.has(prop)) {
       return undefined
@@ -54,7 +66,7 @@ const suiClientProxy = new Proxy({} as SuiJsonRpcClient, {
         const fn = (client as unknown as Record<string | symbol, unknown>)[prop]
         if (typeof fn !== 'function') {
           throw new Error(
-            `[suiClient RN] property '${String(prop)}' is not a function on @mysten/sui/jsonRpc SuiJsonRpcClient`
+            `[suiClient RN] property '${String(prop)}' is not a function on @mysten/sui/graphql SuiGraphQLClient`
           )
         }
         return (fn as (...a: unknown[]) => unknown).apply(client, args)
@@ -62,4 +74,6 @@ const suiClientProxy = new Proxy({} as SuiJsonRpcClient, {
   },
 })
 
-export const getSuiClient = memoize((): SuiJsonRpcClient => suiClientProxy)
+export type { SuiClient }
+
+export const getSuiClient = memoize((): SuiClient => suiClientProxy as unknown as SuiClient)

--- a/packages/sdk/src/platforms/react-native/overrides/suiClient.ts
+++ b/packages/sdk/src/platforms/react-native/overrides/suiClient.ts
@@ -7,7 +7,7 @@
 //    `Intl.PluralRules`, so importing eagerly crashes `sdk.initialize()`.
 //    The Proxy below lazy-imports the client only when a method is invoked.
 //
-// 2. Core now talks gRPC (Sui retired JSON-RPC), but `SuiGrpcClient` speaks
+// 2. Core now talks gRPC (Sui is retiring JSON-RPC), but `SuiGrpcClient` speaks
 //    grpc-web through `GrpcWebFetchTransport`, which reads `Response.body` as
 //    a `ReadableStream`. Hermes' XHR-backed `fetch` exposes no `Response.body`,
 //    so every grpc-web call would throw "missing response body". Sui's other

--- a/packages/sdk/src/tools/balance/otherBalance.ts
+++ b/packages/sdk/src/tools/balance/otherBalance.ts
@@ -348,6 +348,93 @@ export async function getTonJettonBalance(address: string, jettonMaster: string)
 
 // ── Sui ─────────────────────────────────────────────────────────────────────
 
+/**
+ * Sui GraphQL RPC endpoint.
+ *
+ * Sui retired JSON-RPC: it was disabled on Sui Foundation mainnet full nodes
+ * the week of 2026-07-27 and is decommissioned entirely by mid-October 2026,
+ * so `suix_getBalance` / `suix_getAllBalances` against
+ * `sui-rpc.publicnode.com` no longer have a future. gRPC and GraphQL RPC are
+ * the supported replacements; GraphQL is a plain JSON POST, which keeps this
+ * folder's dependency-free `fetchJson` design (the SDK's Sui *client* rail in
+ * `core-chain` uses gRPC instead — these tools deliberately import nothing).
+ */
+const SUI_GRAPHQL_URL = 'https://graphql.mainnet.sui.io/graphql'
+
+type SuiGraphQLResponse<T> = {
+  data?: T | null
+  errors?: Array<{ message?: string }>
+}
+
+/** Throwing GraphQL POST — mirrors what the JSON-RPC calls used to do on failure. */
+async function suiGraphQL<T>(query: string, variables: Record<string, unknown>): Promise<T> {
+  const response = await fetchJson<SuiGraphQLResponse<T>>(SUI_GRAPHQL_URL, { query, variables })
+
+  // GraphQL answers HTTP 200 even for a bad address, carrying `errors` and a
+  // null `data` — treat that as a failure, never as "you hold nothing".
+  if (response.errors?.length) {
+    throw new Error(response.errors.map(e => e.message ?? 'unknown error').join('; '))
+  }
+  if (response.data == null) {
+    throw new Error('Sui GraphQL returned neither data nor errors — malformed upstream response.')
+  }
+
+  return response.data
+}
+
+const SUI_BALANCE_QUERY = `query getBalance($owner: SuiAddress!, $coinType: String = "0x2::sui::SUI") {
+  address(address: $owner) {
+    balance(coinType: $coinType) {
+      totalBalance
+    }
+  }
+}`
+
+const SUI_BALANCES_QUERY = `query listBalances($owner: SuiAddress!, $limit: Int, $cursor: String) {
+  address(address: $owner) {
+    balances(first: $limit, after: $cursor) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        coinType {
+          repr
+        }
+        totalBalance
+      }
+    }
+  }
+}`
+
+type SuiBalanceQueryData = {
+  address?: { balance?: { totalBalance?: string | null } | null } | null
+}
+
+type SuiBalancesQueryData = {
+  address?: {
+    balances?: {
+      pageInfo?: { hasNextPage?: boolean; endCursor?: string | null }
+      nodes?: Array<{ coinType?: { repr?: string | null } | null; totalBalance?: string | null }>
+    } | null
+  } | null
+}
+
+/**
+ * Total balance of one coin type, in base units.
+ *
+ * An address that has never held the coin type resolves to `null` rather than
+ * an error, which is a genuine zero — not an upstream fault.
+ */
+async function fetchSuiTotalBalance(address: string, coinType?: string): Promise<string> {
+  const data = await suiGraphQL<SuiBalanceQueryData>(SUI_BALANCE_QUERY, {
+    owner: address,
+    ...(coinType ? { coinType } : {}),
+  })
+
+  return data.address?.balance?.totalBalance ?? '0'
+}
+
 export type SuiBalance = {
   address: string
   chain: 'Sui'
@@ -359,13 +446,7 @@ export type SuiBalance = {
 
 /** Get the native SUI balance (1 SUI = 1e9 MIST). */
 export async function getSuiBalance(address: string): Promise<SuiBalance> {
-  const response = await fetchJson<{ result: { totalBalance: string } }>('https://sui-rpc.publicnode.com', {
-    jsonrpc: '2.0',
-    id: 1,
-    method: 'suix_getBalance',
-    params: [address],
-  })
-  const mist = response.result.totalBalance
+  const mist = await fetchSuiTotalBalance(address)
   return {
     address,
     chain: 'Sui',
@@ -385,16 +466,10 @@ export type SuiTokenBalance = {
 
 /** Get balance of a specific fungible token on Sui (base units). */
 export async function getSuiTokenBalance(address: string, coinType: string): Promise<SuiTokenBalance> {
-  const response = await fetchJson<{ result: { totalBalance: string } }>('https://sui-rpc.publicnode.com', {
-    jsonrpc: '2.0',
-    id: 1,
-    method: 'suix_getBalance',
-    params: [address, coinType],
-  })
   return {
     address,
     coinType,
-    balance: response.result.totalBalance,
+    balance: await fetchSuiTotalBalance(address, coinType),
     asOf: new Date().toISOString(),
   }
 }
@@ -416,86 +491,93 @@ const SUI_NATIVE_TYPES = new Set([
   '0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI',
 ])
 
+/** Page size and cap for the paginated balances connection. */
+const SUI_BALANCES_PAGE_SIZE = 50
+const SUI_BALANCES_MAX_PAGES = 40
+
 /**
- * Get ALL coin balances for a Sui address in ONE call (native SUI + every
- * fungible token held) via suix_getAllBalances.
+ * Get ALL coin balances for a Sui address (native SUI + every fungible token
+ * held) through the GraphQL `balances` connection.
  *
- * A typo'd address, an upstream fault, or a non-integer balance returns a
- * deterministic `tokens_unavailable` signal rather than masking it as an empty
- * wallet — under-reporting a portfolio as if complete is a fund-visibility bug.
+ * Unlike the retired `suix_getAllBalances`, the connection is PAGINATED, so
+ * this follows the cursor to completion — reading only the first page would
+ * silently under-report a wallet holding more than one page of coin types.
+ * A typo'd address, an upstream fault, a stuck cursor, more pages than the cap,
+ * or a non-integer balance all return a deterministic `tokens_unavailable`
+ * signal rather than masking it as an empty (or partial) wallet — reporting an
+ * incomplete portfolio as if complete is a fund-visibility bug.
  */
 export async function getSuiAllBalances(address: string): Promise<SuiAllBalancesResult> {
-  let response: {
-    result?: Array<{ coinType: string; totalBalance: string; coinObjectCount: number }>
-    error?: { code?: number; message?: string }
-  }
-  try {
-    response = await fetchJson('https://sui-rpc.publicnode.com', {
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'suix_getAllBalances',
-      params: [address],
-    })
-  } catch (e) {
-    return {
-      ok: false,
-      error: 'tokens_unavailable',
-      chain: 'Sui',
-      address,
-      detail: e instanceof Error ? e.message : String(e),
-    }
-  }
-
-  // Sui answers HTTP 200 even for a bad address, carrying { error } instead of
-  // result — surface it as tokens_unavailable, not "you hold nothing".
-  if (response.error) {
-    return {
-      ok: false,
-      error: 'tokens_unavailable',
-      chain: 'Sui',
-      address,
-      detail: response.error.message ?? `Sui RPC error${response.error.code != null ? ` ${response.error.code}` : ''}`,
-    }
-  }
-  if (!Array.isArray(response.result)) {
-    return {
-      ok: false,
-      error: 'tokens_unavailable',
-      chain: 'Sui',
-      address,
-      detail: 'Sui RPC returned neither a result array nor an error — malformed upstream response.',
-    }
-  }
+  const unavailable = (detail: string): SuiAllBalancesResult => ({
+    ok: false,
+    error: 'tokens_unavailable',
+    chain: 'Sui',
+    address,
+    detail,
+  })
 
   const balances: SuiCoinBalance[] = []
-  for (const b of response.result) {
-    let amount: bigint
-    try {
-      amount = BigInt(b.totalBalance)
-    } catch {
-      return {
-        ok: false,
-        error: 'tokens_unavailable',
-        chain: 'Sui',
-        address,
-        detail: `Sui RPC returned a non-integer balance for ${b.coinType} — refusing to report a partial portfolio.`,
-      }
-    }
-    if (amount <= 0n) continue
+  let cursor: string | null | undefined = undefined
+  let pages = 0
 
-    const native = SUI_NATIVE_TYPES.has(b.coinType)
-    // Ticker = outer struct name; strip any generic type-arg suffix first
-    // (…::lp::LP<0x2::sui::SUI,…> → …::lp::LP) so it doesn't read "SUI>".
-    const bareType = b.coinType.split('<')[0]
-    const ticker = native ? 'SUI' : bareType.split('::').pop() || b.coinType
-    balances.push({
-      coinType: b.coinType,
-      ticker,
-      isNative: native,
-      balance: native ? formatBalance(amount, 9) : b.totalBalance,
-      balanceBaseUnits: b.totalBalance,
-    })
-  }
+  do {
+    let data: SuiBalancesQueryData
+    try {
+      data = await suiGraphQL<SuiBalancesQueryData>(SUI_BALANCES_QUERY, {
+        owner: address,
+        limit: SUI_BALANCES_PAGE_SIZE,
+        cursor: cursor ?? null,
+      })
+    } catch (e) {
+      return unavailable(e instanceof Error ? e.message : String(e))
+    }
+
+    const connection = data.address?.balances
+    if (!connection || !Array.isArray(connection.nodes)) {
+      // A resolvable address with no holdings still returns an empty `nodes`
+      // array; a missing connection is a malformed response, not a zero wallet.
+      return unavailable('Sui GraphQL returned no balances connection — malformed upstream response.')
+    }
+
+    for (const node of connection.nodes) {
+      const coinType = node.coinType?.repr
+      const totalBalance = node.totalBalance
+      if (!coinType || totalBalance == null) {
+        return unavailable('Sui GraphQL returned a balance entry without a coin type or amount.')
+      }
+
+      let amount: bigint
+      try {
+        amount = BigInt(totalBalance)
+      } catch {
+        return unavailable(
+          `Sui GraphQL returned a non-integer balance for ${coinType} — refusing to report a partial portfolio.`
+        )
+      }
+      if (amount <= 0n) continue
+
+      const native = SUI_NATIVE_TYPES.has(coinType)
+      // Ticker = outer struct name; strip any generic type-arg suffix first
+      // (…::lp::LP<0x2::sui::SUI,…> → …::lp::LP) so it doesn't read "SUI>".
+      const bareType = coinType.split('<')[0]
+      const ticker = native ? 'SUI' : bareType.split('::').pop() || coinType
+      balances.push({
+        coinType,
+        ticker,
+        isNative: native,
+        balance: native ? formatBalance(amount, 9) : totalBalance,
+        balanceBaseUnits: totalBalance,
+      })
+    }
+
+    cursor = connection.pageInfo?.hasNextPage ? connection.pageInfo.endCursor : null
+
+    if (++pages >= SUI_BALANCES_MAX_PAGES && cursor) {
+      return unavailable(
+        `Sui GraphQL exceeded ${SUI_BALANCES_MAX_PAGES} balance pages — refusing to report a truncated portfolio.`
+      )
+    }
+  } while (cursor)
 
   return { ok: true, address, chain: 'Sui', balances, asOf: new Date().toISOString() }
 }

--- a/packages/sdk/src/tools/balance/otherBalance.ts
+++ b/packages/sdk/src/tools/balance/otherBalance.ts
@@ -351,10 +351,10 @@ export async function getTonJettonBalance(address: string, jettonMaster: string)
 /**
  * Sui GraphQL RPC endpoint.
  *
- * Sui retired JSON-RPC: it was disabled on Sui Foundation mainnet full nodes
- * the week of 2026-07-27 and is decommissioned entirely by mid-October 2026,
- * so `suix_getBalance` / `suix_getAllBalances` against
- * `sui-rpc.publicnode.com` no longer have a future. gRPC and GraphQL RPC are
+ * Sui is retiring JSON-RPC: shutdown on Foundation mainnet full nodes began the
+ * week of 2026-07-27 and it is decommissioned entirely by mid-October 2026, so
+ * `suix_getBalance` / `suix_getAllBalances` against `sui-rpc.publicnode.com`
+ * have no future even though they still answer today. gRPC and GraphQL RPC are
  * the supported replacements; GraphQL is a plain JSON POST, which keeps this
  * folder's dependency-free `fetchJson` design (the SDK's Sui *client* rail in
  * `core-chain` uses gRPC instead — these tools deliberately import nothing).

--- a/packages/sdk/src/vault/services/RawBroadcastService.ts
+++ b/packages/sdk/src/vault/services/RawBroadcastService.ts
@@ -1,4 +1,5 @@
 import { assertIsDeliverTxSuccess } from '@cosmjs/stargate'
+import { fromBase64 } from '@mysten/sui/utils'
 import { sha256 } from '@noble/hashes/sha2'
 import { bytesToHex } from '@noble/hashes/utils'
 import { Chain, CosmosChain, EvmChain, OtherChain, UtxoBasedChain } from '@vultisig/core-chain/Chain'
@@ -10,6 +11,7 @@ import { polkadotRpcUrl } from '@vultisig/core-chain/chains/polkadot/client'
 import { getRippleClient } from '@vultisig/core-chain/chains/ripple/client'
 import { getSolanaClient } from '@vultisig/core-chain/chains/solana/client'
 import { getSuiClient } from '@vultisig/core-chain/chains/sui/client'
+import { getSuiResultTransaction } from '@vultisig/core-chain/chains/sui/transactionResult'
 import { tronRpcUrl } from '@vultisig/core-chain/chains/tron/config'
 import { getBlockchairBaseUrl } from '@vultisig/core-chain/chains/utxo/client/getBlockchairBaseUrl'
 import { isRippleInFlightEngineResult } from '@vultisig/core-chain/tx/broadcast/resolvers/ripple'
@@ -573,10 +575,10 @@ export class RawBroadcastService {
 
     const client = getSuiClient()
     const { data: result, error } = await attempt(
-      client.executeTransactionBlock({
-        transactionBlock: unsignedTx,
-        signature: [signature],
-        options: { showEffects: true },
+      client.executeTransaction({
+        transaction: fromBase64(unsignedTx),
+        signatures: [signature],
+        include: { effects: true },
       })
     )
 
@@ -593,8 +595,15 @@ export class RawBroadcastService {
     }
 
     if (!result) throw new Error('No broadcast result returned')
-    assertSuiTxSucceeded(result.effects)
-    return result.digest
+    assertSuiTxSucceeded(result)
+
+    // Prefer the top-level digest; fall back to the effects' copy so a
+    // response that carries only effects still yields a usable hash.
+    const transaction = getSuiResultTransaction(result)
+    const digest = transaction?.digest ?? transaction?.effects?.transactionDigest
+    if (!digest) throw new Error('No transaction digest returned')
+
+    return digest
   }
 
   /**

--- a/packages/sdk/tests/unit/tools/balance/otherBalance.test.ts
+++ b/packages/sdk/tests/unit/tools/balance/otherBalance.test.ts
@@ -16,6 +16,7 @@ import {
   getCardanoBalance,
   getSuiAllBalances,
   getSuiBalance,
+  getSuiTokenBalance,
   getTaoBalance,
   getTonBalance,
   getTrc20TokenBalance,
@@ -178,24 +179,62 @@ describe('getTonBalance', () => {
   })
 })
 
-describe('getSuiBalance / getSuiAllBalances', () => {
+// Sui retired JSON-RPC (disabled on Foundation mainnet full nodes the week of
+// 2026-07-27), so these tools now POST GraphQL. Fixtures mirror the GraphQL
+// envelope: `{ data: { address: { ... } } }` / `{ data: null, errors: [...] }`.
+describe('getSuiBalance / getSuiTokenBalance / getSuiAllBalances (GraphQL RPC)', () => {
   beforeEach(() => mockFetchJson.mockReset())
 
+  const balancesPage = (
+    nodes: Array<{ coinType: string; totalBalance: string }>,
+    pageInfo: { hasNextPage: boolean; endCursor: string | null } = { hasNextPage: false, endCursor: null }
+  ) => ({
+    data: {
+      address: {
+        balances: {
+          pageInfo,
+          nodes: nodes.map(n => ({ coinType: { repr: n.coinType }, totalBalance: n.totalBalance })),
+        },
+      },
+    },
+  })
+
   it('formats native SUI mist', async () => {
-    mockFetchJson.mockResolvedValueOnce({ result: { totalBalance: '3000000000' } })
+    mockFetchJson.mockResolvedValueOnce({ data: { address: { balance: { totalBalance: '3000000000' } } } })
     const r = await getSuiBalance(SUI_ADDR)
     expect(r.balance).toBe('3')
     expect(r.balanceMist).toBe('3000000000')
+
+    // Posts GraphQL to the GraphQL RPC endpoint, not JSON-RPC to publicnode.
+    const [url, body] = mockFetchJson.mock.calls[0] as [string, { query: string; variables: Record<string, unknown> }]
+    expect(url).toBe('https://graphql.mainnet.sui.io/graphql')
+    expect(body.query).toContain('totalBalance')
+    expect(body.variables).toEqual({ owner: SUI_ADDR })
+  })
+
+  it('treats a never-held coin type as zero, not an error', async () => {
+    // GraphQL resolves `balance` to null when the address has never held the type.
+    mockFetchJson.mockResolvedValueOnce({ data: { address: { balance: null } } })
+    await expect(getSuiBalance(SUI_ADDR)).resolves.toMatchObject({ balance: '0', balanceMist: '0' })
+  })
+
+  it('scopes a token balance query to the coin type', async () => {
+    mockFetchJson.mockResolvedValueOnce({ data: { address: { balance: { totalBalance: '5000000' } } } })
+    const r = await getSuiTokenBalance(SUI_ADDR, '0xabc::usdc::USDC')
+    expect(r.balance).toBe('5000000')
+
+    const [, body] = mockFetchJson.mock.calls[0] as [string, { variables: Record<string, unknown> }]
+    expect(body.variables).toEqual({ owner: SUI_ADDR, coinType: '0xabc::usdc::USDC' })
   })
 
   it('flags native vs token and drops zero holdings', async () => {
-    mockFetchJson.mockResolvedValueOnce({
-      result: [
-        { coinType: '0x2::sui::SUI', totalBalance: '1000000000', coinObjectCount: 1 },
-        { coinType: '0xabc::usdc::USDC', totalBalance: '5000000', coinObjectCount: 1 },
-        { coinType: '0xdef::dust::DUST', totalBalance: '0', coinObjectCount: 1 },
-      ],
-    })
+    mockFetchJson.mockResolvedValueOnce(
+      balancesPage([
+        { coinType: '0x2::sui::SUI', totalBalance: '1000000000' },
+        { coinType: '0xabc::usdc::USDC', totalBalance: '5000000' },
+        { coinType: '0xdef::dust::DUST', totalBalance: '0' },
+      ])
+    )
     const r = await getSuiAllBalances(SUI_ADDR)
     expect(r.ok).toBe(true)
     if (!r.ok) throw new Error('expected ok')
@@ -204,12 +243,76 @@ describe('getSuiBalance / getSuiAllBalances', () => {
     expect(r.balances[1]).toMatchObject({ ticker: 'USDC', isNative: false })
   })
 
-  it('returns tokens_unavailable on a JSON-RPC error (typo address != empty wallet)', async () => {
-    mockFetchJson.mockResolvedValueOnce({ error: { code: -32602, message: 'Invalid params' } })
+  it('follows the cursor so a multi-page portfolio is not under-reported', async () => {
+    // `suix_getAllBalances` returned everything at once; the GraphQL connection
+    // paginates, so a single-page read would silently hide token holdings.
+    mockFetchJson
+      .mockResolvedValueOnce(
+        balancesPage([{ coinType: '0x2::sui::SUI', totalBalance: '1000000000' }], {
+          hasNextPage: true,
+          endCursor: 'cur1',
+        })
+      )
+      .mockResolvedValueOnce(balancesPage([{ coinType: '0xabc::usdc::USDC', totalBalance: '5000000' }]))
+
+    const r = await getSuiAllBalances(SUI_ADDR)
+    expect(r.ok).toBe(true)
+    if (!r.ok) throw new Error('expected ok')
+    expect(r.balances.map(b => b.ticker)).toEqual(['SUI', 'USDC'])
+    expect(mockFetchJson).toHaveBeenCalledTimes(2)
+
+    const [, secondBody] = mockFetchJson.mock.calls[1] as [string, { variables: Record<string, unknown> }]
+    expect(secondBody.variables).toMatchObject({ cursor: 'cur1' })
+  })
+
+  it('returns tokens_unavailable rather than a truncated portfolio when the cursor never advances', async () => {
+    mockFetchJson.mockResolvedValue(
+      balancesPage([{ coinType: '0x2::sui::SUI', totalBalance: '1' }], { hasNextPage: true, endCursor: 'stuck' })
+    )
+
+    const r = await getSuiAllBalances(SUI_ADDR)
+    expect(r.ok).toBe(false)
+    if (r.ok) throw new Error('expected not ok')
+    expect(r.detail).toMatch(/truncated portfolio/)
+    // Bounded, not unbounded.
+    expect(mockFetchJson).toHaveBeenCalledTimes(40)
+  })
+
+  it('returns tokens_unavailable on a GraphQL error (typo address != empty wallet)', async () => {
+    // GraphQL answers HTTP 200 with `errors` + null data for a bad address.
+    mockFetchJson.mockResolvedValueOnce({
+      data: null,
+      errors: [{ message: 'Failed to parse "SuiAddress": Missing \'0x\' prefix' }],
+    })
     const r = await getSuiAllBalances('0xbad')
     expect(r.ok).toBe(false)
     if (r.ok) throw new Error('expected not ok')
     expect(r.error).toBe('tokens_unavailable')
+    expect(r.detail).toMatch(/SuiAddress/)
+  })
+
+  it('returns tokens_unavailable on a malformed response instead of an empty wallet', async () => {
+    mockFetchJson.mockResolvedValueOnce({ data: { address: null } })
+    const r = await getSuiAllBalances(SUI_ADDR)
+    expect(r.ok).toBe(false)
+    if (r.ok) throw new Error('expected not ok')
+    expect(r.error).toBe('tokens_unavailable')
+  })
+
+  it('reports an address with no holdings as an empty-but-complete portfolio', async () => {
+    mockFetchJson.mockResolvedValueOnce(balancesPage([]))
+    const r = await getSuiAllBalances(SUI_ADDR)
+    expect(r.ok).toBe(true)
+    if (!r.ok) throw new Error('expected ok')
+    expect(r.balances).toEqual([])
+  })
+
+  it('refuses to report a partial portfolio on a non-integer balance', async () => {
+    mockFetchJson.mockResolvedValueOnce(balancesPage([{ coinType: '0xabc::x::X', totalBalance: 'not-a-number' }]))
+    const r = await getSuiAllBalances(SUI_ADDR)
+    expect(r.ok).toBe(false)
+    if (r.ok) throw new Error('expected not ok')
+    expect(r.detail).toMatch(/non-integer balance/)
   })
 })
 

--- a/packages/sdk/tests/unit/tools/balance/otherBalance.test.ts
+++ b/packages/sdk/tests/unit/tools/balance/otherBalance.test.ts
@@ -179,7 +179,7 @@ describe('getTonBalance', () => {
   })
 })
 
-// Sui retired JSON-RPC (disabled on Foundation mainnet full nodes the week of
+// Sui is retiring JSON-RPC (Foundation mainnet shutdown began the week of
 // 2026-07-27), so these tools now POST GraphQL. Fixtures mirror the GraphQL
 // envelope: `{ data: { address: { ... } } }` / `{ data: null, errors: [...] }`.
 describe('getSuiBalance / getSuiTokenBalance / getSuiAllBalances (GraphQL RPC)', () => {

--- a/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
+++ b/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
@@ -74,7 +74,7 @@ vi.mock('@vultisig/core-chain/chains/cosmos/client', () => ({
 
 vi.mock('@vultisig/core-chain/chains/sui/client', () => ({
   getSuiClient: () => ({
-    executeTransactionBlock: mockExecuteSuiTx,
+    executeTransaction: mockExecuteSuiTx,
   }),
 }))
 
@@ -99,8 +99,12 @@ describe('RawBroadcastService', () => {
     mockCosmosBroadcastTx.mockResolvedValue({ transactionHash: 'cosmos-hash', code: 0 })
     mockCosmosGetTx.mockResolvedValue(null)
     mockExecuteSuiTx.mockResolvedValue({
-      digest: 'sui-digest',
-      effects: { status: { status: 'success' } },
+      $kind: 'Transaction',
+      Transaction: {
+        digest: 'sui-digest',
+        status: { success: true, error: null },
+        effects: { transactionDigest: 'sui-digest' },
+      },
     })
     mockRippleRequest.mockResolvedValue({
       result: {
@@ -400,27 +404,50 @@ describe('RawBroadcastService', () => {
   it('broadcasts Sui transaction from JSON payload', async () => {
     const hash = await service.broadcastRawTx({
       chain: Chain.Sui,
-      rawTx: JSON.stringify({ unsignedTx: 'tx-block', signature: 'sig-bytes' }),
+      // base64 of 'tx-block' — the raw path decodes it to BCS bytes for the unified client.
+      rawTx: JSON.stringify({ unsignedTx: 'dHgtYmxvY2s=', signature: 'sig-bytes' }),
     })
     expect(hash).toBe('sui-digest')
-    expect(mockExecuteSuiTx).toHaveBeenCalledWith({
-      transactionBlock: 'tx-block',
-      signature: ['sig-bytes'],
-      options: { showEffects: true },
+
+    const request = mockExecuteSuiTx.mock.calls[0]?.[0]
+    expect(request.transaction).toBeInstanceOf(Uint8Array)
+    expect(new TextDecoder().decode(request.transaction)).toBe('tx-block')
+    expect(request.signatures).toEqual(['sig-bytes'])
+    expect(request.include).toEqual({ effects: true })
+  })
+
+  it('falls back to the effects digest when the response omits the top-level one', async () => {
+    mockExecuteSuiTx.mockResolvedValue({
+      $kind: 'Transaction',
+      Transaction: {
+        status: { success: true, error: null },
+        effects: { transactionDigest: 'effects-digest' },
+      },
     })
+
+    await expect(
+      service.broadcastRawTx({
+        chain: Chain.Sui,
+        rawTx: JSON.stringify({ unsignedTx: 'dHgtYmxvY2s=', signature: 'sig-bytes' }),
+      })
+    ).resolves.toBe('effects-digest')
   })
 
   it('rejects finalized Sui transactions with failed execution effects', async () => {
     mockExecuteSuiTx.mockResolvedValue({
-      digest: 'sui-digest',
-      effects: { status: { status: 'failure', error: 'MoveAbort(42)' } },
+      $kind: 'FailedTransaction',
+      FailedTransaction: {
+        digest: 'sui-digest',
+        status: { success: false, error: { message: 'MoveAbort(42)' } },
+        effects: { transactionDigest: 'sui-digest' },
+      },
     })
 
     await expect(
       service.broadcastRawTx({
         chain: Chain.Sui,
         rawTx: JSON.stringify({
-          unsignedTx: 'tx-block',
+          unsignedTx: 'dHgtYmxvY2s=',
           signature: 'sig-bytes',
         }),
       })
@@ -430,25 +457,25 @@ describe('RawBroadcastService', () => {
     })
   })
 
-  it.each([{ digest: 'sui-digest' }, { digest: 'sui-digest', effects: { status: {} } }])(
-    'rejects Sui responses without explicit successful execution effects',
-    async response => {
-      mockExecuteSuiTx.mockResolvedValue(response)
+  it.each([
+    { $kind: 'Transaction', Transaction: { digest: 'sui-digest' } },
+    { $kind: 'Transaction', Transaction: { digest: 'sui-digest', effects: { transactionDigest: 'sui-digest' } } },
+  ])('rejects Sui responses without explicit successful execution status', async response => {
+    mockExecuteSuiTx.mockResolvedValue(response)
 
-      await expect(
-        service.broadcastRawTx({
-          chain: Chain.Sui,
-          rawTx: JSON.stringify({
-            unsignedTx: 'tx-block',
-            signature: 'sig-bytes',
-          }),
-        })
-      ).rejects.toMatchObject({
-        code: VaultErrorCode.BroadcastFailed,
-        message: expect.stringContaining('no effects status returned'),
+    await expect(
+      service.broadcastRawTx({
+        chain: Chain.Sui,
+        rawTx: JSON.stringify({
+          unsignedTx: 'dHgtYmxvY2s=',
+          signature: 'sig-bytes',
+        }),
       })
-    }
-  )
+    ).rejects.toMatchObject({
+      code: VaultErrorCode.BroadcastFailed,
+      message: expect.stringContaining('no execution status returned'),
+    })
+  })
 
   it('broadcasts TON BOC via root API', async () => {
     mockQueryUrl.mockResolvedValue({ result: { hash: 'ton-hash' } })


### PR DESCRIPTION
## Why now

Sui is retiring JSON-RPC. Shutdown on Foundation mainnet full nodes began the week of **2026-07-27**; full decommission — code removal, after which **no provider can serve it** — lands **mid-October 2026**. gRPC and GraphQL RPC are the supported replacements.

**To be precise about urgency: nothing is broken today.** I checked both endpoints on 2026-07-27 and both still answer `suix_getBalance`:

```
sui-rpc.publicnode.com     → {"result":{"totalBalance":"2227801536832",...}}
fullnode.mainnet.sui.io    → {"result":{"totalBalance":"2227801536832",...}}
```

So this is a scheduled migration ahead of a hard deadline, not a hotfix. I'd rather state that plainly than have the PR read as a fire drill.

I searched open and closed issues and PRs for `grpc` / `graphql` / `json-rpc` / `jsonrpc` / `deprecat` and found nothing covering the migration — the Sui work (#1132, #1275, #1338, #1398, #1413, #1430, #1467) is all coin selection, gas convergence and broadcast status, all still on JSON-RPC. Apologies if I missed a plan tracked elsewhere; happy to close this if it's already in hand.

## The part I think matters most

A naive port of the call sites would leave **two silent breaks** behind. These are the reason I opened a PR rather than just an issue — both are non-obvious and both are in the fund path.

**1. `clients/cli` — the permanent-vs-retryable gate goes dead, and it is not fail-safe.**

The Sui branch gates on the JSON-RPC numeric code `-32002`. On gRPC that can never match, so *every* permanent rejection is reclassified as retryable and the CLI re-broadcasts bytes that can never land. Captured live:

```
### grpc executeTransaction / bad signature
  ctor      RpcError
  code      "INVALID_ARGUMENT"      <- a string, not -32002
  message   "invalid%20signature:%20error%20converting%20from%20protobuf:..."
  decoded   "invalid signature: error converting from protobuf:..."
```

Two shape changes at once: `code` is the grpc-status **name**, and the message is **percent-encoded** (grpc-web escapes the `grpc-message` trailer), so a regex containing literal spaces never matches even if the gate passed.

**2. `transientRetry` — 5xx coverage disappears.**

A grpc-web response is **HTTP 200** with the real status in the trailer, so the existing 5xx branch never sees a busy or restarting node. Under JSON-RPC that arrived as an `HttpResponseError` and was retried. Fixed by retrying `UNAVAILABLE` / `DEADLINE_EXCEEDED` / `RESOURCE_EXHAUSTED` (the three gRPC itself designates safe) and decoding the message before pattern-matching. `INVALID_ARGUMENT`, `NOT_FOUND`, `FAILED_PRECONDITION`, `ABORTED` and `INTERNAL` deliberately stay out.

The `DeliverTxFailedError` marker still short-circuits before any code or message test, so an on-chain MoveAbort is not retried even when its chain-controlled text says "aborted" *or* the status looks transient — sdk#1398 re-expressed in the new transport's vocabulary, with a test for exactly that pair.

## A decision that is yours, not mine

**The endpoint has to change, but I do not think I should be the one choosing the replacement.**

You deliberately use `sui-rpc.publicnode.com`. publicnode *does* run a Sui gRPC endpoint — but it speaks native gRPC only and rejects both grpc-web wire formats by name:

```
sui-grpc.publicnode.com    [grpc-web binary] → invalid content-type "application/grpc-web+proto"
sui-grpc.publicnode.com    [grpc-web text]   → invalid content-type "application/grpc-web-text"
sui-graphql.publicnode.com                   → 404
sui-rpc.publicnode.com     [any gRPC format] → Bad Request
```

Browsers cannot speak native gRPC — that is the entire reason grpc-web exists — so the browser, chrome-extension and React Native bundles physically cannot reach it. Node and Electron could, via `@grpc/grpc-js` plus a native transport, but that buys a three-way transport split across platforms.

So a grpc-web-capable endpoint is required. I used `fullnode.mainnet.sui.io` because it works, **not because it is the right production choice** — it is the Foundation public node, rate-limited and not positioned for production load, and avoiding exactly that is plausibly why publicnode was picked in the first place. The same caveat applies to `graphql.mainnet.sui.io` on RN.

A commercial grpc-web provider, or proxying through `api.vultisig.com`, is probably the real answer. **This is one constant in `chains/sui/config.ts`** — none of the API mapping, the second-order fixes, or the tests depend on it. Tell me what you want and I'll change the line.

## What changed

### Core client rail → gRPC

| area | before (JSON-RPC) | after (unified client) |
|---|---|---|
| balance | `getBalance().totalBalance` | `getBalance().balance.balance` |
| metadata | `getCoinMetadata()` | `getCoinMetadata().coinMetadata` |
| coin objects | `getAllCoins({owner, cursor})` | `listCoins({owner, coinType, cursor})` |
| gas price | `getReferenceGasPrice(): bigint` | `getReferenceGasPrice().referenceGasPrice` |
| dry run | `dryRunTransactionBlock({transactionBlock})` | `simulateTransaction({transaction: bytes})` |
| status | `getTransactionBlock({digest, options})` | `getTransaction({digest, include})` |
| broadcast | `executeTransactionBlock({transactionBlock, signature[]})` | `executeTransaction({transaction: bytes, signatures[]})` |

Non-obvious details the live probes surfaced, each pinned by a test:

- **`effects.transactionDigest`, not `digest`.** A simulation leaves the top-level `digest` undefined. `getSuiTxHash` feeds broadcast hash-verification, so reading the wrong field returns `undefined` silently.
- **`iconUrl` is `''`, not `null`.** Mainnet SUI itself returns an empty string, so `?? undefined` leaks `''` through as a logo URL.
- **Status is a union**: `{ $kind: 'Transaction' | 'FailedTransaction' }` *plus* `{ success, error }`. The sdk#1398 fail-closed rule is re-expressed against **both** — a `FailedTransaction` arm claiming `success: true` is still an error.
- **`listCoins` is scoped to one coin type** where `getAllCoins` returned every type, so the keysign resolver fetches exactly the two sets a payload needs (native SUI for gas, plus the sent type) instead of sweeping the wallet.
- **Coin objects report the wrapper type** `0x2::coin::Coin<T>` and `objectId`, where `CoinStruct` gave the inner `coinType` and `coinObjectId`. `listAllSuiCoins` unwraps it, so coin selection, the `SuiCoin` protobuf and every downstream comparison are unchanged. (Checked against `tests/fixtures/mobile/sui.json` — the mobile golden carries the same five fields and no `previous_transaction`, so payload parity holds.)

Pagination and the stuck-cursor bound move out of the keysign resolver into `listAllSuiCoins`, still failing closed rather than under-funding a send.

### React Native → GraphQL RPC

`SuiGrpcClient` speaks grpc-web through `GrpcWebFetchTransport`, which reads `Response.body` as a `ReadableStream`. Hermes' XHR-backed `fetch` exposes no `Response.body`, so **every grpc-web call throws `missing response body` on RN**. `SuiGraphQLClient` is a plain JSON POST and implements the *same* `SuiClientTypes.TransportMethods`, so the RN override swaps transport with **zero callsite changes**. The existing lazy-Proxy (for the Hermes `Intl.PluralRules` crash) is kept as-is.

This asymmetry is a real architectural choice and I'm happy to be overruled on it.

### Dependency-free balance tools

`tools/balance/otherBalance.ts` hand-rolled `suix_getBalance` / `suix_getAllBalances` POSTs. These now POST Sui GraphQL through the same `fetchJson` helper, so the folder keeps its zero-client-dependency design. `suix_getAllBalances` returned everything at once but the GraphQL `balances` connection **paginates**, so `getSuiAllBalances` follows the cursor and returns `tokens_unavailable` on a stuck cursor or page-cap overrun rather than silently reporting a truncated portfolio — consistent with the fund-visibility rule already stated in that file.

## Verification

Endpoints and every response shape asserted in the tests were **verified against mainnet before the code was written** — reference gas price, coin metadata, balance, paginated `listCoins`, a real built-and-simulated PTB, `getTransaction` on an unknown digest, `executeTransaction` with a bad signature, and all four GraphQL queries including the bad-address error path.

Full `check:ci` locally, all green: `check:shared-exports`, `build:all`, `cli:build`, `cli:smoke`, `mcp:build`, `mcp:smoke`, `changeset:check-sdk-bundle`, `quality:contracts`, `lint`, `typecheck`, `knip`, `format:check`, `quality:architecture` (1940 modules, 0 violations), `quality:duplication` (0 clones), `quality:complexity`, `quality:secrets`, `quality:audit`, `quality:docs:markdown`.

```
@vultisig/sdk     203 files, 3036 tests   passed
@vultisig/rujira   24 files,  550 tests   passed (4 skipped)
core (chain+mpc)  227 files, 2218 tests   passed (1 skipped)
@vultisig/cli      73 files,  966 tests   passed
@vultisig/mcp       3 files,   35 tests   passed
```

Bundle check — the migration reaches every shipped artifact, and `sui-rpc.publicnode.com` appears **0 times in all six bundles** (was 4):

| bundle | client | endpoint |
|---|---|---|
| `index.node.esm.js` / `index.node.cjs` | `SuiGrpcClient` | `fullnode.mainnet.sui.io` |
| `index.browser.js` | `SuiGrpcClient` + `GrpcWebFetchTransport` | `fullnode.mainnet.sui.io` |
| `index.electron-main.cjs` | `SuiGrpcClient` | `fullnode.mainnet.sui.io` |
| `index.chrome-extension.js` | `SuiGrpcClient` | `fullnode.mainnet.sui.io` |
| `index.react-native.js` | `@mysten/sui/graphql` only | `graphql.mainnet.sui.io` |

CI on my fork is green on the full change before opening this — all four jobs on the rebased head (`1f32920a`, rebased onto `d1aae2d2`): [run 30248266821](https://github.com/Toby1009/vultisig-sdk/actions/runs/30248266821) (Unit Tests 23m, Lint and Type Check 13m, Integration Tests 5m, Test Summary).

## Breaking

`assertSuiTxSucceeded` (exported from `@vultisig/core-chain/tx/broadcast/resolvers/sui`) now takes the unified client's transaction result (`{ $kind, Transaction | FailedTransaction }`) instead of a JSON-RPC effects object. Changeset: `minor` for `core-chain` / `core-mpc` / `sdk`, `patch` for `cli`.

## Found but deliberately NOT changed

Neither is caused by this migration; folding them in would widen it past a transport swap.

**1. `getSuiTxHash` spends a network round trip for a digest that is derivable locally.** It simulates purely to read `effects.transactionDigest` — which cannot work in the one case its caller cares about, since `verifyBroadcastByHash` runs after a peer won the race, when the input objects are already spent. Pre-existing (`dryRunTransactionBlock` behaved identically), but the new SDK makes the fix trivial and I verified it:

```
local digest : 6MtGKQJxQWbqGn8Zc3Wh3SK83iR4Hine6V325gW8Yukp   <- TransactionDataBuilder.getDigestFromBytes(bytes)
node  digest : 6MtGKQJxQWbqGn8Zc3Wh3SK83iR4Hine6V325gW8Yukp   <- effects.transactionDigest, mainnet
match        : true
```

**2. `selectSuiPayloadCoins` emits the same coin object twice when a payload names SUI as its token id.** `isNativeToken` is `!coin.id`, so `coin.id === '0x2::sui::SUI'` takes the token branch and the object is selected once as the "token" and again as a gas candidate. Not reachable from `getKeysignCoin` in practice, and it fails loudly at signing rather than mis-sending. Documented in a test comment.

## On scope

35 files is a lot for one PR. It is one mechanical change (the transport) plus the two consequences that would otherwise be silent, and I kept them together because the second-order fixes are meaningless without the first. Happy to split it — transport / CLI classifier / transient retry / balance tools are all independently landable — or to close this and hand the analysis over if you'd rather implement it internally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Migrated Sui transaction reads, simulations, broadcasts, and status checks to modern gRPC/GraphQL services.
  * Added complete Sui coin pagination with safeguards against incomplete or looping results.
  * Added shared transaction-result handling for success and failure states.
  * Sui balance portfolios now report `tokens_unavailable` when data cannot be retrieved reliably.

* **Bug Fixes**
  * Improved retry and permanent-error detection, including encoded transport messages.
  * Strengthened transaction success validation and gas estimation.
  * Improved handling of missing metadata, balances, and transaction details.

* **Breaking Changes**
  * Updated the transaction-success assertion API to accept the new transaction result format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->