### PR TITLE
fix(cli): send --max shows resolved amount, not literal 'max' (bead 2lnf8)

### DIFF
--- a/clients/cli/src/commands/transaction.test.ts
+++ b/clients/cli/src/commands/transaction.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolvedMaxAmount } from './transaction'
+
+// bead vultisig-2lnf8: send --max previously echoed the literal 'max' string
+// in the dry-run response's `amount` field. The helper below rehydrates the
+// resolved value from what the SDK already returned (dryResult.total and .fee),
+// which is what previewDryRun now passes to `amount`. These cases pin the
+// arithmetic across the two SDK shapes (native vs token) and across decimal
+// widths from 6 (cosmos) to 18 (EVM).
+describe('resolvedMaxAmount', () => {
+  it('token send: passes total through unchanged (fee is in a different token)', () => {
+    // For a token max, VaultBase.ts:1782 isTokenSend branch sets total = amountBigInt
+    // (i.e. total IS the amount; fee is paid in the native gas token separately).
+    expect(resolvedMaxAmount(true, '1.234567', '0.000021')).toBe('1.234567')
+    expect(resolvedMaxAmount(true, '1000', '5.5')).toBe('1000')
+    expect(resolvedMaxAmount(true, '0.5', '0.00001')).toBe('0.5')
+  })
+
+  it('native send: subtracts fee from total via BigInt-scaled arithmetic', () => {
+    // Native max: SDK returns total = amountBigInt + fee, so amount = total - fee.
+    // EVM-scale (18 decimals). Confirmed against the actual repro:
+    // send ethereum <addr> --max --dry-run → total='0.003973219149949019', fee='0.000025698195113'
+    expect(resolvedMaxAmount(false, '0.003973219149949019', '0.000025698195113')).toBe('0.003947520954836019')
+    // BTC-scale (8 decimals)
+    expect(resolvedMaxAmount(false, '0.001', '0.0001')).toBe('0.0009')
+    // ATOM-scale (6 decimals)
+    expect(resolvedMaxAmount(false, '1.234567', '0.0075')).toBe('1.227067')
+  })
+
+  it('native send: handles when fee > total (edge case, returns 0 instead of negative)', () => {
+    // Should not happen in practice — SDK throws 'Insufficient balance to cover
+    // network fees' when maxSendable <= 0 (VaultBase.ts:1752). Belt-and-suspenders
+    // defense that the display helper never emits a negative amount to the user.
+    expect(resolvedMaxAmount(false, '0.001', '0.002')).toBe('0')
+    expect(resolvedMaxAmount(false, '0.0001', '0.0001')).toBe('0')
+  })
+
+  it('native send: integer-only inputs (no decimal point)', () => {
+    expect(resolvedMaxAmount(false, '100', '2')).toBe('98')
+    expect(resolvedMaxAmount(false, '1000', '0')).toBe('1000')
+  })
+
+  it('trims trailing zeros in the resolved fraction', () => {
+    // 1.5 - 0.5 = 1.0 (no trailing zeros in display)
+    expect(resolvedMaxAmount(false, '1.5', '0.5')).toBe('1')
+    // 0.100 - 0.050 = 0.050 → '0.05' (trailing zero trimmed)
+    expect(resolvedMaxAmount(false, '0.100', '0.050')).toBe('0.05')
+  })
+})

--- a/clients/cli/src/commands/transaction.ts
+++ b/clients/cli/src/commands/transaction.ts
@@ -12,6 +12,43 @@ import { ConfirmationRequiredError } from '../core/errors'
 import { createSpinner, info, isJsonOutput, isNonInteractive, outputJson, warn } from '../lib/output'
 import { confirmTransaction, displayTransactionPreview, displayTransactionResult, escapeTerminalControls } from '../ui'
 
+/**
+ * Compute the resolved max-send display amount from what the SDK already
+ * returned. bead vultisig-2lnf8.
+ *
+ * - Token max: `dryResult.total` IS the amount (fee is paid in a different
+ *   token, per VaultBase.ts:1782 isTokenSend branch). Pass through unchanged.
+ * - Native max: `dryResult.total = amountBigInt + fee` at the SDK layer, so
+ *   the display amount is `total - fee`. Uses BigInt-scaled arithmetic on the
+ *   decimal strings so 18-decimal chains don't lose precision through float
+ *   subtraction.
+ */
+export const resolvedMaxAmount = (isTokenSend: boolean, total: string, fee: string): string => {
+  if (isTokenSend) return total
+  // Decide the scale from the widest fractional part; then convert both to that
+  // scale as BigInt, subtract, and format back. Handles arbitrary decimal widths
+  // (chains from 6dec cosmos to 18dec ETH share this path).
+  const totalDot = total.indexOf('.')
+  const feeDot = fee.indexOf('.')
+  const totalFrac = totalDot < 0 ? 0 : total.length - totalDot - 1
+  const feeFrac = feeDot < 0 ? 0 : fee.length - feeDot - 1
+  const scale = Math.max(totalFrac, feeFrac)
+  const scaleBI = (s: string): bigint => {
+    const dot = s.indexOf('.')
+    const whole = dot < 0 ? s : s.slice(0, dot)
+    const frac = dot < 0 ? '' : s.slice(dot + 1)
+    const padded = frac.padEnd(scale, '0')
+    return BigInt((whole || '0') + padded)
+  }
+  const diff = scaleBI(total) - scaleBI(fee)
+  if (diff <= 0n) return '0'
+  if (scale === 0) return diff.toString()
+  const s = diff.toString().padStart(scale + 1, '0')
+  const whole = s.slice(0, -scale) || '0'
+  const frac = s.slice(-scale).replace(/0+$/, '')
+  return frac ? `${whole}.${frac}` : whole
+}
+
 const getSendPreviewDetails = (
   chain: Chain,
   keysignPayload: KeysignPayload
@@ -108,6 +145,22 @@ async function previewDryRun(
     )
   }
 
+  // bead vultisig-2lnf8: `params.amount` echoes the raw user input verbatim, so
+  // `--max` leaked as `amount: 'max'` in the sign-card display even though the
+  // SDK already resolved it to (balance - fee) in `amountBigInt` (VaultBase.ts
+  // :1750-1754). Rehydrate the display value from what the SDK already gave us —
+  // for a token max, `dryResult.total` IS the amount (fee is paid in a different
+  // token, isTokenSend branch of VaultBase.ts:1782). For a native max, we
+  // subtract via BigInt string arithmetic to avoid float-precision loss at
+  // 18-decimal chains: amount = total - fee, both scaled to `decimals` first.
+  // Non-max amounts pass through unchanged so any user-typed decimal is preserved.
+  //
+  // Contrast: swap-quote already exposes the resolved value via a distinct
+  // `maxSwapable` field (clients/cli/src/commands/swap.ts). This aligns send's
+  // display with that pattern without introducing a new field.
+  const amountDisplay =
+    params.amount === 'max' ? resolvedMaxAmount(isTokenSend, dryResult.total, dryResult.fee) : params.amount
+
   // fee/total come straight from the build the SDK just did. They were previously
   // dropped from the JSON result even though the human preview below prints the fee
   // and `total` is what the insufficient-balance check compares against — so
@@ -116,7 +169,7 @@ async function previewDryRun(
     dryRun: true,
     chain: params.chain,
     to,
-    amount: params.amount,
+    amount: amountDisplay,
     symbol: balance.symbol,
     fee: dryResult.fee,
     feeSymbol: dryResult.feeSymbol,


### PR DESCRIPTION
## Summary
- `send --max` (and positional `send <chain> <addr> max`) now shows the resolved amount instead of the literal `'max'` string
- Bead **vultisig-2lnf8** (dogfood 2026-08-05, P4 display-only)

## Motivation
Repro (Testwallet2 2026-08-05):
```
$ vault-cli send ethereum <addr> --max --dry-run -o json
{
  "amount": "max",                    ← leaks the literal input string
  "symbol": "ETH",
  "fee": "0.000025698195113",
  "total": "0.003973219149949019",
  "balance": "0.003973219149949019"
}
```

The **signed value is correct** — `VaultBase.ts:1750-1754` resolves `'max'` → `maxSendable` (balance - fee) internally. `total` at line 1782 = `maxSendable + fee = balance` for native, or `maxSendable` for token. The bug is display-only: sign-card readers see `'max'` instead of the actual number they're authorizing.

Verify-first triage earlier this session **downgraded this from P2 fund-safety to P4 display-only** after confirming the signed value is correct. This PR closes that display-only tail.

## After
```
$ vault-cli send ethereum <addr> --max --dry-run -o json
{
  "amount": "0.003947520954836019",   ← resolved (balance - fee)
  "symbol": "ETH",
  "fee": "0.000025698195113",
  "total": "0.003973219149949019",
  "balance": "0.003973219149949019"
}
```

Non-max amounts pass through unchanged so user-typed decimals stay verbatim.

## Implementation
Rehydrate the display from what `dryResult` already returned:
- **Token max**: `total` IS the amount (`VaultBase.ts:1782` isTokenSend branch, since fee is paid in a different token) → pass through
- **Native max**: `amount = total - fee` via BigInt-scaled string arithmetic (no float precision loss at 18-decimal chains — verified against the actual repro numbers)

Uses no new SDK fields — keeps the existing `amount` key.

## Contrast
`swap-quote` already exposes the resolved value via a distinct `maxSwapable` field. This PR aligns send's shape with the "resolved value exposed" pattern **without** introducing a new field (uses the existing `amount` key that scripting layers already parse).

## Tests
New `transaction.test.ts` with 5 test cases pinning:
- Token vs native branches
- Decimal widths 6 / 8 / 18 (cosmos / BTC / EVM)
- The exact ETH repro from the bead (`0.003973219149949019 - 0.000025698195113 = 0.003947520954836019`)
- Edge case: fee > total returns `'0'` (belt-and-suspenders defense; SDK throws earlier via `VaultBase.ts:1752` `'Insufficient balance to cover network fees'`)
- Trailing-zero trimming

No existing tests break (helper is standalone, called only when `params.amount === 'max'`).

Fix via Claude Opus 4.7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved `--max` transaction displays in dry-run mode.
  * Native asset sends now show the maximum amount after transaction fees are deducted.
  * Token sends display the full available total.
* **Bug Fixes**
  * Prevented fee calculations from producing negative amounts.
  * Improved decimal precision and formatting, including removal of unnecessary trailing zeros.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->