### PR TITLE
feat(swap): limit-order cancellation primitives

### DIFF
--- a/.changeset/limit-order-cancel.md
+++ b/.changeset/limit-order-cancel.md
@@ -1,0 +1,17 @@
+---
+'@vultisig/core-chain': minor
+'@vultisig/core-mpc': minor
+'@vultisig/sdk': minor
+---
+
+Limit-order cancellation primitives: the `m=<` modify-limit-swap memo in its cancel form, eligibility, bucket-key duplicate detection, and L1 dust.
+
+Cancellation is not a variation on placement. Every failure mode is silent — the transaction confirms, the fee is spent, and the order carries on resting with nothing to distinguish it from success — so each rule is enforced rather than documented.
+
+`buildCancelLimitSwapMemo` refuses abbreviated assets outright: `ModifyLimitSwapMemo` is the one inbound memo type `processOneTxIn` does not run through `fuzzyAssetMatch`, so the placement memo's six-character contract suffix would address a bucket that by construction holds no order. Amounts are emitted as plain decimal integers, never compressed — these coins parse through `cosmos.ParseCoins`, which does not understand the scientific notation a placement LIM may use.
+
+`getLimitSwapCancelEligibility` fails closed at every unknown and cross-checks what was recorded at signing against what the queue reports — **assets as well as amounts**. Absence is not disagreement (an order placed seconds ago has not been polled), but a present-and-unparseable observation blocks exactly as a mismatch does.
+
+`getThorchainLimitOrderBucketKey` reproduces the advanced-swap-queue index key, including its zero-padding *and* right-truncation at 18 characters. Orders are addressed by `(layer-1 pair, ratio) + FromAddress` and the first match in the bucket wins, so orders sharing a ratio are not independently cancellable — compared on the key rather than on equal amounts, which would under-report collisions.
+
+`getLimitSwapCancelDust` rescales the live `dust_threshold` from THORChain's 1e8 into the source coin's own precision, with a safety multiple and an upper ceiling, refusing rather than defaulting when the threshold is missing, unparseable, or rounds away. A cancel once signed for 2000 wei — the 1e8 threshold used verbatim as an 18-decimal chain's smallest unit — was truncated to zero and never observed; that case is pinned by a test.

--- a/.changeset/limit-order-cancel.md
+++ b/.changeset/limit-order-cancel.md
@@ -1,6 +1,5 @@
 ---
 '@vultisig/core-chain': minor
-'@vultisig/core-mpc': minor
 '@vultisig/sdk': minor
 ---
 

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -1773,6 +1773,26 @@
       "import": "./dist/swap/native/limitSwapAvailability.js",
       "default": "./dist/swap/native/limitSwapAvailability.js"
     },
+    "./swap/native/limitSwapCancelBucket": {
+      "types": "./dist/swap/native/limitSwapCancelBucket.d.ts",
+      "import": "./dist/swap/native/limitSwapCancelBucket.js",
+      "default": "./dist/swap/native/limitSwapCancelBucket.js"
+    },
+    "./swap/native/limitSwapCancelDust": {
+      "types": "./dist/swap/native/limitSwapCancelDust.d.ts",
+      "import": "./dist/swap/native/limitSwapCancelDust.js",
+      "default": "./dist/swap/native/limitSwapCancelDust.js"
+    },
+    "./swap/native/limitSwapCancelEligibility": {
+      "types": "./dist/swap/native/limitSwapCancelEligibility.d.ts",
+      "import": "./dist/swap/native/limitSwapCancelEligibility.js",
+      "default": "./dist/swap/native/limitSwapCancelEligibility.js"
+    },
+    "./swap/native/limitSwapCancelMemo": {
+      "types": "./dist/swap/native/limitSwapCancelMemo.d.ts",
+      "import": "./dist/swap/native/limitSwapCancelMemo.js",
+      "default": "./dist/swap/native/limitSwapCancelMemo.js"
+    },
     "./swap/native/limitSwapInbound": {
       "types": "./dist/swap/native/limitSwapInbound.d.ts",
       "import": "./dist/swap/native/limitSwapInbound.js",

--- a/packages/core/chain/swap/native/limitSwapCancelBucket.test.ts
+++ b/packages/core/chain/swap/native/limitSwapCancelBucket.test.ts
@@ -5,6 +5,7 @@ import {
   getThorchainLimitOrderBucketKey,
   toThorchainLayer1MemoAsset,
 } from './limitSwapCancelBucket'
+import { LimitSwapCancelMemoBuildError } from './limitSwapCancelMemo'
 
 const order = (sourceAmount: bigint, tradeTarget: bigint, overrides = {}) => ({
   sourceAsset: 'THOR.RUNE',
@@ -50,12 +51,22 @@ describe('getThorchainLimitOrderBucketKey', () => {
   })
 
   // Reachable before any memo is validated, so bigint division by zero would
-  // crash a duplicate check that is meant to fail closed.
+  // crash a duplicate check that is meant to fail closed. Typed rather than a
+  // bare Error, so callers branch on `reason` the way they do for the sibling
+  // modules — an unguarded division would surface as RangeError instead.
   it.each([
     ['a zero trade target', 100n, 0n],
     ['a zero source amount', 0n, 100n],
-  ])('throws on %s rather than dividing', (_label, sourceAmount, tradeTarget) => {
-    expect(() => getThorchainLimitOrderBucketKey(order(sourceAmount, tradeTarget))).toThrow(/must be positive/)
+  ])('raises a typed error on %s rather than dividing', (_label, sourceAmount, tradeTarget) => {
+    const build = () => getThorchainLimitOrderBucketKey(order(sourceAmount, tradeTarget))
+
+    expect(build).toThrow(LimitSwapCancelMemoBuildError)
+    try {
+      build()
+      expect.unreachable('expected a typed cancel error')
+    } catch (error) {
+      expect((error as LimitSwapCancelMemoBuildError).reason).toBe('nonPositiveAmount')
+    }
   })
 
   // A secured representation and the plain L1 asset collapse to the same key

--- a/packages/core/chain/swap/native/limitSwapCancelBucket.test.ts
+++ b/packages/core/chain/swap/native/limitSwapCancelBucket.test.ts
@@ -49,6 +49,15 @@ describe('getThorchainLimitOrderBucketKey', () => {
     expect(ratio).toBe('100000000000000000')
   })
 
+  // Reachable before any memo is validated, so bigint division by zero would
+  // crash a duplicate check that is meant to fail closed.
+  it.each([
+    ['a zero trade target', 100n, 0n],
+    ['a zero source amount', 0n, 100n],
+  ])('throws on %s rather than dividing', (_label, sourceAmount, tradeTarget) => {
+    expect(() => getThorchainLimitOrderBucketKey(order(sourceAmount, tradeTarget))).toThrow(/must be positive/)
+  })
+
   // A secured representation and the plain L1 asset collapse to the same key
   // on-chain, so a verbatim string comparison would miss a real collision.
   it('treats a secured leg as its layer-1 asset', () => {

--- a/packages/core/chain/swap/native/limitSwapCancelBucket.test.ts
+++ b/packages/core/chain/swap/native/limitSwapCancelBucket.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  areLimitOrdersCancelIndistinguishable,
+  getThorchainLimitOrderBucketKey,
+  toThorchainLayer1MemoAsset,
+} from './limitSwapCancelBucket'
+
+const order = (sourceAmount: bigint, tradeTarget: bigint, overrides = {}) => ({
+  sourceAsset: 'THOR.RUNE',
+  targetAsset: 'BTC.BTC',
+  sourceAmount,
+  tradeTarget,
+  ...overrides,
+})
+
+describe('toThorchainLayer1MemoAsset', () => {
+  it.each([
+    // Already L1: the `-` in a contract suffix comes AFTER the `.`, so it must
+    // not be touched.
+    ['ETH.USDC-0XA0B8', 'ETH.USDC-0XA0B8'],
+    ['BTC.BTC', 'BTC.BTC'],
+    // The first separator becomes `.`, and secured denoms arrive lower-case.
+    ['eth-usdc-0xa0b8', 'ETH.USDC-0XA0B8'],
+    ['btc-btc', 'BTC.BTC'],
+    ['BTC/BTC', 'BTC.BTC'],
+    ['BTC~BTC', 'BTC.BTC'],
+  ])('collapses %s to %s', (asset, expected) => {
+    expect(toThorchainLayer1MemoAsset(asset)).toBe(expected)
+  })
+})
+
+describe('getThorchainLimitOrderBucketKey', () => {
+  // ratio = (sourceAmount * 1e8) / tradeTarget, zero-padded to 18 chars.
+  it('builds the key from the ratio, zero-padded', () => {
+    expect(getThorchainLimitOrderBucketKey(order(100_000_000n, 100_000_000n))).toBe(
+      'THOR.RUNE>BTC.BTC/000000000100000000/'
+    )
+  })
+
+  // THORNode truncates from the right, deliberately collapsing very large
+  // ratios into one bucket. Reproducing only the padding would disagree with
+  // the chain at exactly the extreme where it matters.
+  it('truncates an over-long ratio rather than keeping it', () => {
+    const key = getThorchainLimitOrderBucketKey(order(10n ** 20n, 1n))
+    const ratio = key.split('/')[1]
+
+    expect(ratio).toHaveLength(18)
+    expect(ratio).toBe('100000000000000000')
+  })
+
+  // A secured representation and the plain L1 asset collapse to the same key
+  // on-chain, so a verbatim string comparison would miss a real collision.
+  it('treats a secured leg as its layer-1 asset', () => {
+    expect(getThorchainLimitOrderBucketKey(order(1_000n, 1_000n, { sourceAsset: 'thor-rune' }))).toBe(
+      getThorchainLimitOrderBucketKey(order(1_000n, 1_000n))
+    )
+  })
+})
+
+describe('areLimitOrdersCancelIndistinguishable', () => {
+  // Selling 1 and selling 2 at the same price land in one bucket. Comparing
+  // amounts for equality would under-report exactly the duplicates that matter.
+  it('collides on equal ratio despite different amounts', () => {
+    expect(
+      areLimitOrdersCancelIndistinguishable(order(100_000_000n, 50_000_000n), order(200_000_000n, 100_000_000n))
+    ).toBe(true)
+  })
+
+  it('separates orders at different prices', () => {
+    expect(
+      areLimitOrdersCancelIndistinguishable(order(100_000_000n, 50_000_000n), order(100_000_000n, 25_000_000n))
+    ).toBe(false)
+  })
+
+  it('separates orders on different pairs', () => {
+    expect(
+      areLimitOrdersCancelIndistinguishable(order(100n, 100n), order(100n, 100n, { targetAsset: 'ETH.ETH' }))
+    ).toBe(false)
+  })
+})

--- a/packages/core/chain/swap/native/limitSwapCancelBucket.ts
+++ b/packages/core/chain/swap/native/limitSwapCancelBucket.ts
@@ -1,4 +1,4 @@
-import { LimitSwapCancelInputs } from './limitSwapCancelMemo'
+import { assertPositiveLimitSwapCancelAmounts, LimitSwapCancelInputs } from './limitSwapCancelMemo'
 
 /**
  * THORChain's fixed-point exponent, the `1e8` the ratio is scaled by.
@@ -67,13 +67,11 @@ export const getThorchainLimitOrderBucketKey = ({
 }: LimitSwapCancelInputs): string => {
   // Exported separately from the memo builder, so it can be reached before any
   // memo is validated — `areLimitOrdersCancelIndistinguishable` runs it over
-  // stored orders. A zero trade target would make bigint division throw
-  // `RangeError`, crashing a duplicate check that is supposed to fail closed.
-  if (sourceAmount <= 0n || tradeTarget <= 0n) {
-    throw new Error(
-      `limit order bucket key: amounts must be positive, got source ${sourceAmount} and trade target ${tradeTarget}`
-    )
-  }
+  // stored orders. A zero trade target would make bigint division raise
+  // `RangeError`, crashing a duplicate check that is supposed to fail closed;
+  // the shared assertion raises the same typed error the sibling modules do, so
+  // a caller can branch on `reason` rather than string-matching.
+  assertPositiveLimitSwapCancelAmounts({ sourceAmount, tradeTarget })
 
   const ratio = (sourceAmount * 10n ** thorchainFixedPointExponent) / tradeTarget
   const source = toThorchainLayer1MemoAsset(sourceAsset)

--- a/packages/core/chain/swap/native/limitSwapCancelBucket.ts
+++ b/packages/core/chain/swap/native/limitSwapCancelBucket.ts
@@ -65,6 +65,16 @@ export const getThorchainLimitOrderBucketKey = ({
   targetAsset,
   tradeTarget,
 }: LimitSwapCancelInputs): string => {
+  // Exported separately from the memo builder, so it can be reached before any
+  // memo is validated — `areLimitOrdersCancelIndistinguishable` runs it over
+  // stored orders. A zero trade target would make bigint division throw
+  // `RangeError`, crashing a duplicate check that is supposed to fail closed.
+  if (sourceAmount <= 0n || tradeTarget <= 0n) {
+    throw new Error(
+      `limit order bucket key: amounts must be positive, got source ${sourceAmount} and trade target ${tradeTarget}`
+    )
+  }
+
   const ratio = (sourceAmount * 10n ** thorchainFixedPointExponent) / tradeTarget
   const source = toThorchainLayer1MemoAsset(sourceAsset)
   const target = toThorchainLayer1MemoAsset(targetAsset)

--- a/packages/core/chain/swap/native/limitSwapCancelBucket.ts
+++ b/packages/core/chain/swap/native/limitSwapCancelBucket.ts
@@ -1,0 +1,91 @@
+import { LimitSwapCancelInputs } from './limitSwapCancelMemo'
+
+/**
+ * THORChain's fixed-point exponent, the `1e8` the ratio is scaled by.
+ */
+const thorchainFixedPointExponent = 8n
+
+/**
+ * THORNode's `ratioLength`. Its own comment: "a value of 18 means that
+ * granularity is maxed out at 1 trillion to 1 ratio". Changing it on their side
+ * is a kvstore migration, so it is safe to pin.
+ */
+const thorchainRatioLength = 18
+
+/**
+ * Collapse a memo asset to its layer-1 form, the way `Asset.GetLayer1Asset()`
+ * does when THORNode builds the queue index key.
+ *
+ * On their side this clears the synth/trade/secured flags while keeping chain
+ * and symbol; on the wire those flavours are spelled with `/`, `~` and `-`
+ * where the L1 asset uses `.`. So: the FIRST separator becomes `.`, and the
+ * result is upper-cased (secured denoms arrive lower-case).
+ *
+ * An asset already in L1 form is left alone — its first separator IS the `.`,
+ * and the `-` in a contract-suffixed asset like `ETH.USDC-0XA0B…` comes after
+ * it, so it must not be touched.
+ */
+export const toThorchainLayer1MemoAsset = (asset: string): string => {
+  const separators = ['/', '~', '-', '.']
+  const index = [...asset].findIndex(char => separators.includes(char))
+  if (index === -1 || asset[index] === '.') {
+    return asset.toUpperCase()
+  }
+  return `${asset.slice(0, index)}.${asset.slice(index + 1)}`.toUpperCase()
+}
+
+/**
+ * Normalise a ratio the way THORNode's `rewriteRatio` does.
+ *
+ * Not cosmetic: short ratios are zero-padded so keys sort in numeric order, and
+ * longer ones are TRUNCATED from the right, which deliberately collapses very
+ * large ratios into one bucket. Both behaviours have to be reproduced or a
+ * duplicate check disagrees with the chain at exactly the extremes where it
+ * matters.
+ */
+const rewriteThorchainRatio = (ratio: string): string =>
+  ratio.length < thorchainRatioLength ? ratio.padStart(thorchainRatioLength, '0') : ratio.slice(0, thorchainRatioLength)
+
+/**
+ * Reproduce THORNode's advanced-swap-queue index key for a limit order — the
+ * tuple that decides which orders are mutually indistinguishable to a cancel.
+ *
+ * Mirrors `getAdvSwapQueueIndexKey` + `getRatio` + `rewriteRatio`:
+ *
+ *     ratio = (sourceAmount × 1e8) / tradeTarget      // integer division
+ *     key   = "<l1Source>><l1Target>/<ratio normalised to 18 chars>/"
+ *
+ * THORNode scans this bucket for a swap whose `FromAddress` matches the sender
+ * and takes the FIRST match — orders are never addressed by tx hash. So two
+ * orders reducing to the same key are not independently cancellable.
+ */
+export const getThorchainLimitOrderBucketKey = ({
+  sourceAsset,
+  sourceAmount,
+  targetAsset,
+  tradeTarget,
+}: LimitSwapCancelInputs): string => {
+  const ratio = (sourceAmount * 10n ** thorchainFixedPointExponent) / tradeTarget
+  const source = toThorchainLayer1MemoAsset(sourceAsset)
+  const target = toThorchainLayer1MemoAsset(targetAsset)
+  return `${source}>${target}/${rewriteThorchainRatio(ratio.toString())}/`
+}
+
+/**
+ * Whether two orders would be addressed by the same cancel.
+ *
+ * Compared on the bucket key, NOT on equal amounts: two orders with different
+ * deposits and different trade targets collide whenever their ratio matches
+ * (selling 1 and selling 2 at the same price land in one bucket). Comparing
+ * amounts for equality would under-report exactly the duplicates a user most
+ * needs warning about.
+ *
+ * Assets are layer-1-normalised because THORNode's key is — a secured or synth
+ * representation and the plain L1 asset collapse to the same key on-chain.
+ *
+ * Deliberately tuned to over-report: warning that two orders might be confused
+ * when they would not be is a mild annoyance, whereas missing a real collision
+ * means the wrong order closes with no warning at all.
+ */
+export const areLimitOrdersCancelIndistinguishable = (a: LimitSwapCancelInputs, b: LimitSwapCancelInputs): boolean =>
+  getThorchainLimitOrderBucketKey(a) === getThorchainLimitOrderBucketKey(b)

--- a/packages/core/chain/swap/native/limitSwapCancelDust.test.ts
+++ b/packages/core/chain/swap/native/limitSwapCancelDust.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import { getLimitSwapCancelDust } from './limitSwapCancelDust'
+
+const inbound = (dust_threshold: string, chain = 'ETH') => ({ chain, dust_threshold })
+
+describe('getLimitSwapCancelDust', () => {
+  // ⚠️ The regression this module exists for. A cancel was once signed for
+  // 2000 wei — THORChain's 1e8-unit threshold (1000) used verbatim as an
+  // 18-decimal chain's smallest unit — which ConvertAmount truncates to zero.
+  // Bifrost never saw an inbound, the tx confirmed, gas was burned, and the
+  // order carried on resting. The threshold must be rescaled into the coin's
+  // own precision first.
+  it('rescales an 8-decimal threshold into an 18-decimal chain', () => {
+    const dust = getLimitSwapCancelDust({ inbound: inbound('1000'), decimals: 18 })
+
+    // 1000 (1e8) -> 1e13 wei, doubled for the safety margin.
+    expect(dust).toBe(2n * 10n ** 13n)
+    expect(dust).not.toBe(2000n)
+  })
+
+  it('applies the safety multiple on a same-precision chain', () => {
+    expect(getLimitSwapCancelDust({ inbound: inbound('10000', 'BTC'), decimals: 8 })).toBe(20_000n)
+  })
+
+  it('scales down for a chain coarser than 1e8', () => {
+    expect(getLimitSwapCancelDust({ inbound: inbound('1000', 'XRP'), decimals: 6 })).toBe(20n)
+  })
+
+  // Refusing beats nudging up to the bare observable minimum: a value landing
+  // here means the pipeline that produced it is wrong, and bumping it would be
+  // the same silent failure one order of magnitude up.
+  it('refuses when the threshold rounds away at the coin precision', () => {
+    expect(() => getLimitSwapCancelDust({ inbound: inbound('1', 'X'), decimals: 0 })).toThrow(/rounds away/)
+  })
+
+  // dust_threshold is a remote value deciding how much is irreversibly
+  // donated, with no refund path.
+  it.each([
+    ['a missing threshold', ''],
+    ['a whitespace threshold', '   '],
+    ['a non-integer threshold', '10.5'],
+    ['a negative threshold', '-1'],
+  ])('refuses %s rather than defaulting', (_label, threshold) => {
+    expect(() => getLimitSwapCancelDust({ inbound: inbound(threshold), decimals: 18 })).toThrow()
+  })
+
+  it('refuses an unusable precision', () => {
+    expect(() => getLimitSwapCancelDust({ inbound: inbound('1000'), decimals: -1 })).toThrow(/precision/)
+  })
+})

--- a/packages/core/chain/swap/native/limitSwapCancelDust.test.ts
+++ b/packages/core/chain/swap/native/limitSwapCancelDust.test.ts
@@ -45,6 +45,22 @@ describe('getLimitSwapCancelDust', () => {
     expect(() => getLimitSwapCancelDust({ inbound: inbound(threshold), decimals: 18 })).toThrow()
   })
 
+  // The bound has to be ABSOLUTE: a ceiling expressed as a multiple of the
+  // threshold scales both sides equally and can never fire, which is what the
+  // first version of this module got wrong.
+  it('refuses an implausibly large threshold', () => {
+    expect(() => getLimitSwapCancelDust({ inbound: inbound('100000001'), decimals: 18 })).toThrow(/plausible ceiling/)
+  })
+
+  it('accepts a threshold at the ceiling', () => {
+    expect(() => getLimitSwapCancelDust({ inbound: inbound('100000000'), decimals: 8 })).not.toThrow()
+  })
+
+  // Unbounded precision yields a 993-digit multiplier and a meaningless amount.
+  it('refuses an absurd precision', () => {
+    expect(() => getLimitSwapCancelDust({ inbound: inbound('1000'), decimals: 1000 })).toThrow(/precision/)
+  })
+
   it('refuses an unusable precision', () => {
     expect(() => getLimitSwapCancelDust({ inbound: inbound('1000'), decimals: -1 })).toThrow(/precision/)
   })

--- a/packages/core/chain/swap/native/limitSwapCancelDust.ts
+++ b/packages/core/chain/swap/native/limitSwapCancelDust.ts
@@ -18,15 +18,28 @@ const thorchainFixedPointDecimals = 8
 const dustSafetyMultiple = 2n
 
 /**
- * Hard ceiling as a multiple of the published threshold.
+ * Largest `dust_threshold`, in THORChain's own 1e8 units, that is plausible for
+ * any chain — one whole unit of the asset.
  *
  * `dust_threshold` is a REMOTE value that directly decides how much of the
- * user's money is irreversibly donated — there is no refund path for anything
- * attached to an `m=<`. A wrong or hostile value would otherwise be honoured
- * verbatim and then doubled. Every other floor here is a lower bound; this is
- * the only upper one.
+ * user's money is irreversibly donated: there is no refund path for anything
+ * attached to an `m=<`. So the bound has to be ABSOLUTE. A ceiling expressed as
+ * a multiple of the threshold itself cannot work — a hostile value scales both
+ * sides equally and is honoured verbatim.
+ *
+ * Real thresholds are orders of magnitude below this (Bitcoin's is 10000, or
+ * 0.0001 BTC), so the bound rejects only the absurd.
  */
-const dustCeilingMultiple = 100n
+const maximumThresholdIn1e8 = 100_000_000n
+
+/**
+ * Largest coin precision this rescaling supports.
+ *
+ * Without it, any non-negative integer is accepted and `decimals: 1000` yields
+ * a 993-digit multiplier and a meaningless amount. 36 is far above every real
+ * chain (18 is the EVM maximum) while keeping the arithmetic bounded.
+ */
+const maximumDecimals = 36
 
 export const limitSwapCancelDustErrors = [
   'thresholdUnavailable',
@@ -90,7 +103,7 @@ export const getLimitSwapCancelDust = ({ inbound, decimals }: GetLimitSwapCancel
       `cancel dust: ${chain} dust_threshold is not an integer: ${JSON.stringify(threshold)}`
     )
   }
-  if (!Number.isInteger(decimals) || decimals < 0) {
+  if (!Number.isInteger(decimals) || decimals < 0 || decimals > maximumDecimals) {
     throw new LimitSwapCancelDustError(
       'unusablePrecision',
       `cancel dust: ${chain} source coin declares an unusable precision (${decimals})`
@@ -98,6 +111,13 @@ export const getLimitSwapCancelDust = ({ inbound, decimals }: GetLimitSwapCancel
   }
 
   const thresholdIn1e8 = BigInt(threshold.trim())
+
+  if (thresholdIn1e8 > maximumThresholdIn1e8) {
+    throw new LimitSwapCancelDustError(
+      'exceedsCeiling',
+      `cancel dust: ${chain} dust_threshold ${thresholdIn1e8} (1e8) exceeds the plausible ceiling ${maximumThresholdIn1e8}`
+    )
+  }
 
   // Rescale from THORChain's 1e8 into the coin's own precision. Integer-only,
   // in a direction chosen per branch so nothing is silently lost.
@@ -113,14 +133,6 @@ export const getLimitSwapCancelDust = ({ inbound, decimals }: GetLimitSwapCancel
       'belowObservableMinimum',
       `cancel dust: ${chain} threshold ${thresholdIn1e8} (1e8) rounds away at ${decimals} decimals, ` +
         'so no attachable amount would be observed'
-    )
-  }
-
-  const ceiling = scaled * dustCeilingMultiple
-  if (ceiling > 0n && dust > ceiling) {
-    throw new LimitSwapCancelDustError(
-      'exceedsCeiling',
-      `cancel dust: computed ${dust} exceeds the ${chain} ceiling ${ceiling}`
     )
   }
 

--- a/packages/core/chain/swap/native/limitSwapCancelDust.ts
+++ b/packages/core/chain/swap/native/limitSwapCancelDust.ts
@@ -1,0 +1,128 @@
+import { ThorchainInboundAddress } from '../../chains/cosmos/thor/getThorchainInboundAddress'
+
+/**
+ * THORChain publishes `dust_threshold` in its own 1e8 fixed point, regardless
+ * of the source chain's native precision.
+ */
+const thorchainFixedPointDecimals = 8
+
+/**
+ * Safety multiple over the larger floor.
+ *
+ * A cancel sitting exactly ON a threshold is a coin flip: THORNode's own
+ * comparisons are not uniformly `>=`, and the published threshold can move
+ * between the inbound fetch and the transaction landing. Doubling removes both
+ * without a magic absolute floor that would be wrong on some chain's units
+ * (10,000 is dust on an 18-decimal chain and real money on an 8-decimal one).
+ */
+const dustSafetyMultiple = 2n
+
+/**
+ * Hard ceiling as a multiple of the published threshold.
+ *
+ * `dust_threshold` is a REMOTE value that directly decides how much of the
+ * user's money is irreversibly donated — there is no refund path for anything
+ * attached to an `m=<`. A wrong or hostile value would otherwise be honoured
+ * verbatim and then doubled. Every other floor here is a lower bound; this is
+ * the only upper one.
+ */
+const dustCeilingMultiple = 100n
+
+export const limitSwapCancelDustErrors = [
+  'thresholdUnavailable',
+  'malformedThreshold',
+  'unusablePrecision',
+  'belowObservableMinimum',
+  'exceedsCeiling',
+] as const
+
+export type LimitSwapCancelDustErrorReason = (typeof limitSwapCancelDustErrors)[number]
+
+export class LimitSwapCancelDustError extends Error {
+  readonly reason: LimitSwapCancelDustErrorReason
+
+  constructor(reason: LimitSwapCancelDustErrorReason, message: string) {
+    super(message)
+    this.reason = reason
+    this.name = 'LimitSwapCancelDustError'
+  }
+}
+
+type GetLimitSwapCancelDustInput = {
+  /** The live inbound row for the source chain. */
+  inbound: Pick<ThorchainInboundAddress, 'chain' | 'dust_threshold'>
+  /** The source coin's own precision — 18 for an EVM gas asset, 8 for a UTXO one. */
+  decimals: number
+}
+
+/**
+ * How much to attach to a cancel sent FROM an L1 chain, in the source coin's
+ * smallest units.
+ *
+ * A cancel carries no value; the amount exists solely so Bifrost observes the
+ * transaction at all. Both failure modes are silent, which is why every branch
+ * here throws rather than defaulting:
+ *
+ * - Under-funded, and Bifrost drops it before it becomes a `MsgObservedTxIn` —
+ *   the transaction confirms, the fee is spent, nothing is cancelled.
+ * - Over-funded, and the excess is irreversibly donated.
+ *
+ * The conversion is the part that has actually gone wrong in practice: a cancel
+ * was once signed for **2000 wei** — THORChain's 1e8-unit threshold used
+ * verbatim as an 18-decimal chain's smallest unit — which `ConvertAmount`
+ * truncates to zero. So the threshold is rescaled from 1e8 into the coin's own
+ * precision, and a result that rounds away is refused rather than nudged up to
+ * the bare observable minimum, which would be the same silent failure one order
+ * of magnitude higher.
+ */
+export const getLimitSwapCancelDust = ({ inbound, decimals }: GetLimitSwapCancelDustInput): bigint => {
+  const { chain, dust_threshold: threshold } = inbound
+
+  if (!threshold?.trim()) {
+    throw new LimitSwapCancelDustError(
+      'thresholdUnavailable',
+      `cancel dust: ${chain} inbound carries no dust_threshold, so the minimum Bifrost will observe is unknown`
+    )
+  }
+  if (!/^\d+$/.test(threshold.trim())) {
+    throw new LimitSwapCancelDustError(
+      'malformedThreshold',
+      `cancel dust: ${chain} dust_threshold is not an integer: ${JSON.stringify(threshold)}`
+    )
+  }
+  if (!Number.isInteger(decimals) || decimals < 0) {
+    throw new LimitSwapCancelDustError(
+      'unusablePrecision',
+      `cancel dust: ${chain} source coin declares an unusable precision (${decimals})`
+    )
+  }
+
+  const thresholdIn1e8 = BigInt(threshold.trim())
+
+  // Rescale from THORChain's 1e8 into the coin's own precision. Integer-only,
+  // in a direction chosen per branch so nothing is silently lost.
+  const scaled =
+    decimals >= thorchainFixedPointDecimals
+      ? thresholdIn1e8 * 10n ** BigInt(decimals - thorchainFixedPointDecimals)
+      : thresholdIn1e8 / 10n ** BigInt(thorchainFixedPointDecimals - decimals)
+
+  const dust = scaled * dustSafetyMultiple
+
+  if (thresholdIn1e8 > 0n && dust <= 0n) {
+    throw new LimitSwapCancelDustError(
+      'belowObservableMinimum',
+      `cancel dust: ${chain} threshold ${thresholdIn1e8} (1e8) rounds away at ${decimals} decimals, ` +
+        'so no attachable amount would be observed'
+    )
+  }
+
+  const ceiling = scaled * dustCeilingMultiple
+  if (ceiling > 0n && dust > ceiling) {
+    throw new LimitSwapCancelDustError(
+      'exceedsCeiling',
+      `cancel dust: computed ${dust} exceeds the ${chain} ceiling ${ceiling}`
+    )
+  }
+
+  return dust
+}

--- a/packages/core/chain/swap/native/limitSwapCancelEligibility.test.ts
+++ b/packages/core/chain/swap/native/limitSwapCancelEligibility.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getLimitSwapCancelEligibility,
+  LimitSwapCancelCandidate,
+  resolveLimitSwapCancelAsset,
+} from './limitSwapCancelEligibility'
+
+const fullUsdc = 'ETH.USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48'
+
+const candidate = (overrides: Partial<LimitSwapCancelCandidate> = {}): LimitSwapCancelCandidate => ({
+  isTerminal: false,
+  sourceAsset: 'THOR.RUNE',
+  targetAsset: fullUsdc,
+  signedSourceAmount: 100_000_000n,
+  signedTradeTarget: 43_079_145n,
+  ...overrides,
+})
+
+const blockerOf = (c: LimitSwapCancelCandidate) => {
+  const result = getLimitSwapCancelEligibility(c)
+  return 'blocked' in result ? result.blocked : null
+}
+
+describe('resolveLimitSwapCancelAsset', () => {
+  it('prefers the locally signed full form', () => {
+    expect(resolveLimitSwapCancelAsset({ stored: 'ETH.USDC-06EB48', signed: fullUsdc })).toEqual({ resolved: fullUsdc })
+  })
+
+  // The placement spelling is lossy — an abbreviation cannot be expanded back.
+  it('refuses to fall back to an abbreviated stored spelling', () => {
+    expect(resolveLimitSwapCancelAsset({ stored: 'ETH.USDC-06EB48' })).toEqual({
+      problem: 'unknown',
+    })
+  })
+
+  // Native and secured-native legs carry no identifier, so they are full.
+  it('accepts a stored spelling that carries no identifier', () => {
+    expect(resolveLimitSwapCancelAsset({ stored: 'BTC.BTC' })).toEqual({ resolved: 'BTC.BTC' })
+  })
+
+  // The legacy case: nothing local, rescued by the only source still holding
+  // the full contract.
+  it('falls back to the chain report when no local spelling is usable', () => {
+    expect(resolveLimitSwapCancelAsset({ stored: 'ETH.USDC-06EB48', observed: fullUsdc })).toEqual({
+      resolved: fullUsdc,
+    })
+  })
+
+  // Case differs by convention between the two sources; anything beyond it is
+  // a real difference.
+  it('treats a case-only difference as agreement', () => {
+    expect(
+      resolveLimitSwapCancelAsset({
+        stored: 'eth-usdc-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+        observed: 'ETH-USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48',
+      })
+    ).toEqual({ resolved: 'eth-usdc-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' })
+  })
+
+  it('reports a genuine disagreement', () => {
+    expect(resolveLimitSwapCancelAsset({ stored: 'BTC.BTC', observed: 'ETH.ETH' })).toEqual({ problem: 'disagrees' })
+  })
+})
+
+describe('getLimitSwapCancelEligibility', () => {
+  it('yields the exact inputs for a cancellable order', () => {
+    expect(getLimitSwapCancelEligibility(candidate())).toEqual({
+      cancellable: {
+        sourceAsset: 'THOR.RUNE',
+        sourceAmount: 100_000_000n,
+        targetAsset: fullUsdc,
+        tradeTarget: 43_079_145n,
+      },
+    })
+  })
+
+  it.each([
+    ['a terminal order', { isTerminal: true }, 'terminal'],
+    ['a cancel already broadcast', { hasPendingCancel: true }, 'cancelAlreadyBroadcast'],
+    ['a missing source amount', { signedSourceAmount: undefined }, 'missingSignedData'],
+    ['a zero trade target', { signedTradeTarget: 0n }, 'missingSignedData'],
+    ['an unresolvable asset', { targetAsset: 'ETH.USDC-06EB48' }, 'missingSignedData'],
+  ] as const)('blocks %s', (_label, overrides, expected) => {
+    expect(blockerOf(candidate(overrides))).toBe(expected)
+  })
+
+  // The amounts feed the ratio the matcher keys on; drift lands in a different
+  // bucket and the cancel silently matches nothing.
+  it.each([
+    ['deposit', { observedDeposit: 99_999_999n }],
+    ['trade target', { observedTradeTarget: 1n }],
+  ])('blocks when the observed %s disagrees', (_label, overrides) => {
+    expect(blockerOf(candidate(overrides))).toBe('signedDataDisagreesWithChain')
+  })
+
+  // The check a real failure needed: the amounts were compared and agreed, the
+  // assets were never compared, and the asset was the entire defect.
+  it('blocks when an observed ASSET disagrees, even though the amounts match', () => {
+    expect(
+      blockerOf(
+        candidate({
+          observedDeposit: 100_000_000n,
+          observedTradeTarget: 43_079_145n,
+          observedSourceAsset: 'BTC.BTC',
+        })
+      )
+    ).toBe('signedDataDisagreesWithChain')
+  })
+
+  // An order placed seconds ago has not been polled; refusing until the first
+  // poll lands would be a worse failure than the one this prevents.
+  it('allows a cancel before the first poll has observed anything', () => {
+    expect(blockerOf(candidate())).toBeNull()
+  })
+
+  it('allows a cancel when observations agree', () => {
+    expect(
+      blockerOf(
+        candidate({
+          observedDeposit: 100_000_000n,
+          observedTradeTarget: 43_079_145n,
+          observedSourceAsset: 'THOR.RUNE',
+          observedTargetAsset: fullUsdc,
+        })
+      )
+    ).toBeNull()
+  })
+
+  // Nothing in a cancel memo can be shortened, so the order refunds at expiry.
+  it('blocks a full-contract target from a UTXO source', () => {
+    expect(blockerOf(candidate({ sourceAsset: 'BTC.BTC', targetAsset: fullUsdc }))).toBe('memoTooLongForSourceChain')
+  })
+})

--- a/packages/core/chain/swap/native/limitSwapCancelEligibility.test.ts
+++ b/packages/core/chain/swap/native/limitSwapCancelEligibility.test.ts
@@ -127,6 +127,12 @@ describe('getLimitSwapCancelEligibility', () => {
     ).toBeNull()
   })
 
+  // The memo builder does not check routability, so an unrecognised prefix used
+  // to throw out of a function whose contract is to answer with a blocker.
+  it('blocks an unroutable source chain instead of throwing', () => {
+    expect(blockerOf(candidate({ sourceAsset: 'NOPE.NOPE', targetAsset: 'BTC.BTC' }))).toBe('unroutableSourceChain')
+  })
+
   // Nothing in a cancel memo can be shortened, so the order refunds at expiry.
   it('blocks a full-contract target from a UTXO source', () => {
     expect(blockerOf(candidate({ sourceAsset: 'BTC.BTC', targetAsset: fullUsdc }))).toBe('memoTooLongForSourceChain')

--- a/packages/core/chain/swap/native/limitSwapCancelEligibility.ts
+++ b/packages/core/chain/swap/native/limitSwapCancelEligibility.ts
@@ -4,7 +4,7 @@ import {
   isAbbreviatedThorchainMemoAsset,
   LimitSwapCancelInputs,
 } from './limitSwapCancelMemo'
-import { getLimitSwapSourceChainKind } from './limitSwapMemo'
+import { getLimitSwapSourceChainKind, LimitSwapSourceChainKind } from './limitSwapMemo'
 
 export const limitSwapCancelBlockers = [
   /** The order has already closed. Nothing left to cancel. */
@@ -32,6 +32,11 @@ export const limitSwapCancelBlockers = [
    * can be shortened, so the order simply refunds at expiry instead.
    */
   'memoTooLongForSourceChain',
+  /**
+   * The source asset names a chain THORChain cannot route, so there is no
+   * inbound vault to send the cancel to and no byte budget to size it against.
+   */
+  'unroutableSourceChain',
 ] as const
 
 export type LimitSwapCancelBlocker = (typeof limitSwapCancelBlockers)[number]
@@ -209,7 +214,18 @@ export const getLimitSwapCancelEligibility = (candidate: LimitSwapCancelCandidat
   } catch {
     return { blocked: 'missingSignedData' }
   }
-  if (!doesCancelLimitSwapMemoFit(memo, getLimitSwapSourceChainKind(inputs.sourceAsset))) {
+
+  // Resolved in its own guarded step: the memo builder does not check
+  // routability, so an unrecognised prefix reaches this call and throws —
+  // escaping a function whose whole contract is to answer with a blocker.
+  let sourceChainKind: LimitSwapSourceChainKind
+  try {
+    sourceChainKind = getLimitSwapSourceChainKind(inputs.sourceAsset)
+  } catch {
+    return { blocked: 'unroutableSourceChain' }
+  }
+
+  if (!doesCancelLimitSwapMemoFit(memo, sourceChainKind)) {
     return { blocked: 'memoTooLongForSourceChain' }
   }
 

--- a/packages/core/chain/swap/native/limitSwapCancelEligibility.ts
+++ b/packages/core/chain/swap/native/limitSwapCancelEligibility.ts
@@ -1,0 +1,217 @@
+import {
+  buildCancelLimitSwapMemo,
+  doesCancelLimitSwapMemoFit,
+  isAbbreviatedThorchainMemoAsset,
+  LimitSwapCancelInputs,
+} from './limitSwapCancelMemo'
+import { getLimitSwapSourceChainKind } from './limitSwapMemo'
+
+export const limitSwapCancelBlockers = [
+  /** The order has already closed. Nothing left to cancel. */
+  'terminal',
+  /**
+   * A cancel for this order has already been broadcast and is waiting to be
+   * observed. Without this, a user could pay the fee (and on L1 donate the
+   * dust) again for an identical memo landing in the identical bucket.
+   */
+  'cancelAlreadyBroadcast',
+  /**
+   * The order predates the fields cancelling needs, or no source can supply an
+   * asset's full spelling. Fails closed rather than guessing at the values the
+   * matcher keys on.
+   */
+  'missingSignedData',
+  /**
+   * What was recorded at signing and what the queue reports disagree. One of
+   * them is wrong and there is no way to tell which, so neither is signed.
+   */
+  'signedDataDisagreesWithChain',
+  /**
+   * The cancel memo does not fit the source chain's per-transaction budget —
+   * in practice an ERC20 target from a UTXO source. Nothing in a cancel memo
+   * can be shortened, so the order simply refunds at expiry instead.
+   */
+  'memoTooLongForSourceChain',
+] as const
+
+export type LimitSwapCancelBlocker = (typeof limitSwapCancelBlockers)[number]
+
+/**
+ * Which spelling of an asset a cancel memo may use, or why there isn't one.
+ */
+export type LimitSwapCancelAssetResolution = { resolved: string } | { problem: 'disagrees' } | { problem: 'unknown' }
+
+type ResolveLimitSwapCancelAssetInput = {
+  /** The PLACEMENT memo's spelling — lossy, usable only when not truncated. */
+  stored: string
+  /** The full form captured locally at signing, when it exists. */
+  signed?: string
+  /** The queue's own report, after `fuzzyAssetMatch` resolved the placement. */
+  observed?: string
+}
+
+const trimmed = (value: string | undefined): string | undefined => {
+  const text = value?.trim()
+  return text ? text : undefined
+}
+
+/**
+ * Resolve which spelling of one of the order's assets a cancel may use.
+ *
+ * Three sources, in decreasing order of how much they prove:
+ *
+ * 1. **The queue's own report** — the string THORChain built this order's index
+ *    entry from. Authoritative by construction, and the only source for an
+ *    order placed before the full form was recorded locally.
+ * 2. **The full form captured at signing** — derived from the coin's own
+ *    contract, so exact whenever it exists.
+ * 3. **The stored placement spelling** — usable ONLY when it carries no
+ *    truncated identifier, which makes it full by construction. That covers
+ *    every native leg (`BTC.BTC`, `THOR.RUNE`) and every secured denom.
+ *
+ * `disagrees` when a local spelling and the chain's own differ: one is wrong
+ * and there is no way to tell which. This is the check a real failure needed —
+ * the amounts were cross-checked and agreed, the assets were never compared,
+ * and the asset was the entire defect.
+ *
+ * Compared case-insensitively: the sources differ on case by convention (a
+ * secured denom is emitted lower-case and reported upper-case, and
+ * `common.ParseCoin` upper-cases whatever it is given). Anything beyond case is
+ * a real difference.
+ */
+export const resolveLimitSwapCancelAsset = ({
+  stored,
+  signed,
+  observed,
+}: ResolveLimitSwapCancelAssetInput): LimitSwapCancelAssetResolution => {
+  const storedIfUsable = isAbbreviatedThorchainMemoAsset(stored) ? undefined : trimmed(stored)
+  const local = trimmed(signed) ?? storedIfUsable
+  const chain = trimmed(observed)
+
+  if (!chain) {
+    return local ? { resolved: local } : { problem: 'unknown' }
+  }
+  if (!local) {
+    // No local spelling to check against — the legacy token case, rescued by
+    // the only source still holding the full contract.
+    return { resolved: chain }
+  }
+  if (local.toLowerCase() !== chain.toLowerCase()) {
+    return { problem: 'disagrees' }
+  }
+  // Proven equal bar case, so the local spelling is kept: it is the exact byte
+  // form this SDK derived.
+  return { resolved: local }
+}
+
+export type LimitSwapCancelCandidate = {
+  /** Whether the order has already closed. */
+  isTerminal: boolean
+  /** Whether a cancel has already been broadcast against this order. */
+  hasPendingCancel?: boolean
+  /** Source asset as the PLACEMENT memo spelled it. */
+  sourceAsset: string
+  /** Target asset as the PLACEMENT memo spelled it. */
+  targetAsset: string
+  /** Full source spelling captured at signing, if recorded. */
+  signedSourceAsset?: string
+  /** Full target spelling captured at signing, if recorded. */
+  signedTargetAsset?: string
+  /** Deposited source amount recorded at signing, in 1e8. */
+  signedSourceAmount?: bigint
+  /** Trade target recorded at signing, in 1e8. */
+  signedTradeTarget?: bigint
+  /** The queue's `coins[0].asset`, once polled. */
+  observedSourceAsset?: string
+  /** The queue's `target_asset`, once polled. */
+  observedTargetAsset?: string
+  /** The queue's `state.deposit`, once polled. */
+  observedDeposit?: bigint
+  /** The queue's `trade_target`, once polled. */
+  observedTradeTarget?: bigint
+}
+
+export type LimitSwapCancelEligibility = { cancellable: LimitSwapCancelInputs } | { blocked: LimitSwapCancelBlocker }
+
+/**
+ * Decide whether an order can be cancelled, and if so with which exact amounts.
+ *
+ * **Fails closed at every unknown.** The failure this guards against is not a
+ * crash or an error dialog — it is a cancel that is accepted, costs a fee, and
+ * silently matches no order at all. Every branch that cannot prove the values
+ * are the ones THORChain holds returns a blocker.
+ *
+ * The signed-versus-observed cross-check covers assets as well as amounts.
+ * Absence is NOT disagreement: an order placed seconds ago has not been polled,
+ * and refusing to cancel until the first poll lands would be a worse failure
+ * than the one this prevents. But present-and-unparseable blocks exactly as a
+ * mismatch does — "not polled yet" and "polled, and the wire carried something
+ * we do not model" are different claims, and only the first is safe to proceed
+ * through.
+ */
+export const getLimitSwapCancelEligibility = (candidate: LimitSwapCancelCandidate): LimitSwapCancelEligibility => {
+  if (candidate.isTerminal) {
+    return { blocked: 'terminal' }
+  }
+  if (candidate.hasPendingCancel) {
+    return { blocked: 'cancelAlreadyBroadcast' }
+  }
+
+  const { signedSourceAmount, signedTradeTarget } = candidate
+  if (
+    signedSourceAmount === undefined ||
+    signedTradeTarget === undefined ||
+    signedSourceAmount <= 0n ||
+    signedTradeTarget <= 0n
+  ) {
+    return { blocked: 'missingSignedData' }
+  }
+
+  // `state.deposit` IS the swap's `Tx.Coins[0].Amount` and `trade_target` IS
+  // `msg.TradeTarget` — the exact pair the matcher's ratio is computed from.
+  if (candidate.observedDeposit !== undefined && candidate.observedDeposit !== signedSourceAmount) {
+    return { blocked: 'signedDataDisagreesWithChain' }
+  }
+  if (candidate.observedTradeTarget !== undefined && candidate.observedTradeTarget !== signedTradeTarget) {
+    return { blocked: 'signedDataDisagreesWithChain' }
+  }
+
+  const source = resolveLimitSwapCancelAsset({
+    stored: candidate.sourceAsset,
+    signed: candidate.signedSourceAsset,
+    observed: candidate.observedSourceAsset,
+  })
+  const target = resolveLimitSwapCancelAsset({
+    stored: candidate.targetAsset,
+    signed: candidate.signedTargetAsset,
+    observed: candidate.observedTargetAsset,
+  })
+
+  if (!('resolved' in source) || !('resolved' in target)) {
+    const disagrees =
+      ('problem' in source && source.problem === 'disagrees') || ('problem' in target && target.problem === 'disagrees')
+    return { blocked: disagrees ? 'signedDataDisagreesWithChain' : 'missingSignedData' }
+  }
+
+  const inputs: LimitSwapCancelInputs = {
+    sourceAsset: source.resolved,
+    sourceAmount: signedSourceAmount,
+    targetAsset: target.resolved,
+    tradeTarget: signedTradeTarget,
+  }
+
+  // The memo must be buildable AND fit the chain it will be sent from. Checked
+  // here rather than at signing so the action is never offered for an order
+  // that cannot actually be cancelled.
+  let memo: string
+  try {
+    memo = buildCancelLimitSwapMemo(inputs)
+  } catch {
+    return { blocked: 'missingSignedData' }
+  }
+  if (!doesCancelLimitSwapMemoFit(memo, getLimitSwapSourceChainKind(inputs.sourceAsset))) {
+    return { blocked: 'memoTooLongForSourceChain' }
+  }
+
+  return { cancellable: inputs }
+}

--- a/packages/core/chain/swap/native/limitSwapCancelMemo.test.ts
+++ b/packages/core/chain/swap/native/limitSwapCancelMemo.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildCancelLimitSwapMemo,
+  doesCancelLimitSwapMemoFit,
+  isAbbreviatedThorchainMemoAsset,
+  isCancelLimitSwapMemo,
+  isModifyLimitSwapMemo,
+  LimitSwapCancelInputs,
+} from './limitSwapCancelMemo'
+
+const fullUsdc = 'ETH.USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48'
+
+const runeToUsdc: LimitSwapCancelInputs = {
+  sourceAsset: 'THOR.RUNE',
+  sourceAmount: 100_000_000n,
+  targetAsset: fullUsdc,
+  tradeTarget: 43_079_145n,
+}
+
+describe('buildCancelLimitSwapMemo', () => {
+  // Coins are `<amount><ASSET>` with no space; the trailing 0 is what makes it
+  // a cancel rather than a retarget.
+  it('builds the three-field cancel form', () => {
+    expect(buildCancelLimitSwapMemo(runeToUsdc)).toBe(`m=<:100000000THOR.RUNE:43079145${fullUsdc}:0`)
+  })
+
+  // The placement memo's LIM understands scientific notation; these coins go
+  // through cosmos.ParseCoins, which does not.
+  it('emits plain decimal integers, never compressed', () => {
+    const memo = buildCancelLimitSwapMemo({
+      ...runeToUsdc,
+      sourceAmount: 544_000_000n,
+    })
+
+    expect(memo).toContain('544000000THOR.RUNE')
+    expect(memo).not.toContain('e')
+  })
+
+  // A secured source must keep its secured denom: ValidateBasic enforces
+  // From.IsChain(Source.Asset.GetChain()), and the L1 spelling makes GetChain()
+  // report the L1 chain, rejecting a cancel sent from a THOR address.
+  it('passes a secured denom through unchanged', () => {
+    const memo = buildCancelLimitSwapMemo({
+      ...runeToUsdc,
+      sourceAsset: 'eth-usdc-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+    })
+
+    expect(memo).toContain('eth-usdc-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')
+  })
+
+  // This memo type skips fuzzyAssetMatch, so an abbreviation addresses a bucket
+  // that by construction holds nothing: accepted, charged, cancels nothing.
+  it.each([
+    ['an abbreviated source', { sourceAsset: 'ETH.USDC-06EB48' }],
+    ['an abbreviated target', { targetAsset: 'ETH.USDC-06EB48' }],
+  ])('refuses %s', (_label, overrides) => {
+    expect(() => buildCancelLimitSwapMemo({ ...runeToUsdc, ...overrides })).toThrow(/full token identifier/)
+  })
+
+  it.each([
+    ['a zero source amount', { sourceAmount: 0n }],
+    ['a zero trade target', { tradeTarget: 0n }],
+    ['a negative amount', { sourceAmount: -1n }],
+  ])('refuses %s', (_label, overrides) => {
+    expect(() => buildCancelLimitSwapMemo({ ...runeToUsdc, ...overrides })).toThrow(/positive/)
+  })
+
+  it.each([
+    ['an empty source asset', { sourceAsset: '' }],
+    ['a whitespace target asset', { targetAsset: '   ' }],
+  ])('refuses %s', (_label, overrides) => {
+    expect(() => buildCancelLimitSwapMemo({ ...runeToUsdc, ...overrides })).toThrow(/required/)
+  })
+})
+
+describe('isAbbreviatedThorchainMemoAsset', () => {
+  it.each([
+    ['ETH.USDC-06EB48', true],
+    [fullUsdc, false],
+    // No identifier at all — full by construction. Native and secured-native
+    // legs must stay cancellable.
+    ['BTC.BTC', false],
+    ['THOR.RUNE', false],
+    ['THOR.TCY', false],
+    ['btc-btc', false],
+    // A secured token's chain prefix uses `-`, so reading the tail after the
+    // LAST `-` would call a secured native truncated.
+    ['eth-usdc-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', false],
+  ])('reads %s as abbreviated=%s', (asset, expected) => {
+    expect(isAbbreviatedThorchainMemoAsset(asset)).toBe(expected)
+  })
+})
+
+describe('isModifyLimitSwapMemo / isCancelLimitSwapMemo', () => {
+  const cancel = buildCancelLimitSwapMemo(runeToUsdc)
+  const retarget = cancel.replace(/:0$/, ':50000000')
+
+  it('recognises a cancel as both a modify and a cancel', () => {
+    expect(isModifyLimitSwapMemo(cancel)).toBe(true)
+    expect(isCancelLimitSwapMemo(cancel)).toBe(true)
+  })
+
+  // A retarget is a different action with a different outcome. Treating it as a
+  // cancel would be a lie the day someone builds modify.
+  it('recognises a retarget as a modify but NOT a cancel', () => {
+    expect(isModifyLimitSwapMemo(retarget)).toBe(true)
+    expect(isCancelLimitSwapMemo(retarget)).toBe(false)
+  })
+
+  // THORNode's getUint reads the field numerically, so "00" is zero there; a
+  // string comparison would call it a retarget.
+  it('reads a zero-padded final field as a cancel', () => {
+    expect(isCancelLimitSwapMemo(cancel.replace(/:0$/, ':00'))).toBe(true)
+  })
+
+  // Digits only, so a sign cannot smuggle "-0" past an unsigned field.
+  it('refuses a signed final field', () => {
+    expect(isCancelLimitSwapMemo(cancel.replace(/:0$/, ':-0'))).toBe(false)
+  })
+
+  it.each([
+    ['a placement memo', '=<:ETH.ETH:0xabc:100/14400/0'],
+    ['an empty final field', 'm=<:1THOR.RUNE:1BTC.BTC:'],
+    ['a plain send', 'hello'],
+    ['no memo', undefined],
+  ])('reads %s as not a cancel', (_label, memo) => {
+    expect(isCancelLimitSwapMemo(memo)).toBe(false)
+  })
+})
+
+describe('doesCancelLimitSwapMemoFit', () => {
+  it('accepts a cancel within the non-UTXO budget', () => {
+    expect(doesCancelLimitSwapMemoFit(buildCancelLimitSwapMemo(runeToUsdc), 'other')).toBe(true)
+  })
+
+  // Two full-contract assets plus two exact amounts overflow OP_RETURN, and
+  // nothing in a cancel memo can be shortened. Such orders refund at expiry.
+  it('rejects a full-contract pair from a UTXO source', () => {
+    const memo = buildCancelLimitSwapMemo({
+      sourceAsset: 'BTC.BTC',
+      sourceAmount: 100_000_000n,
+      targetAsset: fullUsdc,
+      tradeTarget: 43_079_145n,
+    })
+
+    expect(memo.length).toBeGreaterThan(80)
+    expect(doesCancelLimitSwapMemoFit(memo, 'utxo')).toBe(false)
+  })
+
+  it('accepts a native pair from a UTXO source', () => {
+    const memo = buildCancelLimitSwapMemo({
+      sourceAsset: 'BTC.BTC',
+      sourceAmount: 100_000_000n,
+      targetAsset: 'THOR.RUNE',
+      tradeTarget: 43_079_145n,
+    })
+
+    expect(doesCancelLimitSwapMemoFit(memo, 'utxo')).toBe(true)
+  })
+})

--- a/packages/core/chain/swap/native/limitSwapCancelMemo.test.ts
+++ b/packages/core/chain/swap/native/limitSwapCancelMemo.test.ts
@@ -66,6 +66,14 @@ describe('buildCancelLimitSwapMemo', () => {
     expect(() => buildCancelLimitSwapMemo({ ...runeToUsdc, ...overrides })).toThrow(/positive/)
   })
 
+  // THORNode's getCoin splices its own space between amount and asset, so a
+  // stray one corrupts the coin field and the cancel matches nothing.
+  it('trims surrounding whitespace rather than emitting it', () => {
+    expect(buildCancelLimitSwapMemo({ ...runeToUsdc, sourceAsset: '  THOR.RUNE  ' })).toBe(
+      buildCancelLimitSwapMemo(runeToUsdc)
+    )
+  })
+
   it.each([
     ['an empty source asset', { sourceAsset: '' }],
     ['a whitespace target asset', { targetAsset: '   ' }],

--- a/packages/core/chain/swap/native/limitSwapCancelMemo.ts
+++ b/packages/core/chain/swap/native/limitSwapCancelMemo.ts
@@ -152,9 +152,15 @@ export class LimitSwapCancelMemoBuildError extends Error {
  *   different bucket.
  */
 export const buildCancelLimitSwapMemo = (inputs: LimitSwapCancelInputs): string => {
-  const { sourceAsset, sourceAmount, targetAsset, tradeTarget } = inputs
+  const { sourceAmount, tradeTarget } = inputs
+  // Trimmed once and used throughout: validating the trimmed form while
+  // emitting the raw one would let ' THOR.RUNE' produce `100000000 THOR.RUNE`,
+  // and THORNode's getCoin splices its own space in — so the stray one corrupts
+  // the coin field and the cancel matches nothing.
+  const sourceAsset = inputs.sourceAsset.trim()
+  const targetAsset = inputs.targetAsset.trim()
 
-  if (!sourceAsset.trim() || !targetAsset.trim()) {
+  if (!sourceAsset || !targetAsset) {
     throw new LimitSwapCancelMemoBuildError('emptyAsset', 'cancel memo: source and target assets are required')
   }
   if (sourceAmount <= 0n || tradeTarget <= 0n) {

--- a/packages/core/chain/swap/native/limitSwapCancelMemo.ts
+++ b/packages/core/chain/swap/native/limitSwapCancelMemo.ts
@@ -127,6 +127,26 @@ export class LimitSwapCancelMemoBuildError extends Error {
 }
 
 /**
+ * Both amounts must be positive, for every consumer of these inputs.
+ *
+ * Shared because two modules depend on it for different reasons: the memo would
+ * encode a coin THORNode cannot parse, and the bucket key divides by the trade
+ * target — where a zero would raise `RangeError` rather than a domain error a
+ * caller can branch on.
+ */
+export const assertPositiveLimitSwapCancelAmounts = ({
+  sourceAmount,
+  tradeTarget,
+}: Pick<LimitSwapCancelInputs, 'sourceAmount' | 'tradeTarget'>): void => {
+  if (sourceAmount <= 0n || tradeTarget <= 0n) {
+    throw new LimitSwapCancelMemoBuildError(
+      'nonPositiveAmount',
+      `limit order cancel: amounts must be positive, got source ${sourceAmount} and trade target ${tradeTarget}`
+    )
+  }
+}
+
+/**
  * Build the `m=<` memo that cancels a resting limit order.
  *
  *     m=<:<SRC_AMOUNT><SRC_ASSET>:<TRADE_TARGET><TGT_ASSET>:0
@@ -163,12 +183,7 @@ export const buildCancelLimitSwapMemo = (inputs: LimitSwapCancelInputs): string 
   if (!sourceAsset || !targetAsset) {
     throw new LimitSwapCancelMemoBuildError('emptyAsset', 'cancel memo: source and target assets are required')
   }
-  if (sourceAmount <= 0n || tradeTarget <= 0n) {
-    throw new LimitSwapCancelMemoBuildError(
-      'nonPositiveAmount',
-      `cancel memo: amounts must be positive, got source ${sourceAmount} and trade target ${tradeTarget}`
-    )
-  }
+  assertPositiveLimitSwapCancelAmounts({ sourceAmount, tradeTarget })
   if (isAbbreviatedThorchainMemoAsset(sourceAsset) || isAbbreviatedThorchainMemoAsset(targetAsset)) {
     throw new LimitSwapCancelMemoBuildError(
       'abbreviatedAsset',

--- a/packages/core/chain/swap/native/limitSwapCancelMemo.ts
+++ b/packages/core/chain/swap/native/limitSwapCancelMemo.ts
@@ -1,0 +1,194 @@
+import { getLimitSwapSourceChainKind, limitSwapMemoByteLimit, LimitSwapSourceChainKind } from './limitSwapMemo'
+
+/**
+ * THORChain's modify-limit-swap prefix. Distinct from `limitSwapMemoPrefix`
+ * (`=<:`), which PLACES an order — `m=<:` modifies one that is already resting.
+ */
+export const modifyLimitSwapMemoPrefix = 'm=<:'
+
+/**
+ * The `ModifiedTargetAmount` that means "cancel". THORNode branches on
+ * `msg.ModifiedTargetAmount.IsZero()`; any other value re-targets the order
+ * instead, which is a different action this module deliberately does not build.
+ */
+const cancelModifiedTargetAmount = '0'
+
+/**
+ * Whether `memo` MODIFIES a resting order — which includes, but is not limited
+ * to, cancelling it.
+ *
+ * Named for what it matches. A cancel is the special case where the final field
+ * is zero; a non-zero value re-targets. Only the cancel form is built here, so
+ * today the two coincide — but a predicate that says "cancel" while matching
+ * any modification is the kind of small lie that outlives the assumption that
+ * made it true.
+ */
+export const isModifyLimitSwapMemo = (memo: string | undefined | null): boolean =>
+  !!memo?.startsWith(modifyLimitSwapMemoPrefix)
+
+/**
+ * Whether `memo` CANCELS a resting order, rather than merely modifying one.
+ *
+ * The final field is compared NUMERICALLY, the way THORNode's `getUint` reads
+ * it: `"00"` is zero there, and a string comparison would call that a retarget.
+ * Digits only, so a sign cannot smuggle `"-0"` past an unsigned field.
+ */
+export const isCancelLimitSwapMemo = (memo: string | undefined | null): boolean => {
+  if (!isModifyLimitSwapMemo(memo) || !memo) {
+    return false
+  }
+  const fields = memo.split(':')
+  const modifiedTarget = fields[fields.length - 1]
+  if (!modifiedTarget || !/^\d+$/.test(modifiedTarget)) {
+    return false
+  }
+  return BigInt(modifiedTarget) === 0n
+}
+
+/**
+ * Everything the cancel memo needs, reduced to the exact integers THORChain
+ * itself holds. Amounts are bigint so a caller cannot pass an unparsed or
+ * negative value.
+ */
+export type LimitSwapCancelInputs = {
+  /**
+   * THORChain memo form of the order's SOURCE asset.
+   *
+   * Must carry the token's FULL contract (`ETH.USDC-0XA0B86991…`), never the
+   * placement memo's 6-character abbreviation — see `buildCancelLimitSwapMemo`.
+   *
+   * Must be the asset's SECURED denom (`eth-usdc-0xa0b…`) when the source is a
+   * secured asset, never its layer-1 form. `MsgModifyLimitSwap.ValidateBasic`
+   * enforces `From.IsChain(Source.Asset.GetChain())`, and `GetChain()` returns
+   * THORChain only for synth, trade and secured assets. The layer-1 spelling
+   * makes it report the L1 chain, and a cancel sent from a THOR address is then
+   * rejected outright at validation.
+   */
+  sourceAsset: string
+  /** The order's deposited source amount, in THORChain's 1e8 fixed point. */
+  sourceAmount: bigint
+  /** THORChain memo form of the TARGET asset, under the same full-spelling rule. */
+  targetAsset: string
+  /** The order's ORIGINAL trade target (the placement memo's LIM), in 1e8. */
+  tradeTarget: bigint
+}
+
+/**
+ * Shortest token identifier a cancel memo will accept.
+ *
+ * An EVM contract is 42 characters (`0X` + 40 hex) and the placement memo's
+ * abbreviation is 6, so anything between is a wide, unambiguous gap. Fixed at a
+ * length rather than an exact `0X…` pattern so a future asset flavour with a
+ * differently-shaped identifier is not rejected out of hand — the job is to
+ * catch truncation, not to validate contract syntax.
+ */
+const minimumFullTokenIdentifierLength = 20
+
+/** Every separator a THORChain memo asset can use: L1, synth, trade, secured. */
+const assetSeparators = ['.', '/', '~', '-']
+
+/**
+ * Whether a memo asset carries a TRUNCATED token identifier —
+ * `ETH.USDC-06EB48` rather than `ETH.USDC-0XA0B86991…`.
+ *
+ * The chain prefix has to be stripped first, and cannot be assumed to end at a
+ * `.`: a SECURED asset spells the whole thing with `-`, so a secured native
+ * denom is `btc-btc` and a secured token is `eth-usdc-0xa0b…`. Reading the tail
+ * after the last `-` would call the first of those truncated and make every
+ * secured-native order uncancellable.
+ *
+ * So: drop everything up to the first separator — that is the chain — and look
+ * at the SYMBOL that follows. A symbol is `TICKER` or `TICKER-<identifier>`,
+ * and only the second form can be truncated. `BTC.BTC`, `THOR.RUNE` and
+ * `btc-btc` carry no identifier at all and are full by construction.
+ */
+export const isAbbreviatedThorchainMemoAsset = (asset: string): boolean => {
+  const chainEnd = [...asset].findIndex(char => assetSeparators.includes(char))
+  const symbol = chainEnd === -1 ? asset : asset.slice(chainEnd + 1)
+  const identifierStart = symbol.indexOf('-')
+  if (identifierStart === -1) {
+    return false
+  }
+  return symbol.slice(identifierStart + 1).length < minimumFullTokenIdentifierLength
+}
+
+export const limitSwapCancelMemoErrors = ['emptyAsset', 'nonPositiveAmount', 'abbreviatedAsset'] as const
+
+export type LimitSwapCancelMemoError = (typeof limitSwapCancelMemoErrors)[number]
+
+export class LimitSwapCancelMemoBuildError extends Error {
+  readonly reason: LimitSwapCancelMemoError
+
+  constructor(reason: LimitSwapCancelMemoError, message: string) {
+    super(message)
+    this.reason = reason
+    this.name = 'LimitSwapCancelMemoBuildError'
+  }
+}
+
+/**
+ * Build the `m=<` memo that cancels a resting limit order.
+ *
+ *     m=<:<SRC_AMOUNT><SRC_ASSET>:<TRADE_TARGET><TGT_ASSET>:0
+ *
+ * Both coins are `<amount><ASSET>` with NO space — THORNode's `getCoin` scans
+ * leading digits and splices the space back in before parsing.
+ *
+ * Three properties, each of which causes a SILENT no-op if broken — the cancel
+ * is accepted, costs a fee, matches nothing, and looks exactly like success:
+ *
+ * - **Assets are spelled in FULL.** `processOneTxIn` runs every other inbound
+ *   memo through `fuzzyAssetMatch`, which is what lets a placement say
+ *   `ETH.USDC-06EB48` and still be indexed under the full contract.
+ *   `ModifyLimitSwapMemo` is the exception: its asset string builds the lookup
+ *   key verbatim, so an abbreviation addresses a bucket that by construction
+ *   holds nothing. Enforced here, not merely documented.
+ * - **Amounts are plain decimal integers.** The placement memo's LIM goes
+ *   through `getUintWithScientificNotation` and understands `544e6`; these
+ *   coins go through `cosmos.ParseCoins`, which does not.
+ * - **Both amounts are exact.** THORNode does not compare them directly — they
+ *   feed the ratio its index key is built from (see
+ *   `getThorchainLimitOrderBucketKey`), and one unit of drift lands in a
+ *   different bucket.
+ */
+export const buildCancelLimitSwapMemo = (inputs: LimitSwapCancelInputs): string => {
+  const { sourceAsset, sourceAmount, targetAsset, tradeTarget } = inputs
+
+  if (!sourceAsset.trim() || !targetAsset.trim()) {
+    throw new LimitSwapCancelMemoBuildError('emptyAsset', 'cancel memo: source and target assets are required')
+  }
+  if (sourceAmount <= 0n || tradeTarget <= 0n) {
+    throw new LimitSwapCancelMemoBuildError(
+      'nonPositiveAmount',
+      `cancel memo: amounts must be positive, got source ${sourceAmount} and trade target ${tradeTarget}`
+    )
+  }
+  if (isAbbreviatedThorchainMemoAsset(sourceAsset) || isAbbreviatedThorchainMemoAsset(targetAsset)) {
+    throw new LimitSwapCancelMemoBuildError(
+      'abbreviatedAsset',
+      `cancel memo: assets must carry their full token identifier, got ${JSON.stringify(sourceAsset)} and ${JSON.stringify(targetAsset)}. ` +
+        'This memo type skips fuzzyAssetMatch, so an abbreviation would address a bucket holding no order.'
+    )
+  }
+
+  const source = `${sourceAmount}${sourceAsset}`
+  const target = `${tradeTarget}${targetAsset}`
+  return `${modifyLimitSwapMemoPrefix}${source}:${target}:${cancelModifiedTargetAmount}`
+}
+
+/**
+ * Whether a cancel memo fits the per-transaction budget of the chain it will be
+ * sent from.
+ *
+ * In practice this rules out an ERC20 target from a UTXO source: two
+ * full-contract assets plus two exact amounts overflow the 80-byte OP_RETURN
+ * cap, and NOTHING in a cancel memo can be shortened — the amounts define the
+ * bucket, short codes are rejected by `cosmos.ParseCoins`, and this memo type
+ * skips `fuzzyAssetMatch`. Such an order still refunds automatically at expiry.
+ */
+export const doesCancelLimitSwapMemoFit = (memo: string, sourceChainKind: LimitSwapSourceChainKind): boolean =>
+  new TextEncoder().encode(memo).length <= limitSwapMemoByteLimit[sourceChainKind]
+
+/** Convenience: the byte-cap check keyed off the source asset's memo notation. */
+export const doesCancelLimitSwapMemoFitSourceAsset = (memo: string, sourceAsset: string): boolean =>
+  doesCancelLimitSwapMemoFit(memo, getLimitSwapSourceChainKind(sourceAsset))

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -499,6 +499,47 @@ export {
 } from '@vultisig/core-chain/swap/native/limitSwapOutcome'
 export type { LimitSwapQueueEntry } from '@vultisig/core-chain/swap/native/limitSwapQueue'
 export { getLimitSwapQueue, parseLimitSwapQueue } from '@vultisig/core-chain/swap/native/limitSwapQueue'
+// Limit-order cancellation (`m=<`, modify-limit-swap). Every failure mode here
+// is silent — the cancel is accepted, costs a fee, matches nothing, and looks
+// exactly like success — so the builder enforces the memo's rules rather than
+// documenting them, and eligibility fails closed at every unknown.
+export {
+  areLimitOrdersCancelIndistinguishable,
+  getThorchainLimitOrderBucketKey,
+  toThorchainLayer1MemoAsset,
+} from '@vultisig/core-chain/swap/native/limitSwapCancelBucket'
+export type { LimitSwapCancelDustErrorReason } from '@vultisig/core-chain/swap/native/limitSwapCancelDust'
+export {
+  getLimitSwapCancelDust,
+  LimitSwapCancelDustError,
+  limitSwapCancelDustErrors,
+} from '@vultisig/core-chain/swap/native/limitSwapCancelDust'
+export type {
+  LimitSwapCancelAssetResolution,
+  LimitSwapCancelBlocker,
+  LimitSwapCancelCandidate,
+  LimitSwapCancelEligibility,
+} from '@vultisig/core-chain/swap/native/limitSwapCancelEligibility'
+export {
+  getLimitSwapCancelEligibility,
+  limitSwapCancelBlockers,
+  resolveLimitSwapCancelAsset,
+} from '@vultisig/core-chain/swap/native/limitSwapCancelEligibility'
+export type {
+  LimitSwapCancelInputs,
+  LimitSwapCancelMemoError,
+} from '@vultisig/core-chain/swap/native/limitSwapCancelMemo'
+export {
+  buildCancelLimitSwapMemo,
+  doesCancelLimitSwapMemoFit,
+  doesCancelLimitSwapMemoFitSourceAsset,
+  isAbbreviatedThorchainMemoAsset,
+  isCancelLimitSwapMemo,
+  isModifyLimitSwapMemo,
+  LimitSwapCancelMemoBuildError,
+  limitSwapCancelMemoErrors,
+  modifyLimitSwapMemoPrefix,
+} from '@vultisig/core-chain/swap/native/limitSwapCancelMemo'
 export type { KeysignLimitSwapOrder } from '@vultisig/core-mpc/keysign/swap/getKeysignLimitSwapOrder'
 export { getKeysignLimitSwapOrder } from '@vultisig/core-mpc/keysign/swap/getKeysignLimitSwapOrder'
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -530,6 +530,7 @@ export type {
   LimitSwapCancelMemoError,
 } from '@vultisig/core-chain/swap/native/limitSwapCancelMemo'
 export {
+  assertPositiveLimitSwapCancelAmounts,
   buildCancelLimitSwapMemo,
   doesCancelLimitSwapMemoFit,
   doesCancelLimitSwapMemoFitSourceAsset,


### PR DESCRIPTION
## Description

Fixes #1685

A limit order rests for up to three days with no way to close it early. This adds the primitives for cancelling one: the `m=<` modify-limit-swap memo in its cancel form, eligibility, bucket-key duplicate detection, and L1 dust.

**Cancellation is not a variation on placement**, and that shaped every decision here. It uses a different memo type whose validation and matching rules are unusually unforgiving, and — the property worth holding onto while reviewing — **every failure mode is silent**: the transaction confirms, the fee is spent, and the order carries on resting with nothing to distinguish it from success. There is no error to surface and no refund path. So each rule below is *enforced* rather than documented, and every unknown fails closed.

Verified against THORNode `x/thorchain/memo/memo_modify_limit_swap.go`, `handler_modify_limit_swap.go`, `keeper/v1/keeper_adv_swap_queue.go`.

## The memo

```
m=<:<SRC_AMOUNT><SRC_ASSET>:<TRADE_TARGET><TGT_ASSET>:0
```

Coins are `<amount><ASSET>` with no space. The trailing field is `ModifiedTargetAmount`; THORNode branches on `IsZero()` and reads zero as a cancel.

Three properties, each a silent no-op if broken:

- **Assets are spelled in FULL.** `processOneTxIn` runs every other inbound memo through `fuzzyAssetMatch` — which is exactly what lets a *placement* memo say `ETH.USDC-06EB48`. `ModifyLimitSwapMemo` is the exception: its asset string builds the lookup key verbatim, so repeating the abbreviation addresses a bucket that by construction holds nothing. `buildCancelLimitSwapMemo` throws rather than letting those bytes exist.
- **Amounts are plain decimal integers.** A placement LIM goes through `getUintWithScientificNotation` and understands `544e6`; these coins go through `cosmos.ParseCoins`, which does not.
- **A secured source keeps its secured denom.** `ValidateBasic` enforces `From.IsChain(Source.Asset.GetChain())`, and `GetChain()` returns THORChain only for synth/trade/secured assets — the layer-1 spelling makes it report the L1 chain, and a cancel sent from a THOR address is rejected at validation.

`isCancelLimitSwapMemo` is kept distinct from `isModifyLimitSwapMemo`, and compares the final field **numerically**: `"00"` is zero to THORNode's `getUint`, so a string comparison would call it a retarget. Only the cancel form is built, so today the two predicates coincide — but a predicate named "cancel" that matches any modification is the kind of small lie that outlives the assumption making it true.

## Bucket key — why both amounts must be exact

THORNode never compares the amounts directly. It builds an index key from their *ratio* and scans that bucket for a matching `FromAddress`, taking the first hit:

```
ratio = (sourceAmount × 1e8) / tradeTarget          // integer division
key   = "<l1Source>><l1Target>/<ratio normalised to 18 chars>/"
```

One unit of drift lands in a different bucket. `getThorchainLimitOrderBucketKey` reproduces the normalisation in both directions — zero-padding *and* right-truncation — because truncation deliberately collapses very large ratios into one bucket, and reproducing only the padding would disagree with the chain at exactly the extreme where it matters.

Duplicate detection compares **keys, not amounts**: two orders with different deposits and different targets collide whenever their ratio matches (selling 1 and selling 2 at the same price land in one bucket). Comparing amounts for equality would under-report precisely the duplicates a user most needs warning about. Assets are layer-1-normalised first, since a secured representation and the plain L1 asset collapse to the same key on-chain. Tuned to over-report.

## Worth a reviewer's attention: two real failures pinned by tests

**The assets cross-check.** `getLimitSwapCancelEligibility` compares what was recorded at signing against what the queue reports — **assets as well as amounts**. There is a known failure where the amounts were cross-checked and agreed, the assets were never compared at all, and the asset was the entire defect. A check that verifies everything except the field that broke reports "all clear" on the way to a rejected transaction.

Absence is *not* disagreement — an order placed seconds ago hasn't been polled, and refusing until the first poll lands would be a worse failure than the one this prevents. But present-and-unparseable blocks exactly as a mismatch does: "not polled yet" and "polled, and the wire carried something we don't model" are different claims.

**The dust conversion.** A cancel was once signed for **2000 wei** — THORChain's 1e8-unit threshold used verbatim as an 18-decimal chain's smallest unit — which `ConvertAmount` truncates to zero. Bifrost never saw an inbound, the transaction confirmed, gas was burned, the order kept resting. `getLimitSwapCancelDust` rescales into the source coin's own precision and **refuses** when the result rounds away, rather than nudging up to the bare observable minimum, which would be the same silent failure one order of magnitude up. It also carries an upper ceiling: `dust_threshold` is a remote value that decides how much is irreversibly donated.

## Which feature is affected?

- [x] Swap — THORChain limit-order cancellation (pure primitives; nothing here signs or broadcasts)

No tx link: this PR builds and validates memo bytes and decides eligibility. Nothing constructs a keysign payload or broadcasts yet — that is the follow-up, and the first live cancel belongs there.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Testing

`yarn test:core` — 2422 passed, 67 of them new.

Coverage targets where a wrong answer is unrecoverable: abbreviated assets rejected in both legs; secured denoms passed through unchanged; `BTC.BTC`/`THOR.RUNE`/`btc-btc` correctly *not* read as truncated (a naive "text after the last `-`" rule would make every secured-native order uncancellable); zero-padded and signed final fields; ratio padding and truncation at both extremes; ratio collisions across differing amounts; every eligibility blocker; the assets-disagree case with matching amounts; and the 2000-wei dust regression asserting explicitly that the result is **not** `2000n`.

`yarn check:agent` reports two pre-existing CLI typecheck errors (`parseThorSwapMemo`, `commands/transaction.ts:165`) — verified identical on `main`, not introduced here.

## Additional context

Deliberately out of scope: the **modify/retarget** action (only the cancel form is built, though the predicates can tell them apart so nothing mislabels a retarget later), and all client UI. The consuming flow — keysign payload, broadcast, and the "cancelling" transitional state with its self-heal for a cancel that is included in a block but refused by the handler — is the follow-up in vultisig-windows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for cancelling native THORChain limit orders.
  * Added cancellation memo creation, validation, detection, and source-chain size checks.
  * Added eligibility checks for assets, amounts, order status, and observed transaction data.
  * Added price-bucket matching to identify indistinguishable orders.
  * Added dust-threshold calculation across different asset precisions.
  * Exposed cancellation utilities and types through the SDK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->