### PR TITLE
fix(stakekit): scope enabled-yield cache by API key

### DIFF
--- a/.changeset/stakekit-cache-api-key-scope-r113.md
+++ b/.changeset/stakekit-cache-api-key-scope-r113.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Scope StakeKit enabled-yield cache entries by API key so one caller's allowed product set cannot be reused for a different project's credentials.

--- a/packages/sdk/src/tools/defi/stakekit/stakekitApi.ts
+++ b/packages/sdk/src/tools/defi/stakekit/stakekitApi.ts
@@ -23,6 +23,10 @@ function authHeaders(apiKey?: string, extra: Record<string, string> = {}): Recor
   return headers
 }
 
+function stakekitAuthScope(apiKey?: string): string {
+  return apiKey ? `key:${apiKey}` : 'key:none'
+}
+
 // --- Simple TTL cache (same pattern as defi-llama.ts) ---
 
 const cache = new Map<string, { data: unknown; expires: number }>()
@@ -207,7 +211,7 @@ export async function searchYields(params: {
   if (params.provider) query.set('provider', params.provider)
   if (params.limit) query.set('limit', String(params.limit))
 
-  const cacheKey = `yield:search:${query.toString()}`
+  const cacheKey = `yield:search:${stakekitAuthScope(params.apiKey)}:${query.toString()}`
   const cached = getCached<YieldProduct[]>(cacheKey)
   if (cached) return cached
 

--- a/packages/sdk/tests/unit/tools/defi/stakekit.test.ts
+++ b/packages/sdk/tests/unit/tools/defi/stakekit.test.ts
@@ -166,6 +166,33 @@ describe('sdk.defi.stakekit', () => {
       expect(opp.isAvailable).toBe(true)
     })
 
+    it('scopes enabled-yield cache entries by API key', async () => {
+      const keyAProduct = makeProduct({ id: 'ethereum-eth-key-a', metadata: { ...makeProduct().metadata, name: 'Key A Product' } })
+      const keyBProduct = makeProduct({ id: 'ethereum-eth-key-b', metadata: { ...makeProduct().metadata, name: 'Key B Product' } })
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({ data: [keyAProduct], hasNextPage: false }),
+          text: async () => '',
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({ data: [keyBProduct], hasNextPage: false }),
+          text: async () => '',
+        } as Response)
+      globalThis.fetch = fetchMock
+
+      const a = await stakekitSearch({ network: 'ethereum', provider: 'lido', apiKey: 'key-a' })
+      const b = await stakekitSearch({ network: 'ethereum', provider: 'lido', apiKey: 'key-b' })
+
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(a[0]?.id).toBe('ethereum-eth-key-a')
+      expect(b[0]?.id).toBe('ethereum-eth-key-b')
+    })
+
     it('applies client-side token filter (stakek.it ignores token param server-side)', async () => {
       const eth = makeProduct({ id: 'ethereum-eth-lido-staking' })
       const usdc = makeProduct({


### PR DESCRIPTION
## Summary
- scope StakeKit enabled-yield cache entries by API key
- add regression coverage proving identical queries from different keys do not reuse cached results
- add a patch changeset for the SDK fix

Closes https://github.com/vultisig/vultisig-sdk/issues/1789

## Receipts
- 
[1m[30m[46m RUN [49m[39m[22m [36mv4.1.8 [39m[90m/private/tmp/sdk-r113/packages/sdk[39m

 [32m✓[39m tests/unit/tools/defi/stakekit.test.ts[2m > [22msdk.defi.stakekit[2m > [22mstakekitSearch[2m > [22mnormalizes public network aliases at the StakeKit request boundary[32m 1[2mms[22m[39m
 [32m✓[39m tests/unit/tools/defi/stakekit.test.ts[2m > [22msdk.defi.stakekit[2m > [22mstakekitSearch[2m > [22mreturns rows with YieldDiscoverOpportunity-compatible shape: apy is fraction, provider nested in metadata, id present[32m 1[2mms[22m[39m
 [32m✓[39m tests/unit/tools/defi/stakekit.test.ts[2m > [22msdk.defi.stakekit[2m > [22mstakekitSearch[2m > [22mscopes enabled-yield cache entries by API key[32m 0[2mms[22m[39m
 [32m✓[39m tests/unit/tools/defi/stakekit.test.ts[2m > [22msdk.defi.stakekit[2m > [22mstakekitSearch[2m > [22mapplies client-side token filter (stakek.it ignores token param server-side)[32m 0[2mms[22m[39m
 [32m✓[39m tests/unit/tools/defi/stakekit.test.ts[2m > [22msdk.defi.stakekit[2m > [22mparseActionDisplay[2m > [22mEVM steps: flat shape with NO tx_encoding field, provider: "yield_xyz" at top level[32m 0[2mms[22m[39m
 [32m✓[39m tests/unit/tools/defi/stakekit.test.ts[2m > [22msdk.defi.stakekit[2m > [22mparseActionDisplay[2m > [22mNon-EVM (Solana) step has tx_encoding: "solana-tx"[32m 0[2mms[22m[39m
 [32m✓[39m tests/unit/tools/defi/stakekit.test.ts[2m > [22msdk.defi.stakekit[2m > [22mparseActionDisplay[2m > [22mall-or-nothing: if any step fails to decode, ALL steps fall back to decoded[][32m 0[2mms[22m[39m
 [32m✓[39m tests/unit/tools/defi/stakekit.test.ts[2m > [22msdk.defi.stakekit[2m > [22mstakekitBuildEnter[2m > [22mreturns unsigned EVM calldata shape: flat {to, value, data, action, description}, provider: "yield_xyz", scan_request[32m 1[2mms[22m[39m
 [32m✓[39m tests/unit/tools/defi/stakekit.test.ts[2m > [22msdk.defi.stakekit[2m > [22mstakekitBuildEnter[2m > [22momits X-API-KEY header when apiKey not supplied[32m 0[2mms[22m[39m
 [32m✓[39m tests/unit/tools/defi/stakekit.test.ts[2m > [22msdk.defi.stakekit[2m > [22mstakekitBuildEnter[2m > [22minjects X-API-KEY header when apiKey is supplied[32m 0[2mms[22m[39m
 [32m✓[39m tests/unit/tools/defi/stakekit.test.ts[2m > [22msdk.defi.stakekit[2m > [22mstakekitBuildExit[2m > [22mreturns same unsigned shape as enter + cooldown_days when cooldown present[32m 0[2mms[22m[39m
 [32m✓[39m tests/unit/tools/defi/stakekit.test.ts[2m > [22msdk.defi.stakekit[2m > [22mstakekitBuildExit[2m > [22momits cooldown_days when no cooldown period[32m 0[2mms[22m[39m
 [32m✓[39m tests/unit/tools/defi/stakekit.test.ts[2m > [22msdk.defi.stakekit[2m > [22mstakekitBalances[2m > [22muses the same canonical network aliases as search[32m 0[2mms[22m[39m
 [32m✓[39m tests/unit/tools/defi/stakekit.test.ts[2m > [22msdk.defi.stakekit[2m > [22mstakekitBalances[2m > [22mreturns null on 403 (restricted endpoint)[32m 0[2mms[22m[39m
 [32m✓[39m tests/unit/tools/defi/stakekit.test.ts[2m > [22maction-input validation (ported from mcp-ts validateActionInput, Apo #192)[2m > [22mvalidateStakekitActionAddress: accepts EVM (40 hex), Sui (64 hex), and non-0x; rejects bad 0x lengths[32m 0[2mms[22m[39m
 [32m✓[39m tests/unit/tools/defi/stakekit.test.ts[2m > [22maction-input validation (ported from mcp-ts validateActionInput, Apo #192)[2m > [22mvalidateStakekitActionInput: rejects non-positive / NaN amounts[32m 0[2mms[22m[39m
 [32m✓[39m tests/unit/tools/defi/stakekit.test.ts[2m > [22maction-input validation (ported from mcp-ts validateActionInput, Apo #192)[2m > [22mstakekitBuildEnter throws on a malformed 0x address BEFORE any network call[32m 1[2mms[22m[39m
 [32m✓[39m tests/unit/tools/defi/stakekit.test.ts[2m > [22maction-input validation (ported from mcp-ts validateActionInput, Apo #192)[2m > [22mstakekitBuildEnter throws on a non-positive amount BEFORE any network call[32m 0[2mms[22m[39m
 [32m✓[39m tests/unit/tools/defi/stakekit.test.ts[2m > [22maction-input validation (ported from mcp-ts validateActionInput, Apo #192)[2m > [22mstakekitBuildExit throws on a malformed 0x address BEFORE any network call[32m 0[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m19 passed[39m[22m[90m (19)[39m
[2m   Start at [22m 09:17:36
[2m   Duration [22m 157ms[2m (transform 62ms, setup 48ms, import 35ms, tests 7ms, environment 0ms)[22m
- 
- broader packages/core/mpc/keysign/signingInputs/resolvers/cardano.ts(72,5): error TS2353: Object literal may only specify known properties, and 'auxiliaryData' does not exist in type 'ISigningInput'. is still red on untouched  ( type mismatch)

## Report
- https://gist.github.com/gomesalexandre/951024d12c935ea998025e742ec8d31f
