### PR TITLE
feat(ripple): resolve logos for XRPL issued currencies

### DIFF
--- a/.changeset/ripple-token-logos.md
+++ b/.changeset/ripple-token-logos.md
@@ -1,0 +1,23 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/sdk': patch
+---
+
+feat(ripple): resolve logos for XRPL issued currencies
+
+Only curated issued currencies (RLUSD) carried a logo, so every other trust-line
+token — SOLO, an issuer's USD, anything added by id or surfaced by ledger
+discovery — resolved with no logo and rendered as a broken-image placeholder in
+clients.
+
+`getRippleTokenMetadata` now reads an uncurated token's official icon from the
+XRPL token registry (xrplmeta), keyed by the `<currency>:<issuer>` pair. This is
+the same shape as the EVM resolver reading `logoURI` from 1inch and the Solana
+resolver returning `icon`; XRPL was the outlier because it has no on-ledger token
+metadata registry of its own.
+
+A curated token is unchanged: it keeps its bundled logo and price provider and
+performs no lookup. An uncurated token may borrow an icon but never a curated
+token's `priceProviderId` — two issuers can share a ticker on XRPL, so the issuer
+is what identifies a token. The lookup fails soft: an unlisted token or an
+unreachable registry still resolves, just without a logo.

--- a/packages/core/chain/coin/token/metadata/resolvers/ripple.test.ts
+++ b/packages/core/chain/coin/token/metadata/resolvers/ripple.test.ts
@@ -1,14 +1,29 @@
 import { Chain } from '@vultisig/core-chain/Chain'
 import { rippleIssuedCurrencyDecimals, rippleTokenId } from '@vultisig/core-chain/chains/ripple/issuedCurrency'
-import { describe, expect, it } from 'vitest'
+import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getRippleTokenMetadata } from './ripple'
 
+vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
+  queryUrl: vi.fn(),
+}))
+
 const RLUSD_ISSUER = 'rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De'
 const SOLO_ISSUER = 'rsoLo2S1kiGeCcn6hCUXVrCpGMWLrRrLZz'
+const SOLO_ICON = 'https://s2.xrplmeta.org/icon/C40439709A.png'
+
+const mockIcon = (icon: string | undefined) => {
+  vi.mocked(queryUrl).mockResolvedValue({ meta: { token: { icon } } } as never)
+}
 
 describe('getRippleTokenMetadata', () => {
-  it('enriches a curated token (RLUSD) with its logo and price provider', async () => {
+  beforeEach(() => {
+    vi.mocked(queryUrl).mockReset()
+    mockIcon(undefined)
+  })
+
+  it('enriches a curated token (RLUSD) with its bundled logo and price provider', async () => {
     const id = rippleTokenId({ currency: 'RLUSD', issuer: RLUSD_ISSUER })
 
     await expect(getRippleTokenMetadata({ chain: Chain.Ripple, id })).resolves.toEqual({
@@ -19,7 +34,56 @@ describe('getRippleTokenMetadata', () => {
     })
   })
 
-  it('derives ticker/decimals for an arbitrary token, with no logo or price', async () => {
+  it('does not query the registry for a curated token', async () => {
+    const id = rippleTokenId({ currency: 'RLUSD', issuer: RLUSD_ISSUER })
+
+    await getRippleTokenMetadata({ chain: Chain.Ripple, id })
+
+    expect(queryUrl).not.toHaveBeenCalled()
+  })
+
+  it('gives an arbitrary token its registry icon', async () => {
+    mockIcon(SOLO_ICON)
+    const id = rippleTokenId({ currency: 'SOLO', issuer: SOLO_ISSUER })
+
+    await expect(getRippleTokenMetadata({ chain: Chain.Ripple, id })).resolves.toEqual({
+      ticker: 'SOLO',
+      decimals: rippleIssuedCurrencyDecimals,
+      logo: SOLO_ICON,
+    })
+  })
+
+  it('looks the token up by its currency and issuer pair', async () => {
+    const id = rippleTokenId({ currency: 'SOLO', issuer: SOLO_ISSUER })
+
+    await getRippleTokenMetadata({ chain: Chain.Ripple, id })
+
+    // Two issuers can share a ticker, so the issuer has to be part of the key.
+    expect(vi.mocked(queryUrl).mock.calls[0][0]).toContain(`:${SOLO_ISSUER}`)
+  })
+
+  it('never gives an arbitrary token a price provider', async () => {
+    mockIcon(SOLO_ICON)
+    const id = rippleTokenId({ currency: 'SOLO', issuer: SOLO_ISSUER })
+
+    const metadata = await getRippleTokenMetadata({ chain: Chain.Ripple, id })
+
+    // A logo it may borrow; a curated token's pricing it may not.
+    expect(metadata).not.toHaveProperty('priceProviderId')
+  })
+
+  it('resolves without a logo when the token is unlisted', async () => {
+    const id = rippleTokenId({ currency: 'SOLO', issuer: SOLO_ISSUER })
+
+    await expect(getRippleTokenMetadata({ chain: Chain.Ripple, id })).resolves.toEqual({
+      ticker: 'SOLO',
+      decimals: rippleIssuedCurrencyDecimals,
+    })
+  })
+
+  it('resolves without a logo when the registry is unreachable', async () => {
+    // The token still resolves — a registry outage is not a metadata failure.
+    vi.mocked(queryUrl).mockRejectedValue(new Error('network down'))
     const id = rippleTokenId({ currency: 'SOLO', issuer: SOLO_ISSUER })
 
     await expect(getRippleTokenMetadata({ chain: Chain.Ripple, id })).resolves.toEqual({

--- a/packages/core/chain/coin/token/metadata/resolvers/ripple.ts
+++ b/packages/core/chain/coin/token/metadata/resolvers/ripple.ts
@@ -6,6 +6,8 @@ import {
   rippleTokenId,
 } from '@vultisig/core-chain/chains/ripple/issuedCurrency'
 import { areEqualCoins, CoinMetadata } from '@vultisig/core-chain/coin/Coin'
+import { attempt } from '@vultisig/lib-utils/attempt'
+import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
 import { TokenMetadataResolver } from '../resolver'
 
@@ -24,18 +26,55 @@ const toIssuedCurrencyTicker = (currency: string): string => {
   return /^[\x20-\x7e]+$/.test(ascii) ? ascii : currency
 }
 
+/** XRPL token registry that maps a `<currency>:<issuer>` pair to community metadata. */
+const xrplMetaBaseUrl = 'https://s1.xrplmeta.org'
+
+type XrplMetaTokenResponse = {
+  meta?: {
+    token?: {
+      icon?: string
+    }
+  }
+}
+
+/**
+ * Official token icon from the XRPL token registry (xrplmeta), or `undefined`
+ * when the token is unlisted or the registry is unreachable.
+ *
+ * XRPL issued currencies carry no on-ledger logo, so — as the EVM (1inch) and
+ * Solana resolvers do for their chains — an arbitrary token borrows its logo
+ * from a community registry, keyed by the `<currency>:<issuer>` pair. A registry
+ * miss or outage is not an error here: the token still resolves, just without a
+ * logo, so the lookup fails soft.
+ */
+const getRippleTokenIcon = async ({
+  currency,
+  issuer,
+}: {
+  currency: string
+  issuer: string
+}): Promise<string | undefined> => {
+  const result = await attempt(() => queryUrl<XrplMetaTokenResponse>(`${xrplMetaBaseUrl}/token/${currency}:${issuer}`))
+
+  if ('error' in result) {
+    return undefined
+  }
+
+  return result.data.meta?.token?.icon || undefined
+}
+
 /**
  * Metadata for a custom XRPL issued currency identified by a `currency.issuer`
  * token id.
  *
- * Unlike EVM/Tron tokens, XRPL issued currencies expose no on-ledger metadata
- * call: issued amounts carry no fixed on-chain decimal count (we model them at
+ * XRPL issued currencies expose no on-ledger metadata call: issued amounts carry
+ * no fixed on-chain decimal count (we model them at
  * {@link rippleIssuedCurrencyDecimals}) and the ticker is derived from the
- * currency code itself, so nothing is fetched. When the token is one we curate,
- * its logo and price provider are merged in; an arbitrary token gets neither, so
- * it renders with a generic icon and no price rather than borrowing a known
- * token's identity — two different issuers can share a ticker on XRPL, so the
- * issuer (encoded in the id) is what actually distinguishes them.
+ * currency code itself. A curated token keeps its bundled logo and price
+ * provider; any other token borrows its official icon from the XRPL token
+ * registry (falling back to no logo), but never a curated token's price — two
+ * issuers can share a ticker on XRPL, so the issuer (encoded in the id) is what
+ * actually distinguishes them.
  */
 export const getRippleTokenMetadata: TokenMetadataResolver<OtherChain.Ripple> = async ({ id, chain }) => {
   const { currency, issuer } = parseRippleTokenId(id)
@@ -49,13 +88,15 @@ export const getRippleTokenMetadata: TokenMetadataResolver<OtherChain.Ripple> = 
     areEqualCoins(token, { chain, id: rippleTokenId({ currency, issuer }) })
   )
 
-  if (!knownToken) {
-    return metadata
+  if (knownToken) {
+    return {
+      ...metadata,
+      logo: knownToken.logo,
+      priceProviderId: knownToken.priceProviderId,
+    }
   }
 
-  return {
-    ...metadata,
-    logo: knownToken.logo,
-    priceProviderId: knownToken.priceProviderId,
-  }
+  const logo = await getRippleTokenIcon({ currency, issuer })
+
+  return logo ? { ...metadata, logo } : metadata
 }


### PR DESCRIPTION
## What

Gives XRPL issued currencies a logo. `getRippleTokenMetadata` now reads an uncurated token's official icon from the XRPL token registry (xrplmeta), keyed by the `<currency>:<issuer>` pair.

## Why

Only curated tokens (RLUSD) carried a logo, so every other trust-line token — SOLO, an issuer's USD, anything a user adds by id or that ledger discovery surfaces — resolved with no `logo` and rendered as a broken-image placeholder in clients. It shows up the moment a custom XRP token is added in vultisig-windows: right ticker, empty grey image box next to it.

This is the same shape as the EVM resolver reading `logoURI` from 1inch and the Solana resolver returning `icon`. XRPL was the outlier only because it has no on-ledger token metadata registry of its own — not because it should behave differently.

## Behaviour

- **Curated token** (RLUSD): unchanged — bundled logo, price provider, and **no lookup** at all.
- **Uncurated token**: may borrow the registry's icon, but **never** a curated token's `priceProviderId`. Two issuers can share a ticker on XRPL, so the issuer is what identifies a token; a lookalike must not inherit a real token's pricing.
- **Unlisted token or unreachable registry**: still resolves, just without a logo. A metadata lookup failing is not a reason to fail the token.

## Tests

`resolvers/ripple.test.ts` mocks `queryUrl` (so nothing hits the network) and covers: curated token keeps its bundled logo, curated token performs no lookup, uncurated token gets the registry icon, the lookup is keyed by issuer, an uncurated token never gains a price provider, and both the unlisted and unreachable cases still resolve.

`yarn build:shared`, `format:check`, `check:shared-exports`, the SDK bundle changeset guard and eslint all pass locally.

## Related

- Closes #1654
- Follows #1567 / #1568 (XRPL custom token support)
- Client side: vultisig/vultisig-windows#4459


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic logo lookup for uncurated XRPL-issued tokens using the XRPL token registry.
  - Tokens continue to resolve successfully when no logo is available or the registry cannot be reached.
  - Curated Ripple tokens retain their existing logos and pricing metadata.
  - Uncurated tokens with registry icons now display the retrieved logo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->