### PR TITLE
fix(evm): floor signed priority fee on Ethereum and Polygon to match mobile clients

### DIFF
--- a/.changeset/evm-priority-fee-floor.md
+++ b/.changeset/evm-priority-fee-floor.md
@@ -1,0 +1,15 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/sdk': patch
+---
+
+Floor the signed EVM `maxPriorityFeePerGas` on tip-auction chains: 1 gwei on
+Ethereum (parity with iOS `FeeService.calculateMaxPriorityFeePerGas` and
+Android `EthereumFeeService`, which both floor at 1 gwei) and 30 gwei on
+Polygon (validators enforce a ~25 gwei minimum tip). In quiet fee markets the
+raw `eth_maxPriorityFeePerGas` suggestion collapses to near zero (~0.0004 gwei
+observed live), and a tx signed with that tip is never picked up by block
+builders — it sat in the public mempool until evicted, so Ethereum mainnet
+sends from extension/desktop broadcast fine but vanished unmined. Rollup L2s
+and the zkSync `estimateFee` path keep their current no-floor behavior, and
+explicit user fee settings still bypass the clamp (vultisig-sdk#1659).

--- a/packages/core/chain/tx/fee/evm/clampEvmPriorityFee.test.ts
+++ b/packages/core/chain/tx/fee/evm/clampEvmPriorityFee.test.ts
@@ -55,4 +55,31 @@ describe('clampEvmPriorityFee', () => {
 
     expect(clampEvmPriorityFee(EvmChain.Ethereum, oneOverCeiling)).toBe(gwei(500))
   })
+
+  it.each([
+    ['near-zero quiet-market suggestion', 398_220n], // ~0.0004 gwei, observed live on api.vultisig.com/eth
+    ['zero', 0n],
+    ['one wei below the floor', gwei(1) - 1n],
+  ])('floors an Ethereum tip too low to be mined (%s) to 1 gwei', (_label, fee) => {
+    expect(clampEvmPriorityFee(EvmChain.Ethereum, fee)).toBe(gwei(1))
+  })
+
+  it('floors a Polygon tip below the validator-enforced minimum to 30 gwei', () => {
+    expect(clampEvmPriorityFee(EvmChain.Polygon, gwei(1))).toBe(gwei(30))
+  })
+
+  it('never floors a fee that sits exactly at the floor', () => {
+    expect(clampEvmPriorityFee(EvmChain.Ethereum, gwei(1))).toBe(gwei(1))
+  })
+
+  it.each([
+    ['Arbitrum', EvmChain.Arbitrum],
+    ['Base', EvmChain.Base],
+    ['Optimism', EvmChain.Optimism],
+    ['Zksync', EvmChain.Zksync],
+  ])('passes a near-zero %s tip through unchanged (rollup sequencers ignore tips)', (_label, chain) => {
+    const nearZero = 398_220n
+
+    expect(clampEvmPriorityFee(chain, nearZero)).toBe(nearZero)
+  })
 })

--- a/packages/core/chain/tx/fee/evm/clampEvmPriorityFee.ts
+++ b/packages/core/chain/tx/fee/evm/clampEvmPriorityFee.ts
@@ -39,20 +39,45 @@ const priorityFeeCeilingWeiByChain: Partial<Record<EvmChain, bigint>> = {
 const defaultPriorityFeeCeilingWei = 500n * GWEI
 
 /**
- * Clamps an RPC-reported EVM maxPriorityFeePerGas to a generous per-chain
- * sanity ceiling. Never throws — a clamp still lets the tx go through at a
- * safe fee, whereas rejecting it would strand the user mid-flow.
+ * Minimum tip (wei) to sign on chains where inclusion is a public tip
+ * auction. In quiet fee markets the RPC-suggested maxPriorityFeePerGas
+ * collapses to near zero (~0.0004 gwei observed on Ethereum L1); a tx signed
+ * with that tip gives block builders no incentive to include it, so it sits
+ * in the public mempool until evicted and shows up as "pending then
+ * disappeared" on explorers. Mirrors the mobile clients, which floor
+ * Ethereum at 1 gwei (iOS FeeService.calculateMaxPriorityFeePerGas, Android
+ * EthereumFeeService) and Polygon at 30 gwei (Polygon validators enforce a
+ * ~25 gwei minimum tip). L2 sequencers include txs regardless of tip, so
+ * rollups deliberately have no floor.
+ */
+const priorityFeeFloorWeiByChain: Partial<Record<EvmChain, bigint>> = {
+  [EvmChain.Ethereum]: 1n * GWEI,
+  [EvmChain.Polygon]: 30n * GWEI,
+}
+
+/**
+ * Clamps an RPC-reported EVM maxPriorityFeePerGas into a per-chain sane
+ * range: a generous ceiling against a compromised RPC inflating the fee, and
+ * a floor (tip-auction chains only) against an honest RPC suggesting a tip
+ * too low to ever be mined. Never throws — a clamp still lets the tx go
+ * through at a safe fee, whereas rejecting it would strand the user mid-flow.
  */
 export const clampEvmPriorityFee = (chain: EvmChain, rpcPriorityFeeWei: bigint): bigint => {
   const ceiling = priorityFeeCeilingWeiByChain[chain] ?? defaultPriorityFeeCeilingWei
 
-  if (rpcPriorityFeeWei <= ceiling) {
-    return rpcPriorityFeeWei
+  if (rpcPriorityFeeWei > ceiling) {
+    console.warn(
+      `[evm] RPC-reported maxPriorityFeePerGas for ${chain} (${rpcPriorityFeeWei} wei) exceeds the sanity ceiling (${ceiling} wei); clamping to the ceiling.`
+    )
+
+    return ceiling
   }
 
-  console.warn(
-    `[evm] RPC-reported maxPriorityFeePerGas for ${chain} (${rpcPriorityFeeWei} wei) exceeds the sanity ceiling (${ceiling} wei); clamping to the ceiling.`
-  )
+  const floor = priorityFeeFloorWeiByChain[chain] ?? 0n
 
-  return ceiling
+  if (rpcPriorityFeeWei < floor) {
+    return floor
+  }
+
+  return rpcPriorityFeeWei
 }

--- a/packages/core/mpc/keysign/fee/resolvers/evm/getEvmFeeQuote.test.ts
+++ b/packages/core/mpc/keysign/fee/resolvers/evm/getEvmFeeQuote.test.ts
@@ -95,7 +95,8 @@ describe('getEvmFeeQuote gas limit buffering', () => {
 
     expect(quote.gasLimit).toBe(900_000n)
     expect(quote.baseFeePerGas).toBe(150n)
-    expect(quote.maxPriorityFeePerGas).toBe(2n)
+    // 2 wei RPC tip is floored to 1 gwei on Ethereum
+    expect(quote.maxPriorityFeePerGas).toBe(1n * 1_000_000_000n)
   })
 
   it('ceil-rounds buffered successful estimates for general swaps', async () => {


### PR DESCRIPTION
## Description

Ethereum mainnet transactions initiated by SDK-based clients (extension/desktop) were signed with the raw `eth_maxPriorityFeePerGas` suggestion — observed live at `0x6138c` = **398,220 wei ≈ 0.0004 gwei** on `api.vultisig.com/eth/`. With an effectively zero tip, block builders never picked the txs up, so they sat in the public mempool until evicted: they broadcast fine, showed as pending on Etherscan, then vanished within minutes, unmined, regardless of gas limit (e.g. `0xf3e5e9ca7572f86a9a41bc7300933654954a9105b1a25ff76501c82bdee35d9b`, since purged everywhere). Mobile was unaffected because both apps floor the signed tip.

This PR turns `clampEvmPriorityFee` into a two-sided clamp. The existing generous per-chain *ceiling* (anti-compromised-RPC guard) is unchanged; below it, a per-chain *floor* now applies:

- **Ethereum: 1 gwei** — parity with iOS ([`FeeService.calculateMaxPriorityFeePerGas`](https://github.com/vultisig/vultisig-ios/blob/a36c035094a0da4060fb021609d15668304e2932/VultisigApp/VultisigApp/Core/Services/Fee/FeeService.swift#L83-L104)) and Android ([`EthereumFeeService`, "picked medium with min of 1 GWEI"](https://github.com/vultisig/vultisig-android/blob/3c18dd3fdb1d46bd3b73db10862573da1d06e666/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt#L296-L302))
- **Polygon: 30 gwei** — mobile parity; Polygon validators enforce a ~25 gwei minimum tip

Rollup L2s deliberately get no floor (sequencers include txs regardless of tip), the zkSync `estimateFee` path is untouched, and explicit user fee settings still bypass the clamp entirely.

Fixes #1659

## Which feature is affected?

- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [x] Sending - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature - Please attach tx link here

Validated on Ethereum mainnet with the patched package: ETH send initiated by the extension with the latest Vultisig Android as co-signer (secure vault) — signed with the floored tip of exactly 1 gwei (`maxFeePerGas` ≈ 3.58 gwei = 1.5 × base fee + 1 gwei) and confirmed in ~12 seconds:

https://etherscan.io/tx/0x6bc5fe321584b1a1177e9981b71edc90359f94fc7bf491015df19f6cf51306bf

Before the fix, the equivalent send was signed with a ~0.0004 gwei tip and was dropped unmined every time.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

- Both call sites of `clampEvmPriorityFee` live in `getEvmFeeQuote` (general path and zkSync path), so every EVM fee quote picks up the floor; zkSync has no floor entry, so its behavior is byte-identical.
- New tests cover the observed live value (398,220 wei → floored to 1 gwei), zero, one-wei-below-floor and exact-floor boundaries, the Polygon floor, and guard that near-zero rollup tips still pass through unchanged. Full suites pass: 30 clamp tests, 93 across fee-quote / golden-compile / EVM chain tests.
- Only Ethereum mainnet exhibited the bug because it is the only supported chain where inclusion is a public tip auction — L2 sequencers ignore tips and BSC signs legacy `gasPrice`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced EVM fee quoting by enforcing a minimum `maxPriorityFeePerGas` floor on tip-auction chains (1 gwei on Ethereum, 30 gwei on Polygon).
* **Bug Fixes**
  * Prevented near-zero RPC priority fees from being used when they could be rejected or fail to mine.
  * Continued clamping overly high RPC priority fees via a per-chain ceiling.
  * Preserved no-floor behavior for quiet-fee scenarios and existing rollup/L2 handling, and respected explicitly set user fees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->