### PR TITLE
fix(sdk): harden React Native Solana broadcasts

### DIFF
--- a/.changeset/calm-bats-verify-solana.md
+++ b/.changeset/calm-bats-verify-solana.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Harden React Native Solana broadcasting with deterministic signatures, idempotent duplicate handling, and signature-status verification for ambiguous send errors.

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1460,6 +1460,12 @@ Each chain kind has specific:
 - **RPC endpoints** - Chain-specific API URLs
 - **Transaction format** - Chain-specific encoding
 
+Transaction construction, broadcast, confirmation, and React Native transport
+have separate ownership boundaries. See
+[Chain transaction ownership](CHAIN-TRANSACTION-OWNERSHIP.md) before changing a
+chain implementation so platform adapters retain the core broadcast and status
+guarantees.
+
 ### Token Support
 
 | Chain Type | Token Standard | Example         |

--- a/docs/architecture/CHAIN-TRANSACTION-OWNERSHIP.md
+++ b/docs/architecture/CHAIN-TRANSACTION-OWNERSHIP.md
@@ -1,0 +1,32 @@
+# Chain transaction ownership
+
+Chain transaction code exists in several trees because the published packages
+and the React Native bundle have different dependency constraints. The trees
+are adapters, not independent specifications. Use the boundaries below when
+adding a chain or changing transaction behavior.
+
+| Concern | Authoritative tree | Adapter rule |
+| --- | --- | --- |
+| Keysign transaction construction | `packages/core/mpc/keysign/signingInputs/resolvers/<chain>` | SDK services should delegate to the core resolver. Standalone primitives in `packages/sdk/src/chains/<chain>` own only their explicitly documented raw/public API. |
+| Shared chain RPC/config primitives | `packages/core/chain/chains/<chain>` | Reuse these outside React Native. Do not duplicate endpoint or chain rules in SDK services. |
+| Broadcast outcome semantics | `packages/core/chain/tx/broadcast/resolvers/<chain>` | `RawBroadcastService` and `packages/sdk/src/platforms/react-native/chains/<chain>` must preserve the same idempotency and ambiguous-error verification guarantees. Platform adapters may change transport, not the success contract. |
+| Confirmation and execution status | `packages/core/chain/tx/status/resolvers/<chain>` | This is the authority for pending/success/error interpretation. A broadcast result means the payload was accepted; callers still poll status to a terminal result. |
+| React Native transport or wire encoding | `packages/sdk/src/platforms/react-native/chains/<chain>` | Keep only code required to avoid Node-only dependency graphs. Share pure parsers/building blocks from `packages/sdk/src/chains/<chain>` and add parity tests against the core contract. |
+
+## Change checklist
+
+When broadcast or confirmation behavior changes for a chain:
+
+1. Change the authoritative core resolver or status resolver first.
+2. Inspect `RawBroadcastService` and the React Native chain adapter for the
+   same chain; update them when the public raw/RN surfaces are affected.
+3. Test duplicate submission, an ambiguous transport failure whose hash is
+   found, an unknown hash, and an explicit on-chain failure.
+4. Keep final confirmation separate from broadcast acceptance. Never turn an
+   unverified transport error into success.
+
+Solana's core and React Native broadcast surfaces are the reference example:
+both derive the primary signature from the signed payload;
+`AlreadyProcessed` is idempotent broadcast acceptance; other ambiguous errors
+are resolved by a bounded, retrying signature lookup; and the status resolver
+remains authoritative for the eventual execution result.

--- a/packages/sdk/src/chains/solana/rawTx.ts
+++ b/packages/sdk/src/chains/solana/rawTx.ts
@@ -1,0 +1,64 @@
+import base58 from 'bs58'
+
+export type SolanaRawTxEncoding = 'auto' | 'base58' | 'base64'
+
+type BufferLike = {
+  from: (input: string, encoding: 'base64') => Uint8Array
+}
+
+const decodeBase64 = (value: string): Uint8Array => {
+  const buffer = (globalThis as unknown as { Buffer?: BufferLike }).Buffer
+  if (buffer?.from) {
+    return new Uint8Array(buffer.from(value, 'base64'))
+  }
+
+  const decode = (globalThis as unknown as { atob?: (input: string) => string }).atob
+  if (!decode) {
+    throw new Error('no base64 decoder available (install the `buffer` polyfill)')
+  }
+
+  const binary = decode(value)
+  return Uint8Array.from(binary, character => character.charCodeAt(0))
+}
+
+/** Decode a signed Solana transaction without importing `@solana/web3.js`. */
+export const decodeSolanaRawTx = (rawTx: string, encoding: SolanaRawTxEncoding = 'auto'): Uint8Array => {
+  const resolvedEncoding =
+    encoding === 'auto' ? (rawTx.includes('=') || /[+/]/.test(rawTx) ? 'base64' : 'base58') : encoding
+
+  return resolvedEncoding === 'base64' ? decodeBase64(rawTx) : base58.decode(rawTx)
+}
+
+/**
+ * Derive the transaction id from the first signature in a serialized Solana
+ * transaction. This pure parser is shared by the regular SDK raw-broadcast
+ * service and the Hermes-safe React Native adapter so both surfaces verify the
+ * same transaction identity.
+ */
+export const deriveSolanaRawTxSignature = (rawTx: string, encoding: SolanaRawTxEncoding = 'auto'): string => {
+  const txBytes = decodeSolanaRawTx(rawTx, encoding)
+  let offset = 0
+  let signatureCount = 0
+  let shift = 0
+  let terminated = false
+
+  while (offset < txBytes.length && shift <= 14) {
+    const byte = txBytes[offset]!
+    signatureCount |= (byte & 0x7f) << shift
+    offset += 1
+
+    if ((byte & 0x80) === 0) {
+      terminated = true
+      break
+    }
+
+    shift += 7
+  }
+
+  const signaturesEnd = offset + signatureCount * 64
+  if (!terminated || signatureCount < 1 || txBytes.length < signaturesEnd) {
+    throw new Error('Solana raw transaction does not contain a complete primary signature')
+  }
+
+  return base58.encode(txBytes.subarray(offset, offset + 64))
+}

--- a/packages/sdk/src/platforms/react-native/chains/index.ts
+++ b/packages/sdk/src/platforms/react-native/chains/index.ts
@@ -37,7 +37,7 @@ export type {
   EvmTxBuilderResult,
 } from './evm'
 export type { BuildXrpSendOptions, BuildXrpSendResult, XrpAccountInfo, XrpPaymentTx, XrpSubmitResult } from './ripple'
-export type { BuildSolanaSendOptions, SolanaTxBuilderResult } from './solana'
+export type { BroadcastSolanaTxOptions, BuildSolanaSendOptions, SolanaTxBuilderResult } from './solana'
 export type {
   BuildTonJettonTransferOptions,
   BuildTonSendOptions,

--- a/packages/sdk/src/platforms/react-native/chains/solana/index.ts
+++ b/packages/sdk/src/platforms/react-native/chains/solana/index.ts
@@ -3,4 +3,5 @@ export type { BuildSolanaSendOptions, SolanaTxBuilderResult } from './tx'
 export { buildSolanaSendTx } from './tx'
 
 // RPC helpers — accept explicit `rpcUrl` so consumers keep control
+export type { BroadcastSolanaTxOptions } from './rpc'
 export { broadcastSolanaTx, getSolanaBalance, getSolanaRecentBlockhash } from './rpc'

--- a/packages/sdk/src/platforms/react-native/chains/solana/rpc.ts
+++ b/packages/sdk/src/platforms/react-native/chains/solana/rpc.ts
@@ -8,7 +8,10 @@
  * would pull `rpc-websockets` into the bundle at import time.
  */
 
-import { jsonRpcCall, JsonRpcCallOptions } from '../../rpcFetch'
+import { attempt } from '@vultisig/lib-utils/attempt'
+
+import { deriveSolanaRawTxSignature } from '../../../../chains/solana/rawTx'
+import { jsonRpcCall, JsonRpcCallOptions, JsonRpcError } from '../../rpcFetch'
 
 type RpcRequestOptions = Pick<JsonRpcCallOptions, 'signal' | 'timeoutMs'>
 
@@ -22,13 +25,61 @@ type RpcBalance = {
   value: number
 }
 
-type RpcSendTxOpts = {
-  encoding?: 'base64' | 'base58'
+export type BroadcastSolanaTxOptions = {
   skipPreflight?: boolean
   preflightCommitment?: 'processed' | 'confirmed' | 'finalized'
   maxRetries?: number
   signal?: AbortSignal
   timeoutMs?: number
+}
+
+type RpcSignatureStatus = {
+  err: unknown | null
+}
+
+type RpcSignatureStatuses = {
+  context: { slot: number }
+  value: Array<RpcSignatureStatus | null>
+}
+
+const broadcastVerificationMaxAttempts = 4
+const broadcastVerificationBaseDelayMs = 500
+
+const wait = (durationMs: number, signal?: AbortSignal) =>
+  new Promise<void>(resolve => {
+    if (signal?.aborted) {
+      resolve()
+      return
+    }
+
+    const onDone = () => {
+      clearTimeout(timeout)
+      signal?.removeEventListener('abort', onDone)
+      resolve()
+    }
+    const timeout = setTimeout(onDone, durationMs)
+    signal?.addEventListener('abort', onDone, { once: true })
+  })
+
+const getSignatureStatus = (value: unknown): RpcSignatureStatus | null | undefined => {
+  if (!value || typeof value !== 'object' || !('value' in value)) return undefined
+
+  const statuses = (value as { value?: unknown }).value
+  if (!Array.isArray(statuses)) return undefined
+
+  const status = statuses[0]
+  if (status === null) return null
+  if (!status || typeof status !== 'object' || !('err' in status)) return undefined
+
+  return status as RpcSignatureStatus
+}
+
+const isAlreadyProcessedError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error ?? '')
+  const data = error instanceof JsonRpcError ? JSON.stringify(error.data ?? '') : ''
+  const detail = `${message} ${data}`.toLowerCase()
+
+  return detail.includes('already been processed') || detail.includes('alreadyprocessed')
 }
 
 /**
@@ -62,30 +113,85 @@ export async function getSolanaBalance(
 }
 
 /**
- * Broadcast a signed Solana transaction (base64-serialized). Returns the
- * on-chain signature (base58). The caller should prefer `sendTransaction`
- * over `sendRawTransaction` — the JSON-RPC method name is the same, but we
- * pass `encoding: 'base64'` explicitly so the node doesn't guess.
+ * Broadcast a signed Solana transaction (base64-serialized). Returns its
+ * deterministic primary signature (base58), never an unverified hash supplied
+ * by the RPC.
+ *
+ * `AlreadyProcessed` is idempotent broadcast success. Every other send error
+ * is ambiguous, so this helper checks `getSignatureStatuses` with bounded
+ * backoff and only resolves when the same signature is already known without
+ * an execution error. If the status remains missing, failed, or unavailable,
+ * the original send error is rethrown. This matches the core broadcast
+ * resolver's acceptance guarantee.
+ *
+ * A returned signature proves broadcast acceptance, not final confirmation.
+ * Consumers must continue polling transaction status until success or failure.
+ * The caller should prefer `sendTransaction` over `sendRawTransaction` — the
+ * JSON-RPC method name is the same, but we pass `encoding: 'base64'`
+ * explicitly so the node doesn't guess.
  *
  * For Jito bundle broadcasting, use a Jito-provided `rpcUrl` (same method).
  */
 export async function broadcastSolanaTx(
   rawTxBase64: string,
   rpcUrl: string,
-  opts: Omit<RpcSendTxOpts, 'encoding'> = {}
+  opts: BroadcastSolanaTxOptions = {}
 ): Promise<string> {
-  return jsonRpcCall<string>(
-    rpcUrl,
-    'sendTransaction',
-    [
-      rawTxBase64,
-      {
-        encoding: 'base64',
-        skipPreflight: opts.skipPreflight ?? false,
-        preflightCommitment: opts.preflightCommitment ?? 'confirmed',
-        maxRetries: opts.maxRetries ?? 3,
-      },
-    ],
-    { signal: opts.signal, timeoutMs: opts.timeoutMs }
+  const signature = deriveSolanaRawTxSignature(rawTxBase64, 'base64')
+  const sendResult = await attempt(
+    jsonRpcCall<string>(
+      rpcUrl,
+      'sendTransaction',
+      [
+        rawTxBase64,
+        {
+          encoding: 'base64',
+          skipPreflight: opts.skipPreflight ?? false,
+          preflightCommitment: opts.preflightCommitment ?? 'confirmed',
+          maxRetries: opts.maxRetries ?? 3,
+        },
+      ],
+      { signal: opts.signal, timeoutMs: opts.timeoutMs }
+    )
   )
+
+  if ('data' in sendResult) {
+    if (sendResult.data !== signature) {
+      throw new Error('Solana RPC returned a signature that does not match the signed transaction')
+    }
+    return signature
+  }
+
+  if (isAlreadyProcessedError(sendResult.error)) {
+    return signature
+  }
+
+  for (let verificationAttempt = 1; verificationAttempt <= broadcastVerificationMaxAttempts; verificationAttempt++) {
+    if (opts.signal?.aborted) break
+
+    const statusResult = await attempt(
+      jsonRpcCall<RpcSignatureStatuses>(
+        rpcUrl,
+        'getSignatureStatuses',
+        [[signature], { searchTransactionHistory: true }],
+        { signal: opts.signal, timeoutMs: opts.timeoutMs }
+      )
+    )
+
+    if ('data' in statusResult) {
+      const status = getSignatureStatus(statusResult.data)
+      if (status?.err === null) {
+        return signature
+      }
+      if (status && status.err !== null) {
+        break
+      }
+    }
+
+    if (verificationAttempt < broadcastVerificationMaxAttempts) {
+      await wait(broadcastVerificationBaseDelayMs * verificationAttempt, opts.signal)
+    }
+  }
+
+  throw sendResult.error
 }

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -168,7 +168,7 @@ export type {
 // Solana bridge type surface — pure primitive reimplementation that does NOT
 // pull @solana/web3.js (and therefore avoids the rpc-websockets / ws cascade
 // that hangs Hermes at module init).
-export type { BuildSolanaSendOptions, SolanaTxBuilderResult } from './chains/solana'
+export type { BroadcastSolanaTxOptions, BuildSolanaSendOptions, SolanaTxBuilderResult } from './chains/solana'
 
 // TON bridge type surface — reimplementation built on @ton/core only, which
 // is Hermes-safe (uses jssha via @ton/crypto peer dep, not crypto.subtle).

--- a/packages/sdk/src/vault/services/RawBroadcastService.ts
+++ b/packages/sdk/src/vault/services/RawBroadcastService.ts
@@ -23,10 +23,10 @@ import { extractErrorMsg } from '@vultisig/lib-utils/error/extractErrorMsg'
 import { isInError } from '@vultisig/lib-utils/error/isInError'
 import { ensureHexPrefix } from '@vultisig/lib-utils/hex/ensureHexPrefix'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
-import base58 from 'bs58'
 import { keccak256 } from 'viem'
 import { hashes as xrplHashes } from 'xrpl'
 
+import { decodeSolanaRawTx, deriveSolanaRawTxSignature } from '../../chains/solana/rawTx'
 import { VaultError, VaultErrorCode } from '../VaultError'
 
 type BlockchairBroadcastResponse =
@@ -54,28 +54,6 @@ const getCosmosRawTxBytes = (rawTx: string): Uint8Array => {
 }
 
 const deriveCosmosRawTxHash = (rawTx: string): string => bytesToHex(sha256(getCosmosRawTxBytes(rawTx))).toUpperCase()
-
-const deriveSolanaRawTxSignature = (rawTx: string): string => {
-  const isBase64 = rawTx.includes('=') || /[+/]/.test(rawTx)
-  const txBytes = isBase64 ? Buffer.from(rawTx, 'base64') : base58.decode(rawTx)
-  let offset = 0
-  let signatureCount = 0
-  let shift = 0
-
-  while (offset < txBytes.length) {
-    const byte = txBytes[offset]
-    signatureCount |= (byte & 0x7f) << shift
-    offset += 1
-    if ((byte & 0x80) === 0) break
-    shift += 7
-  }
-
-  if (signatureCount < 1 || txBytes.length < offset + 64) {
-    throw new Error('Solana raw transaction does not contain a primary signature')
-  }
-
-  return base58.encode(txBytes.subarray(offset, offset + 64))
-}
 
 const deriveRippleRawTxHash = (rawTx: string): string =>
   xrplHashes.hashSignedTx(rawTx.startsWith('0x') ? rawTx.slice(2) : rawTx)
@@ -277,9 +255,7 @@ export class RawBroadcastService {
   private async broadcastSolanaRawTx(rawTx: string): Promise<string> {
     const client = getSolanaClient()
 
-    // Detect format: base58 (no padding, no +/) vs base64 (may have = padding or +/)
-    const isBase64 = rawTx.includes('=') || /[+/]/.test(rawTx)
-    const txBytes = isBase64 ? Buffer.from(rawTx, 'base64') : base58.decode(rawTx)
+    const txBytes = decodeSolanaRawTx(rawTx)
 
     const { data: sentSignature, error } = await attempt(
       client.sendRawTransaction(txBytes, {

--- a/packages/sdk/tests/unit/platforms/react-native/solana-rpc.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/solana-rpc.test.ts
@@ -1,0 +1,220 @@
+import base58 from 'bs58'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { deriveSolanaRawTxSignature } from '../../../../src/chains/solana/rawTx'
+import { broadcastSolanaTx } from '../../../../src/platforms/react-native/chains/solana/rpc'
+
+const RPC_URL = 'https://solana.example'
+const signatureBytes = Uint8Array.from({ length: 64 }, (_, index) => index + 1)
+const rawTxBytes = Uint8Array.from([1, ...signatureBytes, 0])
+const RAW_TX = Buffer.from(rawTxBytes).toString('base64')
+const SIGNATURE = base58.encode(signatureBytes)
+const verificationDelaysMs = [500, 1000, 1500]
+
+const rpcResponse = (result: unknown): Response =>
+  new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result }), {
+    status: 200,
+  })
+
+const rpcError = (message: string, data?: unknown): Response =>
+  new Response(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      error: { code: -32002, message, data },
+    }),
+    { status: 200 }
+  )
+
+const mockFetchSequence = (...responses: Response[]): ReturnType<typeof vi.fn> => {
+  const fetchMock = vi.fn()
+  for (const response of responses) {
+    fetchMock.mockResolvedValueOnce(response)
+  }
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+const settleVerificationRetries = async () => {
+  for (const delay of verificationDelaysMs) {
+    await vi.advanceTimersByTimeAsync(delay)
+  }
+}
+
+describe('React Native Solana broadcast guarantees', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('returns the deterministic primary signature after an ordinary send', async () => {
+    const fetchMock = mockFetchSequence(rpcResponse(SIGNATURE))
+
+    await expect(broadcastSolanaTx(RAW_TX, RPC_URL)).resolves.toBe(SIGNATURE)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(fetchMock.mock.calls[0]![1]!.body as string)).toEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'sendTransaction',
+      params: [
+        RAW_TX,
+        {
+          encoding: 'base64',
+          skipPreflight: false,
+          preflightCommitment: 'confirmed',
+          maxRetries: 3,
+        },
+      ],
+    })
+  })
+
+  it.each([null, {}, 'rpc-supplied-signature'])('rejects an invalid successful send result (%j)', async result => {
+    mockFetchSequence(rpcResponse(result))
+
+    await expect(broadcastSolanaTx(RAW_TX, RPC_URL)).rejects.toThrow('does not match the signed transaction')
+  })
+
+  it.each([
+    ['message', rpcError('This transaction has already been processed')],
+    ['structured error data', rpcError('Transaction simulation failed', { err: 'AlreadyProcessed' })],
+  ])('treats AlreadyProcessed in %s as idempotent success', async (_source, response) => {
+    const fetchMock = mockFetchSequence(response)
+
+    await expect(broadcastSolanaTx(RAW_TX, RPC_URL)).resolves.toBe(SIGNATURE)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns the signature when status lookup confirms an ambiguous send', async () => {
+    const fetchMock = mockFetchSequence(
+      rpcError('request timed out'),
+      rpcResponse({
+        context: { slot: 42 },
+        value: [{ err: null, confirmationStatus: 'processed' }],
+      })
+    )
+
+    await expect(broadcastSolanaTx(RAW_TX, RPC_URL)).resolves.toBe(SIGNATURE)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(JSON.parse(fetchMock.mock.calls[1]![1]!.body as string)).toEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'getSignatureStatuses',
+      params: [[SIGNATURE], { searchTransactionHistory: true }],
+    })
+  })
+
+  it('retries an initially unknown signature until RPC indexing catches up', async () => {
+    vi.useFakeTimers()
+    const fetchMock = mockFetchSequence(
+      rpcError('request timed out'),
+      rpcResponse({ context: { slot: 42 }, value: [null] }),
+      rpcResponse({ context: { slot: 43 }, value: [{ err: null }] })
+    )
+
+    const result = broadcastSolanaTx(RAW_TX, RPC_URL)
+    await vi.advanceTimersByTimeAsync(500)
+
+    await expect(result).resolves.toBe(SIGNATURE)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('rethrows the original send error when the signature is unknown', async () => {
+    vi.useFakeTimers()
+    mockFetchSequence(
+      rpcError('upstream rejected the transaction'),
+      ...Array.from({ length: 4 }, () => rpcResponse({ context: { slot: 42 }, value: [null] }))
+    )
+
+    const result = broadcastSolanaTx(RAW_TX, RPC_URL)
+    const rejection = expect(result).rejects.toThrow('upstream rejected the transaction')
+    await settleVerificationRetries()
+
+    await rejection
+  })
+
+  it('rethrows the original send error when the known signature failed on-chain', async () => {
+    mockFetchSequence(
+      rpcError('request timed out'),
+      rpcResponse({
+        context: { slot: 42 },
+        value: [{ err: { InstructionError: [0, 'Custom'] } }],
+      })
+    )
+
+    await expect(broadcastSolanaTx(RAW_TX, RPC_URL)).rejects.toThrow('request timed out')
+  })
+
+  it('rethrows the original send error when status verification is unavailable', async () => {
+    vi.useFakeTimers()
+    mockFetchSequence(
+      rpcError('request timed out'),
+      ...Array.from({ length: 4 }, () => rpcError('status endpoint unavailable'))
+    )
+
+    const result = broadcastSolanaTx(RAW_TX, RPC_URL)
+    const rejection = expect(result).rejects.toThrow('request timed out')
+    await settleVerificationRetries()
+
+    await rejection
+  })
+
+  it('stops verification backoff when the caller aborts', async () => {
+    vi.useFakeTimers()
+    const controller = new AbortController()
+    const fetchMock = mockFetchSequence(
+      rpcError('request timed out'),
+      rpcResponse({ context: { slot: 42 }, value: [null] })
+    )
+
+    const result = broadcastSolanaTx(RAW_TX, RPC_URL, { signal: controller.signal })
+    const rejection = expect(result).rejects.toThrow('request timed out')
+    await vi.advanceTimersByTimeAsync(0)
+    controller.abort()
+
+    await rejection
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it.each([{}, { value: 'not-an-array' }, { value: [{}] }])(
+    'preserves the original send error after malformed status result %j',
+    async statusResult => {
+      vi.useFakeTimers()
+      mockFetchSequence(rpcError('request timed out'), ...Array.from({ length: 4 }, () => rpcResponse(statusResult)))
+
+      const result = broadcastSolanaTx(RAW_TX, RPC_URL)
+      const rejection = expect(result).rejects.toThrow('request timed out')
+      await settleVerificationRetries()
+
+      await rejection
+    }
+  )
+
+  it('derives the same signature through the Hermes atob fallback', () => {
+    vi.stubGlobal('Buffer', undefined)
+
+    expect(deriveSolanaRawTxSignature(RAW_TX, 'base64')).toBe(SIGNATURE)
+  })
+
+  it('auto-detects a base58 transaction', () => {
+    expect(deriveSolanaRawTxSignature(base58.encode(rawTxBytes))).toBe(SIGNATURE)
+  })
+
+  it('parses a multi-byte compact signature count', () => {
+    const multisigTx = new Uint8Array(2 + 128 * 64)
+    multisigTx.set([0x80, 0x01])
+    multisigTx.set(signatureBytes, 2)
+
+    expect(deriveSolanaRawTxSignature(base58.encode(multisigTx), 'base58')).toBe(SIGNATURE)
+  })
+
+  it('fails before network I/O when the raw transaction has no complete signature', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(broadcastSolanaTx(Buffer.from([1, 2, 3]).toString('base64'), RPC_URL)).rejects.toThrow(
+      'does not contain a complete primary signature'
+    )
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- document transaction ownership across core, SDK, and React Native surfaces
- harden React Native Solana broadcasts with signed-payload identity, duplicate idempotency, bounded status verification, and cancellation
- share the pure raw-transaction parser with the SDK broadcast service

## Runtime proof

An exact-revision local HTTP JSON-RPC run returned the payload-derived signature, recovered after indexing lag, preserved the original error when status stayed unknown, rejected a mismatched RPC identity, and stopped promptly on caller abort.

Closes #1227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Solana raw transaction decoding and signature extraction support.
  * Expanded React Native Solana broadcast options and returned signature handling.
* **Bug Fixes**
  * Improved Solana broadcast reliability by handling duplicate submissions and ambiguous send errors more safely.
  * Added post-send verification to confirm transaction status when results are unclear.
* **Documentation**
  * Added architecture guidance for transaction ownership and broadcast responsibilities.
* **Tests**
  * Added broader coverage for Solana broadcasting, encoding detection, retries, aborts, and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->