### PR TITLE
Fix SDK storage examples

### DIFF
--- a/docs/SDK-USERS-GUIDE.md
+++ b/docs/SDK-USERS-GUIDE.md
@@ -304,7 +304,6 @@ import { Vultisig } from '@vultisig/sdk'
 import * as readline from 'readline'
 
 const sdk = new Vultisig({
-  storage: new FileStorage(),
   onPasswordRequired: async (vaultId: string, vaultName: string) => {
     const rl = readline.createInterface({
       input: process.stdin,
@@ -325,7 +324,6 @@ const sdk = new Vultisig({
 
 ```typescript
 const sdk = new Vultisig({
-  storage: new FileStorage(),
   onPasswordRequired: async (vaultId: string, vaultName: string) => {
     // Retrieve from OS keychain, secure enclave, etc.
     return await secureStorage.getPassword(vaultId)
@@ -2199,8 +2197,7 @@ All configuration is passed to the `Vultisig` constructor. The SDK uses instance
 import { Vultisig, Chain } from '@vultisig/sdk'
 
 const sdk = new Vultisig({
-  // Required: Storage implementation
-  storage: new FileStorage(), // Or MemoryStorage, or custom implementation
+  // Storage is optional; omit it to use the persistent platform default.
 
   // Optional: Default chains for new vaults
   defaultChains: [Chain.Bitcoin, Chain.Ethereum, Chain.Solana],
@@ -2244,15 +2241,17 @@ sdk.dispose()
 You can create multiple isolated SDK instances, each with its own storage and configuration:
 
 ```typescript
+import { FileStorage, Vultisig } from '@vultisig/sdk/node'
+
 // Instance for user 1
 const sdk1 = new Vultisig({
-  storage: new FileStorage('./user1/vaults'),
+  storage: new FileStorage({ basePath: './user1/vaults' }),
   defaultCurrency: 'USD',
 })
 
 // Instance for user 2
 const sdk2 = new Vultisig({
-  storage: new FileStorage('./user2/vaults'),
+  storage: new FileStorage({ basePath: './user2/vaults' }),
   defaultCurrency: 'EUR',
 })
 
@@ -2365,7 +2364,6 @@ Configure cache TTLs:
 
 ```typescript
 const sdk = new Vultisig({
-  storage: new FileStorage(),
   cacheConfig: {
     balanceTTL: 300000, // 5 minutes (default)
     priceTTL: 300000, // 5 minutes (default)
@@ -2379,7 +2377,6 @@ Passwords are cached to avoid repeated prompts (see [Password Management](#passw
 
 ```typescript
 const sdk = new Vultisig({
-  storage: new FileStorage(),
   passwordCache: {
     defaultTTL: 300000, // 5 minutes
   },

--- a/packages/sdk/tests/unit/docs/storage-guide-contract.test.ts
+++ b/packages/sdk/tests/unit/docs/storage-guide-contract.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import { FileStorage } from '../../../src/platforms/node/storage'
+import { Vultisig } from '../../../src/Vultisig'
+
+const guidePath = fileURLToPath(new URL('../../../../../docs/SDK-USERS-GUIDE.md', import.meta.url))
+const guide = readFileSync(guidePath, 'utf8')
+const typescriptBlocks = [...guide.matchAll(/```typescript\n([\s\S]*?)```/g)].map(match => match[1])
+const fileStorageBlocks = typescriptBlocks.filter(block => /new FileStorage\(/.test(block))
+
+describe('SDK users guide storage contract', () => {
+  it('uses platform defaults unless custom storage is required', () => {
+    expect(guide).not.toContain('storage: new FileStorage()')
+  })
+
+  it('imports every FileStorage example from a platform subpath', () => {
+    expect(fileStorageBlocks.length).toBeGreaterThan(0)
+    for (const block of fileStorageBlocks) {
+      expect(block).toMatch(
+        /import\s*{[^}]*\bFileStorage\b[^}]*}\s*from\s*['"]@vultisig\/sdk\/(?:node|electron(?:\/main)?)['"]/
+      )
+    }
+  })
+
+  it('uses only supported FileStorage constructor shapes', () => {
+    for (const block of fileStorageBlocks) {
+      const calls = [...block.matchAll(/new FileStorage\(([^)]*)\)/g)]
+      expect(calls.length).toBeGreaterThan(0)
+      for (const [, rawArgs] of calls) {
+        const args = rawArgs.trim()
+        expect(args === '' || (args.startsWith('{') && args.endsWith('}'))).toBe(true)
+      }
+    }
+  })
+
+  it('constructs the documented Node storage configuration', () => {
+    const storage = new FileStorage({ basePath: '/tmp/vultisig-sdk-users-guide-contract' })
+    const sdk = new Vultisig({ storage })
+
+    expect(storage.basePath).toBe('/tmp/vultisig-sdk-users-guide-contract')
+    sdk.dispose()
+  })
+})

--- a/packages/sdk/tests/unit/docs/storage-guide-contract.test.ts
+++ b/packages/sdk/tests/unit/docs/storage-guide-contract.test.ts
@@ -10,6 +10,7 @@ const guidePath = fileURLToPath(new URL('../../../../../docs/SDK-USERS-GUIDE.md'
 const guide = readFileSync(guidePath, 'utf8')
 const typescriptBlocks = [...guide.matchAll(/```typescript\n([\s\S]*?)```/g)].map(match => match[1])
 const fileStorageBlocks = typescriptBlocks.filter(block => /new FileStorage\(/.test(block))
+const nodeFileStorageBlock = fileStorageBlocks.find(block => /from\s*['"]@vultisig\/sdk\/node['"]/.test(block))
 
 describe('SDK users guide storage contract', () => {
   it('uses platform defaults unless custom storage is required', () => {
@@ -38,12 +39,22 @@ describe('SDK users guide storage contract', () => {
   })
 
   it('constructs the documented Node storage configuration', () => {
+    const documentedBasePath = nodeFileStorageBlock?.match(
+      /new FileStorage\(\s*{\s*basePath:\s*(['"])(.*?)\1\s*}\s*\)/
+    )?.[2]
+
+    expect(documentedBasePath).toBeDefined()
+    if (!documentedBasePath) {
+      throw new Error('Expected the Node storage example to document a FileStorage basePath')
+    }
+
     const storage = new FileStorage({
-      basePath: '/tmp/vultisig-sdk-users-guide-contract',
+      basePath: documentedBasePath,
     })
     const sdk = new Vultisig({ storage })
 
-    expect(storage.basePath).toBe('/tmp/vultisig-sdk-users-guide-contract')
+    expect(storage.basePath).toBe(documentedBasePath)
+    expect(sdk.storage).toBe(storage)
     sdk.dispose()
   })
 })

--- a/packages/sdk/tests/unit/docs/storage-guide-contract.test.ts
+++ b/packages/sdk/tests/unit/docs/storage-guide-contract.test.ts
@@ -13,6 +13,7 @@ const fileStorageBlocks = typescriptBlocks.filter(block => /new FileStorage\(/.t
 
 describe('SDK users guide storage contract', () => {
   it('uses platform defaults unless custom storage is required', () => {
+    expect(guide).toContain('Storage is optional; omit it to use the persistent platform default.')
     expect(guide).not.toContain('storage: new FileStorage()')
   })
 
@@ -37,7 +38,9 @@ describe('SDK users guide storage contract', () => {
   })
 
   it('constructs the documented Node storage configuration', () => {
-    const storage = new FileStorage({ basePath: '/tmp/vultisig-sdk-users-guide-contract' })
+    const storage = new FileStorage({
+      basePath: '/tmp/vultisig-sdk-users-guide-contract',
+    })
     const sdk = new Vultisig({ storage })
 
     expect(storage.basePath).toBe('/tmp/vultisig-sdk-users-guide-contract')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the SDK storage guidance to clarify that `storage` is optional and uses the platform’s persistent default when omitted.
  * Refreshed TypeScript examples to match the current `FileStorage` construction style and correct platform-specific imports.
  * Simplified password and balance caching snippets by removing explicit `storage` wiring where not needed.
* **Tests**
  * Added a unit test that validates the SDK users guide “storage contract” by checking fenced TypeScript examples for correct imports and `new FileStorage(...)` argument shapes, and verifying the documented Node example behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->