### PR TITLE
fix: keep fiat and discount tier amount math exact

### DIFF
--- a/.changeset/exact-fiat-tier-amounts.md
+++ b/.changeset/exact-fiat-tier-amounts.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/sdk': patch
+---
+
+Fix fiat valuation losing base-unit precision through float-first conversion, with regression coverage for exact VULT discount-tier boundaries.

--- a/packages/core/chain/coin/utils/getCoinValue.test.ts
+++ b/packages/core/chain/coin/utils/getCoinValue.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { getCoinValue } from './getCoinValue'
+
+describe('getCoinValue', () => {
+  it('calculates ordinary fiat values', () => {
+    expect(getCoinValue({ amount: 1500000n, decimals: 6, price: 2 })).toBe(3)
+    expect(getCoinValue({ amount: -1500000n, decimals: 6, price: 2 })).toBe(-3)
+  })
+
+  it('converts base units exactly before entering number-based fiat math', () => {
+    const amount = 831048943873725519n
+
+    expect(Number(amount) / 10 ** 6).toBe(831048943873.7256)
+    expect(getCoinValue({ amount, decimals: 6, price: 1 })).toBe(831048943873.7255)
+  })
+})

--- a/packages/core/chain/coin/utils/getCoinValue.ts
+++ b/packages/core/chain/coin/utils/getCoinValue.ts
@@ -1,6 +1,15 @@
-import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
+import { fromChainAmountExact } from '@vultisig/core-chain/amount/fromChainAmountExact'
 import { CoinAmount } from '@vultisig/core-chain/coin/Coin'
 import { EntityWithPrice } from '@vultisig/lib-utils/entities/EntityWithPrice'
 
-export const getCoinValue = ({ amount, decimals, price }: CoinAmount & EntityWithPrice) =>
-  fromChainAmount(amount, decimals) * price
+/**
+ * Convert base units to their exact human decimal before entering the
+ * necessarily number-based price calculation. Converting the raw bigint to a
+ * number first can round once before division and again afterward.
+ */
+export const getCoinValue = ({ amount, decimals, price }: CoinAmount & EntityWithPrice) => {
+  const sign = amount < 0n ? -1 : 1
+  const absoluteAmount = amount < 0n ? -amount : amount
+
+  return sign * Number(fromChainAmountExact(absoluteAmount, decimals)) * price
+}

--- a/packages/core/chain/swap/affiliate/index.test.ts
+++ b/packages/core/chain/swap/affiliate/index.test.ts
@@ -52,4 +52,26 @@ describe('getVultDiscountTier (sdk#1677)', () => {
 
     expect(getSwapAffiliateBps(tier)).toBe(15)
   })
+
+  it('does not round one wei below bronze up into the bronze tier', () => {
+    const bronzeThreshold = toVultBalance(vultDiscountTierMinBalances.bronze)
+
+    expect(getVultDiscountTier({ vultBalance: bronzeThreshold - 1n, thorguardNftBalance: 0n })).toBeNull()
+  })
+
+  it('preserves the Thorguard upgrade rules', () => {
+    expect(getVultDiscountTier({ vultBalance: 0n, thorguardNftBalance: 1n })).toBe('bronze')
+    expect(
+      getVultDiscountTier({
+        vultBalance: toVultBalance(vultDiscountTierMinBalances.gold),
+        thorguardNftBalance: 1n,
+      })
+    ).toBe('platinum')
+    expect(
+      getVultDiscountTier({
+        vultBalance: toVultBalance(vultDiscountTierMinBalances.platinum),
+        thorguardNftBalance: 1n,
+      })
+    ).toBe('platinum')
+  })
 })


### PR DESCRIPTION
Closes #1195

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fiat value calculations for very large balances and negative amounts while preserving exact base-unit precision.
  * Corrected discount-tier evaluation at precise boundaries, preventing balances just below a threshold from being incorrectly upgraded.
  * Improved Thorguard NFT tier handling, including accurate upgrades and preservation of existing higher tiers.

* **Tests**
  * Added regression coverage for precision-sensitive fiat conversions and discount-tier behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->