### PR TITLE
fix(sdk): preserve Bittensor hash on duplicate broadcasts

### DIFF
--- a/.changeset/bittensor-raw-broadcast-dedup.md
+++ b/.changeset/bittensor-raw-broadcast-dedup.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/sdk": patch
+---
+
+Return the deterministic Bittensor extrinsic hash for duplicate or timeout-style raw broadcast submissions.

--- a/packages/sdk/src/vault/services/RawBroadcastService.ts
+++ b/packages/sdk/src/vault/services/RawBroadcastService.ts
@@ -6,6 +6,7 @@ import { Chain, CosmosChain, EvmChain, OtherChain, UtxoBasedChain } from '@vulti
 import { isChainOfKind } from '@vultisig/core-chain/ChainKind'
 import { bittensorRpcUrl } from '@vultisig/core-chain/chains/bittensor/client'
 import { getCosmosClient } from '@vultisig/core-chain/chains/cosmos/client'
+import { getCustomRpcOverride } from '@vultisig/core-chain/chains/customRpc/customRpcOverrides'
 import { getEvmClient } from '@vultisig/core-chain/chains/evm/client'
 import { polkadotRpcUrl } from '@vultisig/core-chain/chains/polkadot/client'
 import { getRippleClient } from '@vultisig/core-chain/chains/ripple/client'
@@ -453,18 +454,30 @@ export class RawBroadcastService {
    * @param rawTx - Hex-encoded extrinsic (with or without 0x prefix)
    */
   private async broadcastBittensorRawTx(rawTx: string): Promise<string> {
-    const hexWithPrefix = ensureHexPrefix(rawTx)
+    const hexWithoutPrefix = rawTx.startsWith('0x') ? rawTx.slice(2) : rawTx
+    if (
+      hexWithoutPrefix.length === 0 ||
+      hexWithoutPrefix.length % 2 !== 0 ||
+      !/^[0-9a-fA-F]+$/.test(hexWithoutPrefix)
+    ) {
+      throw new Error('Bittensor raw transaction must be non-empty, even-length hexadecimal bytes')
+    }
+
+    const hexWithPrefix = ensureHexPrefix(hexWithoutPrefix)
     const rawTxHash = () => this.getBittensorRawTxHash(hexWithPrefix)
 
     const { data: response, error } = await attempt(
-      queryUrl<{ result: string; error?: { message: string } }>(bittensorRpcUrl, {
-        body: {
-          jsonrpc: '2.0',
-          method: 'author_submitExtrinsic',
-          params: [hexWithPrefix],
-          id: 1,
-        },
-      })
+      queryUrl<{ result: string; error?: { message: string } }>(
+        getCustomRpcOverride(OtherChain.Bittensor) ?? bittensorRpcUrl,
+        {
+          body: {
+            jsonrpc: '2.0',
+            method: 'author_submitExtrinsic',
+            params: [hexWithPrefix],
+            id: 1,
+          },
+        }
+      )
     )
 
     if (error) {

--- a/packages/sdk/src/vault/services/RawBroadcastService.ts
+++ b/packages/sdk/src/vault/services/RawBroadcastService.ts
@@ -16,6 +16,7 @@ import { tronRpcUrl } from '@vultisig/core-chain/chains/tron/config'
 import { getBlockchairBaseUrl } from '@vultisig/core-chain/chains/utxo/client/getBlockchairBaseUrl'
 import { isRippleInFlightEngineResult } from '@vultisig/core-chain/tx/broadcast/resolvers/ripple'
 import { assertSuiTxSucceeded } from '@vultisig/core-chain/tx/broadcast/resolvers/sui'
+import { getBittensorTxHash } from '@vultisig/core-chain/tx/hash/resolvers/bittensor'
 import { getTxStatus } from '@vultisig/core-chain/tx/status'
 import { rootApiUrl } from '@vultisig/core-config'
 import { attempt } from '@vultisig/lib-utils/attempt'
@@ -453,6 +454,7 @@ export class RawBroadcastService {
    */
   private async broadcastBittensorRawTx(rawTx: string): Promise<string> {
     const hexWithPrefix = ensureHexPrefix(rawTx)
+    const rawTxHash = () => this.getBittensorRawTxHash(hexWithPrefix)
 
     const { data: response, error } = await attempt(
       queryUrl<{ result: string; error?: { message: string } }>(bittensorRpcUrl, {
@@ -466,6 +468,9 @@ export class RawBroadcastService {
     )
 
     if (error) {
+      if (isInError(error, 'Already Imported', 'already imported', 'timed out', 'timeout')) {
+        return rawTxHash()
+      }
       throw error
     }
 
@@ -474,6 +479,9 @@ export class RawBroadcastService {
     }
 
     if (response.error) {
+      if (isInError(response.error.message, 'Already Imported', 'already imported', 'timed out', 'timeout')) {
+        return rawTxHash()
+      }
       throw new Error(`Bittensor broadcast failed: ${response.error.message}`)
     }
 
@@ -484,6 +492,14 @@ export class RawBroadcastService {
     }
 
     return response.result
+  }
+
+  private async getBittensorRawTxHash(rawTx: string): Promise<string> {
+    const hexWithoutPrefix = ensureHexPrefix(rawTx).slice(2)
+    type BittensorHashInput = Parameters<typeof getBittensorTxHash>[0]
+    return getBittensorTxHash({
+      encoded: Buffer.from(hexWithoutPrefix, 'hex'),
+    } as unknown as BittensorHashInput)
   }
 
   /**

--- a/packages/sdk/src/vault/services/RawBroadcastService.ts
+++ b/packages/sdk/src/vault/services/RawBroadcastService.ts
@@ -18,6 +18,7 @@ import { getBlockchairBaseUrl } from '@vultisig/core-chain/chains/utxo/client/ge
 import { isRippleInFlightEngineResult } from '@vultisig/core-chain/tx/broadcast/resolvers/ripple'
 import { assertSuiTxSucceeded } from '@vultisig/core-chain/tx/broadcast/resolvers/sui'
 import { getBittensorTxHash } from '@vultisig/core-chain/tx/hash/resolvers/bittensor'
+import { isValidTxHash } from '@vultisig/core-chain/tx/isValidTxHash'
 import { getTxStatus } from '@vultisig/core-chain/tx/status'
 import { rootApiUrl } from '@vultisig/core-config'
 import { attempt } from '@vultisig/lib-utils/attempt'
@@ -76,6 +77,23 @@ const deriveTronRawTxHash = (txJson: { raw_data_hex?: unknown; txID?: unknown })
   }
 
   return derivedHash
+}
+
+const isBittensorDuplicateError = (error: unknown): boolean =>
+  /^(?:transaction )?already imported$/i.test(extractErrorMsg(error).trim())
+
+const isBittensorTimeoutError = (error: unknown): boolean => {
+  if (error && typeof error === 'object') {
+    const { code, name } = error as { code?: unknown; name?: unknown }
+    if (code === 'ETIMEDOUT' || code === 'ESOCKETTIMEDOUT') return true
+    if (name === 'TimeoutError' || name === 'FetchTimeoutError') return true
+  }
+
+  const message = extractErrorMsg(error).trim()
+  return (
+    /^(?:request )?(?:timed out|timeout)(?: after \d+(?:\.\d+)? ?(?:ms|milliseconds?|s|seconds?))?$/i.test(message) ||
+    /^queryUrl: request timed out after \d+ms \(https?:\/\/[^)]+\)$/i.test(message)
+  )
 }
 
 const verifyKnownRawTx = async (chain: Chain, hash: string, chainName: string): Promise<string> => {
@@ -467,21 +485,18 @@ export class RawBroadcastService {
     const rawTxHash = () => this.getBittensorRawTxHash(hexWithPrefix)
 
     const { data: response, error } = await attempt(
-      queryUrl<{ result: string; error?: { message: string } }>(
-        getCustomRpcOverride(OtherChain.Bittensor) ?? bittensorRpcUrl,
-        {
-          body: {
-            jsonrpc: '2.0',
-            method: 'author_submitExtrinsic',
-            params: [hexWithPrefix],
-            id: 1,
-          },
-        }
-      )
+      queryUrl<{ result?: unknown; error?: unknown }>(getCustomRpcOverride(OtherChain.Bittensor) ?? bittensorRpcUrl, {
+        body: {
+          jsonrpc: '2.0',
+          method: 'author_submitExtrinsic',
+          params: [hexWithPrefix],
+          id: 1,
+        },
+      })
     )
 
     if (error) {
-      if (isInError(error, 'Already Imported', 'already imported', 'timed out', 'timeout')) {
+      if (isBittensorDuplicateError(error) || isBittensorTimeoutError(error)) {
         return rawTxHash()
       }
       throw error
@@ -491,17 +506,32 @@ export class RawBroadcastService {
       throw new Error('Bittensor broadcast returned no response')
     }
 
-    if (response.error) {
-      if (isInError(response.error.message, 'Already Imported', 'already imported', 'timed out', 'timeout')) {
-        return rawTxHash()
-      }
-      throw new Error(`Bittensor broadcast failed: ${response.error.message}`)
+    const hasResult = Object.prototype.hasOwnProperty.call(response, 'result')
+    const hasError = Object.prototype.hasOwnProperty.call(response, 'error')
+    if (hasResult === hasError) {
+      throw new Error('Bittensor broadcast failed: malformed JSON-RPC response')
     }
 
-    // Same JSON-RPC 2.0 invariant as Polkadot: a response with neither `result` nor `error`
-    // is malformed, not a success - fail closed instead of returning `undefined` as a hash.
-    if (!response.result) {
-      throw new Error('Bittensor broadcast failed: missing extrinsic hash in RPC response')
+    if (hasError) {
+      if (!response.error || typeof response.error !== 'object' || !('message' in response.error)) {
+        throw new Error('Bittensor broadcast failed: malformed JSON-RPC error')
+      }
+      const message = (response.error as { message?: unknown }).message
+      if (typeof message !== 'string') {
+        throw new Error('Bittensor broadcast failed: malformed JSON-RPC error')
+      }
+      if (isBittensorDuplicateError(message) || isBittensorTimeoutError(response.error)) {
+        return rawTxHash()
+      }
+      throw new Error(`Bittensor broadcast failed: ${message}`)
+    }
+
+    if (
+      typeof response.result !== 'string' ||
+      response.result !== response.result.trim() ||
+      !isValidTxHash(Chain.Bittensor, response.result)
+    ) {
+      throw new Error('Bittensor broadcast failed: invalid extrinsic hash in RPC response')
     }
 
     return response.result

--- a/packages/sdk/src/vault/services/RawBroadcastService.ts
+++ b/packages/sdk/src/vault/services/RawBroadcastService.ts
@@ -496,8 +496,11 @@ export class RawBroadcastService {
     )
 
     if (error) {
-      if (isBittensorDuplicateError(error) || isBittensorTimeoutError(error)) {
+      if (isBittensorDuplicateError(error)) {
         return rawTxHash()
+      }
+      if (isBittensorTimeoutError(error)) {
+        return verifyKnownRawTx(OtherChain.Bittensor, await rawTxHash(), 'Bittensor')
       }
       throw error
     }
@@ -520,8 +523,11 @@ export class RawBroadcastService {
       if (typeof message !== 'string') {
         throw new Error('Bittensor broadcast failed: malformed JSON-RPC error')
       }
-      if (isBittensorDuplicateError(message) || isBittensorTimeoutError(response.error)) {
+      if (isBittensorDuplicateError(message)) {
         return rawTxHash()
+      }
+      if (isBittensorTimeoutError(response.error)) {
+        return verifyKnownRawTx(OtherChain.Bittensor, await rawTxHash(), 'Bittensor')
       }
       throw new Error(`Bittensor broadcast failed: ${message}`)
     }

--- a/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
+++ b/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
@@ -571,13 +571,14 @@ describe('RawBroadcastService', () => {
   })
 
   it('broadcasts Bittensor extrinsic via JSON-RPC', async () => {
-    mockQueryUrl.mockResolvedValue({ result: '0xbtensor' })
+    const bittensorHash = `0x${'ab'.repeat(32)}`
+    mockQueryUrl.mockResolvedValue({ result: bittensorHash })
 
     const hash = await service.broadcastRawTx({
       chain: Chain.Bittensor,
       rawTx: 'beef',
     })
-    expect(hash).toBe('0xbtensor')
+    expect(hash).toBe(bittensorHash)
     expect(mockQueryUrl).toHaveBeenCalledWith(
       bittensorRpcUrl,
       expect.objectContaining({
@@ -586,20 +587,26 @@ describe('RawBroadcastService', () => {
     )
   })
 
-  it('throws on a malformed Bittensor response with neither result nor error', async () => {
-    mockQueryUrl.mockResolvedValue({})
+  it.each([
+    {},
+    { result: {} },
+    { result: 123 },
+    { result: '0xbtensor' },
+    { result: `0x${'ab'.repeat(32)}`, error: { message: 'Already Imported' } },
+  ])('throws on malformed Bittensor JSON-RPC response %#', async response => {
+    mockQueryUrl.mockResolvedValue(response)
 
     await expect(
       service.broadcastRawTx({
         chain: Chain.Bittensor,
         rawTx: 'beef',
       })
-    ).rejects.toThrow(/missing extrinsic hash/)
+    ).rejects.toThrow(/malformed JSON-RPC response|invalid extrinsic hash/)
   })
 
   it('uses the configured Bittensor RPC override', async () => {
     mockGetCustomRpcOverride.mockReturnValue('https://controlled-bittensor.test')
-    mockQueryUrl.mockResolvedValue({ result: '0xbtensor' })
+    mockQueryUrl.mockResolvedValue({ result: `0x${'ab'.repeat(32)}` })
 
     await service.broadcastRawTx({ chain: Chain.Bittensor, rawTx: 'beef' })
 
@@ -612,23 +619,26 @@ describe('RawBroadcastService', () => {
     )
   })
 
-  it('returns Bittensor raw tx hash when the extrinsic was already imported', async () => {
-    mockQueryUrl.mockResolvedValue({
-      error: {
-        message: 'Already Imported',
-      },
-    })
+  it.each(['Already Imported', 'TRANSACTION ALREADY IMPORTED'])(
+    'returns Bittensor raw tx hash for duplicate response %j',
+    async duplicateMessage => {
+      mockQueryUrl.mockResolvedValue({
+        error: {
+          message: duplicateMessage,
+        },
+      })
 
-    const hash = await service.broadcastRawTx({
-      chain: Chain.Bittensor,
-      rawTx: 'beef',
-    })
+      const hash = await service.broadcastRawTx({
+        chain: Chain.Bittensor,
+        rawTx: 'beef',
+      })
 
-    expect(hash).toBe('0xbittensorhash')
-    expect(mockGetBittensorTxHash).toHaveBeenCalledWith({
-      encoded: Buffer.from('beef', 'hex'),
-    })
-  })
+      expect(hash).toBe('0xbittensorhash')
+      expect(mockGetBittensorTxHash).toHaveBeenCalledWith({
+        encoded: Buffer.from('beef', 'hex'),
+      })
+    }
+  )
 
   it('returns Bittensor raw tx hash for timeout-style JSON-RPC errors', async () => {
     mockQueryUrl.mockResolvedValue({
@@ -648,8 +658,11 @@ describe('RawBroadcastService', () => {
     })
   })
 
-  it('returns Bittensor raw tx hash for timeout-style submit failures', async () => {
-    mockQueryUrl.mockRejectedValue(new Error('request timed out'))
+  it.each([
+    'request timed out',
+    'queryUrl: request timed out after 20000ms (https://bittensor-finney.api.onfinality.io/public)',
+  ])('returns Bittensor raw tx hash for timeout-style submit failure %j', async timeoutMessage => {
+    mockQueryUrl.mockRejectedValue(new Error(timeoutMessage))
 
     const hash = await service.broadcastRawTx({
       chain: Chain.Bittensor,
@@ -659,6 +672,32 @@ describe('RawBroadcastService', () => {
     expect(hash).toBe('0xbittensorhash')
     expect(mockGetBittensorTxHash).toHaveBeenCalledWith({
       encoded: Buffer.from('beef', 'hex'),
+    })
+  })
+
+  it.each([
+    'Invalid transaction: timeout value is unsupported',
+    'Transaction timed out during validation',
+    'Already Imported transaction is invalid',
+  ])('does not treat unrelated thrown error %j as a Bittensor duplicate', async errorMessage => {
+    mockQueryUrl.mockRejectedValue(new Error(errorMessage))
+
+    await expect(service.broadcastRawTx({ chain: Chain.Bittensor, rawTx: '0xbeef' })).rejects.toMatchObject({
+      code: VaultErrorCode.BroadcastFailed,
+      message: expect.stringContaining(errorMessage),
+    })
+  })
+
+  it.each([
+    'Invalid transaction: timeout value is unsupported',
+    'Transaction timed out during validation',
+    'Already Imported transaction is invalid',
+  ])('does not treat unrelated JSON-RPC error %j as a Bittensor duplicate', async errorMessage => {
+    mockQueryUrl.mockResolvedValue({ error: { message: errorMessage } })
+
+    await expect(service.broadcastRawTx({ chain: Chain.Bittensor, rawTx: '0xbeef' })).rejects.toMatchObject({
+      code: VaultErrorCode.BroadcastFailed,
+      message: expect.stringContaining(errorMessage),
     })
   })
 

--- a/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
+++ b/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
@@ -640,6 +640,24 @@ describe('RawBroadcastService', () => {
     }
   )
 
+  it.each(['Already Imported', 'TRANSACTION ALREADY IMPORTED'])(
+    'returns Bittensor raw tx hash for duplicate submit failure %j',
+    async duplicateMessage => {
+      mockQueryUrl.mockRejectedValue(new Error(duplicateMessage))
+
+      const hash = await service.broadcastRawTx({
+        chain: Chain.Bittensor,
+        rawTx: 'beef',
+      })
+
+      expect(hash).toBe('0xbittensorhash')
+      expect(mockGetBittensorTxHash).toHaveBeenCalledWith({
+        encoded: Buffer.from('beef', 'hex'),
+      })
+      expect(mockQueryUrl).toHaveBeenCalledTimes(1)
+    }
+  )
+
   it('verifies a timeout-style JSON-RPC error via taostats before returning a hash', async () => {
     mockQueryUrl
       .mockResolvedValueOnce({

--- a/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
+++ b/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
@@ -36,6 +36,7 @@ const {
   mockCosmosGetTx,
   mockExecuteSuiTx,
   mockRippleRequest,
+  mockGetBittensorTxHash,
 } = vi.hoisted(() => ({
   mockQueryUrl: vi.fn(),
   mockGetEvmClient: vi.fn(),
@@ -47,6 +48,7 @@ const {
   mockCosmosGetTx: vi.fn(),
   mockExecuteSuiTx: vi.fn(),
   mockRippleRequest: vi.fn(),
+  mockGetBittensorTxHash: vi.fn(),
 }))
 
 vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
@@ -84,6 +86,10 @@ vi.mock('@vultisig/core-chain/chains/ripple/client', () => ({
   })),
 }))
 
+vi.mock('@vultisig/core-chain/tx/hash/resolvers/bittensor', () => ({
+  getBittensorTxHash: (...args: unknown[]) => mockGetBittensorTxHash(...args),
+}))
+
 describe('RawBroadcastService', () => {
   const service = new RawBroadcastService()
 
@@ -113,6 +119,7 @@ describe('RawBroadcastService', () => {
         tx_json: { hash: 'xrp-hash' },
       },
     })
+    mockGetBittensorTxHash.mockReturnValue('0xbittensorhash')
   })
 
   it('throws UnsupportedChain for chains without a raw broadcast path', async () => {
@@ -581,6 +588,56 @@ describe('RawBroadcastService', () => {
         rawTx: 'beef',
       })
     ).rejects.toThrow(/missing extrinsic hash/)
+  })
+
+  it('returns Bittensor raw tx hash when the extrinsic was already imported', async () => {
+    mockQueryUrl.mockResolvedValue({
+      error: {
+        message: 'Already Imported',
+      },
+    })
+
+    const hash = await service.broadcastRawTx({
+      chain: Chain.Bittensor,
+      rawTx: 'beef',
+    })
+
+    expect(hash).toBe('0xbittensorhash')
+    expect(mockGetBittensorTxHash).toHaveBeenCalledWith({
+      encoded: Buffer.from('beef', 'hex'),
+    })
+  })
+
+  it('returns Bittensor raw tx hash for timeout-style JSON-RPC errors', async () => {
+    mockQueryUrl.mockResolvedValue({
+      error: {
+        message: 'request timed out',
+      },
+    })
+
+    const hash = await service.broadcastRawTx({
+      chain: Chain.Bittensor,
+      rawTx: '0xbeef',
+    })
+
+    expect(hash).toBe('0xbittensorhash')
+    expect(mockGetBittensorTxHash).toHaveBeenCalledWith({
+      encoded: Buffer.from('beef', 'hex'),
+    })
+  })
+
+  it('returns Bittensor raw tx hash for timeout-style submit failures', async () => {
+    mockQueryUrl.mockRejectedValue(new Error('request timed out'))
+
+    const hash = await service.broadcastRawTx({
+      chain: Chain.Bittensor,
+      rawTx: '0xbeef',
+    })
+
+    expect(hash).toBe('0xbittensorhash')
+    expect(mockGetBittensorTxHash).toHaveBeenCalledWith({
+      encoded: Buffer.from('beef', 'hex'),
+    })
   })
 
   it('broadcasts Tron transaction JSON', async () => {

--- a/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
+++ b/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
@@ -1,6 +1,6 @@
 import { sha256 } from '@noble/hashes/sha2'
 import { bytesToHex } from '@noble/hashes/utils'
-import { Chain } from '@vultisig/core-chain/Chain'
+import { Chain, OtherChain } from '@vultisig/core-chain/Chain'
 import { bittensorRpcUrl } from '@vultisig/core-chain/chains/bittensor/client'
 import { polkadotRpcUrl } from '@vultisig/core-chain/chains/polkadot/client'
 import { tronRpcUrl } from '@vultisig/core-chain/chains/tron/config'
@@ -37,6 +37,7 @@ const {
   mockExecuteSuiTx,
   mockRippleRequest,
   mockGetBittensorTxHash,
+  mockGetCustomRpcOverride,
 } = vi.hoisted(() => ({
   mockQueryUrl: vi.fn(),
   mockGetEvmClient: vi.fn(),
@@ -49,6 +50,11 @@ const {
   mockExecuteSuiTx: vi.fn(),
   mockRippleRequest: vi.fn(),
   mockGetBittensorTxHash: vi.fn(),
+  mockGetCustomRpcOverride: vi.fn(),
+}))
+
+vi.mock('@vultisig/core-chain/chains/customRpc/customRpcOverrides', () => ({
+  getCustomRpcOverride: (...args: unknown[]) => mockGetCustomRpcOverride(...args),
 }))
 
 vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
@@ -120,6 +126,7 @@ describe('RawBroadcastService', () => {
       },
     })
     mockGetBittensorTxHash.mockReturnValue('0xbittensorhash')
+    mockGetCustomRpcOverride.mockReturnValue(undefined)
   })
 
   it('throws UnsupportedChain for chains without a raw broadcast path', async () => {
@@ -590,6 +597,21 @@ describe('RawBroadcastService', () => {
     ).rejects.toThrow(/missing extrinsic hash/)
   })
 
+  it('uses the configured Bittensor RPC override', async () => {
+    mockGetCustomRpcOverride.mockReturnValue('https://controlled-bittensor.test')
+    mockQueryUrl.mockResolvedValue({ result: '0xbtensor' })
+
+    await service.broadcastRawTx({ chain: Chain.Bittensor, rawTx: 'beef' })
+
+    expect(mockGetCustomRpcOverride).toHaveBeenCalledWith(OtherChain.Bittensor)
+    expect(mockQueryUrl).toHaveBeenCalledWith(
+      'https://controlled-bittensor.test',
+      expect.objectContaining({
+        body: expect.objectContaining({ method: 'author_submitExtrinsic' }),
+      })
+    )
+  })
+
   it('returns Bittensor raw tx hash when the extrinsic was already imported', async () => {
     mockQueryUrl.mockResolvedValue({
       error: {
@@ -638,6 +660,16 @@ describe('RawBroadcastService', () => {
     expect(mockGetBittensorTxHash).toHaveBeenCalledWith({
       encoded: Buffer.from('beef', 'hex'),
     })
+  })
+
+  it.each(['', 'abc', 'zz'])('rejects malformed Bittensor raw tx %j before submission', async rawTx => {
+    await expect(service.broadcastRawTx({ chain: Chain.Bittensor, rawTx })).rejects.toMatchObject({
+      code: VaultErrorCode.BroadcastFailed,
+      message: expect.stringContaining('non-empty, even-length hexadecimal bytes'),
+    })
+
+    expect(mockQueryUrl).not.toHaveBeenCalled()
+    expect(mockGetBittensorTxHash).not.toHaveBeenCalled()
   })
 
   it('broadcasts Tron transaction JSON', async () => {

--- a/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
+++ b/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
@@ -640,10 +640,95 @@ describe('RawBroadcastService', () => {
     }
   )
 
-  it('returns Bittensor raw tx hash for timeout-style JSON-RPC errors', async () => {
-    mockQueryUrl.mockResolvedValue({
+  it('verifies a timeout-style JSON-RPC error via taostats before returning a hash', async () => {
+    mockQueryUrl
+      .mockResolvedValueOnce({
+        error: {
+          message: 'request timed out',
+        },
+      })
+      .mockResolvedValueOnce({
+        pagination: { page: 1, limit: 1, total: 1 },
+        data: [{ hash: '0xbittensorhash', block_number: 1, success: true, timestamp: '2026-01-01T00:00:00Z' }],
+      })
+
+    const hash = await service.broadcastRawTx({
+      chain: Chain.Bittensor,
+      rawTx: '0xbeef',
+    })
+
+    expect(hash).toBe('0xbittensorhash')
+    expect(mockGetBittensorTxHash).toHaveBeenCalledWith({
+      encoded: Buffer.from('beef', 'hex'),
+    })
+    // The submit-timeout branch must confirm the extrinsic actually landed (via taostats)
+    // before handing back a hash - a locally-computed hash is not proof of broadcast.
+    expect(mockQueryUrl).toHaveBeenCalledTimes(2)
+    expect(mockQueryUrl.mock.calls[1][0]).toContain('tao-tx/v1')
+  })
+
+  it('fails closed when a timeout-style JSON-RPC error cannot be verified on-chain', async () => {
+    mockQueryUrl
+      .mockResolvedValueOnce({
+        error: {
+          message: 'request timed out',
+        },
+      })
+      .mockResolvedValueOnce({
+        pagination: { page: 1, limit: 1, total: 0 },
+        data: [],
+      })
+
+    await expect(
+      service.broadcastRawTx({
+        chain: Chain.Bittensor,
+        rawTx: '0xbeef',
+      })
+    ).rejects.toMatchObject({
+      code: VaultErrorCode.BroadcastFailed,
+    })
+    expect(mockQueryUrl).toHaveBeenCalledTimes(2)
+  })
+
+  it.each([
+    'request timed out',
+    'queryUrl: request timed out after 20000ms (https://bittensor-finney.api.onfinality.io/public)',
+  ])('verifies a timeout-style submit failure %j via taostats before returning a hash', async timeoutMessage => {
+    mockQueryUrl.mockRejectedValueOnce(new Error(timeoutMessage)).mockResolvedValueOnce({
+      pagination: { page: 1, limit: 1, total: 1 },
+      data: [{ hash: '0xbittensorhash', block_number: 1, success: true, timestamp: '2026-01-01T00:00:00Z' }],
+    })
+
+    const hash = await service.broadcastRawTx({
+      chain: Chain.Bittensor,
+      rawTx: '0xbeef',
+    })
+
+    expect(hash).toBe('0xbittensorhash')
+    expect(mockGetBittensorTxHash).toHaveBeenCalledWith({
+      encoded: Buffer.from('beef', 'hex'),
+    })
+    expect(mockQueryUrl).toHaveBeenCalledTimes(2)
+  })
+
+  it('fails closed when a timeout-style submit failure cannot be verified on-chain', async () => {
+    mockQueryUrl.mockRejectedValueOnce(new Error('request timed out')).mockRejectedValueOnce(new Error('network down'))
+
+    await expect(
+      service.broadcastRawTx({
+        chain: Chain.Bittensor,
+        rawTx: '0xbeef',
+      })
+    ).rejects.toMatchObject({
+      code: VaultErrorCode.BroadcastFailed,
+    })
+    expect(mockQueryUrl).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not verify duplicate-style Bittensor errors (idempotent immediate return)', async () => {
+    mockQueryUrl.mockResolvedValueOnce({
       error: {
-        message: 'request timed out',
+        message: 'Already Imported',
       },
     })
 
@@ -653,26 +738,9 @@ describe('RawBroadcastService', () => {
     })
 
     expect(hash).toBe('0xbittensorhash')
-    expect(mockGetBittensorTxHash).toHaveBeenCalledWith({
-      encoded: Buffer.from('beef', 'hex'),
-    })
-  })
-
-  it.each([
-    'request timed out',
-    'queryUrl: request timed out after 20000ms (https://bittensor-finney.api.onfinality.io/public)',
-  ])('returns Bittensor raw tx hash for timeout-style submit failure %j', async timeoutMessage => {
-    mockQueryUrl.mockRejectedValue(new Error(timeoutMessage))
-
-    const hash = await service.broadcastRawTx({
-      chain: Chain.Bittensor,
-      rawTx: '0xbeef',
-    })
-
-    expect(hash).toBe('0xbittensorhash')
-    expect(mockGetBittensorTxHash).toHaveBeenCalledWith({
-      encoded: Buffer.from('beef', 'hex'),
-    })
+    // Duplicate detection is a strong in-mempool signal on its own; it must NOT go through
+    // the taostats verification poll the timeout branch requires.
+    expect(mockQueryUrl).toHaveBeenCalledTimes(1)
   })
 
   it.each([


### PR DESCRIPTION
Refs #949
Preserve the deterministic Bittensor extrinsic hash when author_submitExtrinsic reports an already-imported or timeout-style outcome. Controlled JSON-RPC proof exercised the production RawBroadcastService with one signed extrinsic across duplicate, real request-timeout, unrelated rejection, and malformed-input scenarios; duplicate and timeout outcomes returned the same canonical Blake2 hash while unrelated failures remained fail-closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom Bittensor RPC endpoints when broadcasting transactions.
  * Added a standalone raw transaction broadcast option.
  * Duplicate submissions now return a deterministic transaction hash.
  * Timeout submissions return a hash after successful on-chain verification.

* **Bug Fixes**
  * Improved validation and normalization of raw transaction payloads.
  * Rejected malformed RPC responses and invalid transaction data before submission.
  * Improved RPC error handling while preserving unrelated failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->