### PR TITLE
fix(swap): compare VULT discount tier balances in bigint

### DIFF
--- a/.changeset/vult-discount-tier-bigint.md
+++ b/.changeset/vult-discount-tier-bigint.md
@@ -1,0 +1,12 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/sdk': patch
+---
+
+Compare VULT discount tier balances in bigint base units instead of float64.
+`100000n * 10n**18n` is not representable in float64 (`Number` round-trips it
+to 99999.99999999999), so a wallet holding exactly 100,000 VULT — the diamond
+minimum — was demoted to platinum and paid a 25 bps affiliate fee instead of
+15 on every swap. The float rounding also swallowed one-base-unit differences
+around every tier boundary. Comparisons now stay exact via `toChainAmount`
+(vultisig-sdk#1677).

--- a/packages/core/chain/swap/affiliate/index.test.ts
+++ b/packages/core/chain/swap/affiliate/index.test.ts
@@ -1,0 +1,50 @@
+import { vult } from '@vultisig/core-chain/coin/knownTokens'
+import { describe, expect, it } from 'vitest'
+
+import { getSwapAffiliateBps, getVultDiscountTier } from './index'
+import { vultDiscountTierMinBalances } from './config'
+
+const toVultBalance = (amount: number) => BigInt(amount) * 10n ** BigInt(vult.decimals)
+
+describe('getVultDiscountTier (sdk#1677)', () => {
+  // Holding exactly the minimum balance of a tier must grant that tier.
+  // 100000n * 10n**18n is not representable in float64, so a comparison
+  // routed through Number sees 99999.99999999999 and demotes diamond
+  // holders to platinum (25 bps affiliate fee instead of 15).
+  it.each(Object.entries(vultDiscountTierMinBalances))(
+    'grants %s at exactly its minimum balance',
+    (tier, minBalance) => {
+      expect(
+        getVultDiscountTier({
+          vultBalance: toVultBalance(minBalance),
+          thorguardNftBalance: 0n,
+        })
+      ).toBe(tier)
+    }
+  )
+
+  it.each(Object.entries(vultDiscountTierMinBalances))(
+    'does not grant %s one base unit below its minimum balance',
+    (tier, minBalance) => {
+      expect(
+        getVultDiscountTier({
+          vultBalance: toVultBalance(minBalance) - 1n,
+          thorguardNftBalance: 0n,
+        })
+      ).not.toBe(tier)
+    }
+  )
+
+  it('returns null below the lowest tier', () => {
+    expect(getVultDiscountTier({ vultBalance: 0n, thorguardNftBalance: 0n })).toBeNull()
+  })
+
+  it('charges diamond holders 15 bps', () => {
+    const tier = getVultDiscountTier({
+      vultBalance: toVultBalance(vultDiscountTierMinBalances.diamond),
+      thorguardNftBalance: 0n,
+    })
+
+    expect(getSwapAffiliateBps(tier)).toBe(15)
+  })
+})

--- a/packages/core/chain/swap/affiliate/index.test.ts
+++ b/packages/core/chain/swap/affiliate/index.test.ts
@@ -1,39 +1,44 @@
 import { vult } from '@vultisig/core-chain/coin/knownTokens'
 import { describe, expect, it } from 'vitest'
 
+import { VultDiscountTier, vultDiscountTierMinBalances, vultDiscountTiers } from './config'
 import { getSwapAffiliateBps, getVultDiscountTier } from './index'
-import { vultDiscountTierMinBalances } from './config'
 
 const toVultBalance = (amount: number) => BigInt(amount) * 10n ** BigInt(vult.decimals)
+
+const tierBelowMinimum: Record<VultDiscountTier, VultDiscountTier | null> = {
+  bronze: null,
+  silver: 'bronze',
+  gold: 'silver',
+  platinum: 'gold',
+  diamond: 'platinum',
+  ultimate: 'diamond',
+}
 
 describe('getVultDiscountTier (sdk#1677)', () => {
   // Holding exactly the minimum balance of a tier must grant that tier.
   // 100000n * 10n**18n is not representable in float64, so a comparison
   // routed through Number sees 99999.99999999999 and demotes diamond
   // holders to platinum (25 bps affiliate fee instead of 15).
-  it.each(Object.entries(vultDiscountTierMinBalances))(
-    'grants %s at exactly its minimum balance',
-    (tier, minBalance) => {
-      expect(
-        getVultDiscountTier({
-          vultBalance: toVultBalance(minBalance),
-          thorguardNftBalance: 0n,
-        })
-      ).toBe(tier)
-    }
-  )
+  it.each([...vultDiscountTiers])('grants %s at exactly its minimum balance', tier => {
+    expect(
+      getVultDiscountTier({
+        vultBalance: toVultBalance(vultDiscountTierMinBalances[tier]),
+        thorguardNftBalance: 0n,
+      })
+    ).toBe(tier)
+  })
 
-  it.each(Object.entries(vultDiscountTierMinBalances))(
-    'does not grant %s one base unit below its minimum balance',
-    (tier, minBalance) => {
-      expect(
-        getVultDiscountTier({
-          vultBalance: toVultBalance(minBalance) - 1n,
-          thorguardNftBalance: 0n,
-        })
-      ).not.toBe(tier)
-    }
-  )
+  // One base unit below a minimum must land on the tier below it — float
+  // rounding must neither swallow the difference nor skip past a tier.
+  it.each([...vultDiscountTiers])('grants the tier below %s one base unit under its minimum', tier => {
+    expect(
+      getVultDiscountTier({
+        vultBalance: toVultBalance(vultDiscountTierMinBalances[tier]) - 1n,
+        thorguardNftBalance: 0n,
+      })
+    ).toBe(tierBelowMinimum[tier])
+  })
 
   it('returns null below the lowest tier', () => {
     expect(getVultDiscountTier({ vultBalance: 0n, thorguardNftBalance: 0n })).toBeNull()

--- a/packages/core/chain/swap/affiliate/index.ts
+++ b/packages/core/chain/swap/affiliate/index.ts
@@ -3,7 +3,7 @@ import { getLastItem } from '@vultisig/lib-utils/array/getLastItem'
 import { order } from '@vultisig/lib-utils/array/order'
 import { toEntries } from '@vultisig/lib-utils/record/toEntries'
 
-import { fromChainAmount } from '../../amount/fromChainAmount'
+import { toChainAmount } from '../../amount/toChainAmount'
 import { baseAffiliateBps, VultDiscountTier, vultDiscountTierBps, vultDiscountTierMinBalances } from './config'
 
 export type { VultDiscountTier }
@@ -17,11 +17,9 @@ export const getVultDiscountTier = ({
   vultBalance,
   thorguardNftBalance,
 }: GetVultDiscountTierInput): VultDiscountTier | null => {
-  const balance = fromChainAmount(vultBalance, vult.decimals)
-
   const descendingTiers = order(toEntries(vultDiscountTierMinBalances), ({ value }) => value, 'desc')
 
-  const baseTier = descendingTiers.find(({ value }) => balance >= value)?.key
+  const baseTier = descendingTiers.find(({ value }) => vultBalance >= toChainAmount(value, vult.decimals))?.key
 
   if (thorguardNftBalance === 0n) {
     return baseTier ?? null

--- a/yarn.lock
+++ b/yarn.lock
@@ -8519,21 +8519,21 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^1.1.7":
-  version: 1.1.16
-  resolution: "brace-expansion@npm:1.1.16"
+  version: 1.1.18
+  resolution: "brace-expansion@npm:1.1.18"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/b2a915bbedbf4e45840d1fb9a4d391bbf26a79475bd134714d3cee34f1f0edb0ce982738028843be5fbaf8039429f71fa487df8c915b6065ced542c83e58fae6
+  checksum: 10c0/3432c18a9e2ebf94162d4effb62198bd0adea06a9f332b2c0188df5d5e30b1e51ea3c848b6608e47d0b857ebe1ea5b3888ed3326dd3c4f6f9645c94153cf9c14
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^2.0.1, brace-expansion@npm:^2.0.2":
-  version: 2.1.2
-  resolution: "brace-expansion@npm:2.1.2"
+  version: 2.1.4
+  resolution: "brace-expansion@npm:2.1.4"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/5442ecab84045d21826268bc56c81a6ef4215327ee1f5ee153f67928e93f7a915d130ecec9966623143277fa3cce036ebb50020024bcc4d78853cdd6af9a19f8
+  checksum: 10c0/6c0a0e2573eac1dc565b52b1e1bfbeba39bf1830d106ebbc61ff1eaefcf610e9111cd3baa091addd18e33292135c99e019d3184d966389d85dc958fdcdc1449f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #1677.

`getVultDiscountTier` compares the VULT balance against tier minimums after converting it to a JS number. `100000n * 10n**18n` round-trips through float64 as `99999.99999999999`, so holding exactly 100,000 VULT (the diamond minimum) returns platinum and the holder pays 25 bps affiliate fee instead of 15 on every swap. The float rounding also swallows one-base-unit differences near every boundary.

First commit adds the boundary tests only, so CI demonstrates the bug; the fix lands on top and keeps the comparison in bigint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VULT discount-tier classification by using exact balance amounts, ensuring thresholds are applied correctly.
  * Corrected affiliate fee calculations for balances at tier boundaries.

* **Tests**
  * Added coverage for minimum qualifying balances, below-threshold balances, zero balances, and the 15 bps diamond-tier affiliate fee.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->