### PR TITLE
fix(sdk): normalize StakeKit network aliases consistently

### DIFF
--- a/.changeset/brave-stakekit-aliases.md
+++ b/.changeset/brave-stakekit-aliases.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Normalize StakeKit network aliases consistently across search and balance reads.

--- a/packages/sdk/src/tools/defi/stakekit/index.ts
+++ b/packages/sdk/src/tools/defi/stakekit/index.ts
@@ -409,6 +409,20 @@ async function resolveActionArgs(
 
 // --- Builder functions ---
 
+const STAKEKIT_NETWORK_ALIASES: Readonly<Record<string, string>> = {
+  bsc: 'binance',
+  'bnb chain': 'binance',
+  'bnb-chain': 'binance',
+  bnbchain: 'binance',
+  avalanche: 'avalanche-c',
+  avax: 'avalanche-c',
+}
+
+const normalizeStakekitNetwork = (network: string): string => {
+  const normalized = network.toLowerCase()
+  return STAKEKIT_NETWORK_ALIASES[normalized] ?? normalized
+}
+
 /**
  * Search yield opportunities. Wraps searchYields with client-side token/provider filtering.
  * apiKey is injectable; omit for unauthenticated read-only access.
@@ -423,17 +437,7 @@ export async function stakekitSearch(params: {
 }): Promise<YieldProduct[]> {
   const limit = Math.min(Math.max(params.limit ?? 10, 1), 50)
 
-  const NETWORK_ALIASES: Record<string, string> = {
-    bsc: 'binance',
-    'bnb chain': 'binance',
-    'bnb-chain': 'binance',
-    bnbchain: 'binance',
-    avalanche: 'avalanche-c',
-    avax: 'avalanche-c',
-  }
-  const aliasedNetwork = params.network
-    ? (NETWORK_ALIASES[params.network.toLowerCase()] ?? params.network.toLowerCase())
-    : undefined
+  const aliasedNetwork = params.network ? normalizeStakekitNetwork(params.network) : undefined
 
   const wantsClientFilter = !!params.token || !!params.provider
   const apiLimit = wantsClientFilter ? 100 : limit
@@ -497,7 +501,7 @@ export async function stakekitBalances(params: {
   address: string
   network: string
 }): Promise<YieldBalance[] | null> {
-  return getBalances(params.address, params.network?.toLowerCase(), params.apiKey)
+  return getBalances(params.address, normalizeStakekitNetwork(params.network), params.apiKey)
 }
 
 // Action-input validation — ported verbatim from mcp-ts yield-tools.ts

--- a/packages/sdk/tests/unit/tools/defi/stakekit.test.ts
+++ b/packages/sdk/tests/unit/tools/defi/stakekit.test.ts
@@ -124,6 +124,21 @@ describe('sdk.defi.stakekit', () => {
   })
 
   describe('stakekitSearch', () => {
+    it('normalizes public network aliases at the StakeKit request boundary', async () => {
+      const fetchMock = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: [], hasNextPage: false }),
+        text: async () => '',
+      } as Response)
+      globalThis.fetch = fetchMock
+
+      await stakekitSearch({ network: 'BSC' })
+
+      const requestUrl = String(fetchMock.mock.calls[0]?.[0])
+      expect(new URL(requestUrl).searchParams.get('network')).toBe('binance')
+    })
+
     it('returns rows with YieldDiscoverOpportunity-compatible shape: apy is fraction, provider nested in metadata, id present', async () => {
       const product = makeProduct()
       globalThis.fetch = vi.fn().mockResolvedValueOnce({
@@ -511,6 +526,25 @@ describe('sdk.defi.stakekit', () => {
   })
 
   describe('stakekitBalances', () => {
+    it('uses the same canonical network aliases as search', async () => {
+      const fetchMock = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: [], hasNextPage: false }),
+        text: async () => '',
+      } as Response)
+      globalThis.fetch = fetchMock
+
+      const result = await stakekitBalances({
+        address: '0x1234567890123456789012345678901234567890',
+        network: 'AVAX',
+      })
+
+      expect(result).toEqual([])
+      const requestUrl = String(fetchMock.mock.calls[0]?.[0])
+      expect(new URL(requestUrl).searchParams.get('network')).toBe('avalanche-c')
+    })
+
     it('returns null on 403 (restricted endpoint)', async () => {
       // searchYields (to enumerate integration IDs)
       globalThis.fetch = vi


### PR DESCRIPTION
Closes #1523

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized StakeKit network alias handling across both search and balance requests.
  * Ensured common aliases (for example, BSC and AVAX) are normalized to the canonical values expected by the StakeKit backend.

* **Tests**
  * Added unit test coverage to verify the outgoing request URLs use the canonical network query values for both search and balance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->