### PR TITLE
fix(cli): portfolio --currency no longer persists vault preference (bead v1n9u)

### DIFF
--- a/clients/cli/src/commands/balance.test.ts
+++ b/clients/cli/src/commands/balance.test.ts
@@ -391,7 +391,7 @@ describe('executePortfolio partial-failure reporting', () => {
   it('passes --currency through to getValues without touching vault.currency', async () => {
     // The requested currency reaches the pricing layer via the explicit
     // getValues(chain, currency) arg — no vault mutation needed.
-    const getValues = vi.fn(async (chain: Chain, _currency: FiatCurrency) => ({ native: makeValue('50.00') }))
+    const getValues = vi.fn(async (_chain: Chain, _currency: FiatCurrency) => ({ native: makeValue('50.00') }))
     const ctx = makeCtx({
       chains: [Chain.Ethereum],
       balance: async () => makeBalance('ETH'),

--- a/clients/cli/src/commands/balance.test.ts
+++ b/clients/cli/src/commands/balance.test.ts
@@ -369,6 +369,40 @@ describe('executePortfolio partial-failure reporting', () => {
     expect(joined).toContain('Bitcoin')
     expect(joined).toContain('btc unreachable')
   })
+
+  it('does NOT persist --currency to the vault preference (bead v1n9u)', async () => {
+    // Regression guard: `portfolio --currency EUR` previously called
+    // vault.setCurrency('eur') as a side effect, silently persisting EUR as
+    // the vault's default. --currency is a DISPLAY option — vault preference
+    // only changes via the dedicated `currency <X>` command.
+    const ctx = makeCtx({
+      chains: [Chain.Ethereum],
+      balance: async () => makeBalance('ETH'),
+      getValue: async () => makeValue('100.00'),
+    })
+    const vault = await ctx.ensureActiveVault()
+
+    await captureJson(() => executePortfolio(ctx, { currency: 'eur' }))
+
+    // The mock's setCurrency was NOT called — --currency stayed display-only.
+    expect((vault as unknown as { setCurrency: ReturnType<typeof vi.fn> }).setCurrency).not.toHaveBeenCalled()
+  })
+
+  it('passes --currency through to getValues without touching vault.currency', async () => {
+    // The requested currency reaches the pricing layer via the explicit
+    // getValues(chain, currency) arg — no vault mutation needed.
+    const getValues = vi.fn(async (chain: Chain, _currency: FiatCurrency) => ({ native: makeValue('50.00') }))
+    const ctx = makeCtx({
+      chains: [Chain.Ethereum],
+      balance: async () => makeBalance('ETH'),
+      getValue: async () => makeValue('50.00'),
+      getValues,
+    })
+
+    await captureJson(() => executePortfolio(ctx, { currency: 'gbp' }))
+
+    expect(getValues).toHaveBeenCalledWith(Chain.Ethereum, 'gbp')
+  })
 })
 
 describe('executeBalance honours --tokens on a single chain', () => {

--- a/clients/cli/src/commands/balance.ts
+++ b/clients/cli/src/commands/balance.ts
@@ -90,10 +90,13 @@ export async function executePortfolio(ctx: CommandContext, options: PortfolioOp
     throw new Error('Invalid currency')
   }
 
-  if (vault.currency !== currency) {
-    await vault.setCurrency(currency)
-  }
-
+  // bead vultisig-v1n9u: `--currency <X>` is a DISPLAY option, not a preference
+  // change. Previously this ran `vault.setCurrency(currency)` as a side effect,
+  // so `portfolio --currency EUR` silently persisted EUR as the vault's default
+  // — a one-off display became a permanent setting the user never asked for.
+  // getValues(chain, currency) and getValue(chain, _, currency) both accept the
+  // currency explicitly, so no setCurrency call is needed here at all. Vault
+  // preference only changes via the dedicated `currency <X>` command.
   const currencyName = fiatCurrencyNameRecord[currency]
   const spinner = createSpinner(`Loading portfolio in ${currencyName}...`)
 


### PR DESCRIPTION
## Summary
- `portfolio --currency <X>` no longer persists X as the vault's currency preference
- Bead **vultisig-v1n9u** (dogfood 2026-08-05, P3)

## Motivation
`portfolio --currency EUR` silently called `vault.setCurrency('eur')` as a side effect. A user asking for a one-off EUR display had EUR persisted as the vault's default until they ran `currency USD` to fix it. The `--currency` flag became a permanent-setting flag they never asked for.

```
$ vault-cli currency --vault Testwallet2 -o json
{ currency: 'usd', name: 'US Dollar' }

$ vault-cli portfolio --currency EUR --vault Testwallet2 -o json
{ portfolio: { totalValue: { amount: '49.24', currency: 'eur' }, ... } }

$ vault-cli currency --vault Testwallet2 -o json
{ currency: 'eur', name: 'Euro' }   ← silently persisted
```

## Implementation
`getValues(chain, currency)` and `getValue(chain, _, currency)` both accept currency explicitly, so no `setCurrency` call is needed. Simple removal of the `if (vault.currency !== currency) { await vault.setCurrency(currency) }` block at `balance.ts:93-95`.

## Behaviour scope
| Command | Before | After |
|---------|--------|-------|
| `portfolio --currency X` | displays in X **AND** persists X | displays in X, vault unchanged |
| `currency X` (dedicated) | persists X | unchanged |
| `swap-quote`, `balance`, `send`, etc | unchanged (no --currency flag) | unchanged |

## Tests
Two new tests in `balance.test.ts`:
1. `does NOT persist --currency to the vault preference` — pins `setCurrency` is never called from `executePortfolio`
2. `passes --currency through to getValues without touching vault.currency` — pins the requested currency reaches getValues via the explicit arg

Existing tests untouched — they all use `currency: 'usd'` (matching vault's initial 'usd'), so the removed setCurrency call wasn't firing in any pre-existing test path.

## Related
Same "correct layer" family as PRs #1741 (broadcast rawTx), #1743 (slippage 0), #1746 (execute inputs), #1747 (seedphrase order), #1749 (create fast validation) — this one is "side-effect at correct layer" rather than "validate at correct layer".

Fix via Claude Opus 4.7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The portfolio balance command now treats the selected currency as display-only.
  * Running the command no longer changes or persists the vault’s default currency.
  * Portfolio values continue to be displayed in the requested currency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->