### PR TITLE
Preserve hashes after partial bundled broadcasts

### DIFF
--- a/.changeset/broadcast-partial-hashes.md
+++ b/.changeset/broadcast-partial-hashes.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/sdk": patch
+---
+
+Preserve already-broadcast transaction hashes when a later bundled broadcast leg fails.

--- a/packages/sdk/src/adapters/formatSignature.ts
+++ b/packages/sdk/src/adapters/formatSignature.ts
@@ -62,13 +62,17 @@ export function formatSignature(
     format: signatureFormat,
   }
 
-  // For UTXO chains with multiple inputs, include all signatures
+  // Preserve per-message metadata for UTXO inputs and bundled transactions.
   if (messages.length > 1) {
-    signature.signatures = messages.map(msg => ({
-      r: signatureResults[msg].r,
-      s: signatureResults[msg].s,
-      der: signatureResults[msg].der_signature,
-    }))
+    signature.signatures = messages.map(msg => {
+      const result = signatureResults[msg]
+      return {
+        r: result.r,
+        s: result.s,
+        der: result.der_signature,
+        ...(result.recovery_id ? { recovery: parseInt(result.recovery_id) } : {}),
+      }
+    })
   }
 
   return signature

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -19,6 +19,7 @@ export { Vultisig } from './Vultisig'
 // Vault management
 export type { VaultConfig } from './vault'
 export {
+  BroadcastPartialFailureError,
   FastVault,
   SecureVault,
   VaultBase,

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -168,11 +168,12 @@ export type Signature = {
   signature: string
   recovery?: number
   format: 'DER' | 'ECDSA' | 'EdDSA' | 'Ed25519' | 'MLDSA'
-  // For UTXO chains with multiple inputs, includes all signatures
+  // For transactions with multiple message hashes, includes each signature's metadata.
   signatures?: Array<{
     r: string
     s: string
     der: string
+    recovery?: number
   }>
   // ML-DSA-44 post-quantum signature (hex-encoded), present when vault has MLDSA keys
   mldsaSignature?: string

--- a/packages/sdk/src/vault/index.ts
+++ b/packages/sdk/src/vault/index.ts
@@ -11,6 +11,7 @@ import { VaultBase } from './VaultBase'
 export { FastVault, SecureVault, VaultBase }
 
 // Export errors
+export { BroadcastPartialFailureError } from './services/BroadcastService'
 export { VaultError, VaultErrorCode, VaultImportError, VaultImportErrorCode } from './VaultError'
 
 // Export vault configuration

--- a/packages/sdk/src/vault/services/BroadcastService.ts
+++ b/packages/sdk/src/vault/services/BroadcastService.ts
@@ -38,6 +38,34 @@ const extractResolverTxHash = (broadcastResult: unknown): string | undefined => 
   return undefined
 }
 
+type BroadcastPartialFailureInput = {
+  chain: Chain
+  broadcastedTxHashes: string[]
+  failedInputIndex: number
+  cause: unknown
+}
+
+export class BroadcastPartialFailureError extends Error {
+  readonly broadcastedTxHashes: string[]
+  readonly failedInputIndex: number
+  readonly originalError?: Error
+
+  constructor({ chain, broadcastedTxHashes, failedInputIndex, cause }: BroadcastPartialFailureInput) {
+    const errorMessage = cause instanceof Error ? cause.message : String(cause)
+    super(
+      `Broadcast failed on ${chain} input ${failedInputIndex + 1} after ${
+        broadcastedTxHashes.length
+      } transaction(s) were submitted: ${errorMessage}. Broadcasted transaction hashes: ${broadcastedTxHashes.join(
+        ', '
+      )}`
+    )
+    this.name = 'BroadcastPartialFailureError'
+    this.broadcastedTxHashes = broadcastedTxHashes
+    this.failedInputIndex = failedInputIndex
+    this.originalError = cause instanceof Error ? cause : new Error(String(cause))
+  }
+}
+
 /**
  * BroadcastService
  *
@@ -125,7 +153,8 @@ export class BroadcastService {
       // Broadcast all transaction inputs (e.g., approve + swap for EVM token flows).
       // Returns the hash of the last transaction, which is typically the primary one.
       let txHash = ''
-      for (const txInputData of txInputsArray) {
+      const broadcastedTxHashes: string[] = []
+      for (const [index, txInputData] of txInputsArray.entries()) {
         const compiledTx = compileTx({
           publicKey,
           txInputData,
@@ -140,13 +169,28 @@ export class BroadcastService {
         })
 
         const signingOutput = decodeSigningOutput(chain, compiledTx)
+        let broadcastResult: unknown
+        try {
+          broadcastResult = await coreBroadcastTx({
+            chain,
+            tx: signingOutput,
+          })
+        } catch (error) {
+          if (broadcastedTxHashes.length > 0) {
+            throw new BroadcastPartialFailureError({
+              chain,
+              broadcastedTxHashes,
+              failedInputIndex: index,
+              cause: error,
+            })
+          }
+          throw error
+        }
 
-        const broadcastResult = await coreBroadcastTx({
-          chain,
-          tx: signingOutput,
-        })
-
-        txHash = extractResolverTxHash(broadcastResult) ?? (await getTxHash({ chain, tx: signingOutput }))
+        const inputTxHash =
+          extractResolverTxHash(broadcastResult) ?? (await getTxHash({ chain, tx: signingOutput }))
+        broadcastedTxHashes.push(inputTxHash)
+        txHash = inputTxHash
       }
 
       return txHash

--- a/packages/sdk/src/vault/services/BroadcastService.ts
+++ b/packages/sdk/src/vault/services/BroadcastService.ts
@@ -81,7 +81,8 @@ export class BroadcastPartialFailureError extends Error {
 export class BroadcastService {
   constructor(
     private extractMessageHashes: (keysignPayload: KeysignPayload) => Promise<string[]>,
-    private wasmProvider: WasmProvider
+    private wasmProvider: WasmProvider,
+    private broadcastTransaction: typeof coreBroadcastTx = coreBroadcastTx
   ) {}
 
   /**
@@ -171,7 +172,7 @@ export class BroadcastService {
         const signingOutput = decodeSigningOutput(chain, compiledTx)
         let broadcastResult: unknown
         try {
-          broadcastResult = await coreBroadcastTx({
+          broadcastResult = await this.broadcastTransaction({
             chain,
             tx: signingOutput,
           })
@@ -187,8 +188,7 @@ export class BroadcastService {
           throw error
         }
 
-        const inputTxHash =
-          extractResolverTxHash(broadcastResult) ?? (await getTxHash({ chain, tx: signingOutput }))
+        const inputTxHash = extractResolverTxHash(broadcastResult) ?? (await getTxHash({ chain, tx: signingOutput }))
         broadcastedTxHashes.push(inputTxHash)
         txHash = inputTxHash
       }

--- a/packages/sdk/src/vault/utils/convertSignature.ts
+++ b/packages/sdk/src/vault/utils/convertSignature.ts
@@ -86,7 +86,7 @@ export function convertToKeysignSignatures(
         r: sig.r,
         s: sig.s,
         der_signature: sig.der,
-        recovery_id: signature.recovery?.toString(),
+        recovery_id: (sig.recovery ?? signature.recovery)?.toString(),
       }
     })
   } else {

--- a/packages/sdk/tests/unit/adapters/formatSignature.test.ts
+++ b/packages/sdk/tests/unit/adapters/formatSignature.test.ts
@@ -173,6 +173,34 @@ describe('formatSignature', () => {
   })
 
   describe('Multi-Signature Cases (UTXO Chains)', () => {
+    it('preserves each message recovery ID for bundled EVM transactions', () => {
+      const signatureResults: Record<string, KeysignSignature> = {
+        approve: { msg: 'approve', r: 'r1', s: 's1', der_signature: 'der1', recovery_id: '0' },
+        transfer: { msg: 'transfer', r: 'r2', s: 's2', der_signature: 'der2', recovery_id: '1' },
+      }
+
+      const result = formatSignature(signatureResults, ['approve', 'transfer'], 'ecdsa')
+
+      expect(result.signatures).toEqual([
+        { r: 'r1', s: 's1', der: 'der1', recovery: 0 },
+        { r: 'r2', s: 's2', der: 'der2', recovery: 1 },
+      ])
+    })
+
+    it('omits empty recovery IDs for bundled transactions', () => {
+      const signatureResults: Record<string, KeysignSignature> = {
+        approve: { msg: 'approve', r: 'r1', s: 's1', der_signature: 'der1', recovery_id: '' },
+        transfer: { msg: 'transfer', r: 'r2', s: 's2', der_signature: 'der2', recovery_id: '1' },
+      }
+
+      const result = formatSignature(signatureResults, ['approve', 'transfer'], 'ecdsa')
+
+      expect(result.signatures).toEqual([
+        { r: 'r1', s: 's1', der: 'der1' },
+        { r: 'r2', s: 's2', der: 'der2', recovery: 1 },
+      ])
+    })
+
     it('should format Bitcoin transaction with 2 inputs', () => {
       const signatureResults: Record<string, KeysignSignature> = {
         '0xhash1': {

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -145,6 +145,7 @@ describe('@vultisig/sdk public exports', () => {
     expect(typeof sdk.isChainOfKind).toBe('function')
     expect(sdk.chainFeeCoin.Ethereum.ticker).toBe('ETH')
     expect(typeof sdk.VaultBase).toBe('function')
+    expect(typeof sdk.BroadcastPartialFailureError).toBe('function')
   })
 
   it('exports chain kind and native fee coin metadata for client boundary consumers', () => {

--- a/packages/sdk/tests/unit/vault/services/BroadcastService.test.ts
+++ b/packages/sdk/tests/unit/vault/services/BroadcastService.test.ts
@@ -158,6 +158,18 @@ describe('BroadcastService', () => {
     expect(mockGetTxHash).toHaveBeenCalledOnce()
   })
 
+  it('uses an injected broadcaster without calling the network broadcaster', async () => {
+    mockGetEncodedSigningInputs.mockResolvedValue(['approve-input', 'swap-input'])
+    mockGetTxHash.mockResolvedValueOnce('approve-local-hash').mockResolvedValueOnce('swap-local-hash')
+    const injectedBroadcaster = vi.fn().mockResolvedValue(undefined)
+    const injectedService = new BroadcastService(extractMessageHashes, wasmProvider, injectedBroadcaster)
+
+    await injectedService.broadcastTx({ chain: Chain.Ethereum, keysignPayload, signature })
+
+    expect(injectedBroadcaster).toHaveBeenCalledTimes(2)
+    expect(mockCoreBroadcastTx).not.toHaveBeenCalled()
+  })
+
   it('carries already-broadcast hashes when a later input fails', async () => {
     mockGetEncodedSigningInputs.mockResolvedValue(['approve-input', 'swap-input'])
     mockCoreBroadcastTx.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('swap rejected'))

--- a/packages/sdk/tests/unit/vault/services/BroadcastService.test.ts
+++ b/packages/sdk/tests/unit/vault/services/BroadcastService.test.ts
@@ -3,7 +3,7 @@ import type { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { Signature } from '@/types'
-import { BroadcastService } from '@/vault/services/BroadcastService'
+import { BroadcastPartialFailureError, BroadcastService } from '@/vault/services/BroadcastService'
 import { VaultErrorCode } from '@/vault/VaultError'
 
 const {
@@ -156,6 +156,23 @@ describe('BroadcastService', () => {
     expect(hash).toBe('swap-node-hash')
     // Only the first (void-resolver) iteration needed the local fallback.
     expect(mockGetTxHash).toHaveBeenCalledOnce()
+  })
+
+  it('carries already-broadcast hashes when a later input fails', async () => {
+    mockGetEncodedSigningInputs.mockResolvedValue(['approve-input', 'swap-input'])
+    mockCoreBroadcastTx.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('swap rejected'))
+    mockGetTxHash.mockResolvedValueOnce('approve-local-hash')
+
+    const promise = service.broadcastTx({ chain: Chain.Ethereum, keysignPayload, signature })
+
+    await expect(promise).rejects.toMatchObject({
+      code: VaultErrorCode.BroadcastFailed,
+      originalError: expect.objectContaining({
+        broadcastedTxHashes: ['approve-local-hash'],
+        failedInputIndex: 1,
+      }),
+    })
+    await expect(promise).rejects.toHaveProperty('originalError', expect.any(BroadcastPartialFailureError))
   })
 
   it('wraps a broadcast failure in a BroadcastFailed VaultError', async () => {

--- a/packages/sdk/tests/unit/vault/utils/convertSignature.test.ts
+++ b/packages/sdk/tests/unit/vault/utils/convertSignature.test.ts
@@ -156,6 +156,7 @@ describe('convertToKeysignSignatures', () => {
             r: '0xab3c7b6a9e8f2c1d5e4a3f2b1c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d',
             s: '0x7f6e5d4c3b2a1f0e9d8c7b6a5f4e3d2c1b0a9f8e7d6c5b4a3f2e1d0c9b8a7f6e',
             der: '0x3045022100ab3c7b6a9e8f2c1d5e4a3f2b1c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d02207f6e5d4c3b2a1f0e9d8c7b6a5f4e3d2c1b0a9f8e7d6c5b4a3f2e1d0c9b8a7f6e',
+            recovery: 1,
           },
           {
             r: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
@@ -181,7 +182,7 @@ describe('convertToKeysignSignatures', () => {
         r: signature.signatures![0].r,
         s: signature.signatures![0].s,
         der_signature: signature.signatures![0].der,
-        recovery_id: '0',
+        recovery_id: '1',
       })
 
       // Second signature


### PR DESCRIPTION
Closes #941

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Preserve already-broadcast transaction hashes when a later bundled broadcast fails.
  - Expose `BroadcastPartialFailureError`, including the chain, successfully broadcast hashes, and the index of the failed broadcast.
  - Include per-message recovery metadata for multi-signature, multi-message transactions.

- **Bug Fixes**
  - Correct recovery ID derivation to respect individual signature recovery data in multi-message cases.

- **Tests**
  - Added/updated unit tests for partial broadcast failures, public exports, and per-message recovery formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->