### PR TITLE
feat(swap): normalize swap arrival status

### DIFF
--- a/.changeset/swap-arrival-status-terminal-fixes.md
+++ b/.changeset/swap-arrival-status-terminal-fixes.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/sdk': patch
+---
+
+Fix three unsafe terminal-state gaps in `getSwapArrivalStatus`: LI.FI `DONE/PARTIAL` (user received a different token than requested) is now reported as a distinct `partial` status instead of being flattened into `success`; malformed or unknown Midgard action statuses now throw `SwapArrivalStatusRequestError` instead of being reported as a terminal `error`; and THOR/Maya node-only completion now reads THORNode's `planned_out_txs[].refund` flag to report `success`/`refunded` when available, instead of always forcing an artificial `pending` state.

--- a/.changeset/swap-arrival-status.md
+++ b/.changeset/swap-arrival-status.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/core-chain': minor
+'@vultisig/sdk': minor
+---
+
+Add provider-aware swap arrival status normalization for THORChain, MayaChain, Skip Go, and LI.FI.

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -2033,6 +2033,11 @@
       "import": "./dist/swap/SwapFee.js",
       "default": "./dist/swap/SwapFee.js"
     },
+    "./swap/utils/getSwapArrivalStatus": {
+      "types": "./dist/swap/utils/getSwapArrivalStatus/index.d.ts",
+      "import": "./dist/swap/utils/getSwapArrivalStatus/index.js",
+      "default": "./dist/swap/utils/getSwapArrivalStatus/index.js"
+    },
     "./swap/utils/getSwapExplorerUrl": {
       "types": "./dist/swap/utils/getSwapExplorerUrl/index.d.ts",
       "import": "./dist/swap/utils/getSwapExplorerUrl/index.js",

--- a/packages/core/chain/swap/utils/getSwapArrivalStatus/fixtures.json
+++ b/packages/core/chain/swap/utils/getSwapArrivalStatus/fixtures.json
@@ -53,6 +53,14 @@
             "ibc_transfer": {
               "packet_txs": {
                 "send_tx": { "tx_hash": "SKIP-SOURCE" },
+                "receive_tx": { "tx_hash": "SKIP-INTERMEDIATE" }
+              }
+            }
+          },
+          {
+            "ibc_transfer": {
+              "packet_txs": {
+                "send_tx": { "tx_hash": "SKIP-INTERMEDIATE" },
                 "receive_tx": { "tx_hash": "SKIP-DESTINATION" }
               }
             }

--- a/packages/core/chain/swap/utils/getSwapArrivalStatus/fixtures.json
+++ b/packages/core/chain/swap/utils/getSwapArrivalStatus/fixtures.json
@@ -20,6 +20,32 @@
     },
     "out_txs": [{ "id": "THOR-REAL-OUT", "chain": "BTC" }]
   },
+  "thorchainNodeCompleteWithPlannedRefund": {
+    "tx": { "id": "THOR-REFUND-SOURCE" },
+    "stages": {
+      "inbound_observed": { "started": true, "completed": true },
+      "inbound_confirmation_counted": { "completed": true },
+      "inbound_finalised": { "completed": true },
+      "swap_status": { "pending": false },
+      "swap_finalised": { "completed": true },
+      "outbound_signed": { "completed": true }
+    },
+    "planned_out_txs": [{ "chain": "BTC", "refund": true }],
+    "out_txs": [{ "id": "THOR-REAL-OUT", "chain": "BTC" }]
+  },
+  "thorchainNodeCompleteWithPlannedSwapOutput": {
+    "tx": { "id": "THOR-SUCCESS-SOURCE" },
+    "stages": {
+      "inbound_observed": { "started": true, "completed": true },
+      "inbound_confirmation_counted": { "completed": true },
+      "inbound_finalised": { "completed": true },
+      "swap_status": { "pending": false },
+      "swap_finalised": { "completed": true },
+      "outbound_signed": { "completed": true }
+    },
+    "planned_out_txs": [{ "chain": "BTC", "refund": false }],
+    "out_txs": [{ "id": "THOR-REAL-OUT", "chain": "BTC" }]
+  },
   "thorchainMidgardPending": {
     "count": "1",
     "actions": [
@@ -41,6 +67,16 @@
         "in": [{ "txID": "THOR-REFUND-SOURCE" }],
         "out": [{ "txID": "THOR-REFUND-OUT" }],
         "metadata": { "refund": { "reason": "emit asset less than price limit" } }
+      }
+    ]
+  },
+  "thorchainMidgardMalformedSwapStatus": {
+    "count": "1",
+    "actions": [
+      {
+        "type": "swap",
+        "in": [{ "txID": "THOR-SOURCE" }],
+        "out": []
       }
     ]
   },

--- a/packages/core/chain/swap/utils/getSwapArrivalStatus/fixtures.json
+++ b/packages/core/chain/swap/utils/getSwapArrivalStatus/fixtures.json
@@ -8,6 +8,18 @@
       "swap_status": { "pending": true }
     }
   },
+  "thorchainNodeCompleteWithOutbound": {
+    "tx": { "id": "THOR-REFUND-SOURCE" },
+    "stages": {
+      "inbound_observed": { "started": true, "completed": true },
+      "inbound_confirmation_counted": { "completed": true },
+      "inbound_finalised": { "completed": true },
+      "swap_status": { "pending": false },
+      "swap_finalised": { "completed": true },
+      "outbound_signed": { "completed": true }
+    },
+    "out_txs": [{ "id": "THOR-REAL-OUT", "chain": "BTC" }]
+  },
   "thorchainMidgardPending": {
     "count": "1",
     "actions": [

--- a/packages/core/chain/swap/utils/getSwapArrivalStatus/fixtures.json
+++ b/packages/core/chain/swap/utils/getSwapArrivalStatus/fixtures.json
@@ -1,0 +1,87 @@
+{
+  "thorchainNodePending": {
+    "tx": { "id": "THOR-SOURCE" },
+    "stages": {
+      "inbound_observed": { "started": true, "completed": true },
+      "inbound_confirmation_counted": { "completed": true },
+      "inbound_finalised": { "completed": true },
+      "swap_status": { "pending": true }
+    }
+  },
+  "thorchainMidgardPending": {
+    "count": "1",
+    "actions": [
+      {
+        "status": "pending",
+        "type": "swap",
+        "in": [{ "txID": "THOR-SOURCE" }],
+        "out": [],
+        "metadata": { "swap": { "memo": "=:BTC.BTC:bc1destination" } }
+      }
+    ]
+  },
+  "thorchainMidgardRefunded": {
+    "count": "1",
+    "actions": [
+      {
+        "status": "success",
+        "type": "refund",
+        "in": [{ "txID": "THOR-REFUND-SOURCE" }],
+        "out": [{ "txID": "THOR-REFUND-OUT" }],
+        "metadata": { "refund": { "reason": "emit asset less than price limit" } }
+      }
+    ]
+  },
+  "mayachainMidgardSuccess": {
+    "count": "1",
+    "actions": [
+      {
+        "status": "success",
+        "type": "swap",
+        "in": [{ "txID": "MAYA-SOURCE" }],
+        "out": [{ "txID": "MAYA-DESTINATION" }],
+        "metadata": { "swap": { "memo": "=:BTC.BTC:bc1destination" } }
+      }
+    ]
+  },
+  "skipCompleted": {
+    "state": "STATE_COMPLETED_SUCCESS",
+    "transfers": [
+      {
+        "transfer_sequence": [
+          {
+            "ibc_transfer": {
+              "packet_txs": {
+                "send_tx": { "tx_hash": "SKIP-SOURCE" },
+                "receive_tx": { "tx_hash": "SKIP-DESTINATION" }
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "transfer_asset_release": { "chain_id": "osmosis-1", "released": true },
+    "error": null
+  },
+  "skipRefunded": {
+    "state": "STATE_COMPLETED_ERROR",
+    "transfers": [],
+    "transfer_asset_release": { "chain_id": "cosmoshub-4", "released": true },
+    "error": { "message": "route failed and assets returned" }
+  },
+  "lifiPending": {
+    "transactionId": "lifi-pending",
+    "status": "PENDING",
+    "substatus": "WAIT_DESTINATION_TRANSACTION",
+    "substatusMessage": "Waiting for the destination transaction.",
+    "sending": { "txHash": "0xsource" }
+  },
+  "lifiRefunded": {
+    "transactionId": "lifi-refunded",
+    "status": "DONE",
+    "substatus": "REFUNDED",
+    "substatusMessage": "Tokens were refunded.",
+    "sending": { "txHash": "0xsource" },
+    "receiving": { "txHash": "0xrefund" }
+  }
+}

--- a/packages/core/chain/swap/utils/getSwapArrivalStatus/index.test.ts
+++ b/packages/core/chain/swap/utils/getSwapArrivalStatus/index.test.ts
@@ -76,12 +76,34 @@ describe('getSwapArrivalStatus', () => {
         String(input).includes('/v2/actions') ? jsonResponse({ count: '0', actions: [] }) : jsonResponse({}, 404)
       ) as typeof fetch
 
-      await expect(getSwapArrivalStatus({ provider: 'thorchain', txHash: 'UNKNOWN', fetchImpl })).resolves.toEqual({
+      const result = await getSwapArrivalStatus({ provider: 'thorchain', txHash: 'UNKNOWN', fetchImpl })
+
+      expect(result).toEqual({
         provider: 'thorchain',
         txHash: 'UNKNOWN',
         status: 'not_found',
         stage: 'not_found',
       })
+      expect(isSwapArrivalStatusTerminal(result)).toBe(false)
+    })
+
+    it('keeps a THORNode-completed outbound pending when Midgard is unavailable', async () => {
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL) =>
+        String(input).includes('/v2/actions')
+          ? jsonResponse({ message: 'unavailable' }, 502)
+          : jsonResponse(fixtures.thorchainNodeCompleteWithOutbound)
+      ) as typeof fetch
+
+      const result = await getSwapArrivalStatus({ provider: 'thorchain', txHash: 'THOR-REFUND-SOURCE', fetchImpl })
+
+      expect(result).toEqual({
+        provider: 'thorchain',
+        txHash: 'THOR-REFUND-SOURCE',
+        status: 'pending',
+        stage: 'outbound',
+        destinationTxHash: 'THOR-REAL-OUT',
+      })
+      expect(isSwapArrivalStatusTerminal(result)).toBe(false)
     })
 
     it('throws when both THORChain sources are unavailable instead of reporting a terminal swap error', async () => {
@@ -224,6 +246,20 @@ describe('getSwapArrivalStatus', () => {
       expect(fetchImpl).toHaveBeenCalledWith('https://li.quest/v1/status?txHash=0xsource', expect.any(Object))
     })
 
+    it('keeps LI.FI not-found snapshots pollable during provider indexing', async () => {
+      const fetchImpl = vi.fn(async () => jsonResponse({ status: 'NOT_FOUND' })) as typeof fetch
+
+      const result = await getSwapArrivalStatus({ provider: 'li.fi', txHash: '0xsource', fetchImpl })
+
+      expect(result).toEqual({
+        provider: 'li.fi',
+        txHash: '0xsource',
+        status: 'not_found',
+        stage: 'not_found',
+      })
+      expect(isSwapArrivalStatusTerminal(result)).toBe(false)
+    })
+
     it.each([
       [{ status: 'NOT_FOUND' }, 'not_found', 'not_found'],
       [{ status: 'INVALID' }, 'error', 'failed'],
@@ -250,9 +286,12 @@ describe('getSwapArrivalStatus', () => {
     expect(fetchImpl).not.toHaveBeenCalled()
   })
 
-  it('exposes terminal-state classification without treating pending as terminal', () => {
+  it('keeps pending and not-found snapshots pollable while classifying settled outcomes as terminal', () => {
     expect(
       isSwapArrivalStatusTerminal({ provider: 'skip', txHash: 'hash', status: 'pending', stage: 'outbound' })
+    ).toBe(false)
+    expect(
+      isSwapArrivalStatusTerminal({ provider: 'li.fi', txHash: 'hash', status: 'not_found', stage: 'not_found' })
     ).toBe(false)
     expect(
       isSwapArrivalStatusTerminal({ provider: 'skip', txHash: 'hash', status: 'refunded', stage: 'refunded' })

--- a/packages/core/chain/swap/utils/getSwapArrivalStatus/index.test.ts
+++ b/packages/core/chain/swap/utils/getSwapArrivalStatus/index.test.ts
@@ -109,6 +109,18 @@ describe('getSwapArrivalStatus', () => {
         'unknown actions response'
       )
     })
+
+    it('rejects a mixed Midgard action array instead of accepting its valid prefix', async () => {
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL) =>
+        String(input).includes('/v2/actions')
+          ? jsonResponse({ actions: [...fixtures.mayachainMidgardSuccess.actions, null] })
+          : jsonResponse({}, 404)
+      ) as typeof fetch
+
+      await expect(getSwapArrivalStatus({ provider: 'mayachain', txHash: 'MAYA-SOURCE', fetchImpl })).rejects.toThrow(
+        'unknown actions response'
+      )
+    })
   })
 
   describe('Skip', () => {
@@ -200,6 +212,16 @@ describe('getSwapArrivalStatus', () => {
         destinationTxHash: '0xrefund',
         message: 'Tokens were refunded.',
       })
+    })
+
+    it('keeps the default host when a partial host override is undefined', async () => {
+      const fetchImpl = vi.fn(async () => jsonResponse({ status: 'NOT_FOUND' })) as typeof fetch
+
+      await expect(
+        getSwapArrivalStatus({ provider: 'li.fi', txHash: '0xsource', hosts: { lifi: undefined }, fetchImpl })
+      ).resolves.toMatchObject({ status: 'not_found', stage: 'not_found' })
+
+      expect(fetchImpl).toHaveBeenCalledWith('https://li.quest/v1/status?txHash=0xsource', expect.any(Object))
     })
 
     it.each([

--- a/packages/core/chain/swap/utils/getSwapArrivalStatus/index.test.ts
+++ b/packages/core/chain/swap/utils/getSwapArrivalStatus/index.test.ts
@@ -106,6 +106,56 @@ describe('getSwapArrivalStatus', () => {
       expect(isSwapArrivalStatusTerminal(result)).toBe(false)
     })
 
+    it('throws on a malformed/missing Midgard action status instead of reporting a terminal swap error', async () => {
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL) =>
+        String(input).includes('/v2/actions')
+          ? jsonResponse(fixtures.thorchainMidgardMalformedSwapStatus)
+          : jsonResponse({}, 404)
+      ) as typeof fetch
+
+      await expect(getSwapArrivalStatus({ provider: 'thorchain', txHash: 'THOR-SOURCE', fetchImpl })).rejects.toThrow(
+        SwapArrivalStatusRequestError
+      )
+    })
+
+    it('reports a refund when THORNode planned_out_txs marks the outbound as a refund, even without Midgard', async () => {
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL) =>
+        String(input).includes('/v2/actions')
+          ? jsonResponse({ message: 'unavailable' }, 502)
+          : jsonResponse(fixtures.thorchainNodeCompleteWithPlannedRefund)
+      ) as typeof fetch
+
+      const result = await getSwapArrivalStatus({ provider: 'thorchain', txHash: 'THOR-REFUND-SOURCE', fetchImpl })
+
+      expect(result).toEqual({
+        provider: 'thorchain',
+        txHash: 'THOR-REFUND-SOURCE',
+        status: 'refunded',
+        stage: 'refunded',
+        destinationTxHash: 'THOR-REAL-OUT',
+      })
+      expect(isSwapArrivalStatusTerminal(result)).toBe(true)
+    })
+
+    it('reports success when THORNode planned_out_txs marks the outbound as the swap output, even without Midgard', async () => {
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL) =>
+        String(input).includes('/v2/actions')
+          ? jsonResponse({ message: 'unavailable' }, 502)
+          : jsonResponse(fixtures.thorchainNodeCompleteWithPlannedSwapOutput)
+      ) as typeof fetch
+
+      const result = await getSwapArrivalStatus({ provider: 'thorchain', txHash: 'THOR-SUCCESS-SOURCE', fetchImpl })
+
+      expect(result).toEqual({
+        provider: 'thorchain',
+        txHash: 'THOR-SUCCESS-SOURCE',
+        status: 'success',
+        stage: 'complete',
+        destinationTxHash: 'THOR-REAL-OUT',
+      })
+      expect(isSwapArrivalStatusTerminal(result)).toBe(true)
+    })
+
     it('throws when both THORChain sources are unavailable instead of reporting a terminal swap error', async () => {
       const fetchImpl = vi.fn(async () => jsonResponse({ message: 'unavailable' }, 503)) as typeof fetch
 
@@ -236,6 +286,27 @@ describe('getSwapArrivalStatus', () => {
       })
     })
 
+    it('normalizes DONE/PARTIAL as partial instead of flattening it into success', async () => {
+      const fetchImpl = vi.fn(async () =>
+        jsonResponse({
+          status: 'DONE',
+          substatus: 'PARTIAL',
+          substatusMessage: 'The user received less tokens than expected.',
+          sending: { txHash: '0xsource' },
+          receiving: { txHash: '0xreceived' },
+        })
+      ) as typeof fetch
+
+      await expect(getSwapArrivalStatus({ provider: 'li.fi', txHash: '0xsource', fetchImpl })).resolves.toEqual({
+        provider: 'li.fi',
+        txHash: '0xsource',
+        status: 'partial',
+        stage: 'complete',
+        destinationTxHash: '0xreceived',
+        message: 'The user received less tokens than expected.',
+      })
+    })
+
     it('keeps the default host when a partial host override is undefined', async () => {
       const fetchImpl = vi.fn(async () => jsonResponse({ status: 'NOT_FOUND' })) as typeof fetch
 
@@ -265,7 +336,7 @@ describe('getSwapArrivalStatus', () => {
       [{ status: 'INVALID' }, 'error', 'failed'],
       [{ status: 'FAILED' }, 'error', 'failed'],
       [{ status: 'DONE', substatus: 'COMPLETED' }, 'success', 'complete'],
-      [{ status: 'DONE', substatus: 'PARTIAL' }, 'success', 'complete'],
+      [{ status: 'DONE', substatus: 'PARTIAL' }, 'partial', 'complete'],
       [{ status: 'PENDING', substatus: 'WAIT_SOURCE_CONFIRMATIONS' }, 'pending', 'confirming'],
       [{ status: 'PENDING', substatus: 'REFUND_IN_PROGRESS' }, 'pending', 'refunding'],
     ] as const)('maps $status/$substatus to $1/$2', async (body, status, stage) => {

--- a/packages/core/chain/swap/utils/getSwapArrivalStatus/index.test.ts
+++ b/packages/core/chain/swap/utils/getSwapArrivalStatus/index.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import fixtures from './fixtures.json'
+import { getSwapArrivalStatus, isSwapArrivalStatusTerminal, SwapArrivalStatusRequestError } from './index'
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+
+describe('getSwapArrivalStatus', () => {
+  describe('THORChain and MayaChain', () => {
+    it('combines THORNode stages with a pending Midgard action', async () => {
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        return url.includes('/tx/status/')
+          ? jsonResponse(fixtures.thorchainNodePending)
+          : jsonResponse(fixtures.thorchainMidgardPending)
+      }) as typeof fetch
+
+      await expect(
+        getSwapArrivalStatus({
+          provider: 'thorchain',
+          txHash: ' THOR-SOURCE ',
+          hosts: {
+            thorchainNode: 'https://node.example/thorchain/',
+            thorchainMidgard: 'https://midgard.example/',
+          },
+          fetchImpl,
+        })
+      ).resolves.toMatchObject({
+        provider: 'thorchain',
+        txHash: 'THOR-SOURCE',
+        status: 'pending',
+        stage: 'swapping',
+      })
+
+      expect(fetchImpl).toHaveBeenCalledWith('https://node.example/thorchain/tx/status/THOR-SOURCE', expect.any(Object))
+      expect(fetchImpl).toHaveBeenCalledWith('https://midgard.example/v2/actions?txid=THOR-SOURCE', expect.any(Object))
+    })
+
+    it('normalizes a completed THORChain refund and preserves its reason and outbound hash', async () => {
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL) =>
+        String(input).includes('/v2/actions') ? jsonResponse(fixtures.thorchainMidgardRefunded) : jsonResponse({}, 404)
+      ) as typeof fetch
+
+      await expect(
+        getSwapArrivalStatus({ provider: 'thorchain', txHash: 'THOR-REFUND-SOURCE', fetchImpl })
+      ).resolves.toEqual({
+        provider: 'thorchain',
+        txHash: 'THOR-REFUND-SOURCE',
+        status: 'refunded',
+        stage: 'refunded',
+        destinationTxHash: 'THOR-REFUND-OUT',
+        message: 'emit asset less than price limit',
+      })
+    })
+
+    it('normalizes a successful MayaChain action with its destination hash', async () => {
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL) =>
+        String(input).includes('/v2/actions') ? jsonResponse(fixtures.mayachainMidgardSuccess) : jsonResponse({}, 404)
+      ) as typeof fetch
+
+      await expect(getSwapArrivalStatus({ provider: 'mayachain', txHash: 'MAYA-SOURCE', fetchImpl })).resolves.toEqual({
+        provider: 'mayachain',
+        txHash: 'MAYA-SOURCE',
+        status: 'success',
+        stage: 'complete',
+        destinationTxHash: 'MAYA-DESTINATION',
+      })
+    })
+
+    it('uses an empty Midgard result as authoritative not-found evidence', async () => {
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL) =>
+        String(input).includes('/v2/actions') ? jsonResponse({ count: '0', actions: [] }) : jsonResponse({}, 404)
+      ) as typeof fetch
+
+      await expect(getSwapArrivalStatus({ provider: 'thorchain', txHash: 'UNKNOWN', fetchImpl })).resolves.toEqual({
+        provider: 'thorchain',
+        txHash: 'UNKNOWN',
+        status: 'not_found',
+        stage: 'not_found',
+      })
+    })
+
+    it('throws when both THORChain sources are unavailable instead of reporting a terminal swap error', async () => {
+      const fetchImpl = vi.fn(async () => jsonResponse({ message: 'unavailable' }, 503)) as typeof fetch
+
+      await expect(getSwapArrivalStatus({ provider: 'thorchain', txHash: 'TX', fetchImpl })).rejects.toBeInstanceOf(
+        SwapArrivalStatusRequestError
+      )
+    })
+
+    it('throws on malformed successful responses instead of misreporting not_found', async () => {
+      const fetchImpl = vi.fn(async () => jsonResponse({ unexpected: true })) as typeof fetch
+
+      await expect(getSwapArrivalStatus({ provider: 'mayachain', txHash: 'TX', fetchImpl })).rejects.toThrow(
+        'unknown transaction status response'
+      )
+    })
+
+    it('rejects malformed Midgard action entries instead of treating them as an empty result', async () => {
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL) =>
+        String(input).includes('/v2/actions') ? jsonResponse({ actions: [null] }) : jsonResponse({}, 404)
+      ) as typeof fetch
+
+      await expect(getSwapArrivalStatus({ provider: 'thorchain', txHash: 'TX', fetchImpl })).rejects.toThrow(
+        'unknown actions response'
+      )
+    })
+  })
+
+  describe('Skip', () => {
+    it('normalizes a completed multi-hop transfer and extracts its destination hash', async () => {
+      const fetchImpl = vi.fn(async () => jsonResponse(fixtures.skipCompleted)) as typeof fetch
+
+      await expect(
+        getSwapArrivalStatus({ provider: 'skip', txHash: 'SKIP-SOURCE', chainId: 'cosmoshub-4', fetchImpl })
+      ).resolves.toEqual({
+        provider: 'skip',
+        txHash: 'SKIP-SOURCE',
+        status: 'success',
+        stage: 'complete',
+        destinationTxHash: 'SKIP-DESTINATION',
+      })
+
+      expect(fetchImpl).toHaveBeenCalledWith(
+        'https://api.skip.build/v2/tx/status?tx_hash=SKIP-SOURCE&chain_id=cosmoshub-4',
+        expect.any(Object)
+      )
+    })
+
+    it('classifies a completed error as refunded only when assets were released on the source chain', async () => {
+      const fetchImpl = vi.fn(async () => jsonResponse(fixtures.skipRefunded)) as typeof fetch
+
+      await expect(
+        getSwapArrivalStatus({ provider: 'skip', txHash: 'SKIP-SOURCE', chainId: 'cosmoshub-4', fetchImpl })
+      ).resolves.toMatchObject({
+        status: 'refunded',
+        stage: 'refunded',
+        message: 'route failed and assets returned',
+      })
+    })
+
+    it.each([
+      ['STATE_SUBMITTED', 'pending', 'inbound'],
+      ['STATE_PENDING', 'pending', 'outbound'],
+      ['STATE_PENDING_ERROR', 'pending', 'outbound'],
+      ['STATE_ABANDONED', 'error', 'failed'],
+      ['STATE_COMPLETED_ERROR', 'error', 'failed'],
+    ] as const)('maps %s to %s/%s', async (state, status, stage) => {
+      const fetchImpl = vi.fn(async () =>
+        jsonResponse({ state, transfer_asset_release: { chain_id: 'other-chain', released: state.includes('ERROR') } })
+      ) as typeof fetch
+
+      await expect(
+        getSwapArrivalStatus({ provider: 'skip', txHash: 'SKIP-SOURCE', chainId: 'cosmoshub-4', fetchImpl })
+      ).resolves.toMatchObject({ status, stage })
+    })
+
+    it('requires a non-empty source chain id', async () => {
+      await expect(
+        getSwapArrivalStatus({ provider: 'skip', txHash: 'SKIP-SOURCE', chainId: ' ', fetchImpl: vi.fn() })
+      ).rejects.toThrow('chainId is required for Skip')
+    })
+  })
+
+  describe('LI.FI', () => {
+    it('maps destination waiting to the outbound progress stage and forwards query hints and headers', async () => {
+      const fetchImpl = vi.fn(async () => jsonResponse(fixtures.lifiPending)) as typeof fetch
+      const headers = { 'x-lifi-api-key': 'test-key' }
+
+      await expect(
+        getSwapArrivalStatus({
+          provider: 'li.fi',
+          txHash: '0xsource',
+          fromChain: 1,
+          toChain: 137,
+          bridge: 'across',
+          fetchImpl,
+          headers,
+        })
+      ).resolves.toMatchObject({ status: 'pending', stage: 'outbound' })
+
+      expect(fetchImpl).toHaveBeenCalledWith(
+        'https://li.quest/v1/status?txHash=0xsource&fromChain=1&toChain=137&bridge=across',
+        expect.objectContaining({ headers })
+      )
+    })
+
+    it('normalizes DONE/REFUNDED separately from successful DONE outcomes', async () => {
+      const fetchImpl = vi.fn(async () => jsonResponse(fixtures.lifiRefunded)) as typeof fetch
+
+      await expect(getSwapArrivalStatus({ provider: 'li.fi', txHash: '0xsource', fetchImpl })).resolves.toEqual({
+        provider: 'li.fi',
+        txHash: '0xsource',
+        status: 'refunded',
+        stage: 'refunded',
+        destinationTxHash: '0xrefund',
+        message: 'Tokens were refunded.',
+      })
+    })
+
+    it.each([
+      [{ status: 'NOT_FOUND' }, 'not_found', 'not_found'],
+      [{ status: 'INVALID' }, 'error', 'failed'],
+      [{ status: 'FAILED' }, 'error', 'failed'],
+      [{ status: 'DONE', substatus: 'COMPLETED' }, 'success', 'complete'],
+      [{ status: 'DONE', substatus: 'PARTIAL' }, 'success', 'complete'],
+      [{ status: 'PENDING', substatus: 'WAIT_SOURCE_CONFIRMATIONS' }, 'pending', 'confirming'],
+      [{ status: 'PENDING', substatus: 'REFUND_IN_PROGRESS' }, 'pending', 'refunding'],
+    ] as const)('maps $status/$substatus to $1/$2', async (body, status, stage) => {
+      const fetchImpl = vi.fn(async () => jsonResponse(body)) as typeof fetch
+
+      await expect(getSwapArrivalStatus({ provider: 'li.fi', txHash: '0xsource', fetchImpl })).resolves.toMatchObject({
+        status,
+        stage,
+      })
+    })
+  })
+
+  it('rejects an empty transaction hash before making a request', async () => {
+    const fetchImpl = vi.fn()
+    await expect(getSwapArrivalStatus({ provider: 'li.fi', txHash: '  ', fetchImpl })).rejects.toThrow(
+      'txHash must not be empty'
+    )
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('exposes terminal-state classification without treating pending as terminal', () => {
+    expect(
+      isSwapArrivalStatusTerminal({ provider: 'skip', txHash: 'hash', status: 'pending', stage: 'outbound' })
+    ).toBe(false)
+    expect(
+      isSwapArrivalStatusTerminal({ provider: 'skip', txHash: 'hash', status: 'refunded', stage: 'refunded' })
+    ).toBe(true)
+  })
+})

--- a/packages/core/chain/swap/utils/getSwapArrivalStatus/index.ts
+++ b/packages/core/chain/swap/utils/getSwapArrivalStatus/index.ts
@@ -1,0 +1,448 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { cosmosRpcUrl } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
+import { thorchainMidgardBaseUrl } from '@vultisig/core-chain/chains/cosmos/thor/lp/pools'
+
+export const swapArrivalProviders = ['thorchain', 'mayachain', 'skip', 'li.fi'] as const
+
+export type SwapArrivalProvider = (typeof swapArrivalProviders)[number]
+
+export type SwapArrivalPendingStage = 'inbound' | 'confirming' | 'swapping' | 'outbound' | 'refunding'
+
+type SwapArrivalStatusBase = {
+  provider: SwapArrivalProvider
+  txHash: string
+  destinationTxHash?: string
+  message?: string
+}
+
+export type SwapArrivalStatusResult =
+  | (SwapArrivalStatusBase & { status: 'pending'; stage: SwapArrivalPendingStage })
+  | (SwapArrivalStatusBase & { status: 'success'; stage: 'complete' })
+  | (SwapArrivalStatusBase & { status: 'refunded'; stage: 'refunded' })
+  | (SwapArrivalStatusBase & { status: 'not_found'; stage: 'not_found' })
+  | (SwapArrivalStatusBase & { status: 'error'; stage: 'failed' })
+
+export type SwapArrivalStatusHosts = {
+  thorchainNode: string
+  thorchainMidgard: string
+  mayachainNode: string
+  mayachainMidgard: string
+  skip: string
+  lifi: string
+}
+
+export const defaultSwapArrivalStatusHosts: SwapArrivalStatusHosts = {
+  thorchainNode: `${cosmosRpcUrl[Chain.THORChain]}/thorchain`,
+  thorchainMidgard: thorchainMidgardBaseUrl,
+  mayachainNode: `${cosmosRpcUrl[Chain.MayaChain]}/mayachain`,
+  mayachainMidgard: 'https://midgard.mayachain.info',
+  skip: 'https://api.skip.build',
+  lifi: 'https://li.quest',
+}
+
+type GetSwapArrivalStatusBase = {
+  txHash: string
+  hosts?: Partial<SwapArrivalStatusHosts>
+  fetchImpl?: typeof fetch
+  headers?: HeadersInit
+  signal?: AbortSignal
+}
+
+export type GetSwapArrivalStatusInput =
+  | (GetSwapArrivalStatusBase & { provider: 'thorchain' | 'mayachain' })
+  | (GetSwapArrivalStatusBase & { provider: 'skip'; chainId: string })
+  | (GetSwapArrivalStatusBase & {
+      provider: 'li.fi'
+      fromChain?: string | number
+      toChain?: string | number
+      bridge?: string
+    })
+
+type JsonRequestResult = { kind: 'ok'; data: unknown } | { kind: 'not_found' } | { kind: 'error'; error: Error }
+
+type ThorMayaProvider = Extract<SwapArrivalProvider, 'thorchain' | 'mayachain'>
+
+const trimTrailingSlash = (value: string): string => value.replace(/\/+$/, '')
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const getRecord = (value: unknown, key: string): Record<string, unknown> | undefined => {
+  if (!isRecord(value)) return undefined
+  const candidate = value[key]
+  return isRecord(candidate) ? candidate : undefined
+}
+
+const getString = (value: unknown, key: string): string | undefined => {
+  if (!isRecord(value)) return undefined
+  const candidate = value[key]
+  return typeof candidate === 'string' ? candidate : undefined
+}
+
+const getBoolean = (value: unknown, key: string): boolean | undefined => {
+  if (!isRecord(value)) return undefined
+  const candidate = value[key]
+  return typeof candidate === 'boolean' ? candidate : undefined
+}
+
+const messageFromUnknown = (value: unknown): string | undefined => {
+  if (typeof value === 'string' && value.trim()) return value
+  if (!isRecord(value)) return undefined
+  return getString(value, 'message') ?? getString(value, 'reason')
+}
+
+const requestJson = async (
+  fetchImpl: typeof fetch,
+  url: string,
+  init: Pick<RequestInit, 'headers' | 'signal'>
+): Promise<JsonRequestResult> => {
+  try {
+    const response = await fetchImpl(url, init)
+    if (response.status === 404) return { kind: 'not_found' }
+    if (!response.ok) {
+      return { kind: 'error', error: new Error(`Swap arrival status request failed (${response.status}) for ${url}`) }
+    }
+    try {
+      return { kind: 'ok', data: await response.json() }
+    } catch (error) {
+      return {
+        kind: 'error',
+        error: new Error(`Swap arrival status returned invalid JSON for ${url}`, { cause: error }),
+      }
+    }
+  } catch (error) {
+    return {
+      kind: 'error',
+      error: error instanceof Error ? error : new Error(`Swap arrival status request failed for ${url}`),
+    }
+  }
+}
+
+export class SwapArrivalStatusRequestError extends Error {
+  readonly provider: SwapArrivalProvider
+  readonly errors: Error[]
+
+  constructor(provider: SwapArrivalProvider, errors: Error[]) {
+    super(`Unable to read ${provider} swap arrival status: ${errors.map(error => error.message).join('; ')}`)
+    this.name = 'SwapArrivalStatusRequestError'
+    this.provider = provider
+    this.errors = errors
+  }
+}
+
+const resultBase = (provider: SwapArrivalProvider, txHash: string): SwapArrivalStatusBase => ({
+  provider,
+  txHash,
+})
+
+const findDestinationTxHash = (value: unknown, sourceTxHash: string): string | undefined => {
+  const source = sourceTxHash.toLowerCase()
+  const found: string[] = []
+
+  const visit = (candidate: unknown, depth: number): void => {
+    if (depth > 12 || candidate === null || candidate === undefined) return
+    if (Array.isArray(candidate)) {
+      candidate.forEach(item => visit(item, depth + 1))
+      return
+    }
+    if (!isRecord(candidate)) return
+
+    for (const [key, child] of Object.entries(candidate)) {
+      if ((key === 'txID' || key === 'txHash' || key === 'tx_hash') && typeof child === 'string') {
+        const trimmed = child.trim()
+        if (trimmed && trimmed.toLowerCase() !== source) found.push(trimmed)
+      } else {
+        visit(child, depth + 1)
+      }
+    }
+  }
+
+  visit(value, 0)
+  return found.at(-1)
+}
+
+const completed = (stage: unknown): boolean => getBoolean(stage, 'completed') === true
+
+const started = (stage: unknown): boolean => getBoolean(stage, 'started') === true || completed(stage)
+
+const getThorMayaNodeProgress = (
+  provider: ThorMayaProvider,
+  txHash: string,
+  data: unknown
+): SwapArrivalStatusResult | undefined => {
+  const stages = getRecord(data, 'stages')
+  if (!stages) return undefined
+
+  const outboundSigned = stages.outbound_signed
+  const destinationTxHash = findDestinationTxHash(data, txHash)
+  if (completed(outboundSigned)) {
+    return { ...resultBase(provider, txHash), status: 'success', stage: 'complete', destinationTxHash }
+  }
+
+  if (isRecord(outboundSigned) || isRecord(stages.outbound_delay) || completed(stages.swap_finalised)) {
+    return { ...resultBase(provider, txHash), status: 'pending', stage: 'outbound', destinationTxHash }
+  }
+
+  if (isRecord(stages.swap_status) || completed(stages.inbound_finalised)) {
+    return { ...resultBase(provider, txHash), status: 'pending', stage: 'swapping' }
+  }
+
+  if (started(stages.inbound_confirmation_counted)) {
+    return { ...resultBase(provider, txHash), status: 'pending', stage: 'confirming' }
+  }
+
+  if (started(stages.inbound_observed)) {
+    return { ...resultBase(provider, txHash), status: 'pending', stage: 'inbound' }
+  }
+
+  return undefined
+}
+
+const getMidgardActions = (data: unknown): Record<string, unknown>[] => {
+  if (!isRecord(data) || !Array.isArray(data.actions)) return []
+  return data.actions.filter(isRecord)
+}
+
+const isMidgardResponse = (data: unknown): boolean =>
+  isRecord(data) && Array.isArray(data.actions) && data.actions.every(isRecord)
+
+const isThorMayaNodeResponse = (data: unknown): boolean => isRecord(data) && isRecord(data.stages)
+
+const getActionMessage = (action: Record<string, unknown>, type: 'refund' | 'swap'): string | undefined =>
+  messageFromUnknown(getRecord(getRecord(action, 'metadata'), type))
+
+const getThorMayaMidgardStatus = (
+  provider: ThorMayaProvider,
+  txHash: string,
+  data: unknown,
+  nodeProgress: SwapArrivalStatusResult | undefined
+): SwapArrivalStatusResult | undefined => {
+  const actions = getMidgardActions(data)
+  const refund = actions.find(action => getString(action, 'type')?.toLowerCase() === 'refund')
+  if (refund) {
+    const status = getString(refund, 'status')?.toLowerCase()
+    const destinationTxHash = findDestinationTxHash(refund, txHash)
+    const message = getActionMessage(refund, 'refund')
+    if (status === 'success') {
+      return { ...resultBase(provider, txHash), status: 'refunded', stage: 'refunded', destinationTxHash, message }
+    }
+    if (status === 'pending') {
+      return { ...resultBase(provider, txHash), status: 'pending', stage: 'refunding', destinationTxHash, message }
+    }
+    return { ...resultBase(provider, txHash), status: 'error', stage: 'failed', destinationTxHash, message }
+  }
+
+  const swap = actions.find(action => getString(action, 'type')?.toLowerCase() === 'swap')
+  if (!swap) return undefined
+
+  const status = getString(swap, 'status')?.toLowerCase()
+  const destinationTxHash = findDestinationTxHash(swap, txHash)
+  if (status === 'success') {
+    return { ...resultBase(provider, txHash), status: 'success', stage: 'complete', destinationTxHash }
+  }
+  if (status === 'pending') {
+    return nodeProgress ?? { ...resultBase(provider, txHash), status: 'pending', stage: 'swapping' }
+  }
+  return {
+    ...resultBase(provider, txHash),
+    status: 'error',
+    stage: 'failed',
+    destinationTxHash,
+    message: getActionMessage(swap, 'swap'),
+  }
+}
+
+const getThorMayaStatus = async ({
+  provider,
+  txHash,
+  hosts,
+  fetchImpl,
+  headers,
+  signal,
+}: GetSwapArrivalStatusBase & {
+  provider: ThorMayaProvider
+  hosts: SwapArrivalStatusHosts
+  fetchImpl: typeof fetch
+}): Promise<SwapArrivalStatusResult> => {
+  const isThorchain = provider === 'thorchain'
+  const nodeBase = isThorchain ? hosts.thorchainNode : hosts.mayachainNode
+  const midgardBase = isThorchain ? hosts.thorchainMidgard : hosts.mayachainMidgard
+  const [node, midgard] = await Promise.all([
+    requestJson(fetchImpl, `${trimTrailingSlash(nodeBase)}/tx/status/${encodeURIComponent(txHash)}`, {
+      headers,
+      signal,
+    }),
+    requestJson(fetchImpl, `${trimTrailingSlash(midgardBase)}/v2/actions?txid=${encodeURIComponent(txHash)}`, {
+      headers,
+      signal,
+    }),
+  ])
+
+  const nodeProgress = node.kind === 'ok' ? getThorMayaNodeProgress(provider, txHash, node.data) : undefined
+  const midgardStatus =
+    midgard.kind === 'ok' ? getThorMayaMidgardStatus(provider, txHash, midgard.data, nodeProgress) : undefined
+
+  if (midgardStatus) return midgardStatus
+  if (nodeProgress) return nodeProgress
+
+  const errors = [node, midgard].flatMap(result => (result.kind === 'error' ? [result.error] : []))
+  if (node.kind === 'ok' && !isThorMayaNodeResponse(node.data)) {
+    errors.push(new Error(`${provider} node returned an unknown transaction status response`))
+  }
+  if (midgard.kind === 'ok' && !isMidgardResponse(midgard.data)) {
+    errors.push(new Error(`${provider} Midgard returned an unknown actions response`))
+  }
+
+  const midgardAuthoritativelyEmpty =
+    midgard.kind === 'ok' && isMidgardResponse(midgard.data) && getMidgardActions(midgard.data).length === 0
+  if (midgardAuthoritativelyEmpty || errors.length === 0) {
+    return { ...resultBase(provider, txHash), status: 'not_found', stage: 'not_found' }
+  }
+
+  throw new SwapArrivalStatusRequestError(provider, errors)
+}
+
+const getSkipStatus = async ({
+  txHash,
+  chainId,
+  hosts,
+  fetchImpl,
+  headers,
+  signal,
+}: GetSwapArrivalStatusBase & {
+  chainId: string
+  hosts: SwapArrivalStatusHosts
+  fetchImpl: typeof fetch
+}): Promise<SwapArrivalStatusResult> => {
+  if (!chainId.trim()) throw new TypeError('getSwapArrivalStatus: chainId is required for Skip')
+
+  const query = new URLSearchParams({ tx_hash: txHash, chain_id: chainId })
+  const request = await requestJson(fetchImpl, `${trimTrailingSlash(hosts.skip)}/v2/tx/status?${query}`, {
+    headers,
+    signal,
+  })
+  if (request.kind === 'not_found') {
+    return { ...resultBase('skip', txHash), status: 'not_found', stage: 'not_found' }
+  }
+  if (request.kind === 'error') throw new SwapArrivalStatusRequestError('skip', [request.error])
+
+  const state = getString(request.data, 'state')
+  const destinationTxHash = findDestinationTxHash(request.data, txHash)
+  const message = messageFromUnknown(isRecord(request.data) ? request.data.error : undefined)
+  if (state === 'STATE_COMPLETED_SUCCESS') {
+    return { ...resultBase('skip', txHash), status: 'success', stage: 'complete', destinationTxHash }
+  }
+  if (state === 'STATE_SUBMITTED') {
+    return { ...resultBase('skip', txHash), status: 'pending', stage: 'inbound', destinationTxHash }
+  }
+  if (state === 'STATE_PENDING' || state === 'STATE_PENDING_ERROR') {
+    return { ...resultBase('skip', txHash), status: 'pending', stage: 'outbound', destinationTxHash, message }
+  }
+  if (state === 'STATE_ABANDONED' || state === 'STATE_COMPLETED_ERROR') {
+    const assetRelease = getRecord(request.data, 'transfer_asset_release')
+    const releasedOnSource =
+      getBoolean(assetRelease, 'released') === true && getString(assetRelease, 'chain_id') === chainId
+    if (releasedOnSource) {
+      return { ...resultBase('skip', txHash), status: 'refunded', stage: 'refunded', destinationTxHash, message }
+    }
+    return { ...resultBase('skip', txHash), status: 'error', stage: 'failed', destinationTxHash, message }
+  }
+
+  throw new SwapArrivalStatusRequestError('skip', [new Error('Skip returned an unknown transaction state')])
+}
+
+const getLifiPendingStage = (substatus: string | undefined): SwapArrivalPendingStage => {
+  if (substatus === 'WAIT_SOURCE_CONFIRMATIONS') return 'confirming'
+  if (substatus === 'WAIT_DESTINATION_TRANSACTION') return 'outbound'
+  if (substatus === 'REFUND_IN_PROGRESS') return 'refunding'
+  return 'swapping'
+}
+
+const getLifiStatus = async ({
+  txHash,
+  fromChain,
+  toChain,
+  bridge,
+  hosts,
+  fetchImpl,
+  headers,
+  signal,
+}: GetSwapArrivalStatusBase & {
+  fromChain?: string | number
+  toChain?: string | number
+  bridge?: string
+  hosts: SwapArrivalStatusHosts
+  fetchImpl: typeof fetch
+}): Promise<SwapArrivalStatusResult> => {
+  const query = new URLSearchParams({ txHash })
+  if (fromChain !== undefined) query.set('fromChain', String(fromChain))
+  if (toChain !== undefined) query.set('toChain', String(toChain))
+  if (bridge !== undefined) query.set('bridge', bridge)
+
+  const request = await requestJson(fetchImpl, `${trimTrailingSlash(hosts.lifi)}/v1/status?${query}`, {
+    headers,
+    signal,
+  })
+  if (request.kind === 'not_found') {
+    return { ...resultBase('li.fi', txHash), status: 'not_found', stage: 'not_found' }
+  }
+  if (request.kind === 'error') throw new SwapArrivalStatusRequestError('li.fi', [request.error])
+
+  const status = getString(request.data, 'status')
+  const substatus = getString(request.data, 'substatus')
+  const destinationTxHash = getString(getRecord(request.data, 'receiving'), 'txHash')
+  const message = getString(request.data, 'substatusMessage') ?? messageFromUnknown(getRecord(request.data, 'error'))
+
+  if (substatus === 'REFUNDED') {
+    return { ...resultBase('li.fi', txHash), status: 'refunded', stage: 'refunded', destinationTxHash, message }
+  }
+  if (status === 'DONE') {
+    return { ...resultBase('li.fi', txHash), status: 'success', stage: 'complete', destinationTxHash, message }
+  }
+  if (status === 'PENDING') {
+    return {
+      ...resultBase('li.fi', txHash),
+      status: 'pending',
+      stage: getLifiPendingStage(substatus),
+      destinationTxHash,
+      message,
+    }
+  }
+  if (status === 'NOT_FOUND') {
+    return { ...resultBase('li.fi', txHash), status: 'not_found', stage: 'not_found', message }
+  }
+  if (status === 'INVALID' || status === 'FAILED') {
+    return { ...resultBase('li.fi', txHash), status: 'error', stage: 'failed', destinationTxHash, message }
+  }
+
+  throw new SwapArrivalStatusRequestError('li.fi', [new Error('LI.FI returned an unknown transaction status')])
+}
+
+export const isSwapArrivalStatusTerminal = (result: SwapArrivalStatusResult): boolean => result.status !== 'pending'
+
+/**
+ * Reads one provider status snapshot and normalizes it for both UI progress and
+ * terminal agent workflows. This function deliberately does not poll: callers
+ * retain control of cadence, retry budgets and cancellation while sharing the
+ * provider response state machines.
+ *
+ * Network, HTTP and malformed-response failures throw
+ * `SwapArrivalStatusRequestError`; they are not converted to terminal `error`
+ * results because an upstream outage does not mean the swap itself failed.
+ */
+export const getSwapArrivalStatus = async (input: GetSwapArrivalStatusInput): Promise<SwapArrivalStatusResult> => {
+  const txHash = input.txHash.trim()
+  if (!txHash) throw new TypeError('getSwapArrivalStatus: txHash must not be empty')
+
+  const hosts = { ...defaultSwapArrivalStatusHosts, ...input.hosts }
+  const fetchImpl = input.fetchImpl ?? fetch
+  const common = { ...input, txHash, hosts, fetchImpl }
+
+  if (input.provider === 'thorchain' || input.provider === 'mayachain') {
+    return getThorMayaStatus({ ...common, provider: input.provider })
+  }
+  if (input.provider === 'skip') {
+    return getSkipStatus({ ...common, chainId: input.chainId })
+  }
+  return getLifiStatus(common)
+}

--- a/packages/core/chain/swap/utils/getSwapArrivalStatus/index.ts
+++ b/packages/core/chain/swap/utils/getSwapArrivalStatus/index.ts
@@ -200,7 +200,7 @@ const getThorMayaNodeProgress = (
 
 const getMidgardActions = (data: unknown): Record<string, unknown>[] => {
   if (!isRecord(data) || !Array.isArray(data.actions)) return []
-  return data.actions.filter(isRecord)
+  return data.actions.every(isRecord) ? data.actions : []
 }
 
 const isMidgardResponse = (data: unknown): boolean =>
@@ -434,7 +434,10 @@ export const getSwapArrivalStatus = async (input: GetSwapArrivalStatusInput): Pr
   const txHash = input.txHash.trim()
   if (!txHash) throw new TypeError('getSwapArrivalStatus: txHash must not be empty')
 
-  const hosts = { ...defaultSwapArrivalStatusHosts, ...input.hosts }
+  const hostOverrides = Object.fromEntries(
+    Object.entries(input.hosts ?? {}).filter(([, value]) => value !== undefined)
+  ) as Partial<SwapArrivalStatusHosts>
+  const hosts = { ...defaultSwapArrivalStatusHosts, ...hostOverrides }
   const fetchImpl = input.fetchImpl ?? fetch
   const common = { ...input, txHash, hosts, fetchImpl }
 

--- a/packages/core/chain/swap/utils/getSwapArrivalStatus/index.ts
+++ b/packages/core/chain/swap/utils/getSwapArrivalStatus/index.ts
@@ -18,6 +18,7 @@ type SwapArrivalStatusBase = {
 export type SwapArrivalStatusResult =
   | (SwapArrivalStatusBase & { status: 'pending'; stage: SwapArrivalPendingStage })
   | (SwapArrivalStatusBase & { status: 'success'; stage: 'complete' })
+  | (SwapArrivalStatusBase & { status: 'partial'; stage: 'complete' })
   | (SwapArrivalStatusBase & { status: 'refunded'; stage: 'refunded' })
   | (SwapArrivalStatusBase & { status: 'not_found'; stage: 'not_found' })
   | (SwapArrivalStatusBase & { status: 'error'; stage: 'failed' })
@@ -186,6 +187,19 @@ const completed = (stage: unknown): boolean => getBoolean(stage, 'completed') ==
 
 const started = (stage: unknown): boolean => getBoolean(stage, 'started') === true || completed(stage)
 
+/**
+ * THORNode's `planned_out_txs[].refund` flags whether a planned outbound is a
+ * refund or the swap output. Returns `undefined` when the field isn't present
+ * on every planned outbound, since a partially-populated response can't be
+ * trusted to discriminate the outcome.
+ */
+const getPlannedOutTxRefund = (data: unknown): boolean | undefined => {
+  if (!isRecord(data) || !Array.isArray(data.planned_out_txs) || data.planned_out_txs.length === 0) return undefined
+  const refundFlags = data.planned_out_txs.map(plannedOutTx => getBoolean(plannedOutTx, 'refund'))
+  if (refundFlags.some(refund => refund === undefined)) return undefined
+  return refundFlags.some(refund => refund === true)
+}
+
 const getThorMayaNodeProgress = (
   provider: ThorMayaProvider,
   txHash: string,
@@ -197,9 +211,16 @@ const getThorMayaNodeProgress = (
   const outboundSigned = stages.outbound_signed
   const destinationTxHash = findThorMayaNodeDestinationTxHash(data, txHash)
   if (completed(outboundSigned)) {
-    // A signed outbound can be either the swap output or a refund. Only
-    // Midgard's action type can distinguish them, so node-only completion must
-    // remain pollable until Midgard corroborates the terminal outcome.
+    const refund = getPlannedOutTxRefund(data)
+    if (refund === true) {
+      return { ...resultBase(provider, txHash), status: 'refunded', stage: 'refunded', destinationTxHash }
+    }
+    if (refund === false) {
+      return { ...resultBase(provider, txHash), status: 'success', stage: 'complete', destinationTxHash }
+    }
+    // `planned_out_txs[].refund` isn't available on this response, so node
+    // data alone can't distinguish a swap output from a refund. Stay pollable
+    // until Midgard corroborates the terminal outcome.
     return { ...resultBase(provider, txHash), status: 'pending', stage: 'outbound', destinationTxHash }
   }
 
@@ -235,6 +256,19 @@ const isThorMayaNodeResponse = (data: unknown): boolean => isRecord(data) && isR
 const getActionMessage = (action: Record<string, unknown>, type: 'refund' | 'swap'): string | undefined =>
   messageFromUnknown(getRecord(getRecord(action, 'metadata'), type))
 
+// Midgard only documents `success` and `pending` as action statuses. Any other
+// (or missing) value is malformed-response data, not a legitimate terminal
+// failure signal, so it must throw rather than be reported as a swap error.
+const unknownMidgardActionStatus = (
+  provider: ThorMayaProvider,
+  type: 'refund' | 'swap',
+  status: string | undefined
+): never => {
+  throw new SwapArrivalStatusRequestError(provider, [
+    new Error(`${provider} Midgard returned an unknown ${type} action status${status ? `: ${status}` : ''}`),
+  ])
+}
+
 const getThorMayaMidgardStatus = (
   provider: ThorMayaProvider,
   txHash: string,
@@ -253,7 +287,7 @@ const getThorMayaMidgardStatus = (
     if (status === 'pending') {
       return { ...resultBase(provider, txHash), status: 'pending', stage: 'refunding', destinationTxHash, message }
     }
-    return { ...resultBase(provider, txHash), status: 'error', stage: 'failed', destinationTxHash, message }
+    return unknownMidgardActionStatus(provider, 'refund', status)
   }
 
   const swap = actions.find(action => getString(action, 'type')?.toLowerCase() === 'swap')
@@ -267,13 +301,7 @@ const getThorMayaMidgardStatus = (
   if (status === 'pending') {
     return nodeProgress ?? { ...resultBase(provider, txHash), status: 'pending', stage: 'swapping' }
   }
-  return {
-    ...resultBase(provider, txHash),
-    status: 'error',
-    stage: 'failed',
-    destinationTxHash,
-    message: getActionMessage(swap, 'swap'),
-  }
+  return unknownMidgardActionStatus(provider, 'swap', status)
 }
 
 const getThorMayaStatus = async ({
@@ -421,6 +449,11 @@ const getLifiStatus = async ({
     return { ...resultBase('li.fi', txHash), status: 'refunded', stage: 'refunded', destinationTxHash, message }
   }
   if (status === 'DONE') {
+    // PARTIAL means the user received a different (typically lower-value) token
+    // than requested, so it must not be flattened into ordinary `success`.
+    if (substatus === 'PARTIAL') {
+      return { ...resultBase('li.fi', txHash), status: 'partial', stage: 'complete', destinationTxHash, message }
+    }
     return { ...resultBase('li.fi', txHash), status: 'success', stage: 'complete', destinationTxHash, message }
   }
   if (status === 'PENDING') {
@@ -453,7 +486,8 @@ export const isSwapArrivalStatusTerminal = (result: SwapArrivalStatusResult): bo
  *
  * `not_found` is a transient snapshot because providers use it during normal
  * pre-indexing windows. Likewise, THOR/Maya node-only outbound completion stays
- * pending until Midgard identifies the action as a swap or refund.
+ * pending unless the node's `planned_out_txs[].refund` flag or Midgard's
+ * action type can identify it as a swap output or a refund.
  *
  * Network, HTTP and malformed-response failures throw
  * `SwapArrivalStatusRequestError`; they are not converted to terminal `error`

--- a/packages/core/chain/swap/utils/getSwapArrivalStatus/index.ts
+++ b/packages/core/chain/swap/utils/getSwapArrivalStatus/index.ts
@@ -135,12 +135,21 @@ const resultBase = (provider: SwapArrivalProvider, txHash: string): SwapArrivalS
   txHash,
 })
 
+const maxDestinationTxSearchDepth = 12
+
+/**
+ * Provider route payloads list hops and outbound transactions in execution
+ * order, so the last distinct transaction hash is the destination transaction.
+ * The depth cap keeps malformed or unexpectedly recursive payloads bounded.
+ * THORNode's generic `id` field is handled separately on its known `out_txs`
+ * collection so unrelated provider object IDs cannot be mistaken for tx hashes.
+ */
 const findDestinationTxHash = (value: unknown, sourceTxHash: string): string | undefined => {
   const source = sourceTxHash.toLowerCase()
   const found: string[] = []
 
   const visit = (candidate: unknown, depth: number): void => {
-    if (depth > 12 || candidate === null || candidate === undefined) return
+    if (depth > maxDestinationTxSearchDepth || candidate === null || candidate === undefined) return
     if (Array.isArray(candidate)) {
       candidate.forEach(item => visit(item, depth + 1))
       return
@@ -161,6 +170,18 @@ const findDestinationTxHash = (value: unknown, sourceTxHash: string): string | u
   return found.at(-1)
 }
 
+const findThorMayaNodeDestinationTxHash = (data: unknown, sourceTxHash: string): string | undefined => {
+  if (!isRecord(data) || !Array.isArray(data.out_txs)) return findDestinationTxHash(data, sourceTxHash)
+
+  const source = sourceTxHash.toLowerCase()
+  const outboundTxHashes = data.out_txs.flatMap(outboundTx => {
+    const id = getString(outboundTx, 'id')?.trim()
+    return id && id.toLowerCase() !== source ? [id] : []
+  })
+
+  return outboundTxHashes.at(-1) ?? findDestinationTxHash(data, sourceTxHash)
+}
+
 const completed = (stage: unknown): boolean => getBoolean(stage, 'completed') === true
 
 const started = (stage: unknown): boolean => getBoolean(stage, 'started') === true || completed(stage)
@@ -174,9 +195,12 @@ const getThorMayaNodeProgress = (
   if (!stages) return undefined
 
   const outboundSigned = stages.outbound_signed
-  const destinationTxHash = findDestinationTxHash(data, txHash)
+  const destinationTxHash = findThorMayaNodeDestinationTxHash(data, txHash)
   if (completed(outboundSigned)) {
-    return { ...resultBase(provider, txHash), status: 'success', stage: 'complete', destinationTxHash }
+    // A signed outbound can be either the swap output or a refund. Only
+    // Midgard's action type can distinguish them, so node-only completion must
+    // remain pollable until Midgard corroborates the terminal outcome.
+    return { ...resultBase(provider, txHash), status: 'pending', stage: 'outbound', destinationTxHash }
   }
 
   if (isRecord(outboundSigned) || isRecord(stages.outbound_delay) || completed(stages.swap_finalised)) {
@@ -418,13 +442,18 @@ const getLifiStatus = async ({
   throw new SwapArrivalStatusRequestError('li.fi', [new Error('LI.FI returned an unknown transaction status')])
 }
 
-export const isSwapArrivalStatusTerminal = (result: SwapArrivalStatusResult): boolean => result.status !== 'pending'
+export const isSwapArrivalStatusTerminal = (result: SwapArrivalStatusResult): boolean =>
+  result.status !== 'pending' && result.status !== 'not_found'
 
 /**
  * Reads one provider status snapshot and normalizes it for both UI progress and
  * terminal agent workflows. This function deliberately does not poll: callers
  * retain control of cadence, retry budgets and cancellation while sharing the
  * provider response state machines.
+ *
+ * `not_found` is a transient snapshot because providers use it during normal
+ * pre-indexing windows. Likewise, THOR/Maya node-only outbound completion stays
+ * pending until Midgard identifies the action as a swap or refund.
  *
  * Network, HTTP and malformed-response failures throw
  * `SwapArrivalStatusRequestError`; they are not converted to terminal `error`

--- a/packages/sdk/src/Vultisig.ts
+++ b/packages/sdk/src/Vultisig.ts
@@ -8,6 +8,11 @@ import { getCoinPrices as coreCoinPrices } from '@vultisig/core-chain/coin/price
 import { getCoinPricesWithChange as coreCoinPricesWithChange } from '@vultisig/core-chain/coin/price/getCoinPricesWithChange'
 import { scanAddressWithBlockaid } from '@vultisig/core-chain/security/blockaid/address'
 import { scanSiteWithBlockaid } from '@vultisig/core-chain/security/blockaid/site'
+import {
+  getSwapArrivalStatus,
+  type GetSwapArrivalStatusInput,
+  type SwapArrivalStatusResult,
+} from '@vultisig/core-chain/swap/utils/getSwapArrivalStatus'
 import { getSwapExplorerUrl, type SwapExplorerProvider } from '@vultisig/core-chain/swap/utils/getSwapExplorerUrl'
 import { getBlockExplorerUrl } from '@vultisig/core-chain/utils/getBlockExplorerUrl'
 import { isValidAddress } from '@vultisig/core-chain/utils/isValidAddress'
@@ -1242,6 +1247,11 @@ export class Vultisig extends UniversalEventEmitter<SdkEvents> {
    */
   static getSwapExplorerUrl(provider: SwapExplorerProvider, txHash: string, fromChain: Chain): string {
     return getSwapExplorerUrl({ provider, txHash, fromChain })
+  }
+
+  /** Read and normalize one THORChain, MayaChain, Skip Go, or LI.FI swap status snapshot. */
+  static getSwapArrivalStatus(input: GetSwapArrivalStatusInput): Promise<SwapArrivalStatusResult> {
+    return getSwapArrivalStatus(input)
   }
 
   /**

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -370,6 +370,23 @@ export * from './signable-transaction'
 export type { GetSwapExplorerUrlInput, SwapExplorerProvider } from '@vultisig/core-chain/swap/utils/getSwapExplorerUrl'
 export { getSwapExplorerUrl, swapExplorerProviders } from '@vultisig/core-chain/swap/utils/getSwapExplorerUrl'
 
+// Provider-aware swap arrival normalization. One status vocabulary for
+// THORChain, MayaChain, Skip Go and LI.FI keeps app and agent pollers thin.
+export type {
+  GetSwapArrivalStatusInput,
+  SwapArrivalPendingStage,
+  SwapArrivalProvider,
+  SwapArrivalStatusHosts,
+  SwapArrivalStatusResult,
+} from '@vultisig/core-chain/swap/utils/getSwapArrivalStatus'
+export {
+  defaultSwapArrivalStatusHosts,
+  getSwapArrivalStatus,
+  isSwapArrivalStatusTerminal,
+  swapArrivalProviders,
+  SwapArrivalStatusRequestError,
+} from '@vultisig/core-chain/swap/utils/getSwapArrivalStatus'
+
 // Chain-native block explorer URL builder (address/tx) for the non-swap case.
 export { getBlockExplorerUrl } from '@vultisig/core-chain/utils/getBlockExplorerUrl'
 

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -82,6 +82,14 @@ describe('@vultisig/sdk public exports', () => {
     expect(typeof sdk.evmCheckAllowance).toBe('function')
   })
 
+  it('exports provider-aware swap arrival status normalization', () => {
+    expect(typeof sdk.getSwapArrivalStatus).toBe('function')
+    expect(typeof sdk.Vultisig.getSwapArrivalStatus).toBe('function')
+    expect(typeof sdk.isSwapArrivalStatusTerminal).toBe('function')
+    expect(typeof sdk.SwapArrivalStatusRequestError).toBe('function')
+    expect(sdk.swapArrivalProviders).toEqual(['thorchain', 'mayachain', 'skip', 'li.fi'])
+  })
+
   it('exports encodeErc20Approve, encodeErc20Revoke, MAX_UINT256 (ERC-20 approve/revoke calldata)', () => {
     expect(typeof sdk.encodeErc20Approve).toBe('function')
     expect(typeof sdk.encodeErc20Revoke).toBe('function')


### PR DESCRIPTION
Closes #1231
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added unified swap-arrival status tracking across THORChain, MayaChain, Skip Go, and LI.FI.
  - Normalizes pending, successful, refunded, failed, partial, and not-found outcomes.
  - Includes destination transaction details, progress stages, messages, and error information.
  - Exposes the functionality through the SDK and `Vultisig` interface.
  - Supports terminal-status detection and configurable service endpoints.

- **Bug Fixes**
  - Improved handling of partial completions, invalid statuses, and node-only completion or refund scenarios.

- **Tests**
  - Added comprehensive coverage for provider responses, error handling, malformed data, and public exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->