### PR TITLE
feat(swap): let co-signers review a THORChain limit order

### DIFF
--- a/.changeset/limit-order-cosigner-review.md
+++ b/.changeset/limit-order-cosigner-review.md
@@ -1,0 +1,15 @@
+---
+'@vultisig/core-chain': minor
+'@vultisig/core-mpc': minor
+'@vultisig/sdk': minor
+---
+
+Let joining devices review a THORChain limit order instead of approving it as a generic send.
+
+The limit-order builder attaches a swap payload only for ERC20 sources, so RUNE and native-gas-asset orders reached a co-signer as a transfer to an opaque address with an opaque memo — no buy asset, payout destination, or minimum received.
+
+`getKeysignLimitSwapOrder` decodes those terms from `keysignPayload.memo`, which is present on every source branch. Reading the memo also makes the review trustworthy rather than merely present: the memo is the exact string THORChain executes, so terms derived from it cannot disagree with what gets signed, whereas a display field supplied by the initiating device can.
+
+`parseLimitSwapMemo` is the underlying decoder, and `assertLimitSwapMemo` now delegates to it so the grammar has one implementation.
+
+`buildLimitSwapKeysignPayload` now derives the ERC20 branch's `toAmountDecimal` from the memo's LIM rather than from the caller's `expectedToAmount`. That argument is now an optional cross-check: supplying a value that disagrees with the memo throws, which catches a caller that rescaled the LIM into the target coin's own decimals — a mistake that signs a correct order while showing a co-signer a wrong figure.

--- a/packages/core/chain/swap/native/limitSwapMemo.assertMemo.test.ts
+++ b/packages/core/chain/swap/native/limitSwapMemo.assertMemo.test.ts
@@ -86,4 +86,3 @@ describe('parseLimitSwapMemo', () => {
     expect(`=<:${targetAsset}:${destinationAddress}:${limit}/${intervalBlocks}/${quantity}`).toBe(validMemo)
   })
 })
-

--- a/packages/core/chain/swap/native/limitSwapMemo.assertMemo.test.ts
+++ b/packages/core/chain/swap/native/limitSwapMemo.assertMemo.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { assertLimitSwapMemo } from './limitSwapMemo'
+import { assertLimitSwapMemo, parseLimitSwapMemo } from './limitSwapMemo'
 
 const validMemo = '=<:ETH.ETH:0x742d35Cc6634C0532925a3b844Bc454e4438f44e:1600000000/14400/0'
 const validWithAffiliate = `${validMemo}:v0:50`
@@ -51,3 +51,39 @@ describe('assertLimitSwapMemo', () => {
     expect(() => assertLimitSwapMemo(`${validMemo}::50`)).toThrow(/empty affiliate segment/)
   })
 })
+
+// assertLimitSwapMemo delegates here, so every rejection above is this parser's
+// too. These cover what it *returns* — the terms a joining device reviews.
+describe('parseLimitSwapMemo', () => {
+  it('returns the order terms without an affiliate', () => {
+    expect(parseLimitSwapMemo(validMemo)).toEqual({
+      targetAsset: 'ETH.ETH',
+      destinationAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+      limit: 1_600_000_000n,
+      intervalBlocks: 14_400,
+      quantity: 0,
+    })
+  })
+
+  it('returns the affiliate terms when present', () => {
+    expect(parseLimitSwapMemo(validWithAffiliate)).toMatchObject({
+      affiliate: 'v0',
+      affiliateBps: 50,
+    })
+  })
+
+  // The LIM is the order's price floor; a Number round-trip would lose precision
+  // above 2^53, which is reachable for an 18-decimal target.
+  it('keeps the LIM as a bigint', () => {
+    const big = '=<:ETH.ETH:0x742d35Cc6634C0532925a3b844Bc454e4438f44e:99999999999999999999/14400/0'
+
+    expect(parseLimitSwapMemo(big).limit).toBe(99_999_999_999_999_999_999n)
+  })
+
+  it('round-trips the memo it was given', () => {
+    const { targetAsset, destinationAddress, limit, intervalBlocks, quantity } = parseLimitSwapMemo(validMemo)
+
+    expect(`=<:${targetAsset}:${destinationAddress}:${limit}/${intervalBlocks}/${quantity}`).toBe(validMemo)
+  })
+})
+

--- a/packages/core/chain/swap/native/limitSwapMemo.ts
+++ b/packages/core/chain/swap/native/limitSwapMemo.ts
@@ -256,20 +256,43 @@ const limitSwapMemoTradeTargetPattern = /^\d+\/\d+\/\d+$/
 /** Basis points are a bare integer; the affiliate name is a printable, separator-free token. */
 const limitSwapMemoAffiliateBpsPattern = /^\d+$/
 
+/** The order terms a `=<` memo encodes, as decoded from the memo itself. */
+export type ParsedLimitSwapMemo = {
+  /** THORChain asset notation for the buy side, e.g. `ETH.USDC-06EB48`. */
+  targetAsset: string
+  /** Where a filled order pays out. */
+  destinationAddress: string
+  /** Guaranteed-minimum received (LIM), in THORChain's 1e8 fixed point. */
+  limit: bigint
+  /** How long the order rests, in THORChain blocks. */
+  intervalBlocks: number
+  /** Streaming quantity; `0` for the orders this SDK builds. */
+  quantity: number
+  affiliate?: string
+  affiliateBps?: number
+}
+
 /**
- * Fail closed on anything that is not a well-formed THORChain limit-swap memo.
+ * Decode a THORChain limit-swap memo into the order terms it encodes.
  *
- * Guards the signing path. The limit deposit builder accepts a pre-built memo
- * string, so a market (`=>`) memo, an unrelated action, or a truncated/corrupted
- * limit memo would otherwise sign a value-bearing deposit that executes with
- * completely different semantics — or with no price protection at all.
+ * Fail closed on anything that is not a well-formed limit memo. This guards the
+ * signing path: the limit deposit builder accepts a pre-built memo string, so a
+ * market (`=>`) memo, an unrelated action, or a truncated/corrupted limit memo
+ * would otherwise sign a value-bearing deposit that executes with completely
+ * different semantics — or with no price protection at all.
  *
  * Validates the shape `=<:TARGET:DEST:LIM/INTERVAL/QUANTITY[:AFFILIATE:BPS]`
  * rather than only the prefix, because it is the trade-target segment that
  * carries the order's price floor: a memo whose LIM is missing or non-numeric is
  * exactly the case that must never reach a signer.
+ *
+ * Returning the terms rather than only validating them is what lets a *joining*
+ * device review a limit order. The memo is the order — it rides on the keysign
+ * payload for every source branch, and it is the exact string THORChain
+ * executes — so terms derived from it cannot disagree with what gets signed, the
+ * way a separately-supplied display field can.
  */
-export const assertLimitSwapMemo = (memo: string): void => {
+export const parseLimitSwapMemo = (memo: string): ParsedLimitSwapMemo => {
   if (!memo.startsWith(limitSwapMemoPrefix)) {
     throw new Error(
       `memo is not a THORChain limit-swap memo (expected a "${limitSwapMemoPrefix}" prefix): ${JSON.stringify(memo)}`
@@ -299,7 +322,7 @@ export const assertLimitSwapMemo = (memo: string): void => {
     )
   }
 
-  const [limit] = tradeTarget.split('/')
+  const [limit, interval, quantity] = tradeTarget.split('/')
   if (BigInt(limit) === 0n) {
     // THORChain reads a zero trade target as an unprotected market order.
     throw new Error(`limit-swap memo has a zero minimum-received (LIM), which THORChain treats as a market order`)
@@ -314,6 +337,26 @@ export const assertLimitSwapMemo = (memo: string): void => {
       throw new Error(`limit-swap memo affiliate bps must be an integer, got ${JSON.stringify(affiliateBps)}`)
     }
   }
+
+  return {
+    targetAsset,
+    destinationAddress: destAddress,
+    limit: BigInt(limit),
+    intervalBlocks: Number(interval),
+    quantity: Number(quantity),
+    ...(segments.length === 5 ? { affiliate, affiliateBps: Number(affiliateBps) } : {}),
+  }
+}
+
+/**
+ * Fail closed on anything that is not a well-formed THORChain limit-swap memo.
+ *
+ * Thin wrapper over {@link parseLimitSwapMemo} so the grammar has exactly one
+ * implementation — a validator that could drift from the parser is how a memo
+ * ends up reviewed as one order and executed as another.
+ */
+export const assertLimitSwapMemo = (memo: string): void => {
+  parseLimitSwapMemo(memo)
 }
 
 const buildMemo = (inputs: LimitSwapMemoInput, includeAffiliate: boolean): string => {

--- a/packages/core/mpc/keysign/swap/buildLimitSwapKeysignPayload.test.ts
+++ b/packages/core/mpc/keysign/swap/buildLimitSwapKeysignPayload.test.ts
@@ -233,4 +233,42 @@ describe('buildLimitSwapKeysignPayload', () => {
 
     expect(mocks.refineKeysignUtxo).toHaveBeenCalled()
   })
+
+  // sdk#1611: the co-signer's "you receive" row comes from the memo's LIM, not
+  // from a figure the initiating device supplies alongside it. A display value
+  // that can disagree with the signed order is one a co-signer cannot verify.
+  describe('minimum-received display', () => {
+    const erc20Input = { ...baseInput, fromCoin: usdcCoin, toCoin: ethCoin }
+
+    it('derives toAmountDecimal from the memo LIM', async () => {
+      const payload = await buildLimitSwapKeysignPayload(erc20Input)
+
+      // The memo encodes a LIM of 1600000000 in THORChain's 1e8 fixed point.
+      expect(payload.swapPayload.value?.toAmountDecimal).toBe('16.00000000')
+    })
+
+    it('ignores the caller when it agrees with the memo', async () => {
+      const payload = await buildLimitSwapKeysignPayload({ ...erc20Input, expectedToAmount: 1_600_000_000n })
+
+      expect(payload.swapPayload.value?.toAmountDecimal).toBe('16.00000000')
+    })
+
+    it('rejects an expectedToAmount that disagrees with the memo LIM', async () => {
+      await expect(
+        buildLimitSwapKeysignPayload({ ...erc20Input, expectedToAmount: 1n })
+      ).rejects.toThrow(/disagrees with the memo's LIM/)
+    })
+
+    // The exact mistake this guard exists for: rescaling the 1e8 LIM into the
+    // target coin's own decimals. The memo still signs correctly, so nothing
+    // else catches it.
+    it('rejects a LIM rescaled to the target coin decimals', async () => {
+      const rescaledToEthDecimals = (1_600_000_000n * 10n ** 18n) / 10n ** 8n
+
+      await expect(
+        buildLimitSwapKeysignPayload({ ...erc20Input, expectedToAmount: rescaledToEthDecimals })
+      ).rejects.toThrow(/1e8 fixed point/)
+    })
+  })
 })
+

--- a/packages/core/mpc/keysign/swap/buildLimitSwapKeysignPayload.test.ts
+++ b/packages/core/mpc/keysign/swap/buildLimitSwapKeysignPayload.test.ts
@@ -254,9 +254,9 @@ describe('buildLimitSwapKeysignPayload', () => {
     })
 
     it('rejects an expectedToAmount that disagrees with the memo LIM', async () => {
-      await expect(
-        buildLimitSwapKeysignPayload({ ...erc20Input, expectedToAmount: 1n })
-      ).rejects.toThrow(/disagrees with the memo's LIM/)
+      await expect(buildLimitSwapKeysignPayload({ ...erc20Input, expectedToAmount: 1n })).rejects.toThrow(
+        /disagrees with the memo's LIM/
+      )
     })
 
     // The exact mistake this guard exists for: rescaling the 1e8 LIM into the
@@ -271,4 +271,3 @@ describe('buildLimitSwapKeysignPayload', () => {
     })
   })
 })
-

--- a/packages/core/mpc/keysign/swap/buildLimitSwapKeysignPayload.ts
+++ b/packages/core/mpc/keysign/swap/buildLimitSwapKeysignPayload.ts
@@ -15,7 +15,7 @@ import {
   isLimitSwapDestinationHalted,
   shouldBlockRuneDeposit,
 } from '@vultisig/core-chain/swap/native/limitSwapInbound'
-import { assertLimitSwapMemo } from '@vultisig/core-chain/swap/native/limitSwapMemo'
+import { parseLimitSwapMemo } from '@vultisig/core-chain/swap/native/limitSwapMemo'
 import { getNativeSwapDecimals } from '@vultisig/core-chain/swap/native/utils/getNativeSwapDecimals'
 import { WalletCore } from '@trustwallet/wallet-core'
 import { PublicKey } from '@trustwallet/wallet-core/dist/src/wallet-core'
@@ -54,13 +54,15 @@ export type BuildLimitSwapKeysignPayloadInput = {
   libType: KeysignLibType
   walletCore: WalletCore
   /**
-   * The order's guaranteed-minimum output (the memo's LIM) in the target's
-   * smallest units, for cross-device "you receive" display only. Never
-   * influences signing.
+   * Optional cross-check of the caller's own "you receive" figure, in
+   * THORChain's 1e8 fixed point — the same scale the memo's LIM uses, and what
+   * `getNativeSwapDecimals` formats a THORChain swap's output with.
    *
-   * Taken as a chain amount rather than a decimal so it is formatted the same
-   * way the market path formats its expected output — `Number#toString()` would
-   * emit scientific notation for dust values and render as `1e-8` on a co-signer.
+   * Not used to build the payload: the displayed minimum is always taken from
+   * the memo's LIM, so it cannot disagree with the order being signed. Supplying
+   * it asserts the caller's display math agrees with the memo, which catches a
+   * caller that rescaled to the target coin's own decimals — the LIM would still
+   * sign correctly while the co-signer saw a wrong figure.
    */
   expectedToAmount?: bigint
   /** Epoch milliseconds; parameterised so the router expiry is deterministic under test. */
@@ -84,6 +86,20 @@ export type BuildLimitSwapKeysignPayloadInput = {
  *   *without* a swap payload would fall through to a plain ERC20 transfer,
  *   dropping the memo and stranding the tokens on the router — so it must carry
  *   one.
+ *
+ * The swap payload is deliberately NOT attached to the first two branches, even
+ * though it would give co-signers the market path's swap review for free
+ * (sdk#1611). It is not display metadata: every signing-input resolver re-routes
+ * on its presence — UTXO takes both amount and destination from it, EVM and Tron
+ * take the destination from `vaultAddress`, and the Cosmos resolver drops the
+ * tx-body memo (`txMemo: swapPayload ? '' : memo`). Attaching one would change
+ * signed bytes on a working path to improve a display, and for RUNE it would
+ * additionally make `assertNativeSwapReadyForBroadcast` resolve a `THOR` inbound
+ * row that THORChain's own inbound list does not contain, failing the broadcast
+ * guard outright. Joining devices get the order terms from
+ * `getKeysignLimitSwapOrder` instead, which reads the memo that every branch
+ * already carries — and which, being the string THORChain executes, cannot
+ * disagree with what is signed.
  *
  * Fund-safety gates, all fail-closed:
  * - The `EnableAdvSwapQueue` mimir is re-checked here, at sign time. Placement
@@ -116,10 +132,17 @@ export const buildLimitSwapKeysignPayload = async ({
   toPublicKey,
   libType,
   walletCore,
-  expectedToAmount = 0n,
+  expectedToAmount,
   now = Date.now(),
 }: BuildLimitSwapKeysignPayloadInput) => {
-  assertLimitSwapMemo(memo)
+  const order = parseLimitSwapMemo(memo)
+
+  if (expectedToAmount !== undefined && expectedToAmount !== order.limit) {
+    throw new Error(
+      `buildLimitSwapKeysignPayload: expectedToAmount ${expectedToAmount} disagrees with the memo's LIM ${order.limit}. ` +
+        "It must be the LIM in THORChain's 1e8 fixed point, not rescaled to the target coin's decimals."
+    )
+  }
 
   if (amount <= 0n) {
     throw new Error('buildLimitSwapKeysignPayload: amount must be greater than 0')
@@ -184,7 +207,7 @@ export const buildLimitSwapKeysignPayload = async ({
         fromAmount: amount.toString(),
         // Display-only, for the co-signer's "you receive" row. The order's real
         // floor is the LIM inside the memo; these fields are never read here.
-        toAmountDecimal: fromChainAmountDisplay(expectedToAmount, getNativeSwapDecimals(toCoin)),
+        toAmountDecimal: fromChainAmountDisplay(order.limit, getNativeSwapDecimals(toCoin)),
         toAmountLimit: '0',
         streamingInterval: '0',
         streamingQuantity: '0',

--- a/packages/core/mpc/keysign/swap/getKeysignLimitSwapOrder.test.ts
+++ b/packages/core/mpc/keysign/swap/getKeysignLimitSwapOrder.test.ts
@@ -1,0 +1,76 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { describe, expect, it } from 'vitest'
+
+import { getKeysignLimitSwapOrder } from './getKeysignLimitSwapOrder'
+
+const evmAddress = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e'
+const memo = `=<:ETH.USDC-06EB48:${evmAddress}:43079145/14400/0:v0:50`
+
+describe('getKeysignLimitSwapOrder', () => {
+  it('decodes the order terms a limit memo encodes', () => {
+    expect(getKeysignLimitSwapOrder({ memo })).toEqual({
+      targetAsset: 'ETH.USDC-06EB48',
+      targetChain: Chain.Ethereum,
+      destinationAddress: evmAddress,
+      limit: 43_079_145n,
+      minimumReceivedDecimal: '0.43079145',
+      intervalBlocks: 14_400,
+      expiryHours: 24,
+      quantity: 0,
+      affiliate: 'v0',
+      affiliateBps: 50,
+    })
+  })
+
+  // The whole point of reading the memo: it works for RUNE and native-gas
+  // sources too, which carry no swap payload for a co-signer to key off.
+  it('decodes an order regardless of the source branch', () => {
+    const runeSourced = `=<:BTC.BTC:bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh:5000/7200/0`
+
+    expect(getKeysignLimitSwapOrder({ memo: runeSourced })).toMatchObject({
+      targetAsset: 'BTC.BTC',
+      targetChain: Chain.Bitcoin,
+      limit: 5_000n,
+      minimumReceivedDecimal: '0.00005000',
+      expiryHours: 12,
+    })
+  })
+
+  it('omits the affiliate fields when the memo carries none', () => {
+    const order = getKeysignLimitSwapOrder({ memo: `=<:ETH.ETH:${evmAddress}:100/14400/0` })
+
+    expect(order?.affiliate).toBeUndefined()
+    expect(order?.affiliateBps).toBeUndefined()
+  })
+
+  it.each([
+    ['a market swap memo', `=>:ETH.ETH:${evmAddress}:100/14400/0`],
+    ['a plain send', 'hello'],
+    ['an empty memo', ''],
+    ['no memo at all', undefined],
+  ])('returns undefined for %s', (_label, value) => {
+    expect(getKeysignLimitSwapOrder({ memo: value })).toBeUndefined()
+  })
+
+  // A caller reviewing an arbitrary payload wants "not a limit order" rather
+  // than a throw. Signing still rejects these — the builder parses the same memo.
+  it.each([
+    ['a zero LIM', `=<:ETH.ETH:${evmAddress}:0/14400/0`],
+    ['a missing trade target', `=<:ETH.ETH:${evmAddress}`],
+    ['a non-numeric LIM', `=<:ETH.ETH:${evmAddress}:abc/14400/0`],
+    ['an empty destination', '=<:ETH.ETH::100/14400/0'],
+  ])('reports %s as not a limit order rather than throwing', (_label, value) => {
+    expect(getKeysignLimitSwapOrder({ memo: value })).toBeUndefined()
+  })
+
+  it('leaves the target chain undefined for an unroutable asset prefix', () => {
+    const order = getKeysignLimitSwapOrder({ memo: `=<:XYZ.XYZ:${evmAddress}:100/14400/0` })
+
+    expect(order?.targetAsset).toBe('XYZ.XYZ')
+    expect(order?.targetChain).toBeUndefined()
+  })
+
+  it('leaves expiry undefined for an interval this SDK does not build', () => {
+    expect(getKeysignLimitSwapOrder({ memo: `=<:ETH.ETH:${evmAddress}:100/999/0` })?.expiryHours).toBeUndefined()
+  })
+})

--- a/packages/core/mpc/keysign/swap/getKeysignLimitSwapOrder.ts
+++ b/packages/core/mpc/keysign/swap/getKeysignLimitSwapOrder.ts
@@ -1,0 +1,79 @@
+import { fromChainAmountDisplay } from '@vultisig/core-chain/amount/fromChainAmountExact'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
+import {
+  limitSwapExpiryHours,
+  LimitSwapExpiryHours,
+  getLimitSwapIntervalBlocks,
+  limitSwapMemoPrefix,
+  ParsedLimitSwapMemo,
+  parseLimitSwapMemo,
+} from '@vultisig/core-chain/swap/native/limitSwapMemo'
+import { thorchainAssetPrefixToChain } from '@vultisig/core-chain/swap/native/thorchainMemoAsset'
+import { attempt } from '@vultisig/lib-utils/attempt'
+
+import { KeysignPayload } from '../../types/vultisig/keysign/v1/keysign_message_pb'
+
+/** THORChain's fixed point for pool amounts, which the memo's LIM is expressed in. */
+const thorchainDecimals = chainFeeCoin[Chain.THORChain].decimals
+
+const intervalBlocksToExpiryHours: Readonly<Partial<Record<number, LimitSwapExpiryHours>>> = Object.freeze(
+  Object.fromEntries(limitSwapExpiryHours.map(hours => [getLimitSwapIntervalBlocks(hours), hours]))
+)
+
+export type KeysignLimitSwapOrder = ParsedLimitSwapMemo & {
+  /** The buy chain, when the target asset's prefix is one this SDK can route. */
+  targetChain?: Chain
+  /**
+   * Guaranteed-minimum received, as a decimal string in the target asset's
+   * display units. Formatted from the LIM with THORChain's 8 decimals, matching
+   * how `toAmountDecimal` is formatted for market swaps.
+   */
+  minimumReceivedDecimal: string
+  /** The order's resting lifetime, when the interval maps to one this SDK builds. */
+  expiryHours?: LimitSwapExpiryHours
+}
+
+/**
+ * Decode the limit order a keysign payload is about to place, for review.
+ *
+ * Returns `undefined` for any payload that is not a limit order, so a caller can
+ * branch on it directly.
+ *
+ * **This is how a *joining* device reviews a limit order.** The builder attaches
+ * a `swapPayload` only for ERC20 sources — RUNE and native-gas-asset orders are
+ * plain deposits — so a co-signer keying off the swap payload alone sees a
+ * generic send to an opaque address with an opaque memo, and cannot tell what is
+ * being bought, where it pays out, or at what floor.
+ *
+ * Deriving the terms from `keysignPayload.memo` fixes that uniformly, because
+ * the memo is present on every source branch. It is also the *only* trustworthy
+ * source: the memo is the exact string THORChain executes, so terms read from it
+ * cannot disagree with the order that gets signed. A display field carried
+ * alongside the memo can — it is supplied by the initiating device, and a
+ * co-signer has no way to tell a mistaken one from a malicious one.
+ *
+ * Parsing is fail-closed on a malformed memo, but a caller reviewing an
+ * arbitrary payload wants "not a limit order" rather than a throw, so a memo
+ * that does not parse is reported as not-a-limit-order. Signing still rejects it:
+ * `buildLimitSwapKeysignPayload` parses the same memo and throws.
+ */
+export const getKeysignLimitSwapOrder = ({ memo }: Pick<KeysignPayload, 'memo'>): KeysignLimitSwapOrder | undefined => {
+  if (!memo?.startsWith(limitSwapMemoPrefix)) {
+    return undefined
+  }
+
+  const parsed = attempt(() => parseLimitSwapMemo(memo))
+  if ('error' in parsed) {
+    return undefined
+  }
+
+  const { data: order } = parsed
+
+  return {
+    ...order,
+    targetChain: thorchainAssetPrefixToChain[order.targetAsset.split('.')[0].toUpperCase()],
+    minimumReceivedDecimal: fromChainAmountDisplay(order.limit, thorchainDecimals),
+    expiryHours: intervalBlocksToExpiryHours[order.intervalBlocks],
+  }
+}

--- a/packages/core/mpc/package.json
+++ b/packages/core/mpc/package.json
@@ -601,6 +601,11 @@
       "import": "./dist/keysign/swap/cowswap/buildCowSwapApprovalSigningInput.js",
       "default": "./dist/keysign/swap/cowswap/buildCowSwapApprovalSigningInput.js"
     },
+    "./keysign/swap/getKeysignLimitSwapOrder": {
+      "types": "./dist/keysign/swap/getKeysignLimitSwapOrder.d.ts",
+      "import": "./dist/keysign/swap/getKeysignLimitSwapOrder.js",
+      "default": "./dist/keysign/swap/getKeysignLimitSwapOrder.js"
+    },
     "./keysign/swap/getKeysignSwapPayload": {
       "types": "./dist/keysign/swap/getKeysignSwapPayload.d.ts",
       "import": "./dist/keysign/swap/getKeysignSwapPayload.js",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -438,6 +438,28 @@ export type {
   SwapQuoteProviderName,
 } from '@vultisig/core-chain/swap/quote/findSwapQuote'
 
+// THORChain limit orders (`=<` advanced swap queue). The memo IS the order, so
+// `parseLimitSwapMemo` / `getKeysignLimitSwapOrder` are how any device — the
+// initiator or a co-signer reviewing a payload it did not build — reads an
+// order's true terms. Terms decoded from the memo cannot disagree with what
+// gets signed; a display field carried alongside it can.
+export type {
+  LimitSwapExpiryHours,
+  LimitSwapMemoInput,
+  ParsedLimitSwapMemo,
+} from '@vultisig/core-chain/swap/native/limitSwapMemo'
+export {
+  assertLimitSwapMemo,
+  buildLimitSwapMemo,
+  getLimitSwapIntervalBlocks,
+  getLimitSwapLimitAmount,
+  limitSwapExpiryHours,
+  limitSwapMemoPrefix,
+  parseLimitSwapMemo,
+} from '@vultisig/core-chain/swap/native/limitSwapMemo'
+export type { KeysignLimitSwapOrder } from '@vultisig/core-mpc/keysign/swap/getKeysignLimitSwapOrder'
+export { getKeysignLimitSwapOrder } from '@vultisig/core-mpc/keysign/swap/getKeysignLimitSwapOrder'
+
 // THORChain LP primitives (v2: auto-pair, lockup, halts, mimir pause gate)
 export { getThorchainInboundAddress } from '@vultisig/core-chain/chains/cosmos/thor/getThorchainInboundAddress'
 export * from '@vultisig/core-chain/chains/cosmos/thor/lp'


### PR DESCRIPTION
## Description

Fixes #1611

Only ERC20-sourced limit orders carry a swap payload. A RUNE or native-gas order reached a *joining* device as a transfer to an opaque address with an opaque memo — generic send terms, no buy asset, no payout destination, no minimum received. Only the initiating device got a readable review.

`getKeysignLimitSwapOrder` decodes those terms from `keysignPayload.memo`, which every source branch carries.

## Why the memo, and not a swap payload

The issue offered two approaches. I started on the first — attach display metadata to the RUNE and native-gas branches — and abandoned it: **the swap payload is not display metadata.** Every signing-input resolver re-routes on its presence.

| Resolver | What changes when a payload is attached |
|---|---|
| UTXO | takes *both* amount and destination from the payload instead of `keysignPayload` |
| EVM | destination becomes `vaultAddress`; transfer amount becomes `fromAmount` |
| Tron | destination becomes `vaultAddress` |
| Cosmos | drops the tx-body memo — `txMemo: swapPayload ? '' : memo` |

For RUNE it is worse than a byte change: `assertNativeSwapReadyForBroadcast` would then resolve a `THOR` inbound row, and THORChain's own inbound list does not contain one, so the broadcast guard fails outright.

So option 1 means changing signed bytes on a working path to improve a display. Reading the memo is both safer and **strictly more trustworthy**: the memo is the exact string THORChain executes, so terms derived from it cannot disagree with the order being signed. A display field carried alongside it can — it is supplied by the initiating device, and a co-signer has no way to tell a mistaken one from a malicious one.

The rejected approach is documented in the builder's JSDoc so the next person doesn't re-derive it.

## What's in here

- **`parseLimitSwapMemo`** — decodes a `=<` memo into its terms. `assertLimitSwapMemo` now delegates to it, so the grammar has one implementation rather than a validator that can drift from a parser.
- **`getKeysignLimitSwapOrder`** — takes a keysign payload, returns target asset + chain, destination, minimum received, and expiry; `undefined` for anything that isn't a limit order, so callers branch on it directly. Fail-closed parsing, but a malformed memo reports as "not a limit order" rather than throwing — a caller reviewing an arbitrary payload wants a branch, and signing still rejects it because the builder parses the same memo.
- **Builder hardening** — `toAmountDecimal` now comes from the memo's LIM rather than the caller's `expectedToAmount`. That argument became an optional cross-check that throws on disagreement.

That last gate has a real backstory: it catches exactly the bug shipped in vultisig-windows#4470, where the LIM was rescaled into the target coin's own decimals. The order signed correctly while the co-signer saw a figure 100x low for a 6-decimal USDC target and 1e10x high for an 18-decimal ETH one. Nothing else catches that class of mistake, because the memo stays valid. There's a test asserting it.

## Which feature is affected?

- [x] Swap — THORChain limit orders (`=<` advanced swap queue), co-signer review path

No transaction link: this changes what a joining device *displays*, and deliberately leaves signed bytes untouched on every branch. The signing path itself was verified on mainnet from the windows side — [`5CB3698C…40F9C3`](https://runescan.io/tx/5CB3698C77FC719202EB1AEE5C5060B12A86E0BC086B0BB0DCC176711640F9C3), a RUNE→USDC limit order that filled exactly at its LIM.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Testing

`yarn test:core` — 2244 passed. `yarn check:agent` clean apart from two pre-existing `getVultisigConfigDir` errors also present on `main`.

New coverage: parser terms and bigint LIM handling; `getKeysignLimitSwapOrder` across all three source branches, non-limit memos, malformed memos, unroutable asset prefixes, and unknown intervals; builder tests for memo-derived display and the `expectedToAmount` cross-check, including the rescaled-to-target-decimals case specifically.

Also exercised against vultisig-windows with this branch patched into `node_modules`: an integration check confirmed the app's computed value equals the memo's LIM across five pairs, so the new gate does not reject legitimate orders.

## Additional context

The consuming UI is a separate change in vultisig-windows — this PR supplies the data; the join review renders it.

One behaviour worth flagging for review: ERC20-sourced limit orders previously rendered the generic swap review and will now render as limit orders on any client that adopts `getKeysignLimitSwapOrder`. That is intentional — all three source branches then review identically — but it is a visible change to a path that already worked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device co-signers now process THORChain limit-order memos using accurate swap-order semantics and computed minimum-received amounts.
  * Added memo parsing utilities (including affiliate support) and exposed limit-order memo/keysign decoding through the SDK.
* **Bug Fixes**
  * Prevented signing and display mismatches from decimal-rescaling and memo/expected-value disagreements.
* **Refactor**
  * Centralized limit-swap memo grammar by routing validation through the shared parser.
* **Tests**
  * Added coverage for memo parsing, keysign order decoding, and minimum-received display/cross-check behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->