### PR TITLE
ci: schedule read-only SDK E2E checks

### DIFF
--- a/.github/workflows/read-only-e2e.yml
+++ b/.github/workflows/read-only-e2e.yml
@@ -17,6 +17,9 @@ jobs:
     name: Read-only SDK e2e
     runs-on: ubuntu-latest
     timeout-minutes: 35
+    env:
+      TEST_VAULT_PATH: /tmp/e2e-test-vault.vult
+      TEST_VAULT_PASSWORD: ${{ secrets.E2E_TEST_VAULT_PASSWORD }}
 
     steps:
       - name: Checkout code
@@ -42,6 +45,26 @@ jobs:
       - name: Build packages
         run: yarn build:all
 
+      - name: Write test vault fixture
+        env:
+          VAULT_B64_1: ${{ secrets.E2E_TEST_VAULT_FILE_B64_1 }}
+          VAULT_B64_2: ${{ secrets.E2E_TEST_VAULT_FILE_B64_2 }}
+          VAULT_B64_3: ${{ secrets.E2E_TEST_VAULT_FILE_B64_3 }}
+          VAULT_B64_4: ${{ secrets.E2E_TEST_VAULT_FILE_B64_4 }}
+          VAULT_B64_5: ${{ secrets.E2E_TEST_VAULT_FILE_B64_5 }}
+          VAULT_B64_6: ${{ secrets.E2E_TEST_VAULT_FILE_B64_6 }}
+        run: |
+          if [ -z "$TEST_VAULT_PASSWORD" ] ||
+             [ -z "$VAULT_B64_1" ] || [ -z "$VAULT_B64_2" ] ||
+             [ -z "$VAULT_B64_3" ] || [ -z "$VAULT_B64_4" ] ||
+             [ -z "$VAULT_B64_5" ] || [ -z "$VAULT_B64_6" ]; then
+            echo "::error::The dedicated E2E vault fixture is incomplete; refusing to report a green read-only run with skipped suites."
+            exit 1
+          fi
+          printf '%s' "$VAULT_B64_1$VAULT_B64_2$VAULT_B64_3$VAULT_B64_4$VAULT_B64_5$VAULT_B64_6" |
+            base64 -d > "$TEST_VAULT_PATH"
+          chmod 600 "$TEST_VAULT_PATH"
+
       - name: Run swap quote e2e
         run: yarn test:e2e:swap-quotes
 
@@ -53,3 +76,7 @@ jobs:
 
       - name: Run prepare-send e2e
         run: yarn test:e2e:prepare-send
+
+      - name: Remove test vault fixture
+        if: always()
+        run: rm -f "$TEST_VAULT_PATH"

--- a/.github/workflows/read-only-e2e.yml
+++ b/.github/workflows/read-only-e2e.yml
@@ -19,7 +19,6 @@ jobs:
     timeout-minutes: 35
     env:
       TEST_VAULT_PATH: /tmp/e2e-test-vault.vult
-      TEST_VAULT_PASSWORD: ${{ secrets.E2E_TEST_VAULT_PASSWORD }}
 
     steps:
       - name: Checkout code
@@ -53,6 +52,7 @@ jobs:
           VAULT_B64_4: ${{ secrets.E2E_TEST_VAULT_FILE_B64_4 }}
           VAULT_B64_5: ${{ secrets.E2E_TEST_VAULT_FILE_B64_5 }}
           VAULT_B64_6: ${{ secrets.E2E_TEST_VAULT_FILE_B64_6 }}
+          TEST_VAULT_PASSWORD: ${{ secrets.E2E_TEST_VAULT_PASSWORD }}
         run: |
           if [ -z "$TEST_VAULT_PASSWORD" ] ||
              [ -z "$VAULT_B64_1" ] || [ -z "$VAULT_B64_2" ] ||
@@ -66,15 +66,23 @@ jobs:
           chmod 600 "$TEST_VAULT_PATH"
 
       - name: Run swap quote e2e
+        env:
+          TEST_VAULT_PASSWORD: ${{ secrets.E2E_TEST_VAULT_PASSWORD }}
         run: yarn test:e2e:swap-quotes
 
       - name: Run balance e2e
+        env:
+          TEST_VAULT_PASSWORD: ${{ secrets.E2E_TEST_VAULT_PASSWORD }}
         run: yarn test:e2e:balance
 
       - name: Run gas e2e
+        env:
+          TEST_VAULT_PASSWORD: ${{ secrets.E2E_TEST_VAULT_PASSWORD }}
         run: yarn test:e2e:gas
 
       - name: Run prepare-send e2e
+        env:
+          TEST_VAULT_PASSWORD: ${{ secrets.E2E_TEST_VAULT_PASSWORD }}
         run: yarn test:e2e:prepare-send
 
       - name: Remove test vault fixture

--- a/.github/workflows/read-only-e2e.yml
+++ b/.github/workflows/read-only-e2e.yml
@@ -1,0 +1,55 @@
+name: Read-Only E2E
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 3 * * *"
+
+concurrency:
+  group: read-only-e2e-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  NODE_OPTIONS: "--max-old-space-size=8192"
+
+jobs:
+  read-only-e2e:
+    name: Read-only SDK e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4
+        with:
+          node-version: "20"
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Prepare Yarn
+        run: corepack prepare yarn@4.16.0 --activate
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build shared packages
+        run: yarn build:shared
+
+      - name: Build packages
+        run: yarn build:all
+
+      - name: Run swap quote e2e
+        run: yarn test:e2e:swap-quotes
+
+      - name: Run balance e2e
+        run: yarn test:e2e:balance
+
+      - name: Run gas e2e
+        run: yarn test:e2e:gas
+
+      - name: Run prepare-send e2e
+        run: yarn test:e2e:prepare-send

--- a/.github/workflows/read-only-e2e.yml
+++ b/.github/workflows/read-only-e2e.yml
@@ -9,6 +9,9 @@ concurrency:
   group: read-only-e2e-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 env:
   NODE_OPTIONS: "--max-old-space-size=8192"
 
@@ -23,6 +26,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4

--- a/packages/sdk/tests/e2e/balance-operations.test.ts
+++ b/packages/sdk/tests/e2e/balance-operations.test.ts
@@ -124,7 +124,7 @@ describe.skipIf(!HAS_TEST_VAULT_FIXTURE)('E2E: Balance Operations (Production)',
       expect(balance.decimals).toBeDefined()
       expect(balance.amount).toBeTypeOf('string')
       expect(balance.chainId).toBe(Chain.Ethereum)
-      expect(balance.tokenId).toBe(USDC_ADDRESS)
+      expect(balance.tokenId?.toLowerCase()).toBe(USDC_ADDRESS.toLowerCase())
 
       console.log(`💰 USDC: ${balance.amount} ${balance.symbol}`)
     })
@@ -142,7 +142,7 @@ describe.skipIf(!HAS_TEST_VAULT_FIXTURE)('E2E: Balance Operations (Production)',
       expect(balance.decimals).toBeDefined()
       expect(balance.amount).toBeTypeOf('string')
       expect(balance.chainId).toBe(Chain.Ethereum)
-      expect(balance.tokenId).toBe(USDT_ADDRESS)
+      expect(balance.tokenId?.toLowerCase()).toBe(USDT_ADDRESS.toLowerCase())
 
       console.log(`💰 USDT: ${balance.amount} ${balance.symbol}`)
     })


### PR DESCRIPTION
Closes #939
Closes #939

Adds a scheduled and manually dispatchable read-only E2E workflow for swap quotes, balances, gas estimation, and transaction preparation. The workflow reconstructs the dedicated Actions vault from required fixture parts, fails closed when any part is absent, scopes the test password only to validation and suite steps, and leaves funded broadcast coverage manual.

Real runtime proof: all four read-only suites passed against production APIs on the publication revision, with no transactions broadcast.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a scheduled and manually triggered **read-only** end-to-end GitHub Actions workflow.
  * Runs E2E suites sequentially for swap quotes, balances, gas estimates, and send preparation with read-only permissions.
  * Improves reliability by generating a temporary secure Vault fixture for the run, validating required inputs, and cleaning it up afterward.
  * Updated ERC-20 balance assertions for Ethereum USDC and USDT to compare token contract addresses case-insensitively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->