### PR TITLE
fix(cli): swap-quote accepts --slippage (bead zctj6)

### DIFF
--- a/clients/cli/src/commands/index.ts
+++ b/clients/cli/src/commands/index.ts
@@ -62,7 +62,7 @@ export {
 
 // Swap commands
 export type { SwapDryRunResult, SwapOptions, SwapQuoteOptions } from './swap'
-export { executeSwap, executeSwapChains, executeSwapQuote } from './swap'
+export { executeSwap, executeSwapChains, executeSwapQuote, parseSlippage } from './swap'
 
 // Settings commands
 export type { AddressBookEntry, AddressBookOptions } from './settings'

--- a/clients/cli/src/commands/swap.ts
+++ b/clients/cli/src/commands/swap.ts
@@ -3,6 +3,7 @@
  */
 import { toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'
 import type { Chain, SwapQuoteResult } from '@vultisig/sdk'
+import { InvalidArgumentError } from 'commander'
 import { formatUnits } from 'viem'
 
 import type { CommandContext } from '../core'
@@ -126,6 +127,14 @@ export type SwapOptions = {
   password?: string
   signal?: AbortSignal
 } & SwapQuoteOptions
+
+export function parseSlippage(value: string): number {
+  const slippage = Number(value)
+  if (value.trim() === '' || !Number.isFinite(slippage)) {
+    throw new InvalidArgumentError('Slippage must be a number')
+  }
+  return slippage
+}
 
 // `toChainAmount` is the SDK's authoritative parser. Using its supported
 // precision ceiling here validates and canonicalizes without losing any input

--- a/clients/cli/src/commands/swap.ts
+++ b/clients/cli/src/commands/swap.ts
@@ -36,6 +36,13 @@ export type SwapQuoteOptions = {
   amount: string | number
   fromToken?: string
   toToken?: string
+  /**
+   * Slippage tolerance in percent (0-50). Passed through to the underlying
+   * quote request so users can preview how tolerance affects estimatedOutput
+   * before committing to the more-committed `swap --dry-run` path.
+   * bead vultisig-zctj6.
+   */
+  slippage?: number
 }
 
 /**
@@ -55,6 +62,7 @@ export async function executeSwapQuote(ctx: CommandContext, options: SwapQuoteOp
     toChain: options.toChain,
     toSymbol: options.toToken || '',
     amount,
+    ...(options.slippage !== undefined && { slippageTolerance: options.slippage }),
     dryRun: true,
   })
 

--- a/clients/cli/src/commands/swapAmount.test.ts
+++ b/clients/cli/src/commands/swapAmount.test.ts
@@ -24,7 +24,7 @@ vi.mock('../ui', () => ({
 }))
 
 import type { CommandContext } from '../core'
-import { executeSwap, executeSwapQuote, normalizeSwapAmount } from './swap'
+import { executeSwap, executeSwapQuote, normalizeSwapAmount, parseSlippage } from './swap'
 
 const exactAmount = '0.123456789123456789'
 
@@ -130,17 +130,21 @@ describe('CLI swap amount precision', () => {
     }
   )
 
-  it('swap-quote threads --slippage through to the underlying quote request (bead zctj6)', async () => {
+  it('swap-quote threads --slippage 0 through to the underlying quote request (bead zctj6)', async () => {
     const { ctx, swap } = makeContext()
 
     await executeSwapQuote(ctx, {
       fromChain: Chain.Ethereum,
       toChain: Chain.Bitcoin,
       amount: '1',
-      slippage: 3,
+      slippage: parseSlippage('0'),
     })
 
-    expect(swap).toHaveBeenCalledWith(expect.objectContaining({ amount: '1', slippageTolerance: 3, dryRun: true }))
+    expect(swap).toHaveBeenCalledWith(expect.objectContaining({ amount: '1', slippageTolerance: 0, dryRun: true }))
+  })
+
+  it.each(['3abc', '3%', ''])('rejects malformed --slippage value %j', slippage => {
+    expect(() => parseSlippage(slippage)).toThrow('Slippage must be a number')
   })
 
   it('swap-quote omits slippageTolerance when --slippage not passed (backward compatible)', async () => {

--- a/clients/cli/src/commands/swapAmount.test.ts
+++ b/clients/cli/src/commands/swapAmount.test.ts
@@ -129,4 +129,29 @@ describe('CLI swap amount precision', () => {
       expect(swap).not.toHaveBeenCalled()
     }
   )
+
+  it('swap-quote threads --slippage through to the underlying quote request (bead zctj6)', async () => {
+    const { ctx, swap } = makeContext()
+
+    await executeSwapQuote(ctx, {
+      fromChain: Chain.Ethereum,
+      toChain: Chain.Bitcoin,
+      amount: '1',
+      slippage: 3,
+    })
+
+    expect(swap).toHaveBeenCalledWith(expect.objectContaining({ amount: '1', slippageTolerance: 3, dryRun: true }))
+  })
+
+  it('swap-quote omits slippageTolerance when --slippage not passed (backward compatible)', async () => {
+    const { ctx, swap } = makeContext()
+
+    await executeSwapQuote(ctx, {
+      fromChain: Chain.Ethereum,
+      toChain: Chain.Bitcoin,
+      amount: '1',
+    })
+
+    expect(swap.mock.calls[0][0]).not.toHaveProperty('slippageTolerance')
+  })
 })

--- a/clients/cli/src/index.ts
+++ b/clients/cli/src/index.ts
@@ -55,6 +55,7 @@ import {
   executeTxStatus,
   executeVaults,
   executeVerify,
+  parseSlippage,
   resolveTxStatusParams,
 } from './commands'
 import { cachePassword, createPasswordCallback, loadActiveVaultSafely, resolveChainOrThrow } from './core'
@@ -1104,7 +1105,11 @@ program
   .option('--max', 'Swap maximum amount (full balance minus fees for native)')
   .option('--from-token <address>', 'Token address to swap from (default: native)')
   .option('--to-token <address>', 'Token address to swap to (default: native)')
-  .option('--slippage <percent>', 'Slippage tolerance in percent (0-50). Same flag as `swap`; preview how tolerance affects estimatedOutput before signing.', parseFloat)
+  .option(
+    '--slippage <percent>',
+    'Slippage tolerance in percent (0-50). Same flag as `swap`; preview how tolerance affects estimatedOutput before signing.',
+    parseSlippage
+  )
   .addHelpText(
     'after',
     `

--- a/clients/cli/src/index.ts
+++ b/clients/cli/src/index.ts
@@ -1104,12 +1104,14 @@ program
   .option('--max', 'Swap maximum amount (full balance minus fees for native)')
   .option('--from-token <address>', 'Token address to swap from (default: native)')
   .option('--to-token <address>', 'Token address to swap to (default: native)')
+  .option('--slippage <percent>', 'Slippage tolerance in percent (0-50). Same flag as `swap`; preview how tolerance affects estimatedOutput before signing.', parseFloat)
   .addHelpText(
     'after',
     `
 Examples:
   vultisig swap-quote Ethereum Bitcoin 0.1
-  vultisig swap-quote Ethereum Bitcoin --max --output json`
+  vultisig swap-quote Ethereum Bitcoin --max --output json
+  vultisig swap-quote Ethereum Solana 1 --slippage 3`
   )
   .action(
     withExit(
@@ -1117,7 +1119,7 @@ Examples:
         fromChainStr: string,
         toChainStr: string,
         amountStr: string | undefined,
-        options: { max?: boolean; fromToken?: string; toToken?: string }
+        options: { max?: boolean; fromToken?: string; toToken?: string; slippage?: number }
       ) => {
         if (!amountStr && !options.max) throw new Error('Provide an amount or use --max')
         if (amountStr && options.max) throw new Error('Cannot specify both amount and --max')
@@ -1130,6 +1132,7 @@ Examples:
           amount: options.max ? 'max' : amountStr!,
           fromToken: options.fromToken,
           toToken: options.toToken,
+          slippage: options.slippage,
         })
       }
     )


### PR DESCRIPTION
## Summary
- `swap-quote` now accepts `--slippage <percent>` (0-50), mirroring `swap`
- Bead **vultisig-zctj6** (dogfood 2026-08-05, P4)

## Motivation
Repro (2026-08-05):
```
$ vault-cli swap ethereum solana 0.001 --slippage 3 --dry-run --vault X   # works
$ vault-cli swap-quote ethereum solana 0.001 --slippage 3 --vault X
error: unknown option '--slippage'
```

Users evaluating a route naturally want to see how slippage affects the expected output BEFORE committing to the more-involved `swap --dry-run` path (which does more validation, network calls, and preview rendering).

## After
```
$ vault-cli swap-quote ethereum solana 1 --slippage 3 --vault X -o json
{ ..., estimatedOutput: '0.00891...', provider: 'li.fi' }

$ vault-cli swap-quote ethereum solana 1 --slippage 51 --vault X -o json
{ code: 'USAGE_ERROR', message: 'Swap configuration error: slippageTolerance must be a finite, non-negative percent value no greater than 50. Received "51".' }
```

Same range validation as `swap` — no new validation code, just threads the flag through to the same SDK layer.

## Implementation
- Add `slippage?: number` to `SwapQuoteOptions` in `commands/swap.ts`
- Spread `slippageTolerance` into the `vault.swap({dryRun:true})` call when defined
- Add `--slippage <percent>` flag on `swap-quote` command in `index.ts` (uses commander's `parseFloat` handler for numeric coercion)

## Tests
Two new tests in `swapAmount.test.ts`:
1. `--slippage passes through to the swap call` — pins `slippageTolerance: 3`
2. `omits slippageTolerance when --slippage not passed` — backward compatibility

## Related
Same "CLI ergonomics" family as **7eymb** (PR #1745, chains did-you-mean). Range validation for negative / >50 already handled at SDK layer (same reject message as `swap`).

Fix via Claude Opus 4.7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional slippage tolerance to swap quotes.
  * Added the `--slippage <percent>` option to the `swap-quote` command, supporting values from 0–50%.
  * Slippage is applied to quote requests when provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->