### PR TITLE
fix(thorchain): don't append the bank denom to native-token swap deposit symbols

### DIFF
--- a/.changeset/thorchain-native-token-deposit-symbol.md
+++ b/.changeset/thorchain-native-token-deposit-symbol.md
@@ -1,0 +1,28 @@
+---
+'@vultisig/core-mpc': patch
+'@vultisig/sdk': patch
+---
+
+fix(thorchain): don't append the bank denom to a native-token swap deposit symbol
+
+A swap sourced from a THORChain-native token (TCY, RUJI) encoded its
+`MsgDeposit` asset as `` `${ticker}-${contractAddress}` `` — and for these coins
+`contractAddress` IS the bank denom, so the deposit went out as `TCY-tcy`
+instead of `TCY`. iOS (`thorchain.swift` `getSwapPreSignedInputData`) and
+Android (`ThorchainSwapHelper`) both encode the bare ticker.
+
+Because the symbol is part of the signed pre-image, this moved the hash: a
+co-signing joiner rebuilds the payload locally and polls the relay with
+`messageId = getMessageHash(message)`, so it asked for a `message_id` the
+initiator never uploaded and failed with
+`404 Timed out while waiting for setup message`. Reported in
+vultisig/vultisig-windows#4464 as a TCY -> RUNE swap that fails whenever the
+extension co-signs and succeeds against an Apple co-signer.
+
+The `TICKER-CONTRACT` form is now gated on `secured`, which is the case it was
+written for (vultisig-sdk `5a8aacdeb`): a secured-asset withdrawal, where the
+auxiliary coin is the L1 token being pulled off THORChain and the contract
+address genuinely belongs in the symbol (`USDC` + `0xa0b8…` ->
+`USDC-0XA0B8…`, matching THORNode's `ETH.USDC-0XA0B8…`). Both sides of that
+gate are now covered by tests; RUNE, secured assets, and non-swap deposits
+(bond/merge/stake) were never affected.

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos.test.ts
@@ -391,6 +391,141 @@ describe('getCosmosSigningInputs gas limit', () => {
     expect(depositCoin?.decimals.toString()).toBe('8')
   })
 
+  // vultisig/vultisig-windows#4464: a THORChain-native token carries its bank
+  // denom in `contractAddress`, which must NOT be appended to the deposit
+  // symbol. iOS (`thorchain.swift` getSwapPreSignedInputData) and Android
+  // (`ThorchainSwapHelper`) both encode the bare ticker; emitting `TCY-tcy`
+  // moved the pre-image hash and 404'd every mixed-platform co-sign.
+  //
+  // Limited to all-uppercase tickers on purpose: iOS uppercases the deposit
+  // symbol/ticker and Android does not, so a mixed-case ticker (`bRUNE`) is a
+  // separate, still-unadjudicated iOS<->Android divergence. Pinning one side
+  // here would fossilize an unverified choice.
+  it.each([
+    { label: 'TCY', ticker: 'TCY', contractAddress: 'tcy' },
+    { label: 'RUJI', ticker: 'RUJI', contractAddress: 'x/ruji' },
+  ])('encodes an intra-THORChain swap of $label on the bare ticker', async ({ ticker, contractAddress }) => {
+    const [input] = await getCosmosSigningInputs({
+      keysignPayload: create(KeysignPayloadSchema, {
+        coin: create(CoinSchema, {
+          chain: Chain.THORChain,
+          ticker,
+          address: thorSender,
+          contractAddress,
+          decimals: 8,
+          isNativeToken: false,
+          hexPublicKey: publicKeyHex,
+        }),
+        toAddress: '',
+        toAmount: '100000000',
+        memo: `=:THOR.RUNE:${thorSender}`,
+        blockchainSpecific: {
+          case: 'thorchainSpecific',
+          value: create(THORChainSpecificSchema, {
+            accountNumber: 7n,
+            sequence: 3n,
+            fee: 2_000_000n,
+            isDeposit: false,
+            transactionType: TransactionType.UNSPECIFIED,
+          }),
+        },
+        swapPayload: {
+          case: 'thorchainSwapPayload',
+          value: {
+            fromAddress: thorSender,
+            fromCoin: {
+              chain: Chain.THORChain,
+              ticker,
+              address: thorSender,
+              contractAddress,
+              decimals: 8,
+              isNativeToken: false,
+            },
+            toCoin: {
+              chain: Chain.THORChain,
+              ticker: 'RUNE',
+              address: thorSender,
+              contractAddress: '',
+              decimals: 8,
+              isNativeToken: true,
+            },
+            fromAmount: '100000000',
+            vaultAddress: '',
+            routerAddress: '',
+            expirationTime: 0n,
+          },
+        },
+      }),
+      walletCore,
+    })
+
+    const depositCoin = input.messages[0]?.thorchainDepositMessage?.coins?.[0]
+    expect(depositCoin?.asset).toMatchObject({
+      chain: 'THOR',
+      symbol: ticker,
+      ticker,
+      synth: false,
+      secured: false,
+    })
+    expect(depositCoin?.amount).toBe('100000000')
+    expect(depositCoin?.decimals.toString()).toBe('8')
+  })
+
+  // The other side of the same gate: on a secured-asset withdrawal the
+  // auxiliary coin IS an L1 token, and its contract address belongs in the
+  // symbol (`ETH.USDC-0XA0B8…`). Pins the branch #4464's fix narrowed to.
+  it('keeps the contract suffix on a secured withdrawal of an L1 token', async () => {
+    const [input] = await getCosmosSigningInputs({
+      keysignPayload: create(KeysignPayloadSchema, {
+        coin: create(CoinSchema, {
+          chain: Chain.THORChain,
+          ticker: 'RUNE',
+          address: thorSender,
+          decimals: 8,
+          isNativeToken: true,
+          hexPublicKey: publicKeyHex,
+        }),
+        toAddress: '',
+        toAmount: '10000000',
+        memo: 'SECURE-:0x2e8f4c9b1a7d3e6f0b5c8a1d4e7f2a9c6b3d0e8f',
+        blockchainSpecific: {
+          case: 'thorchainSpecific',
+          value: create(THORChainSpecificSchema, {
+            accountNumber: 7n,
+            sequence: 3n,
+            fee: 2_000_000n,
+            isDeposit: true,
+            transactionType: TransactionType.UNSPECIFIED,
+          }),
+        },
+        swapPayload: {
+          case: 'thorchainSwapPayload',
+          value: {
+            fromCoin: {
+              chain: Chain.Ethereum,
+              ticker: 'USDC',
+              contractAddress: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+              decimals: 8,
+            },
+            fromAmount: '10000000',
+            vaultAddress: '',
+            routerAddress: '',
+            expirationTime: 0n,
+          },
+        },
+      }),
+      walletCore,
+    })
+
+    const depositCoin = input.messages[0]?.thorchainDepositMessage?.coins?.[0]
+    expect(depositCoin?.asset).toMatchObject({
+      chain: 'ETH',
+      symbol: 'USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48',
+      ticker: 'USDC',
+      secured: true,
+    })
+  })
+
   it.each(['bogus-usdc', '-usdc', '__proto__-usdc', 'constructor-usdc'])(
     'rejects a secured-asset swap deposit with a non-canonical chain prefix (%s)',
     contractAddress => {

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
@@ -54,8 +54,21 @@ const getThorchainDepositAsset = ({
     (nativeSwapChainIds as Record<string, string>)[assetCoin.chain] ??
     nativeSwapChainIds[chain as VaultBasedCosmosChain]
   const { contractAddress } = assetCoin
+  // The `TICKER-CONTRACT` symbol form belongs to secured-asset withdrawals only,
+  // where `assetCoin` is the L1 coin being pulled off THORChain and
+  // `contractAddress` is its L1 token contract (`USDC` + `0xa0b8…` ->
+  // `USDC-0XA0B8…`, matching THORNode's `ETH.USDC-0XA0B8…`).
+  //
+  // For a plain swap the contract address is the THORChain bank denom
+  // (`tcy`, `x/ruji`), and appending it produced `TCY-tcy` — an asset THORNode
+  // has no pool for, and a pre-image hash that no longer matched the one iOS
+  // (`thorchain.swift` getSwapPreSignedInputData) and Android
+  // (`ThorchainSwapHelper.getSwapPreSignedInputData`) derive from the same
+  // payload. A co-signing joiner then polled a `message_id` the initiator never
+  // uploaded and died on `404 Timed out while waiting for setup message`.
+  // See vultisig/vultisig-windows#4464.
   const rawSymbol =
-    typeof contractAddress === 'string' && contractAddress.trim()
+    secured && typeof contractAddress === 'string' && contractAddress.trim()
       ? `${assetCoin.ticker}-${contractAddress}`
       : assetCoin.ticker
 


### PR DESCRIPTION
## Description

A native swap sourced from a THORChain-native token encoded its `MsgDeposit` asset symbol as `` `${ticker}-${contractAddress}` ``. For these coins `contractAddress` **is the bank denom**, so TCY went out as `TCY-tcy` instead of `TCY`.

The symbol is part of the signed pre-image, so this moved the hash — which is what turned a cosmetic encoding slip into a hard keysign failure.

Fixes vultisig/vultisig-windows#4464 (cross-repo, so it won't auto-close).

## Root cause

`getThorchainDepositAsset` appended the contract address unconditionally:

```ts
const rawSymbol =
  typeof contractAddress === 'string' && contractAddress.trim()
    ? `${assetCoin.ticker}-${contractAddress}`
    : assetCoin.ticker
```

`assetCoin` here is `swapPayload?.fromCoin ?? coin`. The `?? coin` side is an `AccountCoin`, which carries `id` and no `contractAddress` — so this branch only ever fires for the swap payload's raw proto coin, where `contractAddress` is populated straight off the wire.

All three clients read the identical relayed payload and disagreed on one field:

| Client | Code | `THORChainAsset.symbol` |
|---|---|---|
| TS (extension/desktop) | `cosmos/index.ts` | **`TCY-tcy`** |
| Android | `ThorchainSwapHelper.kt` `getTicker(coin)` | `TCY` |
| iOS | `thorchain.swift` `getSwapPreSignedInputData` | `TCY` |

Android's registry sets TCY's `contractAddress = "tcy"` (`Coins.kt`) and relays it verbatim, so the TS client received the right input and encoded it wrong.

`symbol` was the **only** diverging field. I checked chain (`THOR` in all three), ticker, synth, secured, amount, decimals, signer, memo, accountNumber, sequence, mode, signingMode, chainId, and fee gas (20,000,000 in all three: `cosmosGasLimitRecord.ts`, `ThorChainHelper.THOR_CHAIN_GAS_UNIT`, `THORChainConstants.depositGasBaseUnits`).

## Why it failed the way it did

A co-signing joiner rebuilds the payload locally and polls the relay with `messageId = getMessageHash(message)` (`message/setup/ensure.ts`). One byte of divergence and it asks for a `message_id` the initiator never uploaded:

```
TCY  ts=TCY-tcy  hash=caf0d352…7b2d  message_id=001aa80e9c44a81810c21261ee2b3b1d
     native=TCY  hash=f6ca7ea9…a3d9  message_id=bb72d9a62108d815863705cd719c9f09
```

50 retries × 200ms later that surfaces as `404 Timed out while waiting for setup message` — the exact signature in the field report, where the swap failed against an extension co-signer and succeeded against an Apple one.

Worth noting this was never only a co-signing bug: a solo-signed TCY swap was encoding an asset that isn't `THOR.TCY`.

## The fix

Gate the `TICKER-CONTRACT` form on `secured`, which is the case it was added for in `5a8aacdeb` — a secured-asset withdrawal, where the auxiliary coin is the L1 token being pulled off THORChain and the contract address genuinely belongs in the symbol (`USDC` + `0xa0b8…` → `USDC-0XA0B8…`, matching THORNode's `ETH.USDC-0XA0B8…`).

That commit was aimed squarely at secured assets; `4815346d7` later carved the main secured path out into `getSecuredAssetDepositAsset` but left the suffix in the fallback, where it then only ever fired for THORChain-native tokens.

## Blast radius

Affected: any swap **sourced** from a THORChain-native non-RUNE token — TCY (`tcy`), RUJI (`x/ruji`), bRUNE (`x/brune`).

Unaffected, and confirmed unaffected by test: RUNE (empty contract address), secured assets (routed to `getSecuredAssetDepositAsset`), and all non-swap deposits — bond/merge/stake pass an `AccountCoin`, which never had a `contractAddress` to append.

## Verification

Post-fix pre-image hash parity against the mobile encoding:

```
TCY  -> RUNE  ts=TCY                       native=TCY                       MATCH
RUJI -> RUNE  ts=RUJI                      native=RUJI                      MATCH
RUNE -> BTC   ts=RUNE                      native=RUNE                      MATCH
secured USDC  ts=USDC-0XA0B86991…3606EB48  native=USDC-0XA0B86991…3606EB48  MATCH
```

Reverting just the gate fails exactly the two new swap tests and nothing else — they're real regression tests, not tautologies. Full core suite: 2170 passed.

## Not in scope — a second divergence this surfaced

While building the parity matrix I found a **separate, pre-existing iOS↔Android** disagreement: iOS uppercases the deposit symbol/ticker (`.uppercased()` in `thorchain.swift`), Android does not (`getTicker` returns it verbatim). Invisible for all-uppercase tickers, but **bRUNE is swappable** — `toNativeSwapAsset` normalizes `x/brune` to `THOR.bRUNE` — so iOS would emit `BRUNE` where Android and TS emit `bRUNE`. Same 404 failure class, with TS on Android's side.

Adjudicating that needs THORNode ground truth on which symbol it accepts for an `x/` denom, which I could not establish from the client repos. So the new tests are deliberately scoped to all-uppercase tickers rather than fossilizing an unverified choice. Worth its own issue. (`sTCY` is not affected in practice — it normalizes to an invalid quote asset and isn't swappable.)

## On golden vectors

vultisig/vultisig-sdk#1585 correctly flags TCY as having zero vector coverage — I confirmed it: all 5 swap vectors in `thorchainswap.json` source from L1 coins, and the RUJI cases in `thorchain.json` use `bond:`/`withdraw:` memos, which take the safe deposit branch. **None of the 59 vectors exercise this code path**, which is why it shipped.

I have not added a shared vector here on purpose: #1585's ground rule is that expected hashes must come from running at least two of the three real signers, and I could only run TS — seeding the corpus from the implementation that was just broken is exactly what that rule exists to prevent. The unit tests in this PR are the durable guard; the shared vector still belongs to #1585.

## Which feature is affected?

- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending - Please attach a tx link here
- [x] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature - Please attach tx link here

**Field validation** — I ran TCY → RUNE on a Secure vault in **both co-signing directions**, with this branch's build patched into a local `vultisig-windows` checkout:

| Initiator | Co-signer | Result |
|---|---|---|
| Extension | iOS | https://thorchain.net/tx/B784DE684A3EEB1D54B02346B18FD29359A28CD2FF1A3D792F0F5A1CC6838E77 |
| iOS | **Extension** | https://thorchain.net/tx/2605C3B2B5C95633940394256274FB5091769E589D779B94F325674F3A624B38 |

The second row is the reported failure shape — a mobile initiator with the extension co-signing, which is precisely what was 404ing in vultisig/vultisig-windows#4464. The first row exercises the TS client on the *initiating* side. Together they confirm that both clients now derive the same pre-image hash from the same payload, and that THORNode accepts the corrected asset.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional context

The extension inherited this on 2026-03-26 when vultisig-windows migrated to `@vultisig/sdk` 0.8 (`babe1e509`). Before that it carried its own `core/mpc` with `symbol: coin.ticker`, which matches vultisig/vultisig-windows#3501 — a TCY → RUJI swap co-signed Windows↔iOS that completed on 2026-03-07, three weeks before the migration.

Desktop is affected identically to the extension. Both need an `@vultisig/sdk` release plus a bump of `@vultisig/core-mpc` in `clients/extension`, `clients/desktop` and `core/ui`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed THORChain native-token swap deposits to use the correct bare ticker symbol.
  - Prevented incorrect ticker-contract symbols from causing signing failures and timeouts.
  - Preserved contract-suffixed symbols for secured asset withdrawals.

- **Tests**
  - Added coverage for native and non-native swaps, secured withdrawals, and symbol encoding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->