### PR TITLE
fix: validate decoded limit-swap destinations

### DIFF
--- a/.changeset/limit-swap-destination-validation.md
+++ b/.changeset/limit-swap-destination-validation.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/sdk': patch
+---
+
+Reject malformed or wrong-chain limit-swap destinations while decoding a memo, so co-signers fall back to generic payload review instead of seeing an invalid destination as an enriched order.

--- a/packages/core/chain/swap/native/limitSwapMemo.assertMemo.test.ts
+++ b/packages/core/chain/swap/native/limitSwapMemo.assertMemo.test.ts
@@ -80,6 +80,12 @@ describe('parseLimitSwapMemo', () => {
     expect(parseLimitSwapMemo(big).limit).toBe(99_999_999_999_999_999_999n)
   })
 
+  it('rejects a destination that is valid for a different chain', () => {
+    const wrongChain = '=<:BTC.BTC:0x742d35Cc6634C0532925a3b844Bc454e4438f44e:100/14400/0'
+
+    expect(() => parseLimitSwapMemo(wrongChain)).toThrow(/dest_addr is not a valid Bitcoin address/)
+  })
+
   it('round-trips the memo it was given', () => {
     const { targetAsset, destinationAddress, limit, intervalBlocks, quantity } = parseLimitSwapMemo(validMemo)
 

--- a/packages/core/chain/swap/native/limitSwapMemo.ts
+++ b/packages/core/chain/swap/native/limitSwapMemo.ts
@@ -233,11 +233,15 @@ const assertValidLimitSwapDestinationAddress = (targetChain: Chain, address: str
   }
 }
 
+const assertValidLimitSwapDestination = (targetAsset: string, address: string): void => {
+  const targetChain = getSupportedThorchainAssetChain(targetAsset, 'target_asset')
+  assertMemoSegmentSafe(address, 'dest_addr')
+  assertValidLimitSwapDestinationAddress(targetChain, address)
+}
+
 export const validateLimitSwapInputs = (inputs: LimitSwapMemoInput): void => {
   getSupportedThorchainAssetChain(inputs.source_asset, 'source_asset')
-  const targetChain = getSupportedThorchainAssetChain(inputs.target_asset, 'target_asset')
-  assertMemoSegmentSafe(inputs.dest_addr, 'dest_addr')
-  assertValidLimitSwapDestinationAddress(targetChain, inputs.dest_addr)
+  assertValidLimitSwapDestination(inputs.target_asset, inputs.dest_addr)
 
   parsePositiveInteger(inputs.source_amount, 'source_amount')
   parsePositiveDecimal(inputs.target_price, 'target_price')
@@ -337,6 +341,8 @@ export const parseLimitSwapMemo = (memo: string): ParsedLimitSwapMemo => {
       throw new Error(`limit-swap memo affiliate bps must be an integer, got ${JSON.stringify(affiliateBps)}`)
     }
   }
+
+  assertValidLimitSwapDestination(targetAsset, destAddress)
 
   return {
     targetAsset,

--- a/packages/core/mpc/keysign/swap/getKeysignLimitSwapOrder.test.ts
+++ b/packages/core/mpc/keysign/swap/getKeysignLimitSwapOrder.test.ts
@@ -59,15 +59,11 @@ describe('getKeysignLimitSwapOrder', () => {
     ['a missing trade target', `=<:ETH.ETH:${evmAddress}`],
     ['a non-numeric LIM', `=<:ETH.ETH:${evmAddress}:abc/14400/0`],
     ['an empty destination', '=<:ETH.ETH::100/14400/0'],
+    ['a malformed destination', '=<:ETH.ETH:0xnot-an-address:100/14400/0'],
+    ['a destination for a different chain', `=<:BTC.BTC:${evmAddress}:100/14400/0`],
+    ['an unroutable asset prefix', `=<:XYZ.XYZ:${evmAddress}:100/14400/0`],
   ])('reports %s as not a limit order rather than throwing', (_label, value) => {
     expect(getKeysignLimitSwapOrder({ memo: value })).toBeUndefined()
-  })
-
-  it('leaves the target chain undefined for an unroutable asset prefix', () => {
-    const order = getKeysignLimitSwapOrder({ memo: `=<:XYZ.XYZ:${evmAddress}:100/14400/0` })
-
-    expect(order?.targetAsset).toBe('XYZ.XYZ')
-    expect(order?.targetChain).toBeUndefined()
   })
 
   it('leaves expiry undefined for an interval this SDK does not build', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved limit-swap validation to reject malformed, chain-mismatched, and unroutable destination addresses.
  * Invalid memo data now triggers generic payload review instead of producing incomplete swap details.

* **Tests**
  * Expanded coverage for invalid destinations and unsupported asset routes.

* **Chores**
  * Included patch release updates for the core chain and SDK packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->