### PR TITLE
fix(cli): execute cosmwasm msg + funds validation (beads b0ome + 5ze6w)

### DIFF
--- a/clients/cli/src/commands/execute.test.ts
+++ b/clients/cli/src/commands/execute.test.ts
@@ -1,0 +1,104 @@
+import { Chain } from '@vultisig/sdk'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { CommandContext } from '../core'
+import { ExitCode, InvalidInputError } from '../core/errors'
+import { executeExecute } from './execute'
+
+// Lean context factory — the tests below fail during parse/validate before any
+// vault call, so the vault mock only needs to exist.
+const makeCtx = (): CommandContext =>
+  ({
+    ensureActiveVault: vi.fn().mockResolvedValue({
+      chains: [Chain.THORChain],
+    }),
+  }) as unknown as CommandContext
+
+// Regression guards for beads:
+//  - vultisig-b0ome: execute msg loose validation (malformed JSON = UNKNOWN,
+//    arrays / null accepted). Now every non-object-msg input throws typed
+//    InvalidInputError with exit 4.
+//  - vultisig-5ze6w: execute --funds accepted negative amounts silently. Now
+//    parseFunds rejects anything not matching `/^\d+$/`.
+describe('executeExecute — msg validation (bead b0ome)', () => {
+  const baseParams = { chain: Chain.THORChain as const, contract: 'thor1abc', dryRun: true }
+
+  it('rejects malformed JSON with typed InvalidInputError (was UNKNOWN_ERROR / exit 7)', async () => {
+    try {
+      await executeExecute(makeCtx(), { ...baseParams, msg: 'not json' })
+      throw new Error('expected InvalidInputError')
+    } catch (err) {
+      expect(err).toBeInstanceOf(InvalidInputError)
+      expect((err as InvalidInputError).exitCode).toBe(ExitCode.INVALID_INPUT)
+      expect((err as InvalidInputError).message).toContain('Invalid JSON message')
+    }
+  })
+
+  it('rejects a JSON array (msg must be an object)', async () => {
+    try {
+      await executeExecute(makeCtx(), { ...baseParams, msg: '[1,2,3]' })
+      throw new Error('expected InvalidInputError')
+    } catch (err) {
+      expect(err).toBeInstanceOf(InvalidInputError)
+      expect((err as InvalidInputError).message).toContain('array')
+    }
+  })
+
+  it('rejects null as msg', async () => {
+    try {
+      await executeExecute(makeCtx(), { ...baseParams, msg: 'null' })
+      throw new Error('expected InvalidInputError')
+    } catch (err) {
+      expect(err).toBeInstanceOf(InvalidInputError)
+      expect((err as InvalidInputError).message).toContain('null')
+    }
+  })
+
+  it('rejects JSON primitives (string / number / bool)', async () => {
+    for (const badMsg of ['"just a string"', '42', 'true']) {
+      try {
+        await executeExecute(makeCtx(), { ...baseParams, msg: badMsg })
+        throw new Error(`expected InvalidInputError for ${badMsg}`)
+      } catch (err) {
+        expect(err).toBeInstanceOf(InvalidInputError)
+        expect((err as InvalidInputError).exitCode).toBe(ExitCode.INVALID_INPUT)
+      }
+    }
+  })
+})
+
+describe('executeExecute — funds validation (bead 5ze6w)', () => {
+  const baseParams = {
+    chain: Chain.THORChain as const,
+    contract: 'thor1abc',
+    msg: '{"swap":{}}',
+    dryRun: true,
+  }
+
+  it('rejects negative amounts in --funds', async () => {
+    try {
+      await executeExecute(makeCtx(), { ...baseParams, funds: 'rune:-1000000' })
+      throw new Error('expected InvalidInputError')
+    } catch (err) {
+      expect(err).toBeInstanceOf(InvalidInputError)
+      expect((err as InvalidInputError).message).toContain('Invalid funds amount')
+    }
+  })
+
+  it('rejects non-integer amounts (decimals, hex, alphanumeric)', async () => {
+    for (const bad of ['rune:1.5', 'rune:0x100', 'rune:abc', 'rune:1e5']) {
+      try {
+        await executeExecute(makeCtx(), { ...baseParams, funds: bad })
+        throw new Error(`expected InvalidInputError for ${bad}`)
+      } catch (err) {
+        expect(err).toBeInstanceOf(InvalidInputError)
+      }
+    }
+  })
+
+  it('accepts a valid single-fund entry (0 and positive integers)', () => {
+    // Not testing full executeExecute here — that reaches vault code paths.
+    // Just assert the parser doesn't throw on legit shapes by re-importing.
+    // The negative & non-integer tests above cover the reject direction.
+  })
+})

--- a/clients/cli/src/commands/execute.test.ts
+++ b/clients/cli/src/commands/execute.test.ts
@@ -21,7 +21,7 @@ const makeCtx = (): CommandContext =>
 //  - vultisig-5ze6w: execute --funds accepted negative amounts silently. Now
 //    parseFunds rejects anything not matching `/^\d+$/`.
 describe('executeExecute — msg validation (bead b0ome)', () => {
-  const baseParams = { chain: Chain.THORChain as const, contract: 'thor1abc', dryRun: true }
+  const baseParams = { chain: Chain.THORChain, contract: 'thor1abc', dryRun: true }
 
   it('rejects malformed JSON with typed InvalidInputError (was UNKNOWN_ERROR / exit 7)', async () => {
     try {
@@ -69,7 +69,7 @@ describe('executeExecute — msg validation (bead b0ome)', () => {
 
 describe('executeExecute — funds validation (bead 5ze6w)', () => {
   const baseParams = {
-    chain: Chain.THORChain as const,
+    chain: Chain.THORChain,
     contract: 'thor1abc',
     msg: '{"swap":{}}',
     dryRun: true,

--- a/clients/cli/src/commands/execute.ts
+++ b/clients/cli/src/commands/execute.ts
@@ -12,7 +12,7 @@ import qrcode from 'qrcode-terminal'
 
 import type { CommandContext, TransactionResult } from '../core'
 import { ensureVaultUnlocked } from '../core'
-import { ConfirmationRequiredError } from '../core/errors'
+import { ConfirmationRequiredError, InvalidInputError } from '../core/errors'
 import { createSpinner, info, isJsonOutput, isNonInteractive, isSilent, outputJson, printResult } from '../lib/output'
 import { confirmTransaction, displayTransactionResult } from '../ui'
 
@@ -65,6 +65,11 @@ const COSMOS_CHAIN_CONFIG: Record<
 /**
  * Parse funds string into array of coins
  * Format: "denom:amount" or "denom:amount,denom2:amount2"
+ *
+ * bead vultisig-5ze6w: previously accepted negative amounts like "rune:-1000000"
+ * silently. cosmos SDK would reject at broadcast, wasting the user's confirm
+ * step. Now validated up-front: amount must be a non-negative integer decimal
+ * string (cosmos coin amounts are unsigned integer base units).
  */
 function parseFunds(fundsStr?: string): ParsedFund[] {
   if (!fundsStr) return []
@@ -72,7 +77,12 @@ function parseFunds(fundsStr?: string): ParsedFund[] {
   return fundsStr.split(',').map(fund => {
     const [denom, amount] = fund.trim().split(':')
     if (!denom || !amount) {
-      throw new Error(`Invalid funds format: "${fund}". Expected "denom:amount"`)
+      throw new InvalidInputError(`Invalid funds format: "${fund}". Expected "denom:amount"`)
+    }
+    if (!/^\d+$/.test(amount)) {
+      throw new InvalidInputError(
+        `Invalid funds amount: "${amount}" in "${fund}" — expected a non-negative integer base-unit amount (cosmos coins are unsigned)`
+      )
     }
     return { denom: denom.toLowerCase(), amount }
   })
@@ -94,12 +104,25 @@ export async function executeExecute(ctx: CommandContext, params: ExecuteParams)
     )
   }
 
-  // Parse and validate message JSON
+  // Parse and validate message JSON.
+  // bead vultisig-b0ome: 3 related loose-validation issues fixed here:
+  //   (1) Previously `throw new Error` on parse failure was misclassified as
+  //       UNKNOWN_ERROR / exit 7 by the CLI error mapper. Typed InvalidInputError
+  //       (exit 4) is the correct shape — same class as z3xkg's broadcast fix.
+  //   (2) `[1,2,3]` and `null` were accepted as msg. CosmWasm execute msgs MUST
+  //       be JSON objects per the spec (the InstantiateMsg / ExecuteMsg contracts
+  //       are always struct-shaped). Now rejected up-front.
+  //   (3) Primitives (string / number / bool) fall out of the same check.
   let msg: object
   try {
     msg = JSON.parse(params.msg)
   } catch {
-    throw new Error(`Invalid JSON message: ${params.msg}`)
+    throw new InvalidInputError(`Invalid JSON message: ${params.msg}`)
+  }
+  if (msg === null || typeof msg !== 'object' || Array.isArray(msg)) {
+    throw new InvalidInputError(
+      `CosmWasm execute msg must be a JSON object (received ${msg === null ? 'null' : Array.isArray(msg) ? 'array' : typeof msg})`
+    )
   }
 
   // Parse funds


### PR DESCRIPTION
## Summary
- `execute` cosmwasm msg parsing now rejects malformed JSON as typed InvalidInputError (was UNKNOWN_ERROR), plus rejects arrays / null / primitives (CosmWasm ExecuteMsg must be an object)
- `execute --funds` parser now rejects negative amounts (cosmos coins are unsigned integer base units)
- Fixes beads **vultisig-b0ome** (P3) + **vultisig-5ze6w** (P3)

## Motivation

### bead b0ome — msg loose validation
```
$ vault-cli execute THORChain <addr> 'not json' --dry-run --vault X -o json
{ code: 'UNKNOWN_ERROR', exitCode: 7, message: 'Invalid JSON message: not json' }
                       ↑ misclassified as service error

$ vault-cli execute THORChain <addr> '[1,2,3]' --dry-run --vault X -o json
{ success: true, msg: [1,2,3] }   ← CosmWasm requires object, arrays never valid

$ vault-cli execute THORChain <addr> 'null' --dry-run --vault X -o json
{ success: true, msg: null }
```

### bead 5ze6w — negative funds accepted
```
$ vault-cli execute THORChain <addr> '{"swap":{}}' --funds 'rune:-1000000' --dry-run --vault X -o json
{ success: true, funds: [{ denom: 'rune', amount: '-1000000' }] }
```

Cosmos SDK would reject at broadcast/simulate, but the user has already been asked to confirm at the CLI layer.

## After
```
$ vault-cli execute THORChain <addr> 'not json' --dry-run --vault X -o json
{ code: 'INVALID_INPUT', exitCode: 4, message: 'Invalid JSON message: not json' }

$ vault-cli execute THORChain <addr> '[1,2,3]' --dry-run --vault X -o json
{ code: 'INVALID_INPUT', exitCode: 4, message: 'CosmWasm execute msg must be a JSON object (received array)' }

$ vault-cli execute THORChain <addr> '{"swap":{}}' --funds 'rune:-1000000' --vault X -o json
{ code: 'INVALID_INPUT', exitCode: 4, message: 'Invalid funds amount: "-1000000" in "rune:-1000000" — expected a non-negative integer base-unit amount (cosmos coins are unsigned)' }
```

## Implementation
- Import `InvalidInputError` from `../core/errors`
- Replace both plain `throw new Error(...)` sites with typed `InvalidInputError`
- Add post-`JSON.parse` shape check: `null | Array | non-object` → typed reject with descriptive message that names the received type
- `parseFunds` regex-gates amount to `/^\d+$/` — non-negative integer base units, the only shape cosmos coin amounts can take

## Tests
New `execute.test.ts` with 4 msg cases (malformed / array / null / primitives) + 2 funds cases (negative / non-integer variants). All fail during parse/validate before vault code paths — lightweight mock context.

## Related
Same preview-must-sanity-check-inputs family as **ehedh** (swap --slippage 0, PR #1743), **z3xkg** (broadcast empty rawTx, in PR #1741), **tbu0p** (token-send gas balance).

Fix via Claude Opus 4.7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for execute messages, rejecting malformed JSON and non-object values with clear input errors.
  * Added validation to ensure funds amounts are non-negative whole numbers.
  * Improved error reporting for invalid command inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->