### PR TITLE
fix(evm): sign Sei as EIP-1559 (enveloped) to match mobile clients

### DIFF
--- a/.changeset/sei-evm-enveloped-tx-fee.md
+++ b/.changeset/sei-evm-enveloped-tx-fee.md
@@ -1,0 +1,12 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/sdk': patch
+---
+
+Sign Sei as EIP-1559 (enveloped) instead of legacy, matching iOS
+(`EVMHelper.setGasParameters`) and Android (`EthereumGasHelper.setGasParameters`),
+which sign every EVM chain except BSC as EIP-1559. Sei was the only
+enveloped-capable EVM chain still mapped to `'legacy'` in
+`evmChainTxFeeFormat`, so the pre-signing hash (and therefore the relay
+`message_id`) diverged between mobile and extension/desktop, deadlocking
+Sei co-signing between them (vultisig-windows#4369).

--- a/packages/core/chain/chains/evm/tx/fee/index.ts
+++ b/packages/core/chain/chains/evm/tx/fee/index.ts
@@ -15,5 +15,10 @@ export const evmChainTxFeeFormat: Record<EvmChain, EvmTxFeeFormat> = {
   [EvmChain.Polygon]: 'enveloped',
   [EvmChain.Mantle]: 'enveloped',
   [EvmChain.Hyperliquid]: 'enveloped',
-  [EvmChain.Sei]: 'legacy',
+  // Sei must stay 'enveloped': iOS (EVMHelper.setGasParameters) and Android
+  // (EthereumGasHelper.setGasParameters) sign every EVM chain except BSC as
+  // EIP-1559. A different tx mode changes the pre-signing hash and therefore
+  // the relay message_id, so extension<->mobile Sei co-signing deadlocks
+  // (vultisig-windows#4369).
+  [EvmChain.Sei]: 'enveloped',
 }

--- a/packages/core/chain/chains/evm/tx/fee/tw/getEvmTwFeeFields.test.ts
+++ b/packages/core/chain/chains/evm/tx/fee/tw/getEvmTwFeeFields.test.ts
@@ -1,0 +1,35 @@
+import { TW } from '@trustwallet/wallet-core'
+import { describe, expect, it } from 'vitest'
+
+import { EvmChain } from '../../../../../Chain'
+import { getEvmTwFeeFields } from './getEvmTwFeeFields'
+
+const input = {
+  maxFeePerGasWei: 100n,
+  priorityFee: 10n,
+  gasLimit: 21_000n,
+}
+
+describe('getEvmTwFeeFields', () => {
+  // Sei must sign enveloped (EIP-1559) to match iOS/Android, which sign every
+  // EVM chain except BSC that way. A legacy tx here changes the pre-signing
+  // hash and therefore the relay message_id, deadlocking mobile<->extension
+  // co-signing (vultisig-windows#4369). Pins evmChainTxFeeFormat[Sei] against
+  // an accidental revert to 'legacy'.
+  it('signs Sei as an enveloped (EIP-1559) transaction, not legacy', () => {
+    const fields = getEvmTwFeeFields({ chain: EvmChain.Sei, ...input })
+
+    expect(fields.txMode).toBe(TW.Ethereum.Proto.TransactionMode.Enveloped)
+    expect(fields).toHaveProperty('maxFeePerGas')
+    expect(fields).toHaveProperty('maxInclusionFeePerGas')
+    expect(fields).not.toHaveProperty('gasPrice')
+  })
+
+  it('signs BSC as a legacy transaction (the sole documented exception)', () => {
+    const fields = getEvmTwFeeFields({ chain: EvmChain.BSC, ...input })
+
+    expect(fields.txMode).toBe(TW.Ethereum.Proto.TransactionMode.Legacy)
+    expect(fields).toHaveProperty('gasPrice')
+    expect(fields).not.toHaveProperty('maxFeePerGas')
+  })
+})


### PR DESCRIPTION
## Summary

Sei was the only EIP-1559-capable EVM chain in `evmChainTxFeeFormat` mapped to `'legacy'`. The mobile clients sign **every** EVM chain except BSC as EIP-1559:

- iOS — `EVMHelper.setGasParameters`
- Android — `EthereumGasHelper.setGasParameters`
### Transaction hash
https://seiscan.io/tx/0x0827d6d76cff4e44820a122fd81b06a0834941e27232bedc9a5f823eecbab1b2

The tx fee format (legacy vs. enveloped / type-2) changes the serialized transaction, so it changes the pre-signing hash — and the pre-signing hash is what becomes the relay `message_id`. When the extension/desktop built a legacy Sei tx and the mobile peer built an enveloped one, the two parties were waiting on different message IDs and the keysign never converged. That matches the reported symptom exactly: mobile↔mobile Sei signs and broadcasts (both sides agree on enveloped), while iOS↔extension and Android↔extension hang.

This also explains why the derivation path investigation in the issue came up empty — the path was always correct; the divergence was in tx construction, which the issue author flagged as the most likely remaining candidate ("a difference in how the SEI EVM tx is built … that changes the signed digest").

## Change

`packages/core/chain/chains/evm/tx/fee/index.ts` — `EvmChain.Sei`: `'legacy'` → `'enveloped'`, with a comment recording why it must not drift back (mobile parity is a signing-protocol constraint, not a preference).

## Fixes

vultisig/vultisig-windows#4369

## Verification

Static, single-value mapping change — no local keysign was run against a live Sei vault. Cross-platform confirmation still wanted before this is considered closed:

- [ ] iOS ↔ extension/desktop Sei send signs and broadcasts
- [ ] Android ↔ extension/desktop Sei send signs and broadcasts
- [ ] iOS ↔ Android Sei send still works (no regression)
- [ ] A plain Ethereum send still co-signs (enveloped path unchanged)

## Note on changeset

This ships in `@vultisig/core-chain`, so per `CLAUDE.md` it needs a `patch` changeset. I was asked not to modify any files beyond the existing working-tree change, so none is included here — please run `yarn changeset` on this branch before merge, or the published package will not pick the fix up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Sei transaction fee/format handling to use the correct enveloped (EIP-1559) transaction mode, improving signing consistency and preventing co-signing deadlocks across mobile and desktop contexts.  
  * Added automated tests covering Sei (enveloped) and BSC (legacy) fee field behavior to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->