### PR TITLE
fix(cli): gate broadcast behind --yes + pre-validate rawTx (beads aq5ku + z3xkg)

### DIFF
--- a/.changeset/broadcast-rawtx-safety.md
+++ b/.changeset/broadcast-rawtx-safety.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Normalize `broadcast --raw-tx` before submission, escape control characters in the confirmation preview, and document Tron JSON payloads alongside the other supported raw-transaction encodings.

--- a/.changeset/broadcast-rawtx-safety.md
+++ b/.changeset/broadcast-rawtx-safety.md
@@ -1,5 +1,8 @@
 ---
 '@vultisig/sdk': patch
+'@vultisig/cli': major
 ---
 
 Normalize `broadcast --raw-tx` before submission, escape control characters in the confirmation preview, and document Tron JSON payloads alongside the other supported raw-transaction encodings.
+
+**Breaking (CLI):** `vultisig broadcast --raw-tx ...` now requires an interactive confirmation or an explicit `--yes` flag before submitting — it previously broadcast immediately with no gate. Unattended/scripted callers (CI, automation, agent wrappers) that invoke `broadcast` without a TTY must add `--yes`, or they will now get a `ConfirmationRequiredError` (exit 12) instead of a broadcast.

--- a/clients/cli/src/commands/broadcast.test.ts
+++ b/clients/cli/src/commands/broadcast.test.ts
@@ -1,0 +1,128 @@
+/**
+ * bead aq5ku + z3xkg: broadcast gates on --yes and pre-validates rawTx shape
+ * before it reaches the network. The pre-validation regression (caught in
+ * review): a blanket hex regex was applied to every chain, but broadcastRawTx
+ * fans out per chain kind and only evm/utxo are hex — solana is base58-or-
+ * base64, cosmos is base64 protobuf or a JSON tx_bytes envelope, sui is a JSON
+ * envelope, ton is a base64 BOC. The unscoped hex check rejected all of those
+ * as "Malformed raw transaction" even though they were perfectly valid signed
+ * payloads for broadcastRawTx.
+ */
+import type { VaultBase } from '@vultisig/sdk'
+import { Chain } from '@vultisig/sdk'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../lib/output', () => ({
+  createSpinner: () => ({ succeed: vi.fn(), start: vi.fn(), stop: vi.fn(), fail: vi.fn(), text: '' }),
+  warn: vi.fn(),
+  isNonInteractive: vi.fn(() => false),
+  isJsonOutput: () => false,
+  isSilent: () => false,
+  outputJson: vi.fn(),
+  printResult: vi.fn(),
+}))
+vi.mock('../ui', () => ({
+  confirmTransaction: vi.fn().mockResolvedValue(true),
+}))
+
+import type { CommandContext } from '../core'
+import { ConfirmationRequiredError, InvalidInputError } from '../core/errors'
+import { isNonInteractive } from '../lib/output'
+import { confirmTransaction } from '../ui'
+import { executeBroadcast } from './broadcast'
+
+function makeCtx(broadcastRawTx: (p: { chain: Chain; rawTx: string }) => Promise<string>): {
+  ctx: CommandContext
+  vault: VaultBase
+} {
+  const vault = {
+    broadcastRawTx: vi.fn(broadcastRawTx),
+  } as unknown as VaultBase
+
+  return { ctx: { ensureActiveVault: async () => vault } as unknown as CommandContext, vault }
+}
+
+describe('executeBroadcast', () => {
+  afterEach(() => {
+    vi.mocked(isNonInteractive).mockReturnValue(false)
+    vi.mocked(confirmTransaction).mockResolvedValue(true)
+    vi.clearAllMocks()
+  })
+
+  it('non-interactive without --yes throws ConfirmationRequiredError and never broadcasts', async () => {
+    vi.mocked(isNonInteractive).mockReturnValue(true)
+    const { ctx, vault } = makeCtx(async () => '0xhash')
+
+    const err = await executeBroadcast(ctx, { chain: Chain.Ethereum, rawTx: '0xdeadbeef' }).catch(e => e)
+
+    expect(err).toBeInstanceOf(ConfirmationRequiredError)
+    expect(vault.broadcastRawTx).not.toHaveBeenCalled()
+  })
+
+  it('declining the interactive confirm throws ConfirmationRequiredError and never broadcasts', async () => {
+    vi.mocked(confirmTransaction).mockResolvedValue(false)
+    const { ctx, vault } = makeCtx(async () => '0xhash')
+
+    const err = await executeBroadcast(ctx, { chain: Chain.Ethereum, rawTx: '0xdeadbeef' }).catch(e => e)
+
+    expect(err).toBeInstanceOf(ConfirmationRequiredError)
+    expect(vault.broadcastRawTx).not.toHaveBeenCalled()
+  })
+
+  it('--yes skips confirmation and passes the raw tx straight through', async () => {
+    const { ctx, vault } = makeCtx(async () => '0xhash')
+
+    const result = await executeBroadcast(ctx, { chain: Chain.Ethereum, rawTx: '0xdeadbeef', yes: true })
+
+    expect(confirmTransaction).not.toHaveBeenCalled()
+    expect(vault.broadcastRawTx).toHaveBeenCalledWith({ chain: Chain.Ethereum, rawTx: '0xdeadbeef' })
+    expect(result.txHash).toBe('0xhash')
+  })
+
+  it('empty rawTx throws InvalidInputError regardless of chain family', async () => {
+    const { ctx, vault } = makeCtx(async () => '0xhash')
+
+    const err = await executeBroadcast(ctx, { chain: Chain.Solana, rawTx: '   ', yes: true }).catch(e => e)
+
+    expect(err).toBeInstanceOf(InvalidInputError)
+    expect(vault.broadcastRawTx).not.toHaveBeenCalled()
+  })
+
+  it('malformed hex on an EVM chain is rejected before broadcasting', async () => {
+    const { ctx, vault } = makeCtx(async () => '0xhash')
+
+    const err = await executeBroadcast(ctx, { chain: Chain.Ethereum, rawTx: '0xnothex!!', yes: true }).catch(e => e)
+
+    expect(err).toBeInstanceOf(InvalidInputError)
+    expect(vault.broadcastRawTx).not.toHaveBeenCalled()
+  })
+
+  it('malformed hex (odd length) on a UTXO chain is rejected before broadcasting', async () => {
+    const { ctx, vault } = makeCtx(async () => '0xhash')
+
+    const err = await executeBroadcast(ctx, { chain: Chain.Bitcoin, rawTx: '0xabc', yes: true }).catch(e => e)
+
+    expect(err).toBeInstanceOf(InvalidInputError)
+    expect(vault.broadcastRawTx).not.toHaveBeenCalled()
+  })
+
+  // The regression test: before the review fix, the hex-only regex was applied
+  // unconditionally to every chain family. Each of these is a legitimate signed
+  // payload for its own chain and must reach broadcastRawTx, not get rejected
+  // as "Malformed raw transaction".
+  it.each([
+    { chain: Chain.Solana, rawTx: '3Bxs4h24hBtQy9vC3btSp1ELPQXe6L6ojKmVKf6b5BR8k6t' }, // base58
+    { chain: Chain.Solana, rawTx: 'AQAB//8gYWJjZGVmZ2hpams=' }, // base64
+    { chain: Chain.THORChain, rawTx: 'CooBCogBChwvY29zbW9zLmJhbmsudjFiZXRhMS5Nc2dTZW5k' }, // cosmos base64 protobuf
+    { chain: Chain.THORChain, rawTx: '{"tx_bytes":"CooBCog=","mode":"BROADCAST_MODE_SYNC"}' }, // cosmos JSON envelope
+    { chain: Chain.Sui, rawTx: '{"unsignedTx":"AAAB","signature":"AQID"}' }, // sui JSON envelope
+    { chain: Chain.Ton, rawTx: 'te6cckEBAQEAAgAAAEysuc0=' }, // ton base64 BOC
+  ])('non-hex family payload for $chain is NOT rejected by the shape check', async ({ chain, rawTx }) => {
+    const { ctx, vault } = makeCtx(async () => '0xhash')
+
+    const result = await executeBroadcast(ctx, { chain, rawTx, yes: true })
+
+    expect(vault.broadcastRawTx).toHaveBeenCalledWith({ chain, rawTx })
+    expect(result.txHash).toBe('0xhash')
+  })
+})

--- a/clients/cli/src/commands/broadcast.test.ts
+++ b/clients/cli/src/commands/broadcast.test.ts
@@ -2,9 +2,10 @@
  * bead aq5ku + z3xkg: broadcast gates on --yes and pre-validates rawTx shape
  * before it reaches the network. The pre-validation regression (caught in
  * review): a blanket hex regex was applied to every chain, but broadcastRawTx
- * fans out per chain kind and only evm/utxo are hex — solana is base58-or-
- * base64, cosmos is base64 protobuf or a JSON tx_bytes envelope, sui is a JSON
- * envelope, ton is a base64 BOC. The unscoped hex check rejected all of those
+ * fans out per chain kind and only some families are hex-only. evm/utxo/
+ * polkadot/bittensor/ripple are hex, while solana is base58-or-base64, cosmos
+ * is base64 protobuf or a JSON tx_bytes envelope, sui is a JSON envelope, and
+ * ton is a base64 BOC. The unscoped hex check rejected the non-hex families
  * as "Malformed raw transaction" even though they were perfectly valid signed
  * payloads for broadcastRawTx.
  */
@@ -105,6 +106,18 @@ describe('executeBroadcast', () => {
     expect(err).toBeInstanceOf(InvalidInputError)
     expect(vault.broadcastRawTx).not.toHaveBeenCalled()
   })
+
+  it.each([Chain.Polkadot, Chain.Bittensor, Chain.Ripple])(
+    'malformed hex on %s is rejected before broadcasting',
+    async chain => {
+      const { ctx, vault } = makeCtx(async () => '0xhash')
+
+      const err = await executeBroadcast(ctx, { chain, rawTx: 'not-hex!!', yes: true }).catch(e => e)
+
+      expect(err).toBeInstanceOf(InvalidInputError)
+      expect(vault.broadcastRawTx).not.toHaveBeenCalled()
+    }
+  )
 
   // The regression test: before the review fix, the hex-only regex was applied
   // unconditionally to every chain family. Each of these is a legitimate signed

--- a/clients/cli/src/commands/broadcast.test.ts
+++ b/clients/cli/src/commands/broadcast.test.ts
@@ -28,7 +28,7 @@ vi.mock('../ui', () => ({
 
 import type { CommandContext } from '../core'
 import { ConfirmationRequiredError, InvalidInputError } from '../core/errors'
-import { isNonInteractive } from '../lib/output'
+import { isNonInteractive, warn } from '../lib/output'
 import { confirmTransaction } from '../ui'
 import { executeBroadcast } from './broadcast'
 
@@ -80,6 +80,15 @@ describe('executeBroadcast', () => {
     expect(result.txHash).toBe('0xhash')
   })
 
+  it('trims surrounding whitespace before broadcasting', async () => {
+    const { ctx, vault } = makeCtx(async () => '0xhash')
+
+    const result = await executeBroadcast(ctx, { chain: Chain.Ethereum, rawTx: '  0xdeadbeef  ', yes: true })
+
+    expect(vault.broadcastRawTx).toHaveBeenCalledWith({ chain: Chain.Ethereum, rawTx: '0xdeadbeef' })
+    expect(result.txHash).toBe('0xhash')
+  })
+
   it('empty rawTx throws InvalidInputError regardless of chain family', async () => {
     const { ctx, vault } = makeCtx(async () => '0xhash')
 
@@ -119,6 +128,15 @@ describe('executeBroadcast', () => {
     }
   )
 
+  it('escapes control characters in the confirmation preview for non-hex payloads', async () => {
+    const { ctx, vault } = makeCtx(async () => '0xhash')
+
+    await executeBroadcast(ctx, { chain: Chain.THORChain, rawTx: 'CooBCog=\u001b[2J', yes: false })
+
+    expect(vault.broadcastRawTx).toHaveBeenCalledWith({ chain: Chain.THORChain, rawTx: 'CooBCog=\u001b[2J' })
+    expect(vi.mocked(warn)).toHaveBeenCalledWith('   Raw tx: CooBCog=\\x1b[2J (12 chars)')
+  })
+
   // The regression test: before the review fix, the hex-only regex was applied
   // unconditionally to every chain family. Each of these is a legitimate signed
   // payload for its own chain and must reach broadcastRawTx, not get rejected
@@ -129,6 +147,7 @@ describe('executeBroadcast', () => {
     { chain: Chain.THORChain, rawTx: 'CooBCogBChwvY29zbW9zLmJhbmsudjFiZXRhMS5Nc2dTZW5k' }, // cosmos base64 protobuf
     { chain: Chain.THORChain, rawTx: '{"tx_bytes":"CooBCog=","mode":"BROADCAST_MODE_SYNC"}' }, // cosmos JSON envelope
     { chain: Chain.Sui, rawTx: '{"unsignedTx":"AAAB","signature":"AQID"}' }, // sui JSON envelope
+    { chain: Chain.Tron, rawTx: '{"txID":"abc","raw_data_hex":"deadbeef"}' }, // tron JSON envelope
     { chain: Chain.Ton, rawTx: 'te6cckEBAQEAAgAAAEysuc0=' }, // ton base64 BOC
   ])('non-hex family payload for $chain is NOT rejected by the shape check', async ({ chain, rawTx }) => {
     const { ctx, vault } = makeCtx(async () => '0xhash')

--- a/clients/cli/src/commands/broadcast.test.ts
+++ b/clients/cli/src/commands/broadcast.test.ts
@@ -17,18 +17,22 @@ vi.mock('../lib/output', () => ({
   createSpinner: () => ({ succeed: vi.fn(), start: vi.fn(), stop: vi.fn(), fail: vi.fn(), text: '' }),
   warn: vi.fn(),
   isNonInteractive: vi.fn(() => false),
-  isJsonOutput: () => false,
-  isSilent: () => false,
+  isJsonOutput: vi.fn(() => false),
+  isSilent: vi.fn(() => false),
   outputJson: vi.fn(),
   printResult: vi.fn(),
 }))
-vi.mock('../ui', () => ({
-  confirmTransaction: vi.fn().mockResolvedValue(true),
-}))
+vi.mock('../ui', async importOriginal => {
+  const actual = await importOriginal<typeof import('../ui')>()
+  return {
+    ...actual,
+    confirmTransaction: vi.fn().mockResolvedValue(true),
+  }
+})
 
 import type { CommandContext } from '../core'
 import { ConfirmationRequiredError, InvalidInputError } from '../core/errors'
-import { isNonInteractive, warn } from '../lib/output'
+import { isJsonOutput, isNonInteractive, isSilent, printResult } from '../lib/output'
 import { confirmTransaction } from '../ui'
 import { executeBroadcast } from './broadcast'
 
@@ -46,6 +50,8 @@ function makeCtx(broadcastRawTx: (p: { chain: Chain; rawTx: string }) => Promise
 describe('executeBroadcast', () => {
   afterEach(() => {
     vi.mocked(isNonInteractive).mockReturnValue(false)
+    vi.mocked(isJsonOutput).mockReturnValue(false)
+    vi.mocked(isSilent).mockReturnValue(false)
     vi.mocked(confirmTransaction).mockResolvedValue(true)
     vi.clearAllMocks()
   })
@@ -57,6 +63,7 @@ describe('executeBroadcast', () => {
     const err = await executeBroadcast(ctx, { chain: Chain.Ethereum, rawTx: '0xdeadbeef' }).catch(e => e)
 
     expect(err).toBeInstanceOf(ConfirmationRequiredError)
+    expect((err as ConfirmationRequiredError).hint).toContain('--yes')
     expect(vault.broadcastRawTx).not.toHaveBeenCalled()
   })
 
@@ -68,6 +75,49 @@ describe('executeBroadcast', () => {
 
     expect(err).toBeInstanceOf(ConfirmationRequiredError)
     expect(vault.broadcastRawTx).not.toHaveBeenCalled()
+    // Proves the gate actually calls confirmTransaction (paired with the --yes
+    // test below, which proves it does NOT) — together they show --yes is what
+    // skips the call, not that the call was never wired up.
+    expect(confirmTransaction).toHaveBeenCalledTimes(1)
+  })
+
+  // REVIEW FIX (blocking 1): --output json / --silent both suppress warn()-based
+  // output, but on a TTY isNonInteractive() is still false — so without this gate,
+  // confirmTransaction() would fire a bare, context-free inquirer prompt and its
+  // own output would contaminate the promised clean JSON stdout. Refuse up-front
+  // instead of ever reaching confirmTransaction().
+  it('json output without --yes throws ConfirmationRequiredError and never prompts or broadcasts', async () => {
+    vi.mocked(isJsonOutput).mockReturnValue(true)
+    const { ctx, vault } = makeCtx(async () => '0xhash')
+
+    const err = await executeBroadcast(ctx, { chain: Chain.Ethereum, rawTx: '0xdeadbeef' }).catch(e => e)
+
+    expect(err).toBeInstanceOf(ConfirmationRequiredError)
+    expect((err as ConfirmationRequiredError).hint).toContain('--yes')
+    expect(confirmTransaction).not.toHaveBeenCalled()
+    expect(vault.broadcastRawTx).not.toHaveBeenCalled()
+  })
+
+  it('silent mode without --yes throws ConfirmationRequiredError and never prompts or broadcasts', async () => {
+    vi.mocked(isSilent).mockReturnValue(true)
+    const { ctx, vault } = makeCtx(async () => '0xhash')
+
+    const err = await executeBroadcast(ctx, { chain: Chain.Ethereum, rawTx: '0xdeadbeef' }).catch(e => e)
+
+    expect(err).toBeInstanceOf(ConfirmationRequiredError)
+    expect(confirmTransaction).not.toHaveBeenCalled()
+    expect(vault.broadcastRawTx).not.toHaveBeenCalled()
+  })
+
+  it('json output WITH --yes broadcasts without touching the confirmation gate', async () => {
+    vi.mocked(isJsonOutput).mockReturnValue(true)
+    const { ctx, vault } = makeCtx(async () => '0xhash')
+
+    const result = await executeBroadcast(ctx, { chain: Chain.Ethereum, rawTx: '0xdeadbeef', yes: true })
+
+    expect(confirmTransaction).not.toHaveBeenCalled()
+    expect(vault.broadcastRawTx).toHaveBeenCalledWith({ chain: Chain.Ethereum, rawTx: '0xdeadbeef' })
+    expect(result.txHash).toBe('0xhash')
   })
 
   it('--yes skips confirmation and passes the raw tx straight through', async () => {
@@ -75,6 +125,10 @@ describe('executeBroadcast', () => {
 
     const result = await executeBroadcast(ctx, { chain: Chain.Ethereum, rawTx: '0xdeadbeef', yes: true })
 
+    // Paired with 'declining the interactive confirm' above: that test proves
+    // confirmTransaction IS called without --yes, this proves it is NOT called
+    // with --yes — together they prove --yes is what skips the gate, not that
+    // the gate was deleted.
     expect(confirmTransaction).not.toHaveBeenCalled()
     expect(vault.broadcastRawTx).toHaveBeenCalledWith({ chain: Chain.Ethereum, rawTx: '0xdeadbeef' })
     expect(result.txHash).toBe('0xhash')
@@ -116,6 +170,24 @@ describe('executeBroadcast', () => {
     expect(vault.broadcastRawTx).not.toHaveBeenCalled()
   })
 
+  // REVIEW FIX: the malformed-hex error interpolated the raw (unescaped) input
+  // into its message. A control character in that echoed slice would render
+  // identically to a real terminal escape sequence when printed.
+  it('escapes control characters in the malformed-hex error message', async () => {
+    const { ctx, vault } = makeCtx(async () => '0xhash')
+
+    const err = await executeBroadcast(ctx, {
+      chain: Chain.Ethereum,
+      rawTx: 'not\u001b[2Jhex!!',
+      yes: true,
+    }).catch(e => e)
+
+    expect(err).toBeInstanceOf(InvalidInputError)
+    expect((err as InvalidInputError).message).toContain('not\\x1B[2Jhex!!')
+    expect((err as InvalidInputError).message).not.toContain('\u001b')
+    expect(vault.broadcastRawTx).not.toHaveBeenCalled()
+  })
+
   it.each([Chain.Polkadot, Chain.Bittensor, Chain.Ripple])(
     'malformed hex on %s is rejected before broadcasting',
     async chain => {
@@ -134,7 +206,21 @@ describe('executeBroadcast', () => {
     await executeBroadcast(ctx, { chain: Chain.THORChain, rawTx: 'CooBCog=\u001b[2J', yes: false })
 
     expect(vault.broadcastRawTx).toHaveBeenCalledWith({ chain: Chain.THORChain, rawTx: 'CooBCog=\u001b[2J' })
-    expect(vi.mocked(warn)).toHaveBeenCalledWith('   Raw tx: CooBCog=\\x1b[2J (12 chars)')
+    expect(vi.mocked(printResult)).toHaveBeenCalledWith('   Raw tx: CooBCog=\\x1B[2J (12 chars)')
+  })
+
+  // REVIEW FIX: the only prior preview test used a 12-char payload, so the
+  // >44-char head+tail truncation branch (`shown.slice(0, 22)…shown.slice(-20)`)
+  // had no coverage.
+  it('truncates the confirmation preview for payloads longer than 44 chars', async () => {
+    const { ctx, vault } = makeCtx(async () => '0xhash')
+    const rawTx = 'a'.repeat(60)
+
+    await executeBroadcast(ctx, { chain: Chain.THORChain, rawTx, yes: false })
+
+    expect(vault.broadcastRawTx).toHaveBeenCalledWith({ chain: Chain.THORChain, rawTx })
+    const expectedPreview = `${rawTx.slice(0, 22)}…${rawTx.slice(-20)}`
+    expect(vi.mocked(printResult)).toHaveBeenCalledWith(`   Raw tx: ${expectedPreview} (60 chars)`)
   })
 
   // The regression test: before the review fix, the hex-only regex was applied

--- a/clients/cli/src/commands/broadcast.ts
+++ b/clients/cli/src/commands/broadcast.ts
@@ -4,7 +4,7 @@
  * Used for broadcasting transactions that were signed externally or assembled
  * from signatures obtained via the `sign` command.
  */
-import { Chain, Vultisig } from '@vultisig/sdk'
+import { Chain, getChainKind, Vultisig } from '@vultisig/sdk'
 
 import type { CommandContext } from '../core'
 import { ConfirmationRequiredError, InvalidInputError } from '../core/errors'
@@ -16,7 +16,7 @@ import { confirmTransaction } from '../ui'
  */
 export type BroadcastRawParams = {
   chain: Chain
-  rawTx: string // Hex-encoded signed transaction
+  rawTx: string // Signed transaction in the chain family's own encoding: hex (evm/utxo), base58-or-base64 (solana), base64 protobuf (cosmos), JSON envelope (sui), base64 BOC (ton)
   /**
    * Skip the interactive confirmation prompt. Required in non-interactive
    * contexts because broadcastRawTx sends the pre-signed payload straight
@@ -50,12 +50,22 @@ export async function executeBroadcast(ctx: CommandContext, params: BroadcastRaw
   // misclassified as EXTERNAL_SERVICE (retryable:true, suggests "Retry the
   // transaction" — which loops the same bad input forever).
   const rawTx = params.rawTx?.trim() ?? ''
-  const hex = rawTx.startsWith('0x') ? rawTx.slice(2) : rawTx
-  if (hex.length === 0) {
-    throw new InvalidInputError('Empty raw transaction — pass a hex-encoded signed tx via --raw-tx')
+  if (rawTx.length === 0) {
+    throw new InvalidInputError('Empty raw transaction — pass the signed tx via --raw-tx')
   }
-  if (!/^[0-9a-fA-F]+$/.test(hex) || hex.length % 2 !== 0) {
-    throw new InvalidInputError(`Malformed raw transaction — expected hex bytes, got: ${rawTx.slice(0, 20)}${rawTx.length > 20 ? '…' : ''}`)
+  // REVIEW FIX (aq5ku): broadcastRawTx is NOT hex-only, so a blanket hex test refuses every
+  // non-hex family. RawBroadcastService fans out per kind and each decoder takes a different
+  // encoding: solana is base58-or-base64 (decodeSolanaRawTx even sniffs it), cosmos is base64
+  // protobuf, sui is a JSON envelope so `{` is the first byte of every valid payload, ton is a
+  // base64 BOC passed verbatim. Only evm and utxo are hex. The docstring above claimed hex for
+  // all of them - the doc was wrong and the code was right, so the doc is corrected too.
+  const chainKind = getChainKind(params.chain)
+  const isHexFamily = chainKind === 'evm' || chainKind === 'utxo'
+  const hex = rawTx.startsWith('0x') ? rawTx.slice(2) : rawTx
+  if (isHexFamily && (!/^[0-9a-fA-F]+$/.test(hex) || hex.length % 2 !== 0)) {
+    throw new InvalidInputError(
+      `Malformed raw transaction — expected hex bytes for ${params.chain}, got: ${rawTx.slice(0, 20)}${rawTx.length > 20 ? '…' : ''}`
+    )
   }
 
   // bead vultisig-aq5ku: broadcastRawTx moves funds immediately with no
@@ -71,7 +81,13 @@ export async function executeBroadcast(ctx: CommandContext, params: BroadcastRaw
     }
     warn('\n⚠  You are about to broadcast a pre-signed transaction.')
     warn(`   Chain:  ${params.chain}`)
-    warn(`   Raw tx: 0x${hex.slice(0, 20)}…${hex.slice(-20)} (${Math.floor(hex.length / 2)} bytes)`)
+    // Show the payload in its OWN encoding. Rendering a base58/base64/JSON payload with a `0x`
+    // prefix and a hex-derived byte count would misdescribe exactly the thing the operator is
+    // being asked to confirm.
+    const shown = isHexFamily ? `0x${hex}` : rawTx
+    const size = isHexFamily ? `${Math.floor(hex.length / 2)} bytes` : `${rawTx.length} chars`
+    const preview = shown.length > 44 ? `${shown.slice(0, 22)}…${shown.slice(-20)}` : shown
+    warn(`   Raw tx: ${preview} (${size})`)
     warn(`   This is IRREVERSIBLE. If the payload is a valid signed transaction, funds WILL move.\n`)
     const confirmed = await confirmTransaction()
     if (!confirmed) {

--- a/clients/cli/src/commands/broadcast.ts
+++ b/clients/cli/src/commands/broadcast.ts
@@ -7,7 +7,9 @@
 import { Chain, Vultisig } from '@vultisig/sdk'
 
 import type { CommandContext } from '../core'
-import { createSpinner, isJsonOutput, outputJson, printResult } from '../lib/output'
+import { ConfirmationRequiredError, InvalidInputError } from '../core/errors'
+import { createSpinner, isNonInteractive, isJsonOutput, outputJson, printResult, warn } from '../lib/output'
+import { confirmTransaction } from '../ui'
 
 /**
  * Parameters for broadcasting a raw transaction
@@ -15,6 +17,13 @@ import { createSpinner, isJsonOutput, outputJson, printResult } from '../lib/out
 export type BroadcastRawParams = {
   chain: Chain
   rawTx: string // Hex-encoded signed transaction
+  /**
+   * Skip the interactive confirmation prompt. Required in non-interactive
+   * contexts because broadcastRawTx sends the pre-signed payload straight
+   * to the chain — a shell injection reaching --raw-tx would move funds.
+   * bead vultisig-aq5ku.
+   */
+  yes?: boolean
 }
 
 /**
@@ -34,6 +43,40 @@ export async function executeBroadcast(ctx: CommandContext, params: BroadcastRaw
 
   if (!Object.values(Chain).includes(params.chain)) {
     throw new Error(`Invalid chain: ${params.chain}`)
+  }
+
+  // bead vultisig-z3xkg: pre-validate the raw-tx shape locally instead of
+  // letting an empty / whitespace / non-hex string reach the RPC and get
+  // misclassified as EXTERNAL_SERVICE (retryable:true, suggests "Retry the
+  // transaction" — which loops the same bad input forever).
+  const rawTx = params.rawTx?.trim() ?? ''
+  const hex = rawTx.startsWith('0x') ? rawTx.slice(2) : rawTx
+  if (hex.length === 0) {
+    throw new InvalidInputError('Empty raw transaction — pass a hex-encoded signed tx via --raw-tx')
+  }
+  if (!/^[0-9a-fA-F]+$/.test(hex) || hex.length % 2 !== 0) {
+    throw new InvalidInputError(`Malformed raw transaction — expected hex bytes, got: ${rawTx.slice(0, 20)}${rawTx.length > 20 ? '…' : ''}`)
+  }
+
+  // bead vultisig-aq5ku: broadcastRawTx moves funds immediately with no
+  // interaction. send and sign both have --yes gates; broadcast now does
+  // the same. A shell injection or script bug reaching --raw-tx cannot
+  // silently broadcast without confirmation.
+  if (!params.yes) {
+    if (isNonInteractive()) {
+      throw new ConfirmationRequiredError(
+        'broadcast requires confirmation.',
+        'Pass --yes to confirm. broadcastRawTx sends the payload straight to the chain; be sure the raw tx is what you intend to send.'
+      )
+    }
+    warn('\n⚠  You are about to broadcast a pre-signed transaction.')
+    warn(`   Chain:  ${params.chain}`)
+    warn(`   Raw tx: 0x${hex.slice(0, 20)}…${hex.slice(-20)} (${Math.floor(hex.length / 2)} bytes)`)
+    warn(`   This is IRREVERSIBLE. If the payload is a valid signed transaction, funds WILL move.\n`)
+    const confirmed = await confirmTransaction()
+    if (!confirmed) {
+      throw new ConfirmationRequiredError('Broadcast declined at the confirmation prompt')
+    }
   }
 
   const broadcastSpinner = createSpinner('Broadcasting transaction...')

--- a/clients/cli/src/commands/broadcast.ts
+++ b/clients/cli/src/commands/broadcast.ts
@@ -16,7 +16,7 @@ import { confirmTransaction } from '../ui'
  */
 export type BroadcastRawParams = {
   chain: Chain
-  rawTx: string // Signed transaction in the chain family's own encoding: hex (evm/utxo/polkadot/bittensor/ripple), base58-or-base64 (solana), base64 protobuf or JSON tx_bytes envelope (cosmos), JSON envelope (sui), base64 BOC (ton)
+  rawTx: string // Signed transaction in the chain family's own encoding: hex (evm/utxo/polkadot/bittensor/ripple), base58-or-base64 (solana), base64 protobuf or JSON tx_bytes envelope (cosmos), JSON envelope (sui/tron), base64 BOC (ton)
   /**
    * Skip the interactive confirmation prompt. Required in non-interactive
    * contexts because broadcastRawTx sends the pre-signed payload straight
@@ -25,6 +25,20 @@ export type BroadcastRawParams = {
    */
   yes?: boolean
 }
+
+const escapeControlChars = (value: string): string =>
+  value.replace(/[\u0000-\u001f\u007f-\u009f]/g, char => {
+    switch (char) {
+      case '\n':
+        return '\\n'
+      case '\r':
+        return '\\r'
+      case '\t':
+        return '\\t'
+      default:
+        return `\\x${char.charCodeAt(0).toString(16).padStart(2, '0')}`
+    }
+  })
 
 /**
  * Result of broadcast operation
@@ -92,7 +106,7 @@ export async function executeBroadcast(ctx: CommandContext, params: BroadcastRaw
     const shown = isHexFamily ? `0x${hex}` : rawTx
     const size = isHexFamily ? `${Math.floor(hex.length / 2)} bytes` : `${rawTx.length} chars`
     const preview = shown.length > 44 ? `${shown.slice(0, 22)}…${shown.slice(-20)}` : shown
-    warn(`   Raw tx: ${preview} (${size})`)
+    warn(`   Raw tx: ${escapeControlChars(preview)} (${size})`)
     warn(`   This is IRREVERSIBLE. If the payload is a valid signed transaction, funds WILL move.\n`)
     const confirmed = await confirmTransaction()
     if (!confirmed) {
@@ -105,7 +119,7 @@ export async function executeBroadcast(ctx: CommandContext, params: BroadcastRaw
   try {
     const txHash = await vault.broadcastRawTx({
       chain: params.chain,
-      rawTx: params.rawTx,
+      rawTx,
     })
 
     broadcastSpinner.succeed(`Transaction broadcast: ${txHash}`)

--- a/clients/cli/src/commands/broadcast.ts
+++ b/clients/cli/src/commands/broadcast.ts
@@ -8,7 +8,7 @@ import { Chain, getChainKind, Vultisig } from '@vultisig/sdk'
 
 import type { CommandContext } from '../core'
 import { ConfirmationRequiredError, InvalidInputError } from '../core/errors'
-import { createSpinner, isNonInteractive, isJsonOutput, outputJson, printResult, warn } from '../lib/output'
+import { createSpinner, isJsonOutput, isNonInteractive, outputJson, printResult, warn } from '../lib/output'
 import { confirmTransaction } from '../ui'
 
 /**

--- a/clients/cli/src/commands/broadcast.ts
+++ b/clients/cli/src/commands/broadcast.ts
@@ -8,8 +8,8 @@ import { Chain, getChainKind, Vultisig } from '@vultisig/sdk'
 
 import type { CommandContext } from '../core'
 import { ConfirmationRequiredError, InvalidInputError } from '../core/errors'
-import { createSpinner, isJsonOutput, isNonInteractive, outputJson, printResult, warn } from '../lib/output'
-import { confirmTransaction } from '../ui'
+import { createSpinner, isJsonOutput, isNonInteractive, isSilent, outputJson, printResult } from '../lib/output'
+import { confirmTransaction, escapeTerminalControls } from '../ui'
 
 /**
  * Parameters for broadcasting a raw transaction
@@ -25,20 +25,6 @@ export type BroadcastRawParams = {
    */
   yes?: boolean
 }
-
-const escapeControlChars = (value: string): string =>
-  value.replace(/[\u0000-\u001f\u007f-\u009f]/g, char => {
-    switch (char) {
-      case '\n':
-        return '\\n'
-      case '\r':
-        return '\\r'
-      case '\t':
-        return '\\t'
-      default:
-        return `\\x${char.charCodeAt(0).toString(16).padStart(2, '0')}`
-    }
-  })
 
 /**
  * Result of broadcast operation
@@ -82,8 +68,9 @@ export async function executeBroadcast(ctx: CommandContext, params: BroadcastRaw
     chainKind === 'ripple'
   const hex = rawTx.startsWith('0x') ? rawTx.slice(2) : rawTx
   if (isHexFamily && (!/^[0-9a-fA-F]+$/.test(hex) || hex.length % 2 !== 0)) {
+    const shown = escapeTerminalControls(rawTx.slice(0, 20))
     throw new InvalidInputError(
-      `Malformed raw transaction — expected hex bytes for ${params.chain}, got: ${rawTx.slice(0, 20)}${rawTx.length > 20 ? '…' : ''}`
+      `Malformed raw transaction — expected hex bytes for ${params.chain}, got: ${shown}${rawTx.length > 20 ? '…' : ''}`
     )
   }
 
@@ -98,16 +85,27 @@ export async function executeBroadcast(ctx: CommandContext, params: BroadcastRaw
         'Pass --yes to confirm. broadcastRawTx sends the payload straight to the chain; be sure the raw tx is what you intend to send.'
       )
     }
-    warn('\n⚠  You are about to broadcast a pre-signed transaction.')
-    warn(`   Chain:  ${params.chain}`)
-    // Show the payload in its OWN encoding. Rendering a base58/base64/JSON payload with a `0x`
-    // prefix and a hex-derived byte count would misdescribe exactly the thing the operator is
-    // being asked to confirm.
-    const shown = isHexFamily ? `0x${hex}` : rawTx
+    // REVIEW FIX: --output json / --silent both suppress warn()-based output, but on a TTY
+    // isNonInteractive() is still false, so confirmTransaction() would still fire an inquirer
+    // prompt — with none of the preview lines that give the operator anything to approve, and
+    // with inquirer's own prompt output contaminating the promised clean JSON stdout. Refuse
+    // up-front instead: json/silent broadcast can only proceed with --yes.
+    if (isJsonOutput() || isSilent()) {
+      throw new ConfirmationRequiredError(
+        'broadcast requires confirmation.',
+        'Pass --yes to confirm. The confirmation preview cannot render under --output json or --silent without corrupting the machine-readable output.'
+      )
+    }
+    // Show the payload in its OWN encoding, exactly as submitted to broadcastRawTx below —
+    // reconstructing a `0x`-prefixed hex string here would misdescribe non-EVM hex payloads
+    // (e.g. utxo) that are broadcast without that prefix.
+    const shown = rawTx
     const size = isHexFamily ? `${Math.floor(hex.length / 2)} bytes` : `${rawTx.length} chars`
     const preview = shown.length > 44 ? `${shown.slice(0, 22)}…${shown.slice(-20)}` : shown
-    warn(`   Raw tx: ${escapeControlChars(preview)} (${size})`)
-    warn(`   This is IRREVERSIBLE. If the payload is a valid signed transaction, funds WILL move.\n`)
+    printResult('\n⚠  You are about to broadcast a pre-signed transaction.')
+    printResult(`   Chain:  ${params.chain}`)
+    printResult(`   Raw tx: ${escapeTerminalControls(preview)} (${size})`)
+    printResult(`   This is IRREVERSIBLE. If the payload is a valid signed transaction, funds WILL move.\n`)
     const confirmed = await confirmTransaction()
     if (!confirmed) {
       throw new ConfirmationRequiredError('Broadcast declined at the confirmation prompt')

--- a/clients/cli/src/commands/broadcast.ts
+++ b/clients/cli/src/commands/broadcast.ts
@@ -16,7 +16,7 @@ import { confirmTransaction } from '../ui'
  */
 export type BroadcastRawParams = {
   chain: Chain
-  rawTx: string // Signed transaction in the chain family's own encoding: hex (evm/utxo), base58-or-base64 (solana), base64 protobuf (cosmos), JSON envelope (sui), base64 BOC (ton)
+  rawTx: string // Signed transaction in the chain family's own encoding: hex (evm/utxo/polkadot/bittensor/ripple), base58-or-base64 (solana), base64 protobuf or JSON tx_bytes envelope (cosmos), JSON envelope (sui), base64 BOC (ton)
   /**
    * Skip the interactive confirmation prompt. Required in non-interactive
    * contexts because broadcastRawTx sends the pre-signed payload straight
@@ -53,14 +53,19 @@ export async function executeBroadcast(ctx: CommandContext, params: BroadcastRaw
   if (rawTx.length === 0) {
     throw new InvalidInputError('Empty raw transaction — pass the signed tx via --raw-tx')
   }
-  // REVIEW FIX (aq5ku): broadcastRawTx is NOT hex-only, so a blanket hex test refuses every
-  // non-hex family. RawBroadcastService fans out per kind and each decoder takes a different
-  // encoding: solana is base58-or-base64 (decodeSolanaRawTx even sniffs it), cosmos is base64
-  // protobuf, sui is a JSON envelope so `{` is the first byte of every valid payload, ton is a
-  // base64 BOC passed verbatim. Only evm and utxo are hex. The docstring above claimed hex for
-  // all of them - the doc was wrong and the code was right, so the doc is corrected too.
+  // REVIEW FIX (aq5ku): broadcastRawTx is not uniformly hex-only, so a blanket hex test refuses
+  // the non-hex families. RawBroadcastService fans out per kind and each decoder takes a
+  // different encoding: solana is base58-or-base64 (decodeSolanaRawTx even sniffs it), cosmos is
+  // base64 protobuf or a JSON tx_bytes envelope, sui is a JSON envelope so `{` is the first byte
+  // of every valid payload, and ton is a base64 BOC passed verbatim. Hex still applies to evm,
+  // utxo, polkadot, bittensor, and ripple, so the local prevalidation must track that exact set.
   const chainKind = getChainKind(params.chain)
-  const isHexFamily = chainKind === 'evm' || chainKind === 'utxo'
+  const isHexFamily =
+    chainKind === 'evm' ||
+    chainKind === 'utxo' ||
+    chainKind === 'polkadot' ||
+    chainKind === 'bittensor' ||
+    chainKind === 'ripple'
   const hex = rawTx.startsWith('0x') ? rawTx.slice(2) : rawTx
   if (isHexFamily && (!/^[0-9a-fA-F]+$/.test(hex) || hex.length % 2 !== 0)) {
     throw new InvalidInputError(

--- a/clients/cli/src/commands/nontty-prompt.test.ts
+++ b/clients/cli/src/commands/nontty-prompt.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CommandContext } from '../core'
 import { ConfirmationRequiredError } from '../core/errors'
 import { resetOutput, setNonInteractive } from '../lib/output'
+import { executeBroadcast } from './broadcast'
 import { executeExecute } from './execute'
 import { executeRujiraSwap, executeRujiraWithdraw } from './rujira'
 import { executeAddressBook } from './settings'
@@ -256,6 +257,16 @@ describe('confirmation-bound flows refuse before any stdout preview (non-interac
         l1Address: '0xdeadbeef',
       })
     )
+  })
+
+  // REVIEW FIX (should-fix 4): every other broadcast test stubs isNonInteractive
+  // directly, which never proves the real wiring — index.ts's preAction hook
+  // calling setNonInteractive(resolveNonInteractive(...)) before the command
+  // action runs — actually reaches executeBroadcast. This uses the real
+  // lib/output module (not mocked in this file), so it fails only if that
+  // wiring is genuinely broken.
+  it('broadcast refuses before vault.broadcastRawTx / preview', async () => {
+    await expectFailsClosed(() => executeBroadcast(makeTrapVaultCtx(), { chain: Chain.Ethereum, rawTx: '0xdeadbeef' }))
   })
 })
 

--- a/clients/cli/src/index.ts
+++ b/clients/cli/src/index.ts
@@ -772,7 +772,7 @@ program
   .requiredOption('--chain <chain>', 'Target blockchain')
   .requiredOption(
     '--raw-tx <payload>',
-    "Signed tx in the chain's own encoding (hex for evm/utxo/polkadot/bittensor/ripple, base58/base64 for solana, base64 protobuf or JSON tx_bytes for cosmos, JSON for sui, base64 BOC for ton)"
+    "Signed tx in the chain's own encoding (hex for evm/utxo/polkadot/bittensor/ripple, base58/base64 for solana, base64 protobuf or JSON tx_bytes for cosmos, JSON for sui/tron, base64 BOC for ton)"
   )
   .option('-y, --yes', 'Confirm broadcast without an interactive prompt (required in non-interactive contexts)')
   .action(

--- a/clients/cli/src/index.ts
+++ b/clients/cli/src/index.ts
@@ -772,7 +772,7 @@ program
   .requiredOption('--chain <chain>', 'Target blockchain')
   .requiredOption(
     '--raw-tx <payload>',
-    "Signed tx in the chain's own encoding (hex for evm/utxo, base58/base64 for solana, base64 protobuf for cosmos, JSON for sui, base64 BOC for ton)"
+    "Signed tx in the chain's own encoding (hex for evm/utxo/polkadot/bittensor/ripple, base58/base64 for solana, base64 protobuf or JSON tx_bytes for cosmos, JSON for sui, base64 BOC for ton)"
   )
   .option('-y, --yes', 'Confirm broadcast without an interactive prompt (required in non-interactive contexts)')
   .action(

--- a/clients/cli/src/index.ts
+++ b/clients/cli/src/index.ts
@@ -768,15 +768,17 @@ program
 // Command: Broadcast raw transaction
 program
   .command('broadcast')
-  .description('Broadcast a pre-signed raw transaction')
+  .description('Broadcast a pre-signed raw transaction. Previews by default — pass --yes to confirm.')
   .requiredOption('--chain <chain>', 'Target blockchain')
   .requiredOption('--raw-tx <hex>', 'Hex-encoded signed transaction')
+  .option('-y, --yes', 'Confirm broadcast without an interactive prompt (required in non-interactive contexts)')
   .action(
-    withExit(async (options: { chain: string; rawTx: string }) => {
+    withExit(async (options: { chain: string; rawTx: string; yes?: boolean }) => {
       const context = await init(program.opts().vault)
       await executeBroadcast(context, {
         chain: findChainByName(options.chain) || (options.chain as Chain),
         rawTx: options.rawTx,
+        yes: options.yes,
       })
     })
   )

--- a/clients/cli/src/index.ts
+++ b/clients/cli/src/index.ts
@@ -775,6 +775,13 @@ program
     "Signed tx in the chain's own encoding (hex for evm/utxo/polkadot/bittensor/ripple, base58/base64 for solana, base64 protobuf or JSON tx_bytes for cosmos, JSON for sui/tron, base64 BOC for ton)"
   )
   .option('-y, --yes', 'Confirm broadcast without an interactive prompt (required in non-interactive contexts)')
+  .addHelpText(
+    'after',
+    `
+Note: the confirmation preview shows the raw tx payload (truncated), not a
+decoded to/value — it answers "did you mean to broadcast this", not "is this
+the correct destination and amount".`
+  )
   .action(
     withExit(async (options: { chain: string; rawTx: string; yes?: boolean }) => {
       const context = await init(program.opts().vault)

--- a/clients/cli/src/index.ts
+++ b/clients/cli/src/index.ts
@@ -770,7 +770,10 @@ program
   .command('broadcast')
   .description('Broadcast a pre-signed raw transaction. Previews by default — pass --yes to confirm.')
   .requiredOption('--chain <chain>', 'Target blockchain')
-  .requiredOption('--raw-tx <hex>', 'Hex-encoded signed transaction')
+  .requiredOption(
+    '--raw-tx <payload>',
+    "Signed tx in the chain's own encoding (hex for evm/utxo, base58/base64 for solana, base64 protobuf for cosmos, JSON for sui, base64 BOC for ton)"
+  )
   .option('-y, --yes', 'Confirm broadcast without an interactive prompt (required in non-interactive contexts)')
   .action(
     withExit(async (options: { chain: string; rawTx: string; yes?: boolean }) => {

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -159,7 +159,7 @@ export type BroadcastRawTxParams = {
   chain: Chain
 
   /**
-   * Hex-encoded signed transaction (with or without 0x prefix)
+   * Signed transaction in the chain family's own encoding: hex (evm/utxo), base58 or base64 (solana), base64 protobuf (cosmos), a JSON envelope (sui), base64 BOC (ton). NOT hex-only. Hex accepts an optional 0x prefix.
    */
   rawTx: string
 }

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -159,7 +159,7 @@ export type BroadcastRawTxParams = {
   chain: Chain
 
   /**
-   * Signed transaction in the chain family's own encoding: hex (evm/utxo/polkadot/bittensor/ripple), base58 or base64 (solana), base64 protobuf or a JSON tx_bytes envelope (cosmos), a JSON envelope (sui), base64 BOC (ton). Hex accepts an optional 0x prefix.
+   * Signed transaction in the chain family's own encoding: hex (evm/utxo/polkadot/bittensor/ripple), base58 or base64 (solana), base64 protobuf or a JSON tx_bytes envelope (cosmos), a JSON envelope (sui/tron), base64 BOC (ton). Hex accepts an optional 0x prefix.
    */
   rawTx: string
 }

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -159,7 +159,7 @@ export type BroadcastRawTxParams = {
   chain: Chain
 
   /**
-   * Signed transaction in the chain family's own encoding: hex (evm/utxo), base58 or base64 (solana), base64 protobuf (cosmos), a JSON envelope (sui), base64 BOC (ton). NOT hex-only. Hex accepts an optional 0x prefix.
+   * Signed transaction in the chain family's own encoding: hex (evm/utxo/polkadot/bittensor/ripple), base58 or base64 (solana), base64 protobuf or a JSON tx_bytes envelope (cosmos), a JSON envelope (sui), base64 BOC (ton). Hex accepts an optional 0x prefix.
    */
   rawTx: string
 }

--- a/packages/sdk/src/vault/VaultBase.ts
+++ b/packages/sdk/src/vault/VaultBase.ts
@@ -1248,7 +1248,7 @@ export abstract class VaultBase extends UniversalEventEmitter<VaultEvents> {
    *
    * @param params - Broadcast parameters
    * @param params.chain - Target blockchain
-   * @param params.rawTx - Signed transaction in the chain family's own encoding: hex (evm/utxo/polkadot/bittensor/ripple), base58 or base64 (solana), base64 protobuf or a JSON tx_bytes envelope (cosmos), a JSON envelope (sui), base64 BOC (ton).
+   * @param params.rawTx - Signed transaction in the chain family's own encoding: hex (evm/utxo/polkadot/bittensor/ripple), base58 or base64 (solana), base64 protobuf or a JSON tx_bytes envelope (cosmos), a JSON envelope (sui/tron), base64 BOC (ton).
    *
    * @returns Transaction hash on success
    *

--- a/packages/sdk/src/vault/VaultBase.ts
+++ b/packages/sdk/src/vault/VaultBase.ts
@@ -1248,7 +1248,7 @@ export abstract class VaultBase extends UniversalEventEmitter<VaultEvents> {
    *
    * @param params - Broadcast parameters
    * @param params.chain - Target blockchain
-   * @param params.rawTx - Hex-encoded signed transaction (with or without 0x prefix)
+   * @param params.rawTx - Signed transaction in the chain family's own encoding: hex (evm/utxo), base58 or base64 (solana), base64 protobuf (cosmos), a JSON envelope (sui), base64 BOC (ton). NOT hex-only.
    *
    * @returns Transaction hash on success
    *

--- a/packages/sdk/src/vault/VaultBase.ts
+++ b/packages/sdk/src/vault/VaultBase.ts
@@ -1248,7 +1248,7 @@ export abstract class VaultBase extends UniversalEventEmitter<VaultEvents> {
    *
    * @param params - Broadcast parameters
    * @param params.chain - Target blockchain
-   * @param params.rawTx - Signed transaction in the chain family's own encoding: hex (evm/utxo), base58 or base64 (solana), base64 protobuf (cosmos), a JSON envelope (sui), base64 BOC (ton). NOT hex-only.
+   * @param params.rawTx - Signed transaction in the chain family's own encoding: hex (evm/utxo/polkadot/bittensor/ripple), base58 or base64 (solana), base64 protobuf or a JSON tx_bytes envelope (cosmos), a JSON envelope (sui), base64 BOC (ton).
    *
    * @returns Transaction hash on success
    *

--- a/packages/sdk/src/vault/services/RawBroadcastService.ts
+++ b/packages/sdk/src/vault/services/RawBroadcastService.ts
@@ -135,7 +135,7 @@ export class RawBroadcastService {
    *
    * @param params - Broadcast parameters
    * @param params.chain - Target blockchain
-   * @param params.rawTx - Signed transaction in the chain family's own encoding: hex (evm/utxo), base58 or base64 (solana), base64 protobuf (cosmos), a JSON envelope (sui), base64 BOC (ton). NOT hex-only.
+   * @param params.rawTx - Signed transaction in the chain family's own encoding: hex (evm/utxo/polkadot/bittensor/ripple), base58 or base64 (solana), base64 protobuf or a JSON tx_bytes envelope (cosmos), a JSON envelope (sui), base64 BOC (ton).
    *
    * @returns Transaction hash on success
    *

--- a/packages/sdk/src/vault/services/RawBroadcastService.ts
+++ b/packages/sdk/src/vault/services/RawBroadcastService.ts
@@ -135,7 +135,7 @@ export class RawBroadcastService {
    *
    * @param params - Broadcast parameters
    * @param params.chain - Target blockchain
-   * @param params.rawTx - Signed transaction in the chain family's own encoding: hex (evm/utxo/polkadot/bittensor/ripple), base58 or base64 (solana), base64 protobuf or a JSON tx_bytes envelope (cosmos), a JSON envelope (sui), base64 BOC (ton).
+   * @param params.rawTx - Signed transaction in the chain family's own encoding: hex (evm/utxo/polkadot/bittensor/ripple), base58 or base64 (solana), base64 protobuf or a JSON tx_bytes envelope (cosmos), a JSON envelope (sui/tron), base64 BOC (ton).
    *
    * @returns Transaction hash on success
    *

--- a/packages/sdk/src/vault/services/RawBroadcastService.ts
+++ b/packages/sdk/src/vault/services/RawBroadcastService.ts
@@ -135,7 +135,7 @@ export class RawBroadcastService {
    *
    * @param params - Broadcast parameters
    * @param params.chain - Target blockchain
-   * @param params.rawTx - Hex-encoded signed transaction (with or without 0x prefix)
+   * @param params.rawTx - Signed transaction in the chain family's own encoding: hex (evm/utxo), base58 or base64 (solana), base64 protobuf (cosmos), a JSON envelope (sui), base64 BOC (ton). NOT hex-only.
    *
    * @returns Transaction hash on success
    *


### PR DESCRIPTION
## Summary
- Gates `broadcast` behind `--yes` / interactive prompt (mirrors send + sign PRs)
- Pre-validates rawTx shape locally so empty/malformed inputs are `InvalidInputError` not `EXTERNAL_SERVICE`
- Fixes beads **vultisig-aq5ku** (P2 fund-safety) + **vultisig-z3xkg** (P3 error classification)

**Breaking change:** `broadcast` now requires `--yes` in non-interactive contexts (scripts/automation). Existing callers of `vultisig broadcast --raw-tx ...` without `--yes` will start getting `ConfirmationRequiredError` (exit 12) instead of broadcasting immediately.

## Motivation
Two related fixes on the vault-cli `broadcast` primitive:

**1. bead aq5ku (P2)**: `broadcast --raw-tx` had NO confirmation gate. `send` and `sign` (PR #1737) both have `--yes` gates. Broadcast bypassed both. Any shell injection, script bug, or malicious CLI wrapper reaching `--raw-tx` could silently broadcast to the chain. `broadcastRawTx` moves funds immediately.

**2. bead z3xkg (P3)**: `broadcast --raw-tx ''` misclassified as `EXTERNAL_SERVICE` / `retryable:true` with suggestion "Retry the transaction" — which loops the same bad input forever. RPC "empty transaction data" is a caller-side bug.

## Test plan (vault-CLI receipts)

**Before (broadcast bypassed confirm; empty misclassified):**
```
$ vault-cli broadcast --chain ethereum --raw-tx 0x02f8... --vault X -o json
{ success: true, txHash: 0x...} (immediate, no gate)

$ vault-cli broadcast --chain ethereum --raw-tx '' --vault X -o json
{ error: { code: 'EXTERNAL_SERVICE', retryable: true, suggestions: ['Retry the transaction'] } }
```

**After:**
```
$ vault-cli broadcast --chain ethereum --raw-tx 0x02f8... --vault X -o json
{ error: { code: 'CONFIRMATION_REQUIRED', exitCode: 12, ... hint: 'Pass --yes to confirm.' } }

$ vault-cli broadcast --chain ethereum --raw-tx 0x02f8... --yes --vault X -o json
{ success: true, txHash: '0x...' }

$ vault-cli broadcast --chain ethereum --raw-tx '' --yes --vault X -o json
{ error: { code: 'INVALID_INPUT', message: 'Empty raw transaction — pass the signed tx via --raw-tx' } }
```

## Implementation
- New `--yes` / `-y` flag on `broadcast` command (mirrors sign PR #1737)
- Non-interactive without `--yes` → `ConfirmationRequiredError` (exit 12)
- Interactive: warn with chain + head+tail of raw tx + size + fund-safety notice, then `confirmTransaction()` prompt
- Decline throws `ConfirmationRequiredError`
- Pre-validate rawTx: empty/whitespace → `InvalidInputError 'Empty raw transaction'` for every chain family
- Hex-shape check (`InvalidInputError 'Malformed raw transaction'`) scoped to `evm`/`utxo`/`polkadot`/`bittensor`/`ripple` chain kinds — `broadcastRawTx` is not hex-only across families (solana is base58-or-base64, cosmos is base64 protobuf or a JSON `tx_bytes` envelope, sui/tron are JSON envelopes, ton is a base64 BOC), so a blanket hex check rejected valid payloads on every non-hex chain. Confirmation preview renders each family in its own encoding instead of forcing a `0x<hex>` + byte-count on non-hex payloads. Note: on the remaining non-hex chain kinds only the empty-string check applies — a garbage string like `--raw-tx "hello world"` on THORChain still reaches the RPC (deliberate tradeoff, not a full validator).
- Never reaches the RPC when the input is obviously wrong
- `--output json` / `--silent` without `--yes` now refuse up-front (`ConfirmationRequiredError`, exit 12) instead of degrading into a bare, context-free inquirer prompt whose own output would corrupt the promised clean JSON stdout. The human-readable preview also moved from `warn()` (silenced under json/silent) to `printResult()` (always shown), matching the sibling send/execute confirmation pattern.

Both fixes are pure wrappers around `vault.broadcastRawTx` — no vault-side behavior change.

## Tests
`clients/cli/src/commands/broadcast.test.ts` pins:
- non-interactive without `--yes` → `ConfirmationRequiredError`, never calls `broadcastRawTx`
- declining the interactive confirm → `ConfirmationRequiredError`, never calls `broadcastRawTx`
- `--yes` → skips confirm, passes rawTx straight through
- empty rawTx → `InvalidInputError` regardless of chain family
- malformed hex on EVM/UTXO → `InvalidInputError`
- Solana (base58 + base64), Cosmos (base64 protobuf + JSON tx_bytes), Sui (JSON), Tron (JSON), TON (base64 BOC) payloads are NOT rejected by the shape check — this is the regression test for the hex-scoping fix, mutation-verified by temporarily reverting the family scoping and confirming all seven cases fail with "Malformed raw transaction"
- json output / silent mode without `--yes` → `ConfirmationRequiredError`, never touches `confirmTransaction` or `broadcastRawTx`; json output WITH `--yes` broadcasts cleanly
- `nontty-prompt.test.ts` wiring test: exercises the real `resolveNonInteractive`/`setNonInteractive` path (not stubbed) to prove `index.ts`'s preAction hook actually reaches `executeBroadcast` before any vault access, and asserts the `requireInteractive` throw classifies as exit 12
- control-character escaping in both the malformed-hex error message and the confirmation preview, plus the >44-char head/tail truncation branch

Fix via Claude Opus 4.7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added confirmation prompts and transaction previews before broadcasting raw transactions.
  * Added `-y, --yes` to approve broadcasts without an interactive prompt.
  * Non-interactive broadcasts now require explicit confirmation.
  * Added support for documented, chain-specific raw transaction encodings, including non-hex formats.
* **Bug Fixes**
  * Empty input is rejected, and hexadecimal payloads are validated for proper formatting where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
