### PR TITLE
fix(cli): chains --add / resolve emit 'Did you mean' suggestions (bead 7eymb)

### DIFF
--- a/clients/cli/src/commands/chains.ts
+++ b/clients/cli/src/commands/chains.ts
@@ -7,6 +7,7 @@ import chalk from 'chalk'
 
 import type { CommandContext } from '../core'
 import { InvalidChainError } from '../core'
+import { suggestChainNames } from '../core/chain-resolver'
 import { createSpinner, info, isJsonOutput, outputJson, printResult, success } from '../lib/output'
 import { displayAddresses } from '../ui'
 
@@ -45,11 +46,19 @@ export async function executeChains(ctx: CommandContext, options: ChainsOptions 
     // then throw on every subsequent address derivation. Fail closed: nothing is
     // persisted for a chain that isn't supported.
     if (!SUPPORTED_CHAINS.includes(options.add)) {
+      // bead vultisig-7eymb: add did-you-mean hint so `chains --add Cronos` points
+      // to the SDK-enum name `CronosChain` instead of forcing the user to `vultisig
+      // chains` and grep.
+      const suggestions = suggestChainNames(String(options.add))
+      const hint =
+        suggestions.length > 0
+          ? `Did you mean: ${suggestions.join(', ')}? Or run "vultisig chains" to see the supported chains.`
+          : 'Run "vultisig chains" to see the supported chains, or check the spelling.'
       throw new InvalidChainError(
         `Unsupported chain: "${options.add}"`,
-        'Run "vultisig chains" to see the supported chains, or check the spelling.',
+        hint,
         undefined,
-        { chain: String(options.add) }
+        { chain: String(options.add), ...(suggestions.length > 0 ? { suggestions: suggestions.join(',') } : {}) }
       )
     }
     const alreadyActive = vault.chains.includes(options.add)

--- a/clients/cli/src/commands/chains.ts
+++ b/clients/cli/src/commands/chains.ts
@@ -54,12 +54,10 @@ export async function executeChains(ctx: CommandContext, options: ChainsOptions 
         suggestions.length > 0
           ? `Did you mean: ${suggestions.join(', ')}? Or run "vultisig chains" to see the supported chains.`
           : 'Run "vultisig chains" to see the supported chains, or check the spelling.'
-      throw new InvalidChainError(
-        `Unsupported chain: "${options.add}"`,
-        hint,
-        undefined,
-        { chain: String(options.add), ...(suggestions.length > 0 ? { suggestions: suggestions.join(',') } : {}) }
-      )
+      throw new InvalidChainError(`Unsupported chain: "${options.add}"`, hint, undefined, {
+        chain: String(options.add),
+        ...(suggestions.length > 0 ? { suggestions: suggestions.join(',') } : {}),
+      })
     }
     const alreadyActive = vault.chains.includes(options.add)
     if (!alreadyActive) {

--- a/clients/cli/src/core/chain-resolver.test.ts
+++ b/clients/cli/src/core/chain-resolver.test.ts
@@ -11,7 +11,7 @@
 import { Chain } from '@vultisig/sdk'
 import { describe, expect, it } from 'vitest'
 
-import { resolveChainOrThrow } from './chain-resolver'
+import { resolveChainOrThrow, suggestChainNames } from './chain-resolver'
 import { ExitCode, InvalidChainError } from './errors'
 
 describe('resolveChainOrThrow', () => {
@@ -51,5 +51,56 @@ describe('resolveChainOrThrow', () => {
 
   it('does not accept the empty string as a chain', () => {
     expect(() => resolveChainOrThrow('')).toThrow(InvalidChainError)
+  })
+
+  // bead vultisig-7eymb: `Cronos` (the brand) forced users to know the SDK enum
+  // name `CronosChain`. Did-you-mean suggestion surfaces the closest match(es)
+  // in both the human hint AND the error context so JSON callers can consume.
+  it('suggests CronosChain when user types the Cronos brand', () => {
+    try {
+      resolveChainOrThrow('Cronos')
+      throw new Error('expected resolveChainOrThrow to throw')
+    } catch (err) {
+      const chainErr = err as InvalidChainError
+      expect(chainErr.hint ?? '').toMatch(/Did you mean.*CronosChain/)
+      // context.suggestions is a comma-joined string (context values must be strings)
+      expect(chainErr.context?.suggestions ?? '').toContain(Chain.CronosChain)
+    }
+  })
+
+  it('falls back to the generic hint when no suggestion is close enough', () => {
+    try {
+      resolveChainOrThrow('zzzzzzzz')
+      throw new Error('expected resolveChainOrThrow to throw')
+    } catch (err) {
+      const chainErr = err as InvalidChainError
+      // No did-you-mean, just the original generic hint.
+      expect(chainErr.hint ?? '').toMatch(/vultisig chains/)
+      expect(chainErr.hint ?? '').not.toMatch(/Did you mean/)
+    }
+  })
+})
+
+describe('suggestChainNames', () => {
+  it('suggests CronosChain for Cronos (prefix match, high score)', () => {
+    const s = suggestChainNames('Cronos')
+    expect(s[0]).toBe(Chain.CronosChain)
+  })
+
+  it('is case-insensitive', () => {
+    expect(suggestChainNames('cronos')[0]).toBe(Chain.CronosChain)
+    expect(suggestChainNames('CRONOS')[0]).toBe(Chain.CronosChain)
+  })
+
+  it('returns [] for empty input', () => {
+    expect(suggestChainNames('')).toEqual([])
+    expect(suggestChainNames('   ')).toEqual([])
+  })
+
+  it('caps the number of suggestions', () => {
+    // A short common substring like "chain" matches multiple entries — the limit
+    // guards against dumping half the enum into the error hint.
+    const s = suggestChainNames('chain', 2)
+    expect(s.length).toBeLessThanOrEqual(2)
   })
 })

--- a/clients/cli/src/core/chain-resolver.ts
+++ b/clients/cli/src/core/chain-resolver.ts
@@ -1,10 +1,41 @@
-import type { Chain } from '@vultisig/sdk'
+import { Chain } from '@vultisig/sdk'
 
 // Imported from the leaf module rather than the '../interactive' barrel: the barrel
 // pulls in the shell session, which imports '../core' back, and that cycle would make
 // core transitively load the whole shell + command tree.
 import { findChainByName } from '../interactive/completer'
 import { InvalidChainError } from './errors'
+
+/**
+ * Compact string-distance for "did you mean" hints. Not a full Levenshtein —
+ * this only needs to spot brand-name close-matches like Cronos↔CronosChain,
+ * Arb↔Arbitrum, so we combine (a) case-insensitive substring containment
+ * (either direction) with (b) prefix match, weighting shorter deltas higher.
+ * Returns up to `limit` suggestions ordered by relevance. bead vultisig-7eymb.
+ */
+export function suggestChainNames(input: string, limit = 3): Chain[] {
+  const raw = input.trim()
+  if (!raw) return []
+  const lower = raw.toLowerCase()
+  const all = Object.values(Chain) as string[]
+
+  const scored: Array<{ name: string; score: number }> = []
+  for (const c of all) {
+    const cLower = c.toLowerCase()
+    if (cLower === lower) continue // exact match wouldn't reach this path anyway
+    let score = 0
+    // Prefix match: 'cronos' → 'cronoschain' scores highest
+    if (cLower.startsWith(lower)) score = 100 - (cLower.length - lower.length)
+    // Reverse prefix: 'arbitrum' input, 'arb' known would score too — but rare
+    else if (lower.startsWith(cLower)) score = 90 - (lower.length - cLower.length)
+    // Substring contains
+    else if (cLower.includes(lower)) score = 60 - Math.abs(cLower.length - lower.length)
+    else if (lower.includes(cLower)) score = 50 - Math.abs(lower.length - cLower.length)
+    if (score > 0) scored.push({ name: c, score })
+  }
+  scored.sort((a, b) => b.score - a.score)
+  return scored.slice(0, limit).map(s => s.name as Chain)
+}
 
 /**
  * Resolve a user-supplied chain name, or throw INVALID_CHAIN.
@@ -17,15 +48,26 @@ import { InvalidChainError } from './errors'
  *
  * `label` names the argument in the message, so a two-chain command can say which
  * side was wrong.
+ *
+ * On miss, includes a "Did you mean" hint (bead vultisig-7eymb) so common brand
+ * names like `Cronos` (SDK enum is `CronosChain`) or `Arb` (`Arbitrum`) don't
+ * force the user to `vultisig chains` and grep.
  */
 export function resolveChainOrThrow(input: string, label = 'chain'): Chain {
   const chain = findChainByName(input)
   if (!chain) {
+    const suggestions = suggestChainNames(input)
+    const hint =
+      suggestions.length > 0
+        ? `Did you mean: ${suggestions.join(', ')}? Or run "vultisig chains" to see the supported chains.`
+        : 'Run "vultisig chains" to see the supported chains, or check the spelling.'
     throw new InvalidChainError(
       `Unsupported ${label}: "${input}"`,
-      'Run "vultisig chains" to see the supported chains, or check the spelling.',
+      hint,
       undefined,
-      { chain: input }
+      // context values must be strings — flatten suggestions into a comma-joined
+      // field so JSON callers can parse it back deterministically.
+      { chain: input, ...(suggestions.length > 0 ? { suggestions: suggestions.join(',') } : {}) }
     )
   }
   return chain


### PR DESCRIPTION
## Summary
- `chains --add` and `resolveChainOrThrow` now emit "Did you mean: CronosChain?" style hints when the input is close to a known chain
- Bead **vultisig-7eymb** (dogfood 2026-08-05, P4)

## Motivation
Chain-name resolution is strict-match with no aliasing — common brand names like `Cronos` (the actual product brand) get rejected because only the SDK enum `CronosChain` matches. Error hint just says "check the spelling" — the user has to run `vultisig chains` and grep.

```
$ vault-cli chains --add Cronos --vault X -o json
{
  "code": "INVALID_CHAIN",
  "message": "Unsupported chain: \"Cronos\"",
  "hint": "Run \"vultisig chains\" to see the supported chains, or check the spelling."
}
```

Compare with `balance --token` which has a great "Did you mean --tokens?" hint. This PR gives chain resolution the same UX.

## After
```
$ vault-cli chains --add Cronos --vault X -o json
{
  "code": "INVALID_CHAIN",
  "message": "Unsupported chain: \"Cronos\"",
  "hint": "Did you mean: CronosChain? Or run \"vultisig chains\" to see the supported chains.",
  "context": { "chain": "Cronos", "suggestions": "CronosChain" }
}
```

Common cases covered: `Cronos` → `CronosChain`, prefix matches, case-insensitive.

## Implementation
- New `suggestChainNames(input, limit=3)` helper in `chain-resolver.ts` scores Chain enum entries by prefix + reverse-prefix + substring, returns top-N
- `resolveChainOrThrow` calls it on miss, appends "Did you mean" to the hint, adds `suggestions` to context (comma-joined string; VsigError context values must be strings)
- `chains --add` uses the same helper for its dedicated `InvalidChainError` path

Exact-match resolution is unchanged (fast path). Non-close inputs (`zzzzzzzz`) get the original generic hint.

## Tests
`chain-resolver.test.ts` gets:
- 2 new `resolveChainOrThrow` cases: Cronos → CronosChain suggestion; generic-hint fallback for zzzzzzzz
- 4 new `suggestChainNames` cases: prefix match, case-insensitivity, empty-input, cap-limit

5 pre-existing assertions unchanged.

Fix via Claude Opus 4.7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added helpful chain-name suggestions when an invalid chain is entered.
  * Suggestions are case-insensitive, recognize brand-name variations, and display up to three likely matches.
  * Suggested matches are included in both readable error messages and structured error details.

* **Bug Fixes**
  * Improved invalid-chain guidance while retaining a generic message when no close match is found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->