### PR TITLE
fix: validate Bittensor balance addresses

### DIFF
--- a/.changeset/bittensor-address-validation.md
+++ b/.changeset/bittensor-address-validation.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/core-chain': patch
+---
+
+Validate Bittensor SS58 prefix and checksum before reading TAO balances.

--- a/packages/core/chain/coin/balance/resolvers/bittensor.test.ts
+++ b/packages/core/chain/coin/balance/resolvers/bittensor.test.ts
@@ -1,0 +1,101 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const queryUrlMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
+  queryUrl: queryUrlMock,
+}))
+
+import { getBittensorCoinBalance } from './bittensor'
+
+// Alice's SS58-42 address and its 32-byte public key.
+// Public key: d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
+const VALID_TAO_ADDRESS = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
+const POLKADOT_ADDRESS_SAME_ACCOUNT = '15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5'
+
+const u128LE = (value: bigint): string => {
+  const bytes = Array.from({ length: 16 }, (_, index) =>
+    ((value >> BigInt(index * 8)) & 0xffn).toString(16).padStart(2, '0')
+  )
+  return bytes.join('')
+}
+
+const buildSystemAccountHex = (free: bigint): string =>
+  '0x' +
+  '00000000' + // nonce
+  '00000000' + // consumers
+  '01000000' + // providers
+  '00000000' + // sufficients
+  u128LE(free) +
+  u128LE(0n) +
+  u128LE(0n) +
+  u128LE(0n)
+
+describe('getBittensorCoinBalance', () => {
+  beforeEach(() => {
+    queryUrlMock.mockReset()
+  })
+
+  it('fetches native TAO balance for a valid Bittensor SS58 address', async () => {
+    queryUrlMock.mockResolvedValue({ result: buildSystemAccountHex(1_500_000_000n) })
+
+    const balance = await getBittensorCoinBalance({
+      chain: Chain.Bittensor,
+      address: VALID_TAO_ADDRESS,
+    })
+
+    expect(balance).toBe(1_500_000_000n)
+    expect(queryUrlMock).toHaveBeenCalledTimes(1)
+
+    const storageKey: string = queryUrlMock.mock.calls[0][1].body.params[0]
+    expect(storageKey.startsWith('0x26aa394eea5630e07c48ae0c9558cef7')).toBe(true)
+    expect(storageKey.endsWith('d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d')).toBe(true)
+  })
+
+  it('rejects a Polkadot SS58 address before any RPC call', async () => {
+    await expect(
+      getBittensorCoinBalance({
+        chain: Chain.Bittensor,
+        address: POLKADOT_ADDRESS_SAME_ACCOUNT,
+      })
+    ).rejects.toThrow(/Not a Bittensor address/)
+
+    expect(queryUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an address with an invalid SS58 checksum before any RPC call', async () => {
+    const typoAddress = VALID_TAO_ADDRESS.slice(0, -1) + 'X'
+
+    await expect(
+      getBittensorCoinBalance({
+        chain: Chain.Bittensor,
+        address: typoAddress,
+      })
+    ).rejects.toThrow(/Invalid SS58 checksum/)
+
+    expect(queryUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 0n for a null RPC result', async () => {
+    queryUrlMock.mockResolvedValue({ result: null })
+
+    const balance = await getBittensorCoinBalance({
+      chain: Chain.Bittensor,
+      address: VALID_TAO_ADDRESS,
+    })
+
+    expect(balance).toBe(0n)
+  })
+
+  it('propagates Bittensor RPC errors', async () => {
+    queryUrlMock.mockResolvedValue({ error: { code: -32000, message: 'storage error' } })
+
+    await expect(
+      getBittensorCoinBalance({
+        chain: Chain.Bittensor,
+        address: VALID_TAO_ADDRESS,
+      })
+    ).rejects.toThrow(/Bittensor balance RPC error/)
+  })
+})

--- a/packages/core/chain/coin/balance/resolvers/bittensor.ts
+++ b/packages/core/chain/coin/balance/resolvers/bittensor.ts
@@ -16,15 +16,31 @@ type RpcResponse<T> = {
 // System.Account storage key prefix: twox128("System") ++ twox128("Account")
 const systemAccountPrefix = '0x26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da9'
 
+const bittensorSs58Prefix = 42
 const ss58AddressByteLength = 35
 const ss58PublicKeyOffset = 1
 const ss58PublicKeyEnd = 33
+const ss58ChecksumPreamble = new TextEncoder().encode('SS58PRE')
 
 const decodeSs58PublicKey = (address: string): Uint8Array => {
   const decoded = bs58.decode(address)
   if (decoded.length !== ss58AddressByteLength) {
     throw new Error(`Invalid SS58 address length: expected ${ss58AddressByteLength} bytes, got ${decoded.length}`)
   }
+  if (decoded[0] !== bittensorSs58Prefix) {
+    throw new Error(`Not a Bittensor address: SS58 network prefix ${decoded[0]}, expected ${bittensorSs58Prefix}`)
+  }
+
+  const body = decoded.subarray(0, ss58PublicKeyEnd)
+  const checksum = decoded.subarray(ss58PublicKeyEnd)
+  const checksumInput = new Uint8Array(ss58ChecksumPreamble.length + body.length)
+  checksumInput.set(ss58ChecksumPreamble)
+  checksumInput.set(body, ss58ChecksumPreamble.length)
+  const expected = blake2b(checksumInput, { dkLen: 64 })
+  if (expected[0] !== checksum[0] || expected[1] !== checksum[1]) {
+    throw new Error('Invalid SS58 checksum')
+  }
+
   return decoded.slice(ss58PublicKeyOffset, ss58PublicKeyEnd)
 }
 


### PR DESCRIPTION
Closes #946

Reject non-Bittensor SS58 network prefixes and invalid checksums before querying account storage.

Refs #946

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened Bittensor SS58 address validation by verifying expected network prefix and checksum before reading TAO balances.
  * Addresses that are invalid, incompatible, or have incorrect checksums are rejected without making any RPC request.
  * More robust behavior for empty or failing balance lookups (returning zero for null results and surfacing RPC errors clearly).
* **Tests**
  * Added coverage for Bittensor balance resolution, including valid address handling, rejection cases, null responses, and RPC error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->