### PR TITLE
fix(sdk): align Solana duplicate broadcast semantics

### DIFF
--- a/.changeset/quiet-rivers-accept-solana-duplicates.md
+++ b/.changeset/quiet-rivers-accept-solana-duplicates.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Align raw Solana duplicate-broadcast handling with the core and React Native resolvers by treating `AlreadyProcessed` as broadcast acceptance and leaving execution outcome checks to transaction status resolution.

--- a/.changeset/quiet-rivers-accept-solana-duplicates.md
+++ b/.changeset/quiet-rivers-accept-solana-duplicates.md
@@ -2,4 +2,4 @@
 '@vultisig/sdk': patch
 ---
 
-Align raw Solana duplicate-broadcast handling with the core and React Native resolvers by treating `AlreadyProcessed` as broadcast acceptance and leaving execution outcome checks to transaction status resolution.
+Align raw Solana duplicate-broadcast handling with the core and React Native resolvers by accepting `AlreadyProcessed` when status is pending or unavailable while still rejecting explicit on-chain failures.

--- a/packages/sdk/src/vault/services/RawBroadcastService.ts
+++ b/packages/sdk/src/vault/services/RawBroadcastService.ts
@@ -267,9 +267,23 @@ export class RawBroadcastService {
 
     if (error) {
       if (isInError(error, 'already been processed', 'AlreadyProcessed')) {
-        // Match the authoritative core resolver: the node already accepted this
-        // exact signed payload, while execution outcome remains status-layer work.
-        return deriveSolanaRawTxSignature(rawTx)
+        const signature = deriveSolanaRawTxSignature(rawTx)
+
+        // A duplicate error proves that the node has seen this exact signed payload, but it
+        // does not prove successful execution. Reject only when the node already exposes an
+        // explicit failure; an unavailable or not-yet-indexed status remains accepted.
+        const { data: statuses } = await attempt(
+          client.getSignatureStatuses([signature], { searchTransactionHistory: true })
+        )
+        const signatureStatus = statuses?.value?.[0]
+        if (signatureStatus?.err) {
+          throw new VaultError(
+            VaultErrorCode.BroadcastFailed,
+            `Solana transaction was already processed but failed on-chain: ${JSON.stringify(signatureStatus.err)}`
+          )
+        }
+
+        return signature
       }
       throw error
     }

--- a/packages/sdk/src/vault/services/RawBroadcastService.ts
+++ b/packages/sdk/src/vault/services/RawBroadcastService.ts
@@ -265,20 +265,16 @@ export class RawBroadcastService {
       })
     )
 
-    let signature = sentSignature
-    let isDuplicate = false
     if (error) {
       if (isInError(error, 'already been processed', 'AlreadyProcessed')) {
-        // "AlreadyProcessed" only proves the node has seen and executed this signature before -
-        // not that the original execution succeeded. It must go through the same on-chain-failure
-        // check below as a fresh send, not be handed back as a hash unconditionally.
-        signature = deriveSolanaRawTxSignature(rawTx)
-        isDuplicate = true
-      } else {
-        throw error
+        // Match the authoritative core resolver: the node already accepted this
+        // exact signed payload, while execution outcome remains status-layer work.
+        return deriveSolanaRawTxSignature(rawTx)
       }
+      throw error
     }
 
+    const signature = sentSignature
     if (!signature) throw new Error('No transaction signature returned')
 
     // sendRawTransaction only confirms the node ACCEPTED the payload into its queue - it is
@@ -290,9 +286,7 @@ export class RawBroadcastService {
     // this bounded, non-blocking status check catches that without adding real broadcast
     // latency: it never blocks/throws on "not yet confirmed" (the normal state right after
     // submission), only on an explicit on-chain error already attached to this signature.
-    // This also covers the "already been processed" idempotent-retry path above: a duplicate
-    // signature that already failed on-chain must still fail closed here, not report success.
-    const { data: statuses, error: statusError } = await attempt(
+    const { data: statuses } = await attempt(
       client.getSignatureStatuses([signature], { searchTransactionHistory: true })
     )
     const signatureStatus = statuses?.value?.[0]
@@ -300,16 +294,6 @@ export class RawBroadcastService {
       throw new VaultError(
         VaultErrorCode.BroadcastFailed,
         `Solana transaction was submitted but failed on-chain: ${JSON.stringify(signatureStatus.err)}`
-      )
-    }
-
-    if (isDuplicate && !signatureStatus) {
-      const lookupMessage =
-        statusError instanceof Error ? statusError.message : String(statusError ?? 'transaction status not found')
-      throw new VaultError(
-        VaultErrorCode.BroadcastFailed,
-        `Solana transaction may already have been processed, but its execution result could not be verified: ${lookupMessage}`,
-        statusError instanceof Error ? statusError : new Error(lookupMessage)
       )
     }
 

--- a/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
+++ b/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
@@ -221,11 +221,10 @@ describe('RawBroadcastService', () => {
     expect(hash).toBe('sol-signature')
   })
 
-  it('treats duplicate-style Solana broadcast errors as idempotent success', async () => {
+  it('treats duplicate-style Solana broadcast errors as acceptance without requiring a status lookup', async () => {
     const signature = Uint8Array.from({ length: 64 }, (_, index) => index + 1)
     const rawTx = Buffer.from(Uint8Array.from([1, ...signature, 0])).toString('base64')
     mockSendSolanaRawTx.mockRejectedValue(new Error('AlreadyProcessed'))
-    mockGetSolanaSignatureStatuses.mockResolvedValue({ value: [{ err: null }] })
 
     const hash = await service.broadcastRawTx({
       chain: Chain.Solana,
@@ -233,54 +232,7 @@ describe('RawBroadcastService', () => {
     })
 
     expect(hash).toBe(base58.encode(signature))
-  })
-
-  // Fund-safety: "AlreadyProcessed" only proves the node executed this signature before, not
-  // that the execution succeeded. The idempotent-retry path must run through the same
-  // on-chain-failure status check as a fresh send, not report success unconditionally.
-  it('fails closed on a duplicate-style Solana broadcast error when the signature already failed on-chain', async () => {
-    const signature = Uint8Array.from({ length: 64 }, (_, index) => index + 1)
-    const rawTx = Buffer.from(Uint8Array.from([1, ...signature, 0])).toString('base64')
-    mockSendSolanaRawTx.mockRejectedValue(new Error('AlreadyProcessed'))
-    mockGetSolanaSignatureStatuses.mockResolvedValue({
-      value: [{ err: { InstructionError: [0, 'Custom'] } }],
-    })
-
-    await expect(
-      service.broadcastRawTx({
-        chain: Chain.Solana,
-        rawTx,
-      })
-    ).rejects.toMatchObject({
-      code: VaultErrorCode.BroadcastFailed,
-      message: expect.stringContaining('failed on-chain'),
-    })
-  })
-
-  it.each([
-    {
-      name: 'the status lookup finds no record',
-      arrange: () => mockGetSolanaSignatureStatuses.mockResolvedValue({ value: [null] }),
-    },
-    {
-      name: 'the status lookup errors',
-      arrange: () => mockGetSolanaSignatureStatuses.mockRejectedValue(new Error('rpc down')),
-    },
-  ])('fails closed on a duplicate-style Solana broadcast error when $name', async ({ arrange }) => {
-    const signature = Uint8Array.from({ length: 64 }, (_, index) => index + 1)
-    const rawTx = Buffer.from(Uint8Array.from([1, ...signature, 0])).toString('base64')
-    mockSendSolanaRawTx.mockRejectedValue(new Error('AlreadyProcessed'))
-    arrange()
-
-    await expect(
-      service.broadcastRawTx({
-        chain: Chain.Solana,
-        rawTx,
-      })
-    ).rejects.toMatchObject({
-      code: VaultErrorCode.BroadcastFailed,
-      message: expect.stringContaining('could not be verified'),
-    })
+    expect(mockGetSolanaSignatureStatuses).not.toHaveBeenCalled()
   })
 
   it('broadcasts Cosmos tx when rawTx is JSON with tx_bytes', async () => {

--- a/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
+++ b/packages/sdk/tests/unit/vault/services/RawBroadcastService.test.ts
@@ -221,10 +221,33 @@ describe('RawBroadcastService', () => {
     expect(hash).toBe('sol-signature')
   })
 
-  it('treats duplicate-style Solana broadcast errors as acceptance without requiring a status lookup', async () => {
+  it('rejects a duplicate Solana transaction with an explicit on-chain failure', async () => {
     const signature = Uint8Array.from({ length: 64 }, (_, index) => index + 1)
     const rawTx = Buffer.from(Uint8Array.from([1, ...signature, 0])).toString('base64')
     mockSendSolanaRawTx.mockRejectedValue(new Error('AlreadyProcessed'))
+    mockGetSolanaSignatureStatuses.mockResolvedValue({
+      value: [{ err: { InstructionError: [0, 'Custom'] } }],
+    })
+
+    await expect(
+      service.broadcastRawTx({
+        chain: Chain.Solana,
+        rawTx,
+      })
+    ).rejects.toMatchObject({
+      code: VaultErrorCode.BroadcastFailed,
+      message: expect.stringContaining('failed on-chain'),
+    })
+    expect(mockGetSolanaSignatureStatuses).toHaveBeenCalledWith([base58.encode(signature)], {
+      searchTransactionHistory: true,
+    })
+  })
+
+  it('accepts a duplicate Solana transaction when its status is not indexed yet', async () => {
+    const signature = Uint8Array.from({ length: 64 }, (_, index) => index + 1)
+    const rawTx = Buffer.from(Uint8Array.from([1, ...signature, 0])).toString('base64')
+    mockSendSolanaRawTx.mockRejectedValue(new Error('AlreadyProcessed'))
+    mockGetSolanaSignatureStatuses.mockResolvedValue({ value: [null] })
 
     const hash = await service.broadcastRawTx({
       chain: Chain.Solana,
@@ -232,7 +255,20 @@ describe('RawBroadcastService', () => {
     })
 
     expect(hash).toBe(base58.encode(signature))
-    expect(mockGetSolanaSignatureStatuses).not.toHaveBeenCalled()
+  })
+
+  it('accepts a duplicate Solana transaction when its best-effort status lookup is unavailable', async () => {
+    const signature = Uint8Array.from({ length: 64 }, (_, index) => index + 1)
+    const rawTx = Buffer.from(Uint8Array.from([1, ...signature, 0])).toString('base64')
+    mockSendSolanaRawTx.mockRejectedValue(new Error('AlreadyProcessed'))
+    mockGetSolanaSignatureStatuses.mockRejectedValue(new Error('rpc down'))
+
+    const hash = await service.broadcastRawTx({
+      chain: Chain.Solana,
+      rawTx,
+    })
+
+    expect(hash).toBe(base58.encode(signature))
   })
 
   it('broadcasts Cosmos tx when rawTx is JSON with tx_bytes', async () => {


### PR DESCRIPTION
## Summary

- Treat Solana `AlreadyProcessed` responses as broadcast-layer acceptance in `RawBroadcastService`, matching the core and React Native resolvers.
- Leave execution success or failure to the transaction-status layer.
- Add regression coverage and a patch changeset.

Follow-up to #1754.

## Testing

- `yarn vitest run --config tests/unit/vitest.config.ts tests/unit/vault/services/RawBroadcastService.test.ts tests/unit/platforms/react-native/solana-rpc.test.ts`
- `yarn workspace @vultisig/sdk typecheck`
- `yarn format:check`
- `yarn changeset status --since origin/main`

Closes #1227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Solana transaction broadcasting to handle duplicate submissions more reliably.
  * Returned transaction signatures when duplicate transactions are pending or their status cannot yet be confirmed.
  * Continued rejecting transactions explicitly reported as failed on-chain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->