### PR TITLE
fix(ci): unblock the static quality gate on the js-yaml advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,7 +195,6 @@
     "axios": "1.18.1",
     "esbuild@npm:~0.28.0": "0.28.1",
     "shell-quote": "1.10.0",
-    "js-yaml@npm:4.1.1": "^4.3.0",
     "tmp@npm:^0.0.33": "0.2.7",
     "tmp@npm:^0.2.0": "0.2.7",
     "esbuild": "^0.28.1",
@@ -224,6 +223,11 @@
     "brace-expansion@npm:^1.1.7": "1.1.18",
     "brace-expansion@npm:^2.0.1": "2.1.4",
     "brace-expansion@npm:^2.0.2": "2.1.4",
-    "brace-expansion@npm:^5.0.5": "5.0.9"
+    "brace-expansion@npm:^5.0.5": "5.0.9",
+    "js-yaml@npm:^3.6.1": "3.15.1",
+    "js-yaml@npm:^4.1.0": "^4.3.1",
+    "js-yaml@npm:^4.1.1": "^4.3.1",
+    "js-yaml@npm:^4.3.0": "^4.3.1",
+    "js-yaml@npm:4.1.1": "^4.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13534,26 +13534,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^3.6.1":
-  version: 3.15.0
-  resolution: "js-yaml@npm:3.15.0"
+"js-yaml@npm:3.15.1":
+  version: 3.15.1
+  resolution: "js-yaml@npm:3.15.1"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/ca966bd354ac5b1b7a4694ebdba46526796aa3a6a99529fa540af2abf85918bd155a50ccc0166b413130a00622999973754458ec01e7095bc902177bfdbd5b64
+  checksum: 10c0/6c693b8c59ffe12021df3b36994b090df19d920826dd810baab81652b40861e1974509dd11fe92225ab4c00cc14de053300c94db015c2c0e211edea39b118737
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1, js-yaml@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "js-yaml@npm:4.3.0"
+"js-yaml@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "js-yaml@npm:4.3.1"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
+  checksum: 10c0/13c500ca322e0c3f8c81686e6ecda96d2ea37b45247a420c17c7db36932d6965cc27391abc2d1a104501600e7f0d947a5f8b7be6db619c4fefa87901b3512807
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## what

Unblocks the **entire SDK merge queue**. `Lint and Type Check` is currently failing on every open PR, and `Test Summary` fails downstream of it, so nothing can merge.

## it is not any branch's fault

Established by differential, not by guessing. Six unrelated PRs were re-run after `update-branch` and all six failed the same step, including #1246, which is a pure dependabot lockfile bump with no source changes at all:

```
#1763  Lint and Type Check   FAIL
#1744  Lint and Type Check   FAIL
#1624  Lint and Type Check   FAIL
#1621  Lint and Type Check   FAIL
#1618  Lint and Type Check   FAIL
#1246  Lint and Type Check   FAIL   <- lockfile-only bump
```

The failing step is `quality:audit`, which is `yarn npm audit --recursive --all --severity high`.

## root cause

`GHSA-5p4m-2wfm-xmqj` was published against **js-yaml**: quadratic CPU consumption in `!!omap` resolution, severity high, the CVE-2026-59870 fix not backported. The tree carried two vulnerable instances:

```
js-yaml 3.15.0   via read-yaml-file@1.1.0    vulnerable >=3.0.0 <3.15.1
js-yaml 4.3.0    via the existing 4.x pin    vulnerable >=4.0.0 <4.3.1
```

Both are transitive and dev-only, and both have a published patch, so the fix is a lockfile move with no source change.

## the fix, and the trap in it

Resolutions for every js-yaml descriptor actually present in the tree. The 3.x range had none at all, which is why it was never caught before.

Worth flagging one thing, because I walked into it while writing this. My first pass replaced the pre-existing `"js-yaml@npm:4.1.1": "^4.3.0"` entry with caret-ranged ones and re-resolved. The lock came back with a `js-yaml@npm:4.1.1` entry pinned at **4.1.1**, still inside the vulnerable range. An **exact** descriptor is not matched by a caret resolution, so removing that entry quietly reopened the hole the change was meant to close. It is restored, pointing at `^4.3.1`.

## receipts

```
before:  audit exits 1, both advisories reported   (this is exactly what CI saw)
after:   audit exits 0, "No audit suggestions"

js-yaml in the refreshed lock:
  "js-yaml@npm:3.15.1"   -> 3.15.1
  "js-yaml@npm:^4.3.1"   -> 4.3.1
```

Both now sit above the advisory line, and no `4.1.1` entry survives. The lock diff resolves `js-yaml` and nothing else, verified by extracting every changed `resolution:` line.

Note that one audit run failed mid-verification with `ETIMEDOUT` reaching the registry rather than with a finding. That is a network flake, not a result; the clean run above is the real one.

## risk

Low. Dev-only transitive dependency, patch-level moves within the same majors, no source change. The gate itself was behaving correctly the whole time and stays fail-closed.
