### PR TITLE
fix(swap): allow RUNE/CACAO-source native swaps past the broadcast guard

### DIFF
--- a/.changeset/native-source-swap-broadcast-guard.md
+++ b/.changeset/native-source-swap-broadcast-guard.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/core-mpc': patch
+'@vultisig/sdk': patch
+---
+
+Allow native swaps whose source is the protocol's own chain (RUNE on THORChain, CACAO on MayaChain) past the broadcast guard: those routes are MsgDeposits with no inbound vault and never appear in /inbound_addresses, so the inbound-existence and vault-address checks are skipped for them while quote-expiry and trading-halt checks still run.

--- a/packages/core/mpc/keysign/swap/assertNativeSwapReadyForBroadcast.ts
+++ b/packages/core/mpc/keysign/swap/assertNativeSwapReadyForBroadcast.ts
@@ -111,9 +111,17 @@ export const assertNativeSwapReadyForBroadcast = async ({
   }
   const inboundByChainId = new Map(inboundAddresses.map(info => [info.chain.toUpperCase(), info]))
 
+  // sdk#1726: a swap whose SOURCE is the protocol's own chain (RUNE on THORChain, CACAO on
+  // MayaChain) is a MsgDeposit straight to the network - it has no inbound vault, and
+  // /inbound_addresses only lists external chains, so the lookup below is undefined by design.
+  // Skip the inbound-existence and vault-address checks for those routes (the same tolerance the
+  // halt loop below already applies); quote expiry and the halt checks still run. A RUNE source
+  // routed VIA Maya is NOT exempt: Maya's feed lists THOR as an external chain.
+  const sourceIsProtocolChain = chain === native.chain
+
   const activeInbound = inboundByChainId.get(sourceChainId.toUpperCase())
 
-  if (!activeInbound?.address) {
+  if (!sourceIsProtocolChain && !activeInbound?.address) {
     throw new NativeSwapBroadcastGuardError(
       'network_error',
       `Cannot validate ${native.chain} inbound vault for source chain ${sourceChainId}`
@@ -154,7 +162,13 @@ export const assertNativeSwapReadyForBroadcast = async ({
     }
   }
 
-  if (activeInbound.address.toLowerCase() !== native.vaultAddress.toLowerCase()) {
+  // MsgDeposit payloads carry no vault address, so the staleness comparison is meaningless for
+  // protocol-chain sources even if the feed ever grew a THOR/MAYA entry.
+  if (sourceIsProtocolChain) {
+    return
+  }
+
+  if (!activeInbound?.address || activeInbound.address.toLowerCase() !== native.vaultAddress.toLowerCase()) {
     throw new NativeSwapBroadcastGuardError(
       'invalid_vault',
       `${native.chain} inbound vault address changed; refresh the swap quote before broadcasting`

--- a/packages/sdk/tests/unit/vault/services/nativeSwapBroadcastGuard.test.ts
+++ b/packages/sdk/tests/unit/vault/services/nativeSwapBroadcastGuard.test.ts
@@ -175,11 +175,11 @@ describe('assertNativeSwapReadyForBroadcast', () => {
     expect(getInboundAddresses).not.toHaveBeenCalled()
   })
 
+  // sdk#1726 changed the non-exempt observable: THOR-source routes no longer run the
+  // vault-address check (RUNE deposits have no inbound vault), so a lookalike payload that fails
+  // the secured-withdrawal detection is now caught by the expiry check its exemption would skip.
   it('does not exempt a secure-memo payload that carries an inbound vault', async () => {
-    const getInboundAddresses = vi.fn(async nativeChain => {
-      expect(nativeChain).toBe(Chain.THORChain)
-      return [makeInbound('THOR', 'thor1active')]
-    })
+    const getInboundAddresses = vi.fn()
 
     await expect(
       assertNativeSwapReadyForBroadcast({
@@ -187,36 +187,30 @@ describe('assertNativeSwapReadyForBroadcast', () => {
         keysignPayload: makeSecuredAssetWithdrawalPayload({
           vaultAddress: 'thor1stale',
           memo: 'secure-:bc1qdestination',
-          expirationTime: 1_700_000_100n,
         }),
         getInboundAddresses,
         now: () => 1_700_000_000_000,
       })
-    ).rejects.toThrow(/inbound vault address changed/)
+    ).rejects.toThrow(/missing or invalid expiration/)
 
-    expect(getInboundAddresses).toHaveBeenCalledOnce()
+    expect(getInboundAddresses).not.toHaveBeenCalled()
   })
 
   it('does not treat a standard liquidity-withdraw memo as a secured-asset withdrawal', async () => {
-    const getInboundAddresses = vi.fn(async nativeChain => {
-      expect(nativeChain).toBe(Chain.THORChain)
-      return [makeInbound('THOR', 'thor1active')]
-    })
+    const getInboundAddresses = vi.fn()
 
     await expect(
       assertNativeSwapReadyForBroadcast({
         chain: Chain.THORChain,
         keysignPayload: makeSecuredAssetWithdrawalPayload({
-          vaultAddress: 'thor1stale',
           memo: '-:BTC.BTC:10000',
-          expirationTime: 1_700_000_100n,
         }),
         getInboundAddresses,
         now: () => 1_700_000_000_000,
       })
-    ).rejects.toThrow(/inbound vault address changed/)
+    ).rejects.toThrow(/missing or invalid expiration/)
 
-    expect(getInboundAddresses).toHaveBeenCalledOnce()
+    expect(getInboundAddresses).not.toHaveBeenCalled()
   })
 
   it('rejects expired Maya native swap payloads before fetching inbound addresses', async () => {
@@ -398,6 +392,98 @@ describe('assertNativeSwapReadyForBroadcast', () => {
         now: () => 1_700_000_000_000,
       })
     ).resolves.toBeUndefined()
+  })
+
+  // sdk#1726: a RUNE/CACAO-source swap is a MsgDeposit with no inbound vault, and the
+  // /inbound_addresses feed never lists the protocol's own chain - the guard must not demand an
+  // inbound entry (or a vault-address match) for those routes, or every native-source swap is
+  // refused before broadcast.
+  it('allows a RUNE-source THORChain swap even though the feed has no THOR entry', async () => {
+    await expect(
+      assertNativeSwapReadyForBroadcast({
+        chain: Chain.THORChain,
+        keysignPayload: makeThorchainSwapPayload({ vaultAddress: '', toChain: Chain.Ethereum }),
+        getInboundAddresses: async () => [makeInbound('ETH', '0xactive')],
+        now: () => 1_700_000_000_000,
+      })
+    ).resolves.toBeUndefined()
+  })
+
+  it('allows a CACAO-source MayaChain swap even though the feed has no MAYA entry', async () => {
+    await expect(
+      assertNativeSwapReadyForBroadcast({
+        chain: Chain.MayaChain,
+        keysignPayload: makeMayachainSwapPayload({ vaultAddress: '' }),
+        getInboundAddresses: async () => [makeInbound('DASH', 'dash1active')],
+        now: () => 1_700_000_000_000,
+      })
+    ).resolves.toBeUndefined()
+  })
+
+  it('still rejects a RUNE-source swap when the destination chain is halted', async () => {
+    await expect(
+      assertNativeSwapReadyForBroadcast({
+        chain: Chain.THORChain,
+        keysignPayload: makeThorchainSwapPayload({ vaultAddress: '', toChain: Chain.Ethereum }),
+        getInboundAddresses: async () => [makeInbound('ETH', '0xactive', { halted: true })],
+        now: () => 1_700_000_000_000,
+      })
+    ).rejects.toThrow(/trading is halted for ETH/)
+  })
+
+  it('still rejects a RUNE-source swap when global trading is paused', async () => {
+    await expect(
+      assertNativeSwapReadyForBroadcast({
+        chain: Chain.THORChain,
+        keysignPayload: makeThorchainSwapPayload({ vaultAddress: '', toChain: Chain.Ethereum }),
+        getInboundAddresses: async () => [makeInbound('ETH', '0xactive', { global_trading_paused: true })],
+        now: () => 1_700_000_000_000,
+      })
+    ).rejects.toThrow(/trading is halted/)
+  })
+
+  it('still rejects an expired RUNE-source swap quote before fetching inbound addresses', async () => {
+    const getInboundAddresses = vi.fn()
+
+    await expect(
+      assertNativeSwapReadyForBroadcast({
+        chain: Chain.THORChain,
+        keysignPayload: makeThorchainSwapPayload({
+          vaultAddress: '',
+          expirationTime: 1_700_000_000n,
+          toChain: Chain.Ethereum,
+        }),
+        getInboundAddresses,
+        now: () => 1_700_000_001_000,
+      })
+    ).rejects.toThrow(/expired/)
+
+    expect(getInboundAddresses).not.toHaveBeenCalled()
+  })
+
+  it('skips the vault-address comparison for a RUNE-source swap even if the feed lists THOR', async () => {
+    await expect(
+      assertNativeSwapReadyForBroadcast({
+        chain: Chain.THORChain,
+        keysignPayload: makeThorchainSwapPayload({ vaultAddress: '', toChain: Chain.Ethereum }),
+        getInboundAddresses: async () => [makeInbound('THOR', 'thor1unexpected'), makeInbound('ETH', '0xactive')],
+        now: () => 1_700_000_000_000,
+      })
+    ).resolves.toBeUndefined()
+  })
+
+  it('still validates the inbound vault when RUNE is the source of a MayaChain swap', async () => {
+    await expect(
+      assertNativeSwapReadyForBroadcast({
+        chain: Chain.THORChain,
+        keysignPayload: makeMayachainSwapPayload({ vaultAddress: 'thor1old' }),
+        getInboundAddresses: async nativeChain => {
+          expect(nativeChain).toBe(Chain.MayaChain)
+          return [makeInbound('THOR', 'thor1active')]
+        },
+        now: () => 1_700_000_000_000,
+      })
+    ).rejects.toThrow(/MayaChain inbound vault address changed/)
   })
 
   it('rejects when global_trading_paused is set on any inbound entry, not only the source', async () => {


### PR DESCRIPTION
Fixes #1726

## Problem

`assertNativeSwapReadyForBroadcast` resolves the swap's **source** chain in the `/inbound_addresses` feed and throws when it finds no entry. That feed only lists external chains — THOR and MAYA are never in it, by design: a native RUNE/CACAO swap is a `MsgDeposit` sent straight to the network and has no inbound vault. So every RUNE-source (and CACAO-source) swap was signed and then refused locally at the broadcast step, with a misleading "network rejected this transaction" error. Nothing ever reached the network.

## Fix

When the swap source is the protocol's own chain (`chain === native.chain`), skip the inbound-vault existence check and the vault-address staleness comparison — the same tolerance the halt-check loop in this file already applies to route legs with no inbound entry. Everything else still runs for those routes:

- quote-expiry validation
- source/destination trading-halt checks (`halted`, `chain_trading_paused`)
- network-wide `global_trading_paused`

A RUNE source routed **via Maya** is deliberately not exempt: Maya's feed lists THOR as an external chain, so the full vault validation still applies there (covered by a test).

## Tests

Added regression coverage for source-is-native-chain routes (the gap called out in the issue): RUNE- and CACAO-source swaps pass with no THOR/MAYA feed entry, still reject on destination halt / global pause / expired quote, and skip the vault-address comparison even if the feed ever grew a THOR entry.

Two existing tests pinned the secured-withdrawal non-exemption behavior through the vault-address check on a THOR-source payload — an observable this fix removes on purpose. They now pin the same non-exemption through the expiry check the exemption would have skipped.

`yarn check` passes; the guard suite is 29/29. The handful of CLI config-dir/credential-permission test failures in `yarn test` are pre-existing on `main` (verified via stash) and unrelated.