### PR TITLE
fix(swap): bind vault-free quote safety

### DIFF
--- a/.changeset/guard-vault-free-evm-swaps.md
+++ b/.changeset/guard-vault-free-evm-swaps.md
@@ -4,3 +4,5 @@
 ---
 
 Bind raw swap quotes to their exact coin identities, requested source amount, absolute expiry, and returned transaction, then reject missing, stale, mismatched, or mutated quotes in the vault-free swap preparation path before any payload construction.
+
+Consumers must pass the bound quote returned by `findSwapQuote` or `getSwapQuote` into preparation instead of constructing or persisting an unbound raw quote.

--- a/.changeset/guard-vault-free-evm-swaps.md
+++ b/.changeset/guard-vault-free-evm-swaps.md
@@ -1,8 +1,8 @@
 ---
-"@vultisig/core-chain": patch
-"@vultisig/sdk": patch
+"@vultisig/core-chain": minor
+"@vultisig/sdk": minor
 ---
 
-Bind raw swap quotes to their exact coin identities, requested source amount, absolute expiry, and returned transaction, then reject missing, stale, mismatched, or mutated quotes in the vault-free swap preparation path before any payload construction.
+Bind raw swap quotes to their exact coin identities, requested source amount, absolute expiry, and returned transaction, then reject missing, stale, mismatched, or mutated quotes in the vault-free swap preparation path before any payload construction. General quotes remain preparation-valid for five minutes while SDK presentation continues to recommend refreshing after 60 seconds, and vault-free callers can catch `SwapQuoteExpiredError` to requote.
 
-Consumers must pass the bound quote returned by `findSwapQuote` or `getSwapQuote` into preparation instead of constructing or persisting an unbound raw quote.
+Consumers must pass the live bound quote returned by `findSwapQuote` or `getSwapQuote` into preparation instead of constructing or persisting an unbound raw quote. Structured cloning is supported; JSON round-tripping is not because it loses required runtime value types such as `bigint`.

--- a/.changeset/guard-vault-free-evm-swaps.md
+++ b/.changeset/guard-vault-free-evm-swaps.md
@@ -1,0 +1,6 @@
+---
+"@vultisig/core-chain": patch
+"@vultisig/sdk": patch
+---
+
+Bind raw swap quotes to their exact coin identities, requested source amount, absolute expiry, and returned transaction, then reject missing, stale, mismatched, or mutated quotes in the vault-free swap preparation path before any payload construction.

--- a/examples/electron/electron/ipc-handlers.ts
+++ b/examples/electron/electron/ipc-handlers.ts
@@ -464,8 +464,9 @@ export function registerIpcHandlers(ipcMain: IpcMain): void {
     const vault = await sdk.getVaultById(vaultId)
     if (!vault) throw new VaultError(VaultErrorCode.VaultNotFound, 'Vault not found')
     const result = await vault.prepareSwapTx(params)
-    // Serialize for IPC (convert BigInt to string)
-    return JSON.parse(JSON.stringify(result, (_key, value) => (typeof value === 'bigint' ? value.toString() : value)))
+    // Preserve the echoed quote's BigInt and Uint8Array values so it remains
+    // consistent with the safety binding when it crosses Electron IPC.
+    return result
   })
 
   // === TRANSACTION OPERATIONS ===

--- a/examples/electron/electron/ipc-handlers.ts
+++ b/examples/electron/electron/ipc-handlers.ts
@@ -452,8 +452,11 @@ export function registerIpcHandlers(ipcMain: IpcMain): void {
     const vault = await sdk.getVaultById(vaultId)
     if (!vault) throw new VaultError(VaultErrorCode.VaultNotFound, 'Vault not found')
     const quote = await vault.getSwapQuote(params)
-    // Serialize for IPC (convert BigInt to string)
-    return JSON.parse(JSON.stringify(quote, (_key, value) => (typeof value === 'bigint' ? value.toString() : value)))
+    // Electron IPC uses structured clone, which preserves the BigInt and
+    // Uint8Array values covered by the quote safety fingerprint. JSON
+    // serialization would change those values and make a valid quote fail the
+    // preparation-time integrity check when it returns from the renderer.
+    return quote
   })
 
   ipcMain.handle('vault:prepareSwapTx', async (_event, vaultId: string, params: any) => {

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -1908,6 +1908,11 @@
       "import": "./dist/swap/quote/getSwapQuoteProviderName.js",
       "default": "./dist/swap/quote/getSwapQuoteProviderName.js"
     },
+    "./swap/quote/getSwapQuoteSafetyFingerprint": {
+      "types": "./dist/swap/quote/getSwapQuoteSafetyFingerprint.d.ts",
+      "import": "./dist/swap/quote/getSwapQuoteSafetyFingerprint.js",
+      "default": "./dist/swap/quote/getSwapQuoteSafetyFingerprint.js"
+    },
     "./swap/quote/SwapQuote": {
       "types": "./dist/swap/quote/SwapQuote.d.ts",
       "import": "./dist/swap/quote/SwapQuote.js",

--- a/packages/core/chain/swap/quote/SwapQuote.ts
+++ b/packages/core/chain/swap/quote/SwapQuote.ts
@@ -20,10 +20,14 @@ export type SwapQuote = {
   requestedAmount?: bigint
   /** Absolute quote expiry in milliseconds, bound by `findSwapQuote`. Absent on legacy/manually constructed quotes. */
   expiresAt?: number
-  /** Integrity binding for the request identity, expiry, and exact returned transaction. */
+  /** Mutation/stale-reuse binding for the request identity, expiry, and exact returned transaction. */
   safetyFingerprint?: string
 }
 
-/** A canonical quote returned by `findSwapQuote`, with fund-safety metadata present. */
+/**
+ * A canonical quote returned by `findSwapQuote`, with fund-safety metadata
+ * present. Keep this as the live returned object (structured cloning is safe);
+ * JSON round-tripping loses required runtime value types such as `bigint`.
+ */
 export type BoundSwapQuote = SwapQuote &
   Required<Pick<SwapQuote, 'requestedAmount' | 'expiresAt' | 'safetyFingerprint'>>

--- a/packages/core/chain/swap/quote/SwapQuote.ts
+++ b/packages/core/chain/swap/quote/SwapQuote.ts
@@ -16,4 +16,14 @@ export type SwapQuoteResult = {
 export type SwapQuote = {
   quote: SwapQuoteResult
   discounts: SwapDiscount[]
+  /** Source amount, in base units, bound by `findSwapQuote`. Absent on legacy/manually constructed quotes. */
+  requestedAmount?: bigint
+  /** Absolute quote expiry in milliseconds, bound by `findSwapQuote`. Absent on legacy/manually constructed quotes. */
+  expiresAt?: number
+  /** Integrity binding for the request identity, expiry, and exact returned transaction. */
+  safetyFingerprint?: string
 }
+
+/** A canonical quote returned by `findSwapQuote`, with fund-safety metadata present. */
+export type BoundSwapQuote = SwapQuote &
+  Required<Pick<SwapQuote, 'requestedAmount' | 'expiresAt' | 'safetyFingerprint'>>

--- a/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
@@ -1,4 +1,5 @@
 import { Chain } from '@vultisig/core-chain/Chain'
+import type { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
 import { getCowSwapQuote } from '@vultisig/core-chain/swap/general/cowswap/api/getCowSwapQuote'
 import type { GeneralSwapQuote } from '@vultisig/core-chain/swap/general/GeneralSwapQuote'
 import { getJupiterSwapQuote } from '@vultisig/core-chain/swap/general/jupiter/api/getJupiterSwapQuote'
@@ -18,6 +19,7 @@ import { HttpResponseError } from '@vultisig/lib-utils/fetch/HttpResponseError'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { findSwapQuote } from './findSwapQuote'
+import { getSwapQuoteSafetyFingerprint } from './getSwapQuoteSafetyFingerprint'
 
 vi.mock('@vultisig/core-chain/swap/general/cowswap/api/getCowSwapQuote', () => ({
   getCowSwapQuote: vi.fn(),
@@ -205,6 +207,82 @@ describe('findSwapQuote parallel selection', () => {
       throw new Error('Expected general quote')
     }
     expect(quote.quote.general.provider).toBe('kyber')
+  })
+
+  it('binds the request identity, source amount, expiry, and returned transaction to a general quote', async () => {
+    vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('skip inch'))
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
+    vi.mocked(getSwapKitQuote).mockRejectedValue(new Error('skip swapkit'))
+    vi.mocked(getNativeSwapQuote).mockRejectedValue(new Error('native unavailable'))
+    vi.mocked(getKyberSwapQuote).mockResolvedValue(minimalGeneralQuote('1000000', 'kyber'))
+
+    const requestedAmount = 123n
+    const before = Date.now()
+    const quote = await findSwapQuote({
+      ...evmSameChainCoins,
+      amount: requestedAmount,
+    })
+    const after = Date.now()
+
+    expect(quote.requestedAmount).toBe(requestedAmount)
+    expect(quote.expiresAt).toBeGreaterThanOrEqual(before + 60_000)
+    expect(quote.expiresAt).toBeLessThanOrEqual(after + 60_000)
+    expect(quote.safetyFingerprint).toBe(
+      getSwapQuoteSafetyFingerprint({
+        ...evmSameChainCoins,
+        requestedAmount,
+        expiresAt: quote.expiresAt as number,
+        quote: quote.quote,
+      })
+    )
+    expect(quote.safetyFingerprint).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('binds a deferred provider response to the entry snapshot when caller coins mutate', async () => {
+    vi.mocked(getOneInchSwapQuote).mockRejectedValue(new Error('skip inch'))
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(new Error('skip lifi'))
+    vi.mocked(getSwapKitQuote).mockRejectedValue(new Error('skip swapkit'))
+    vi.mocked(getNativeSwapQuote).mockRejectedValue(new Error('native unavailable'))
+
+    let resolveKyber!: (quote: GeneralSwapQuote) => void
+    vi.mocked(getKyberSwapQuote).mockReturnValue(
+      new Promise(resolve => {
+        resolveKyber = resolve
+      })
+    )
+
+    const input: { from: AccountCoin; to: AccountCoin; amount: bigint } = {
+      from: { ...evmSameChainCoins.from },
+      to: { ...evmSameChainCoins.to },
+      amount: 123n,
+    }
+    const expectedFrom = { ...input.from }
+    const expectedTo = { ...input.to }
+    const pending = findSwapQuote(input)
+
+    input.to.id = '0xmutated-destination'
+    input.to.address = '0xmutated-account'
+    resolveKyber(minimalGeneralQuote('1000000', 'kyber'))
+
+    const quote = await pending
+    expect(quote.safetyFingerprint).toBe(
+      getSwapQuoteSafetyFingerprint({
+        from: expectedFrom,
+        to: expectedTo,
+        requestedAmount: input.amount,
+        expiresAt: quote.expiresAt as number,
+        quote: quote.quote,
+      })
+    )
+    expect(quote.safetyFingerprint).not.toBe(
+      getSwapQuoteSafetyFingerprint({
+        from: input.from,
+        to: input.to,
+        requestedAmount: input.amount,
+        expiresAt: quote.expiresAt as number,
+        quote: quote.quote,
+      })
+    )
   })
 
   it('does not let a failing provider hide a succeeding one', async () => {
@@ -405,7 +483,10 @@ describe('findSwapQuote parallel selection', () => {
     vi.mocked(getNativeSwapQuote).mockRejectedValue(new Error('skip native'))
     vi.mocked(getJupiterSwapQuote).mockResolvedValue(minimalGeneralQuote('1000000', 'jupiter'))
 
-    const quote = await findSwapQuote({ ...solanaSameChainCoins, amount: 100000000n })
+    const quote = await findSwapQuote({
+      ...solanaSameChainCoins,
+      amount: 100000000n,
+    })
 
     expect('general' in quote.quote).toBe(true)
     if (!('general' in quote.quote)) {
@@ -498,13 +579,26 @@ describe('findSwapQuote parallel selection', () => {
     vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) => minimalNativeQuote(swapChain, '1000'))
 
     await findSwapQuote({
-      from: { chain: Chain.Cardano, address: 'addr1source', decimals: 6, ticker: 'ADA' },
-      to: { chain: Chain.Ethereum, address: '0xdestination', decimals: 18, ticker: 'ETH' },
+      from: {
+        chain: Chain.Cardano,
+        address: 'addr1source',
+        decimals: 6,
+        ticker: 'ADA',
+      },
+      to: {
+        chain: Chain.Ethereum,
+        address: '0xdestination',
+        decimals: 18,
+        ticker: 'ETH',
+      },
       amount: 1_000_000n,
     })
 
     expect(getNativeSwapQuote).toHaveBeenCalledWith(
-      expect.objectContaining({ swapChain: Chain.MayaChain, from: expect.objectContaining({ chain: Chain.Cardano }) })
+      expect.objectContaining({
+        swapChain: Chain.MayaChain,
+        from: expect.objectContaining({ chain: Chain.Cardano }),
+      })
     )
   })
 
@@ -851,7 +945,10 @@ describe('findSwapQuote parallel selection', () => {
       minimalNativeQuote(swapChain, '100000000')
     )
 
-    const quote = await findSwapQuote({ ...nativeOnlyCoins, amount: 1_000_000n })
+    const quote = await findSwapQuote({
+      ...nativeOnlyCoins,
+      amount: 1_000_000n,
+    })
 
     expect('native' in quote.quote).toBe(true)
   })
@@ -875,8 +972,18 @@ describe('findSwapQuote parallel selection', () => {
     // only compute THORChain's minimum, so eager-failing on it would wrongly
     // block an amount MayaChain might fill at a lower minimum. Quotes must fire.
     const thorAndMayaCoins = {
-      from: { chain: Chain.THORChain, address: 'thor1src', decimals: 8, ticker: 'RUNE' },
-      to: { chain: Chain.Bitcoin, address: 'bc1qdst', decimals: 8, ticker: 'BTC' },
+      from: {
+        chain: Chain.THORChain,
+        address: 'thor1src',
+        decimals: 8,
+        ticker: 'RUNE',
+      },
+      to: {
+        chain: Chain.Bitcoin,
+        address: 'bc1qdst',
+        decimals: 8,
+        ticker: 'BTC',
+      },
     } as const
     vi.mocked(getNativeSwapMinAmountIn).mockResolvedValue(minResult(1_000_000n, '0.01'))
     vi.mocked(getNativeSwapQuote).mockImplementation(async ({ swapChain }) =>
@@ -1544,12 +1651,24 @@ describe('findSwapQuote net-output provider selection (issues #605/#804)', () =>
     vi.mocked(getCowSwapQuote).mockResolvedValue(minimalCowSwapQuote('1000000'))
     vi.mocked(getKyberSwapQuote).mockResolvedValue(
       minimalGeneralQuote('1000000', 'kyber', {
-        evm: { from: '0xsender', to: '0xrouter', data: '0x', value: '0', gasLimit: 100_000n },
+        evm: {
+          from: '0xsender',
+          to: '0xrouter',
+          data: '0x',
+          value: '0',
+          gasLimit: 100_000n,
+        },
       })
     )
     vi.mocked(getOneInchSwapQuote).mockResolvedValue(
       minimalGeneralQuote('1000000', '1inch', {
-        evm: { from: '0xsender', to: '0xrouter', data: '0x', value: '0', gasLimit: 90_000n },
+        evm: {
+          from: '0xsender',
+          to: '0xrouter',
+          data: '0x',
+          value: '0',
+          gasLimit: 90_000n,
+        },
       })
     )
     vi.mocked(getSwapKitQuote).mockResolvedValue(minimalGeneralQuote('1000000', 'swapkit'))

--- a/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
@@ -18,7 +18,7 @@ import { NativeSwapQuote } from '@vultisig/core-chain/swap/native/NativeSwapQuot
 import { HttpResponseError } from '@vultisig/lib-utils/fetch/HttpResponseError'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { findSwapQuote } from './findSwapQuote'
+import { findSwapQuote, GENERAL_QUOTE_PREPARATION_TTL_MS } from './findSwapQuote'
 import { getSwapQuoteSafetyFingerprint } from './getSwapQuoteSafetyFingerprint'
 
 vi.mock('@vultisig/core-chain/swap/general/cowswap/api/getCowSwapQuote', () => ({
@@ -225,8 +225,8 @@ describe('findSwapQuote parallel selection', () => {
     const after = Date.now()
 
     expect(quote.requestedAmount).toBe(requestedAmount)
-    expect(quote.expiresAt).toBeGreaterThanOrEqual(before + 60_000)
-    expect(quote.expiresAt).toBeLessThanOrEqual(after + 60_000)
+    expect(quote.expiresAt).toBeGreaterThanOrEqual(before + GENERAL_QUOTE_PREPARATION_TTL_MS)
+    expect(quote.expiresAt).toBeLessThanOrEqual(after + GENERAL_QUOTE_PREPARATION_TTL_MS)
     expect(quote.safetyFingerprint).toBe(
       getSwapQuoteSafetyFingerprint({
         ...evmSameChainCoins,

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -619,7 +619,7 @@ const toProviderSlippage = (slippageTolerance: number | undefined): ProviderSlip
   }
 }
 
-export const findSwapQuote = async (input: FindSwapQuoteInput): Promise<SwapQuote> => {
+export const findSwapQuote = async (input: FindSwapQuoteInput): Promise<BoundSwapQuote> => {
   // Provider requests yield before the returned transaction is safety-bound. Own a synchronous
   // snapshot so caller mutations cannot make a response for pair A receive pair B's fingerprint.
   const {

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -50,7 +50,8 @@ import { HttpResponseError } from '@vultisig/lib-utils/fetch/HttpResponseError'
 import { pick } from '@vultisig/lib-utils/record/pick'
 import { TransferDirection } from '@vultisig/lib-utils/TransferDirection'
 
-import { SwapQuote } from './SwapQuote'
+import { cloneSwapSafetyValue, getSwapQuoteSafetyFingerprint } from './getSwapQuoteSafetyFingerprint'
+import type { BoundSwapQuote, SwapQuote } from './SwapQuote'
 
 /** Optional per-aggregator affiliate overrides. When absent each aggregator
  * falls back to its own vultisig-0 default — no behavior change for existing
@@ -115,17 +116,47 @@ export type SwapQuoteProviderExcludeName = SwapQuoteProviderName | GeneralSwapPr
 
 type SwapQuoteFetcher = {
   providerName: SwapQuoteProviderName
-  fetch: () => Promise<SwapQuote>
+  fetch: () => Promise<UnboundSwapQuote>
 }
 
+type UnboundSwapQuote = Omit<SwapQuote, 'requestedAmount' | 'expiresAt' | 'safetyFingerprint'>
+
 type RankedSwapQuote = {
-  quote: SwapQuote
+  quote: BoundSwapQuote
   outputAmount: bigint
   sourceGasUnits?: bigint
   providerName: SwapQuoteProviderName
 }
 
 const QUOTE_FETCH_TIMEOUT_MS = 30_000
+const GENERAL_QUOTE_TTL_MS = 60_000
+
+const bindQuoteSafetyMetadata = (
+  quote: UnboundSwapQuote,
+  from: AccountCoin,
+  to: AccountCoin,
+  requestedAmount: bigint
+): BoundSwapQuote => {
+  const now = Date.now()
+  const expiresAt = 'native' in quote.quote ? quote.quote.native.expiry * 1000 : now + GENERAL_QUOTE_TTL_MS
+  const effectiveExpiresAt =
+    'general' in quote.quote && 'cowswap_order' in quote.quote.general.tx
+      ? Math.min(expiresAt, quote.quote.general.tx.cowswap_order.validTo * 1000)
+      : expiresAt
+
+  return {
+    ...quote,
+    requestedAmount,
+    expiresAt: effectiveExpiresAt,
+    safetyFingerprint: getSwapQuoteSafetyFingerprint({
+      from,
+      to,
+      requestedAmount,
+      expiresAt: effectiveExpiresAt,
+      quote: quote.quote,
+    }),
+  }
+}
 
 // Node/undici network-layer error codes — mirrors agent-backend-ts's
 // `TRANSIENT_QUOTE_CODE_RE` (execute_swap.ts) for the same reason: a provider's raw
@@ -426,7 +457,7 @@ const getSameChainEvmSourceGasUnits = (q: SwapQuote, from: AccountCoin, to: Acco
   return undefined
 }
 
-function selectBestEligibleQuote(settled: PromiseSettledResult<RankedSwapQuote>[]): SwapQuote | null {
+function selectBestEligibleQuote(settled: PromiseSettledResult<RankedSwapQuote>[]): BoundSwapQuote | null {
   const candidates: RankedSwapQuote[] = []
 
   for (let i = 0; i < settled.length; i++) {
@@ -588,17 +619,20 @@ const toProviderSlippage = (slippageTolerance: number | undefined): ProviderSlip
   }
 }
 
-export const findSwapQuote = async ({
-  from,
-  to,
-  amount,
-  referral,
-  vultDiscountTier,
-  affiliateConfig,
-  recipient,
-  slippageTolerance,
-  excludeProviders,
-}: FindSwapQuoteInput): Promise<SwapQuote> => {
+export const findSwapQuote = async (input: FindSwapQuoteInput): Promise<SwapQuote> => {
+  // Provider requests yield before the returned transaction is safety-bound. Own a synchronous
+  // snapshot so caller mutations cannot make a response for pair A receive pair B's fingerprint.
+  const {
+    from,
+    to,
+    amount,
+    referral,
+    vultDiscountTier,
+    affiliateConfig,
+    recipient,
+    slippageTolerance,
+    excludeProviders,
+  } = cloneSwapSafetyValue(input)
   // Runtime guard: THORName affiliateFeeAddress must be lowercase.
   // THORChain memo parsing is case-sensitive — passing 'STVS' instead of 'stvs'
   // silently routes affiliate fees to the vultisig-0 default instead of the
@@ -660,7 +694,7 @@ export const findSwapQuote = async ({
   const getNativeFetchers = (): SwapQuoteFetcher[] =>
     matchingSwapChains.map(swapChain => ({
       providerName: swapChain === Chain.THORChain ? 'THORChain' : 'MayaChain',
-      fetch: async (): Promise<SwapQuote> => {
+      fetch: async (): Promise<UnboundSwapQuote> => {
         await assertNativeTradingOpen({ from, to, swapChain })
 
         const fromDecimals = from.decimals
@@ -715,7 +749,7 @@ export const findSwapQuote = async ({
       const buyToken = to.id
       result.push({
         providerName: 'CowSwap',
-        fetch: async (): Promise<SwapQuote> => {
+        fetch: async (): Promise<UnboundSwapQuote> => {
           const general = await getCowSwapQuote({
             sellToken,
             buyToken,
@@ -739,7 +773,7 @@ export const findSwapQuote = async ({
     ) {
       result.push({
         providerName: 'KyberSwap',
-        fetch: async (): Promise<SwapQuote> => {
+        fetch: async (): Promise<UnboundSwapQuote> => {
           const general = await getKyberSwapQuote({
             from: {
               ...from,
@@ -763,7 +797,7 @@ export const findSwapQuote = async ({
     if (!hasCustomRecipient && isOneOf(from.chain, oneInchSwapEnabledChains) && from.chain === to.chain) {
       result.push({
         providerName: '1inch',
-        fetch: async (): Promise<SwapQuote> => {
+        fetch: async (): Promise<UnboundSwapQuote> => {
           const general = await getOneInchSwapQuote({
             account: pick(from, ['address', 'chain']),
             // Pass the raw `.id` (undefined for a chain's native/fee coin) — NOT a ticker
@@ -793,7 +827,7 @@ export const findSwapQuote = async ({
     if (!hasCustomRecipient && isOneOf(fromChain, jupiterSwapEnabledChains) && fromChain === toChain) {
       result.push({
         providerName: 'Jupiter',
-        fetch: async (): Promise<SwapQuote> => {
+        fetch: async (): Promise<UnboundSwapQuote> => {
           const general = await getJupiterSwapQuote({
             from: {
               ...from,
@@ -817,7 +851,7 @@ export const findSwapQuote = async ({
     if (!hasCustomRecipient && isOneOf(fromChain, lifiSwapEnabledChains) && isOneOf(toChain, lifiSwapEnabledChains)) {
       result.push({
         providerName: 'LiFi',
-        fetch: async (): Promise<SwapQuote> => {
+        fetch: async (): Promise<UnboundSwapQuote> => {
           const general = await getLifiSwapQuote({
             from: {
               ...from,
@@ -841,7 +875,7 @@ export const findSwapQuote = async ({
     if (!hasCustomRecipient && isOneOf(fromChain, swapKitSourceChains) && isOneOf(toChain, swapKitEnabledChains)) {
       result.push({
         providerName: 'SwapKit',
-        fetch: async (): Promise<SwapQuote> => {
+        fetch: async (): Promise<UnboundSwapQuote> => {
           const general = await getSwapKitQuote({
             from: {
               ...from,
@@ -921,7 +955,12 @@ export const findSwapQuote = async ({
 
   const settled = await Promise.allSettled(
     fetchers.map(async (fetcher): Promise<RankedSwapQuote> => {
-      const quote = await withTimeout(fetcher.fetch(), QUOTE_FETCH_TIMEOUT_MS)
+      const quote = bindQuoteSafetyMetadata(
+        await withTimeout(fetcher.fetch(), QUOTE_FETCH_TIMEOUT_MS),
+        from,
+        to,
+        amount
+      )
       return {
         quote,
         outputAmount: getComparableOutputAmount(quote, to, fetcher.providerName),

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -129,7 +129,13 @@ type RankedSwapQuote = {
 }
 
 const QUOTE_FETCH_TIMEOUT_MS = 30_000
-const GENERAL_QUOTE_TTL_MS = 60_000
+/**
+ * General aggregators do not expose a uniform quote deadline. Keep the bound
+ * transaction usable for a normal review-and-sign round trip while the SDK's
+ * presentation layer continues to recommend a refresh after 60 seconds.
+ * Provider-supplied deadlines (currently CoW's `validTo`) still win when sooner.
+ */
+export const GENERAL_QUOTE_PREPARATION_TTL_MS = 5 * 60_000
 
 const bindQuoteSafetyMetadata = (
   quote: UnboundSwapQuote,
@@ -138,7 +144,7 @@ const bindQuoteSafetyMetadata = (
   requestedAmount: bigint
 ): BoundSwapQuote => {
   const now = Date.now()
-  const expiresAt = 'native' in quote.quote ? quote.quote.native.expiry * 1000 : now + GENERAL_QUOTE_TTL_MS
+  const expiresAt = 'native' in quote.quote ? quote.quote.native.expiry * 1000 : now + GENERAL_QUOTE_PREPARATION_TTL_MS
   const effectiveExpiresAt =
     'general' in quote.quote && 'cowswap_order' in quote.quote.general.tx
       ? Math.min(expiresAt, quote.quote.general.tx.cowswap_order.validTo * 1000)

--- a/packages/core/chain/swap/quote/getSwapQuoteSafetyFingerprint.test.ts
+++ b/packages/core/chain/swap/quote/getSwapQuoteSafetyFingerprint.test.ts
@@ -1,0 +1,31 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { describe, expect, it } from 'vitest'
+
+import { getSwapQuoteSafetyFingerprint } from './getSwapQuoteSafetyFingerprint'
+
+const coin = {
+  chain: Chain.Ethereum,
+  address: '0x1111111111111111111111111111111111111111',
+  id: '0x2222222222222222222222222222222222222222',
+  ticker: 'TOKEN',
+  decimals: 18,
+}
+
+const fingerprint = (value: unknown) =>
+  getSwapQuoteSafetyFingerprint({
+    from: coin,
+    to: coin,
+    requestedAmount: 1n,
+    expiresAt: 1,
+    quote: { general: { value } } as never,
+  })
+
+describe('getSwapQuoteSafetyFingerprint', () => {
+  it('keeps canonical bigint tags distinct from provider object keys', () => {
+    expect(fingerprint(5n)).not.toBe(fingerprint({ $bigint: '5' }))
+  })
+
+  it('canonicalizes explicit undefined array values and sparse holes consistently', () => {
+    expect(fingerprint([undefined])).toBe(fingerprint(new Array(1)))
+  })
+})

--- a/packages/core/chain/swap/quote/getSwapQuoteSafetyFingerprint.ts
+++ b/packages/core/chain/swap/quote/getSwapQuoteSafetyFingerprint.ts
@@ -1,0 +1,80 @@
+import { sha256 } from '@noble/hashes/sha256'
+import { bytesToHex } from '@noble/hashes/utils'
+import type { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+
+import type { SwapQuoteResult } from './SwapQuote'
+
+type Input = {
+  from: AccountCoin
+  to: AccountCoin
+  requestedAmount: bigint
+  expiresAt: number
+  quote: SwapQuoteResult
+}
+
+export const cloneSwapSafetyValue = <T>(value: T): T => {
+  if (value === null || typeof value !== 'object') return value
+  if (value instanceof Uint8Array) return new Uint8Array(value) as T
+  if (Array.isArray(value)) return value.map(cloneSwapSafetyValue) as T
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, nestedValue]) => [
+      key,
+      cloneSwapSafetyValue(nestedValue),
+    ])
+  ) as T
+}
+
+const canonicalize = (value: unknown): string => {
+  if (value === null) return 'null'
+  if (value instanceof Uint8Array) return `{"$bytes":${JSON.stringify(bytesToHex(value))}}`
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(',')}]`
+
+  switch (typeof value) {
+    case 'bigint':
+      return `{"$bigint":${JSON.stringify(value.toString())}}`
+    case 'boolean':
+    case 'number':
+    case 'string':
+      return JSON.stringify(value)
+    case 'object': {
+      const record = value as Record<string, unknown>
+      return `{${Object.keys(record)
+        .filter(key => record[key] !== undefined)
+        .sort()
+        .map(key => `${JSON.stringify(key)}:${canonicalize(record[key])}`)
+        .join(',')}}`
+    }
+    default:
+      throw new Error(`Unsupported swap quote safety value: ${typeof value}`)
+  }
+}
+
+const coinIdentity = ({ chain, address, id, ticker, decimals }: AccountCoin) => ({
+  chain,
+  address,
+  id,
+  ticker,
+  decimals,
+})
+
+/**
+ * Integrity-binds a canonical quote to the exact request identity and signable
+ * transaction it was returned with. Pure and platform-neutral so preparation
+ * can recompute the same value before any wallet/key/payload work.
+ */
+export const getSwapQuoteSafetyFingerprint = ({ from, to, requestedAmount, expiresAt, quote }: Input): string =>
+  bytesToHex(
+    sha256(
+      new TextEncoder().encode(
+        canonicalize({
+          version: 1,
+          from: coinIdentity(from),
+          to: coinIdentity(to),
+          requestedAmount,
+          expiresAt,
+          quote,
+        })
+      )
+    )
+  )

--- a/packages/core/chain/swap/quote/getSwapQuoteSafetyFingerprint.ts
+++ b/packages/core/chain/swap/quote/getSwapQuoteSafetyFingerprint.ts
@@ -28,7 +28,11 @@ export const cloneSwapSafetyValue = <T>(value: T): T => {
 const canonicalize = (value: unknown): string => {
   if (value === null) return 'null'
   if (value instanceof Uint8Array) return `{"$bytes":${JSON.stringify(bytesToHex(value))}}`
-  if (Array.isArray(value)) return `[${value.map(canonicalize).join(',')}]`
+  if (Array.isArray(value)) {
+    return `[${Array.from({ length: value.length }, (_, index) =>
+      index in value && value[index] !== undefined ? canonicalize(value[index]) : '{"$undefined":true}'
+    ).join(',')}]`
+  }
 
   switch (typeof value) {
     case 'bigint':
@@ -42,7 +46,10 @@ const canonicalize = (value: unknown): string => {
       return `{${Object.keys(record)
         .filter(key => record[key] !== undefined)
         .sort()
-        .map(key => `${JSON.stringify(key)}:${canonicalize(record[key])}`)
+        // `$...` is reserved for canonical type tags above. Escape real object
+        // keys in that namespace so, for example, `5n` cannot collide with a
+        // provider object shaped like `{ $bigint: '5' }`.
+        .map(key => `${JSON.stringify(key.startsWith('$') ? `$${key}` : key)}:${canonicalize(record[key])}`)
         .join(',')}}`
     }
     default:
@@ -59,9 +66,11 @@ const coinIdentity = ({ chain, address, id, ticker, decimals }: AccountCoin) => 
 })
 
 /**
- * Integrity-binds a canonical quote to the exact request identity and signable
- * transaction it was returned with. Pure and platform-neutral so preparation
- * can recompute the same value before any wallet/key/payload work.
+ * Detects accidental mutation and stale or mismatched reuse by binding a
+ * canonical quote to the exact request identity and signable transaction it
+ * was returned with. This unkeyed digest is not an authenticity boundary.
+ * Pure and platform-neutral so preparation can recompute the same value before
+ * any wallet/key/payload work.
  */
 export const getSwapQuoteSafetyFingerprint = ({ from, to, requestedAmount, expiresAt, quote }: Input): string =>
   bytesToHex(

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1024,6 +1024,7 @@ export {
   SUI_NATIVE_COIN_TYPE,
   supportedIbcDestinationsFrom,
   supportedUtxoBalanceChains,
+  SwapQuoteExpiredError,
   symbolFromCoinGeckoId,
   TERRA_CHAIN_ID,
   TERRA_LCD,

--- a/packages/sdk/src/tools/index.ts
+++ b/packages/sdk/src/tools/index.ts
@@ -386,6 +386,7 @@ export {
   type SplTransferResult,
   SUI_NATIVE_COIN_TYPE,
   supportedIbcDestinationsFrom,
+  SwapQuoteExpiredError,
   TRC20_TRANSFER_SELECTOR,
   type UndelegateParams,
   type UnsignedTrc20Transfer,

--- a/packages/sdk/src/tools/prep/index.ts
+++ b/packages/sdk/src/tools/prep/index.ts
@@ -46,7 +46,7 @@ export {
   type PrepareSuiTokenTransferFromKeysParams,
   SUI_NATIVE_COIN_TYPE,
 } from './suiTokenTransfer'
-export { prepareSwapTxFromKeys, type PrepareSwapTxFromKeysParams } from './swap'
+export { prepareSwapTxFromKeys, type PrepareSwapTxFromKeysParams, SwapQuoteExpiredError } from './swap'
 export {
   prepareThorchainMsgDepositTxFromKeys,
   type PrepareThorchainMsgDepositTxFromKeysParams,

--- a/packages/sdk/src/tools/prep/swap.ts
+++ b/packages/sdk/src/tools/prep/swap.ts
@@ -2,6 +2,10 @@ import type { WalletCore } from '@trustwallet/wallet-core'
 import { toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'
 import type { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
 import { getPublicKey } from '@vultisig/core-chain/publicKey/getPublicKey'
+import {
+  cloneSwapSafetyValue,
+  getSwapQuoteSafetyFingerprint,
+} from '@vultisig/core-chain/swap/quote/getSwapQuoteSafetyFingerprint'
 import type { SwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
 import { buildSwapKeysignPayload } from '@vultisig/core-mpc/keysign/swap/build'
 import type { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
@@ -17,15 +21,52 @@ export type PrepareSwapTxFromKeysParams = {
   swapQuote: SwapQuote
 }
 
+// Snapshot all amount/coin/quote inputs synchronously. Validation and payload construction must
+// consume the same immutable-by-ownership copy: wallet and UTXO resolution both yield, so retaining
+// caller-owned objects after the fingerprint check would create a mutation window before signing.
+const snapshotPreparationParams = (params: PrepareSwapTxFromKeysParams): PrepareSwapTxFromKeysParams =>
+  cloneSwapSafetyValue(params)
+
 // Fund-safety, agent-reachable (audit ABTS-005/plan 005): this is the vault-free swap builder,
-// so it's the one path an agent (no key shares) can drive. It previously enforced NEITHER quote
-// expiry NOR amount↔quote consistency, unlike the vault-wrapped `SwapService.prepareSwapTx`.
-//
-// Native-quote expiry (`quote.native.expiry`) is a REAL absolute deadline sourced from the
-// THORChain/Maya quote API — mirrors core's own `assertQuoteNotExpired`
-// (nativeSwapQuoteToSwapPayload.ts).
-// CoW-swap expiry (`cowswap_order.validTo`) is a Unix-second deadline on the EIP-712 order itself.
-// Other general-quote routes carry no expiry field the SDK can assert here.
+// so it validates the source amount and expiry bound by `findSwapQuote` before any wallet-core or
+// public-key work. Embedded native/CoW deadlines are retained below as defense-in-depth.
+const assertQuoteSafetyBinding = (params: PrepareSwapTxFromKeysParams, requestedAmount: bigint): void => {
+  const { swapQuote } = params
+  const { requestedAmount: boundAmount, expiresAt, safetyFingerprint } = swapQuote
+  if (
+    typeof boundAmount !== 'bigint' ||
+    typeof expiresAt !== 'number' ||
+    !Number.isFinite(expiresAt) ||
+    typeof safetyFingerprint !== 'string'
+  ) {
+    throw new Error(
+      'prepareSwapTxFromKeys: swap quote is missing its amount/expiry safety binding; refresh it with findSwapQuote before signing'
+    )
+  }
+  if (expiresAt <= Date.now()) {
+    throw new Error('prepareSwapTxFromKeys: swap quote has expired; refresh the quote before signing')
+  }
+  if (boundAmount !== requestedAmount) {
+    throw new Error(
+      `prepareSwapTxFromKeys: requested amount (${requestedAmount} base units) does not match the quote's requested source amount (${boundAmount} base units) — the quote may be stale or for a different request`
+    )
+  }
+  const expectedFingerprint = getSwapQuoteSafetyFingerprint({
+    from: params.fromCoin,
+    to: params.toCoin,
+    requestedAmount: boundAmount,
+    expiresAt,
+    quote: swapQuote.quote,
+  })
+  if (safetyFingerprint !== expectedFingerprint) {
+    throw new Error(
+      'prepareSwapTxFromKeys: swap quote does not match the requested coins or its original transaction; refresh the quote before signing'
+    )
+  }
+}
+
+// Native-quote expiry (`quote.native.expiry`) is a real absolute deadline sourced from the
+// THORChain/Maya quote API. CoW's `validTo` is the deadline on the EIP-712 order itself.
 const assertNativeQuoteNotExpired = (expirySeconds: number): void => {
   if (expirySeconds <= Math.floor(Date.now() / 1000)) {
     throw new Error('prepareSwapTxFromKeys: native swap quote has expired; refresh the quote before signing')
@@ -40,13 +81,9 @@ const assertCowQuoteNotExpired = (validTo: number): void => {
   }
 }
 
-// Cross-checks the caller's `amount` against the quote's CoW gross sell amount only.
-// `general.transfer` amount is provider-committed and legitimately diverges from the caller's
-// input by small fee adjustments (e.g. request 100_000n → committed 99_999n), so an exact
-// comparison would false-reject every UTXO/Cosmos SwapKit route. For CoW the gross value
-// (sellAmount + feeAmount) is what gets committed to the EIP-712 order the caller must sign,
-// and the caller's amount is expected to match it exactly.
-// Native/evm/solana fail open — no confidently-comparable committed sell field is available.
+// Defense-in-depth for CoW: the quote-level requested amount must also match the gross value
+// committed to the EIP-712 order. Other tx variants are covered by the quote-level binding above;
+// `transfer.amount` may legitimately differ because providers subtract deposit-channel fees.
 const assertAmountMatchesCommittedSellAmount = (params: PrepareSwapTxFromKeysParams): void => {
   const { quote } = params.swapQuote
   if (!('general' in quote)) return
@@ -76,12 +113,10 @@ const assertAmountMatchesCommittedSellAmount = (params: PrepareSwapTxFromKeysPar
  *
  * Coin-input resolution must be performed by the caller — the vault layer owns
  * that responsibility because it requires `getAddress`. This helper enforces
- * quote-expiry (native quotes) and amount↔quote consistency (general quotes
- * with a confidently-comparable committed sell amount) itself, so every
- * caller — vault-wrapped and vault-free alike — gets those checks; see the
- * inline reasoning above `assertNativeQuoteNotExpired` /
- * `assertAmountMatchesCommittedSellAmount` for exactly what is and isn't
- * covered.
+ * quote expiry and caller-amount↔quote consistency itself, so every caller —
+ * vault-wrapped and vault-free alike — gets those checks. The raw quote must
+ * come from `findSwapQuote`, which binds the requested base-unit amount and an
+ * absolute expiry before returning it.
  *
  * If the swap requires an ERC-20 approval, the resulting payload will have
  * `erc20ApprovePayload` set by core; this wrapper returns the payload as-is
@@ -98,19 +133,22 @@ export const prepareSwapTxFromKeys = async (
   params: PrepareSwapTxFromKeysParams,
   walletCoreOverride?: WalletCore
 ): Promise<KeysignPayload> => {
-  const { quote } = params.swapQuote
+  const safeParams = snapshotPreparationParams(params)
+  const { quote } = safeParams.swapQuote
+  const requestedAmount = toChainAmount(safeParams.amount, safeParams.fromCoin.decimals)
+  assertQuoteSafetyBinding(safeParams, requestedAmount)
   if ('native' in quote) {
     assertNativeQuoteNotExpired(quote.native.expiry)
   }
   if ('general' in quote && 'cowswap_order' in quote.general.tx) {
     assertCowQuoteNotExpired(quote.general.tx.cowswap_order.validTo)
   }
-  assertAmountMatchesCommittedSellAmount(params)
+  assertAmountMatchesCommittedSellAmount(safeParams)
 
   const walletCore = walletCoreOverride ?? (await getWalletCore())
 
   const fromPublicKey = getPublicKey({
-    chain: params.fromCoin.chain,
+    chain: safeParams.fromCoin.chain,
     walletCore,
     publicKeys: {
       ecdsa: identity.ecdsaPublicKey,
@@ -121,7 +159,7 @@ export const prepareSwapTxFromKeys = async (
   })
 
   const toPublicKey = getPublicKey({
-    chain: params.toCoin.chain,
+    chain: safeParams.toCoin.chain,
     walletCore,
     publicKeys: {
       ecdsa: identity.ecdsaPublicKey,
@@ -132,10 +170,10 @@ export const prepareSwapTxFromKeys = async (
   })
 
   return buildSwapKeysignPayload({
-    fromCoin: params.fromCoin,
-    toCoin: params.toCoin,
-    amount: params.amount,
-    swapQuote: params.swapQuote,
+    fromCoin: safeParams.fromCoin,
+    toCoin: safeParams.toCoin,
+    amount: safeParams.amount,
+    swapQuote: safeParams.swapQuote,
     vaultId: identity.ecdsaPublicKey,
     localPartyId: identity.localPartyId,
     fromPublicKey,

--- a/packages/sdk/src/tools/prep/swap.ts
+++ b/packages/sdk/src/tools/prep/swap.ts
@@ -6,7 +6,7 @@ import {
   cloneSwapSafetyValue,
   getSwapQuoteSafetyFingerprint,
 } from '@vultisig/core-chain/swap/quote/getSwapQuoteSafetyFingerprint'
-import type { SwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
+import type { BoundSwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
 import { buildSwapKeysignPayload } from '@vultisig/core-mpc/keysign/swap/build'
 import type { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
 import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
@@ -18,7 +18,18 @@ export type PrepareSwapTxFromKeysParams = {
   fromCoin: AccountCoin
   toCoin: AccountCoin
   amount: string | number
-  swapQuote: SwapQuote
+  /** Live bound quote returned by `findSwapQuote`; do not JSON round-trip it. */
+  swapQuote: BoundSwapQuote
+}
+
+/** Catchable signal that the caller should fetch a fresh quote and retry. */
+export class SwapQuoteExpiredError extends Error {
+  readonly code = 'SWAP_QUOTE_EXPIRED'
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'SwapQuoteExpiredError'
+  }
 }
 
 // Snapshot all amount/coin/quote inputs synchronously. Validation and payload construction must
@@ -44,7 +55,7 @@ const assertQuoteSafetyBinding = (params: PrepareSwapTxFromKeysParams, requested
     )
   }
   if (expiresAt <= Date.now()) {
-    throw new Error('prepareSwapTxFromKeys: swap quote has expired; refresh the quote before signing')
+    throw new SwapQuoteExpiredError('prepareSwapTxFromKeys: swap quote has expired; refresh the quote before signing')
   }
   if (boundAmount !== requestedAmount) {
     throw new Error(
@@ -60,7 +71,7 @@ const assertQuoteSafetyBinding = (params: PrepareSwapTxFromKeysParams, requested
   })
   if (safetyFingerprint !== expectedFingerprint) {
     throw new Error(
-      'prepareSwapTxFromKeys: swap quote does not match the requested coins or its original transaction; refresh the quote before signing'
+      'prepareSwapTxFromKeys: swap quote does not match the requested coins, amount, value types, or original transaction; fetch a fresh quote without JSON round-tripping it'
     )
   }
 }
@@ -69,21 +80,25 @@ const assertQuoteSafetyBinding = (params: PrepareSwapTxFromKeysParams, requested
 // THORChain/Maya quote API. CoW's `validTo` is the deadline on the EIP-712 order itself.
 const assertNativeQuoteNotExpired = (expirySeconds: number): void => {
   if (expirySeconds <= Math.floor(Date.now() / 1000)) {
-    throw new Error('prepareSwapTxFromKeys: native swap quote has expired; refresh the quote before signing')
+    throw new SwapQuoteExpiredError(
+      'prepareSwapTxFromKeys: native swap quote has expired; refresh the quote before signing'
+    )
   }
 }
 
 const assertCowQuoteNotExpired = (validTo: number): void => {
   if (validTo <= Math.floor(Date.now() / 1000)) {
-    throw new Error(
+    throw new SwapQuoteExpiredError(
       'prepareSwapTxFromKeys: CoW swap order has expired (validTo in the past); refresh the quote before signing'
     )
   }
 }
 
 // Defense-in-depth for CoW: the quote-level requested amount must also match the gross value
-// committed to the EIP-712 order. Other tx variants are covered by the quote-level binding above;
-// `transfer.amount` may legitimately differ because providers subtract deposit-channel fees.
+// committed to the EIP-712 order. Native/evm/solana do not expose a separate committed-sell
+// field here, so they intentionally fail open after the quote-level amount binding above;
+// `transfer.amount` may legitimately differ (for example, 100_000n -> 99_999n) because providers
+// subtract deposit-channel fees.
 const assertAmountMatchesCommittedSellAmount = (params: PrepareSwapTxFromKeysParams): void => {
   const { quote } = params.swapQuote
   if (!('general' in quote)) return

--- a/packages/sdk/src/tools/swap/findSwapQuote.ts
+++ b/packages/sdk/src/tools/swap/findSwapQuote.ts
@@ -6,7 +6,7 @@ import {
   SwapAffiliateConfig,
   SwapQuoteProviderExcludeName,
 } from '@vultisig/core-chain/swap/quote/findSwapQuote'
-import type { SwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
+import type { BoundSwapQuote, SwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
 
 export type { SwapAffiliateConfig, SwapQuoteProviderExcludeName }
 
@@ -63,7 +63,7 @@ export type FindSwapQuoteParams = {
   excludeProviders?: SwapQuoteProviderExcludeName[]
 }
 
-export type { SwapQuote }
+export type { BoundSwapQuote, SwapQuote }
 
 /**
  * Find the best swap quote across all providers (THORChain, MayaChain, 1inch, LiFi, KyberSwap).
@@ -84,7 +84,7 @@ export type { SwapQuote }
  * })
  * ```
  */
-export const findSwapQuote = async (params: FindSwapQuoteParams): Promise<SwapQuote> => {
+export const findSwapQuote = async (params: FindSwapQuoteParams): Promise<BoundSwapQuote> => {
   const from: AccountCoin = {
     chain: params.fromChain,
     address: params.fromAddress,

--- a/packages/sdk/src/vault/services/SwapService.ts
+++ b/packages/sdk/src/vault/services/SwapService.ts
@@ -359,9 +359,13 @@ export class SwapService {
     const { quote: quoteData } = swapQuote
     const isNative = 'native' in quoteData
 
-    // Calculate expiry
-    const expiresIn = isNative ? quoteData.native.expiry * 1000 - Date.now() : DEFAULT_QUOTE_EXPIRY_MS
-    const expiresAt = Date.now() + Math.min(expiresIn, DEFAULT_QUOTE_EXPIRY_MS)
+    // Preserve the raw quote's receive-time expiry. Native quotes also keep the
+    // SDK's existing 60-second maximum presentation window.
+    // `formatQuoteResult` only receives canonical `findSwapQuote` results. The
+    // base type keeps these fields optional so legacy/manual quote fixtures stay
+    // source-compatible; the vault-free builder still validates them at runtime.
+    const quoteExpiresAt = swapQuote.expiresAt as number
+    const expiresAt = isNative ? Math.min(quoteExpiresAt, Date.now() + DEFAULT_QUOTE_EXPIRY_MS) : quoteExpiresAt
 
     // Native swap APIs report output in their protocol precision. SDK consumers
     // expect the destination coin's base units, matching general provider quotes.

--- a/packages/sdk/src/vault/services/SwapService.ts
+++ b/packages/sdk/src/vault/services/SwapService.ts
@@ -134,8 +134,9 @@ export class SwapService {
    */
   async prepareSwapTx(params: SwapTxParams): Promise<SwapPrepareResult> {
     try {
-      // Validate quote hasn't expired
-      if (Date.now() > params.swapQuote.expiresAt) {
+      // `SwapQuoteBase.expiresAt` is the presentation refresh window. The raw
+      // bound quote carries the preparation deadline enforced again below.
+      if (Date.now() > params.swapQuote.quote.expiresAt) {
         throw new VaultError(VaultErrorCode.InvalidConfig, 'Swap quote has expired. Please refresh the quote.')
       }
 
@@ -359,10 +360,10 @@ export class SwapService {
     const { quote: quoteData } = swapQuote
     const isNative = 'native' in quoteData
 
-    // Preserve the raw quote's receive-time expiry. Native quotes also keep the
-    // SDK's existing 60-second maximum presentation window.
+    // Keep the SDK's existing 60-second presentation refresh window separate
+    // from the raw bound quote's longer preparation deadline.
     const quoteExpiresAt = swapQuote.expiresAt
-    const expiresAt = isNative ? Math.min(quoteExpiresAt, Date.now() + DEFAULT_QUOTE_EXPIRY_MS) : quoteExpiresAt
+    const expiresAt = Math.min(quoteExpiresAt, Date.now() + DEFAULT_QUOTE_EXPIRY_MS)
 
     // Native swap APIs report output in their protocol precision. SDK consumers
     // expect the destination coin's base units, matching general provider quotes.

--- a/packages/sdk/src/vault/services/SwapService.ts
+++ b/packages/sdk/src/vault/services/SwapService.ts
@@ -19,7 +19,7 @@ import { chainsWithTokenMetadataDiscovery } from '@vultisig/core-chain/coin/toke
 import { getCoinValue } from '@vultisig/core-chain/coin/utils/getCoinValue'
 import { nativeSwapAmountToCoinBaseUnit } from '@vultisig/core-chain/swap/native/utils/nativeSwapAmountToCoinBaseUnit'
 import { findSwapQuote, FindSwapQuoteInput } from '@vultisig/core-chain/swap/quote/findSwapQuote'
-import { SwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
+import { BoundSwapQuote, SwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
 import { swapEnabledChains } from '@vultisig/core-chain/swap/swapEnabledChains'
 import { SwapError, SwapErrorCode } from '@vultisig/core-chain/swap/SwapError'
 import { getEvmBaseFee } from '@vultisig/core-chain/tx/fee/evm/baseFee'
@@ -350,7 +350,7 @@ export class SwapService {
    * Format quote into SwapQuoteBase
    */
   private async formatQuoteResult(
-    swapQuote: SwapQuote,
+    swapQuote: BoundSwapQuote,
     fromCoin: AccountCoin,
     toCoin: AccountCoin,
     approvalInfo?: SwapApprovalInfo,
@@ -361,10 +361,7 @@ export class SwapService {
 
     // Preserve the raw quote's receive-time expiry. Native quotes also keep the
     // SDK's existing 60-second maximum presentation window.
-    // `formatQuoteResult` only receives canonical `findSwapQuote` results. The
-    // base type keeps these fields optional so legacy/manual quote fixtures stay
-    // source-compatible; the vault-free builder still validates them at runtime.
-    const quoteExpiresAt = swapQuote.expiresAt as number
+    const quoteExpiresAt = swapQuote.expiresAt
     const expiresAt = isNative ? Math.min(quoteExpiresAt, Date.now() + DEFAULT_QUOTE_EXPIRY_MS) : quoteExpiresAt
 
     // Native swap APIs report output in their protocol precision. SDK consumers

--- a/packages/sdk/src/vault/swap-types.ts
+++ b/packages/sdk/src/vault/swap-types.ts
@@ -7,7 +7,7 @@
 import type { Chain } from '@vultisig/core-chain/Chain'
 import type { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
 import type { SwapAffiliateConfig, SwapQuoteProviderExcludeName } from '@vultisig/core-chain/swap/quote/findSwapQuote'
-import type { SwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
+import type { BoundSwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
 import type { FiatCurrency } from '@vultisig/core-config/FiatCurrency'
 import type { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
 
@@ -15,7 +15,7 @@ import type { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v
 export type { GeneralSwapProvider } from '@vultisig/core-chain/swap/general/GeneralSwapProvider'
 export type { GeneralSwapQuote } from '@vultisig/core-chain/swap/general/GeneralSwapQuote'
 export type { NativeSwapQuote } from '@vultisig/core-chain/swap/native/NativeSwapQuote'
-export type { SwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
+export type { BoundSwapQuote, SwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
 export type { FiatCurrency } from '@vultisig/core-config/FiatCurrency'
 
 /**
@@ -123,7 +123,7 @@ export type ResolvedCoinInfo = {
  */
 export type SwapQuoteBase = {
   /** Raw quote from core (for use with prepareSwapTx) */
-  quote: SwapQuote
+  quote: BoundSwapQuote
   /** Expected output amount (in smallest unit, e.g., wei) */
   estimatedOutput: bigint
   /** Expected output amount in fiat (when fiatCurrency was requested) */

--- a/packages/sdk/tests/integration/swap/swap-quote.test.ts
+++ b/packages/sdk/tests/integration/swap/swap-quote.test.ts
@@ -211,6 +211,9 @@ describe('Integration: Swap Quote', () => {
           },
         },
         discounts: [],
+        requestedAmount: 1_000_000_000_000_000_000n,
+        expiresAt: Date.now() + 60_000,
+        safetyFingerprint: 'test-fingerprint',
       }
 
       vi.mocked(findSwapQuote).mockResolvedValue(mockQuote as any)
@@ -276,6 +279,9 @@ describe('Integration: Swap Quote', () => {
           },
         },
         discounts: [],
+        requestedAmount: 1_000_000_000n,
+        expiresAt: Date.now() + 60_000,
+        safetyFingerprint: 'test-fingerprint',
       }
 
       vi.mocked(findSwapQuote).mockResolvedValue(mockQuote)

--- a/packages/sdk/tests/integration/swap/swap-quote.test.ts
+++ b/packages/sdk/tests/integration/swap/swap-quote.test.ts
@@ -14,6 +14,7 @@
  */
 
 import { Chain } from '@vultisig/core-chain/Chain'
+import { getSwapQuoteSafetyFingerprint } from '@vultisig/core-chain/swap/quote/getSwapQuoteSafetyFingerprint'
 import type { Vault as CoreVault } from '@vultisig/core-mpc/vault/Vault'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
@@ -187,33 +188,54 @@ describe('Integration: Swap Quote', () => {
   describe('Quote Fetching', () => {
     it('should get swap quote for native token swap', async () => {
       const { findSwapQuote } = await import('@vultisig/core-chain/swap/quote/findSwapQuote')
+      const fromCoin = {
+        chain: Chain.Ethereum,
+        address: '0x1234567890abcdef1234567890abcdef12345678',
+        ticker: 'ETH',
+        decimals: 18,
+      }
+      const toCoin = {
+        chain: Chain.Bitcoin,
+        address: 'bc1qtest...',
+        ticker: 'BTC',
+        decimals: 8,
+      }
+      const requestedAmount = 1_000_000_000_000_000_000n
+      const expiresAt = Date.now() + 60_000
 
       // Mock THORChain quote
-      const mockQuote = {
-        quote: {
-          native: {
-            swapChain: 'THORChain' as const,
-            expected_amount_out: '5000000', // 0.05 BTC in sats
-            expiry: Math.floor(Date.now() / 1000) + 600,
-            fees: {
-              affiliate: '0',
-              asset: 'BTC',
-              outbound: '10000',
-              total: '10000',
-            },
-            inbound_address: 'bc1q...',
-            memo: '=:BTC.BTC:bc1q...',
-            notes: '',
-            outbound_delay_blocks: 0,
-            outbound_delay_seconds: 0,
-            recommended_min_amount_in: '100000000000000000',
-            warning: '',
+      const rawQuote = {
+        native: {
+          swapChain: 'THORChain' as const,
+          expected_amount_out: '5000000', // 0.05 BTC in sats
+          expiry: Math.floor(Date.now() / 1000) + 600,
+          fees: {
+            affiliate: '0',
+            asset: 'BTC',
+            outbound: '10000',
+            total: '10000',
           },
+          inbound_address: 'bc1q...',
+          memo: '=:BTC.BTC:bc1q...',
+          notes: '',
+          outbound_delay_blocks: 0,
+          outbound_delay_seconds: 0,
+          recommended_min_amount_in: '100000000000000000',
+          warning: '',
         },
+      }
+      const mockQuote = {
+        quote: rawQuote,
         discounts: [],
-        requestedAmount: 1_000_000_000_000_000_000n,
-        expiresAt: Date.now() + 60_000,
-        safetyFingerprint: 'test-fingerprint',
+        requestedAmount,
+        expiresAt,
+        safetyFingerprint: getSwapQuoteSafetyFingerprint({
+          from: fromCoin,
+          to: toCoin,
+          requestedAmount,
+          expiresAt,
+          quote: rawQuote,
+        }),
       }
 
       vi.mocked(findSwapQuote).mockResolvedValue(mockQuote as any)
@@ -221,18 +243,8 @@ describe('Integration: Swap Quote', () => {
       receivedEvents = []
 
       const quote = await vault.getSwapQuote({
-        fromCoin: {
-          chain: Chain.Ethereum,
-          address: '0x1234567890abcdef1234567890abcdef12345678',
-          ticker: 'ETH',
-          decimals: 18,
-        },
-        toCoin: {
-          chain: Chain.Bitcoin,
-          address: 'bc1qtest...',
-          ticker: 'BTC',
-          decimals: 8,
-        },
+        fromCoin,
+        toCoin,
         amount: 1.0,
       })
 
@@ -260,28 +272,50 @@ describe('Integration: Swap Quote', () => {
     it('should get swap quote with approval required for ERC-20', async () => {
       const { findSwapQuote } = await import('@vultisig/core-chain/swap/quote/findSwapQuote')
       const { getErc20Allowance } = await import('@vultisig/core-chain/chains/evm/erc20/getErc20Allowance')
+      const fromCoin = {
+        chain: Chain.Ethereum,
+        address: '0x1234567890abcdef1234567890abcdef12345678',
+        id: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', // USDC
+        ticker: 'USDC',
+        decimals: 6,
+      }
+      const toCoin = {
+        chain: Chain.Ethereum,
+        address: '0x1234567890abcdef1234567890abcdef12345678',
+        ticker: 'ETH',
+        decimals: 18,
+      }
+      const requestedAmount = 1_000_000_000n
+      const expiresAt = Date.now() + 60_000
 
       // Mock 1inch quote
-      const mockQuote = {
-        quote: {
-          general: {
-            dstAmount: '1000000000000000000', // 1 ETH
-            provider: '1inch' as const,
-            tx: {
-              evm: {
-                from: '0x1234...',
-                to: '0x1111111254fb6c44bAC0beD2854e76F90643097d',
-                data: '0x...',
-                value: '0',
-                gasLimit: 300000n,
-              },
+      const rawQuote = {
+        general: {
+          dstAmount: '1000000000000000000', // 1 ETH
+          provider: '1inch' as const,
+          tx: {
+            evm: {
+              from: '0x1234...',
+              to: '0x1111111254fb6c44bAC0beD2854e76F90643097d',
+              data: '0x...',
+              value: '0',
+              gasLimit: 300000n,
             },
           },
         },
+      }
+      const mockQuote = {
+        quote: rawQuote,
         discounts: [],
-        requestedAmount: 1_000_000_000n,
-        expiresAt: Date.now() + 60_000,
-        safetyFingerprint: 'test-fingerprint',
+        requestedAmount,
+        expiresAt,
+        safetyFingerprint: getSwapQuoteSafetyFingerprint({
+          from: fromCoin,
+          to: toCoin,
+          requestedAmount,
+          expiresAt,
+          quote: rawQuote,
+        }),
       }
 
       vi.mocked(findSwapQuote).mockResolvedValue(mockQuote)
@@ -290,19 +324,8 @@ describe('Integration: Swap Quote', () => {
       receivedEvents = []
 
       const quote = await vault.getSwapQuote({
-        fromCoin: {
-          chain: Chain.Ethereum,
-          address: '0x1234567890abcdef1234567890abcdef12345678',
-          id: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', // USDC
-          ticker: 'USDC',
-          decimals: 6,
-        },
-        toCoin: {
-          chain: Chain.Ethereum,
-          address: '0x1234567890abcdef1234567890abcdef12345678',
-          ticker: 'ETH',
-          decimals: 18,
-        },
+        fromCoin,
+        toCoin,
         amount: 1000, // 1000 USDC
       })
 

--- a/packages/sdk/tests/unit/services/SwapService.test.ts
+++ b/packages/sdk/tests/unit/services/SwapService.test.ts
@@ -367,6 +367,7 @@ describe('SwapService', () => {
         discounts: [],
         requestedAmount: 100_000_000n,
         expiresAt,
+        safetyFingerprint: 'test-fingerprint',
       }
 
       vi.mocked(findSwapQuote).mockResolvedValue(mockQuote)
@@ -422,6 +423,9 @@ describe('SwapService', () => {
           },
         },
         discounts: [],
+        requestedAmount: 100_000_000n,
+        expiresAt: Date.now() + 60_000,
+        safetyFingerprint: 'test-fingerprint',
       })
       vi.mocked(getErc20Allowance).mockResolvedValue(0n)
 
@@ -471,6 +475,9 @@ describe('SwapService', () => {
           },
         },
         discounts: [],
+        requestedAmount: 100_000_000n,
+        expiresAt: Date.now() + 60_000,
+        safetyFingerprint: 'test-fingerprint',
       }
 
       vi.mocked(findSwapQuote).mockResolvedValue(mockQuote)
@@ -518,6 +525,9 @@ describe('SwapService', () => {
           },
         },
         discounts: [],
+        requestedAmount: 1_000_000_000_000_000_000n,
+        expiresAt: Date.now() + 60_000,
+        safetyFingerprint: 'test-fingerprint',
       })
 
       const result = await service.getQuote({
@@ -847,6 +857,7 @@ describe('SwapService', () => {
           discounts: [],
           requestedAmount: 1_000_000_000_000_000_000n,
           expiresAt: Date.now() + 60_000,
+          safetyFingerprint: '',
         },
         estimatedOutput: 1000000000n,
         provider: '1inch',
@@ -934,6 +945,7 @@ describe('SwapService', () => {
           discounts: [],
           requestedAmount: 100_000_000n,
           expiresAt: Date.now() + 60_000,
+          safetyFingerprint: '',
         },
         estimatedOutput: 1000000000n,
         provider: 'thorchain',
@@ -1001,6 +1013,7 @@ describe('SwapService', () => {
           discounts: [],
           requestedAmount: 100_000_000n,
           expiresAt: Date.now() + 60_000,
+          safetyFingerprint: '',
         },
         estimatedOutput: 1000000000000000000n,
         provider: '1inch',

--- a/packages/sdk/tests/unit/services/SwapService.test.ts
+++ b/packages/sdk/tests/unit/services/SwapService.test.ts
@@ -1,4 +1,5 @@
 import { Chain } from '@vultisig/core-chain/Chain'
+import { getSwapQuoteSafetyFingerprint } from '@vultisig/core-chain/swap/quote/getSwapQuoteSafetyFingerprint'
 import { SwapError, SwapErrorCode } from '@vultisig/core-chain/swap/SwapError'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -345,6 +346,7 @@ describe('SwapService', () => {
     it('should fetch a swap quote for ERC-20 token requiring approval', async () => {
       const { findSwapQuote } = await import('@vultisig/core-chain/swap/quote/findSwapQuote')
       const { getErc20Allowance } = await import('@vultisig/core-chain/chains/evm/erc20/getErc20Allowance')
+      const expiresAt = Date.now() + 45_000
 
       const mockQuote = {
         quote: {
@@ -363,6 +365,8 @@ describe('SwapService', () => {
           },
         },
         discounts: [],
+        requestedAmount: 100_000_000n,
+        expiresAt,
       }
 
       vi.mocked(findSwapQuote).mockResolvedValue(mockQuote)
@@ -387,6 +391,7 @@ describe('SwapService', () => {
 
       expect(result).toBeDefined()
       expect(result.provider).toBe('1inch')
+      expect(result.expiresAt).toBe(expiresAt)
       expect(result.requiresApproval).toBe(true)
       expect(result.approvalInfo).toBeDefined()
       expect(result.approvalInfo?.spender).toBe('0x1111111254fb6c44bAC0beD2854e76F90643097d')
@@ -840,6 +845,8 @@ describe('SwapService', () => {
             },
           },
           discounts: [],
+          requestedAmount: 1_000_000_000_000_000_000n,
+          expiresAt: Date.now() + 60_000,
         },
         estimatedOutput: 1000000000n,
         provider: '1inch',
@@ -857,6 +864,24 @@ describe('SwapService', () => {
         balance: 10n ** 18n,
         maxSwapable: 10n ** 18n,
       }
+      mockQuoteResult.quote.safetyFingerprint = getSwapQuoteSafetyFingerprint({
+        from: {
+          chain: Chain.Ethereum,
+          address: '0x1234567890abcdef1234567890abcdef12345678',
+          ticker: 'ETH',
+          decimals: 18,
+        },
+        to: {
+          chain: Chain.Ethereum,
+          address: '0x1234567890abcdef1234567890abcdef12345678',
+          id: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+          ticker: 'USDC',
+          decimals: 6,
+        },
+        requestedAmount: mockQuoteResult.quote.requestedAmount as bigint,
+        expiresAt: mockQuoteResult.quote.expiresAt as number,
+        quote: mockQuoteResult.quote.quote,
+      })
 
       const result = await service.prepareSwapTx({
         fromCoin: {
@@ -907,6 +932,8 @@ describe('SwapService', () => {
             },
           },
           discounts: [],
+          requestedAmount: 100_000_000n,
+          expiresAt: Date.now() + 60_000,
         },
         estimatedOutput: 1000000000n,
         provider: 'thorchain',
@@ -972,6 +999,8 @@ describe('SwapService', () => {
             },
           },
           discounts: [],
+          requestedAmount: 100_000_000n,
+          expiresAt: Date.now() + 60_000,
         },
         estimatedOutput: 1000000000000000000n,
         provider: '1inch',
@@ -994,6 +1023,24 @@ describe('SwapService', () => {
         balance: 10n ** 18n,
         maxSwapable: 10n ** 18n,
       }
+      mockQuoteResult.quote.safetyFingerprint = getSwapQuoteSafetyFingerprint({
+        from: {
+          chain: Chain.Ethereum,
+          address: '0x1234567890abcdef1234567890abcdef12345678',
+          id: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+          ticker: 'USDC',
+          decimals: 6,
+        },
+        to: {
+          chain: Chain.Ethereum,
+          address: '0x1234567890abcdef1234567890abcdef12345678',
+          ticker: 'ETH',
+          decimals: 18,
+        },
+        requestedAmount: mockQuoteResult.quote.requestedAmount as bigint,
+        expiresAt: mockQuoteResult.quote.expiresAt as number,
+        quote: mockQuoteResult.quote.quote,
+      })
 
       await service.prepareSwapTx({
         fromCoin: {

--- a/packages/sdk/tests/unit/services/SwapService.test.ts
+++ b/packages/sdk/tests/unit/services/SwapService.test.ts
@@ -398,6 +398,46 @@ describe('SwapService', () => {
       expect(result.approvalInfo?.spender).toBe('0x1111111254fb6c44bAC0beD2854e76F90643097d')
     })
 
+    it('keeps the 60-second presentation refresh separate from the raw preparation deadline', async () => {
+      const { findSwapQuote } = await import('@vultisig/core-chain/swap/quote/findSwapQuote')
+      const now = Date.now()
+      const preparationExpiresAt = now + 5 * 60_000
+
+      vi.mocked(findSwapQuote).mockResolvedValue({
+        quote: {
+          general: {
+            dstAmount: '1000000',
+            provider: '1inch',
+            tx: { evm: { from: '0xsender', to: '0xrouter', data: '0x', value: '0' } },
+          },
+        },
+        discounts: [],
+        requestedAmount: 1n,
+        expiresAt: preparationExpiresAt,
+        safetyFingerprint: 'test-fingerprint',
+      })
+
+      const result = await service.getQuote({
+        fromCoin: {
+          chain: Chain.Ethereum,
+          address: '0x1234567890abcdef1234567890abcdef12345678',
+          ticker: 'ETH',
+          decimals: 18,
+        },
+        toCoin: {
+          chain: Chain.Ethereum,
+          address: '0x1234567890abcdef1234567890abcdef12345678',
+          ticker: 'USDC',
+          decimals: 6,
+        },
+        amount: 0.000000000000000001,
+      })
+
+      expect(result.expiresAt).toBeGreaterThanOrEqual(now + 60_000)
+      expect(result.expiresAt).toBeLessThanOrEqual(Date.now() + 60_000)
+      expect(result.quote.expiresAt).toBe(preparationExpiresAt)
+    })
+
     it('should use the quote approvalAddress as the ERC-20 spender when it differs from the router', async () => {
       const { findSwapQuote } = await import('@vultisig/core-chain/swap/quote/findSwapQuote')
       const { getErc20Allowance } = await import('@vultisig/core-chain/chains/evm/erc20/getErc20Allowance')
@@ -944,12 +984,12 @@ describe('SwapService', () => {
           },
           discounts: [],
           requestedAmount: 100_000_000n,
-          expiresAt: Date.now() + 60_000,
+          expiresAt: Date.now() - 10_000,
           safetyFingerprint: '',
         },
         estimatedOutput: 1000000000n,
         provider: 'thorchain',
-        expiresAt: Date.now() - 10000, // Expired
+        expiresAt: Date.now() + 60_000, // Presentation refresh can outlive the raw preparation deadline.
         requiresApproval: false,
         fees: { network: 0n, total: 0n },
         warnings: [],

--- a/packages/sdk/tests/unit/tools/prep/swap.test.ts
+++ b/packages/sdk/tests/unit/tools/prep/swap.test.ts
@@ -1,4 +1,5 @@
 import { Chain } from '@vultisig/core-chain/Chain'
+import { getSwapQuoteSafetyFingerprint } from '@vultisig/core-chain/swap/quote/getSwapQuoteSafetyFingerprint'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { mockBuildSwapKeysignPayload, mockGetPublicKey, mockGetWalletCore } = vi.hoisted(() => ({
@@ -53,9 +54,33 @@ const btcCoin = {
   ticker: 'BTC',
 } as any
 
+const bindSwapQuote = (
+  quote: any,
+  requestedAmount: bigint,
+  {
+    expiresAt = Date.now() + 600_000,
+    fromCoin = ethCoin,
+    toCoin = btcCoin,
+  }: { expiresAt?: number; fromCoin?: any; toCoin?: any } = {}
+) =>
+  ({
+    quote,
+    discounts: [],
+    requestedAmount,
+    expiresAt,
+    safetyFingerprint: getSwapQuoteSafetyFingerprint({
+      from: fromCoin,
+      to: toCoin,
+      requestedAmount,
+      expiresAt,
+      quote,
+    }),
+  }) as any
+
 // A non-expired native quote (expiry is a future unix-seconds timestamp) — the shape that
-// exercises the real `'native' in quote` branch without tripping the new expiry guard.
-const swapQuoteStub = { quote: { native: { expiry: Math.floor(Date.now() / 1000) + 600 } } } as any
+// exercises the real `'native' in quote` branch without tripping the expiry guards.
+const freshNativeQuote = (requestedAmount: bigint, fromCoin = ethCoin, toCoin = btcCoin) =>
+  bindSwapQuote({ native: { expiry: Math.floor(Date.now() / 1000) + 600 } }, requestedAmount, { fromCoin, toCoin })
 
 describe('prepareSwapTxFromKeys', () => {
   beforeEach(() => {
@@ -66,13 +91,14 @@ describe('prepareSwapTxFromKeys', () => {
 
   it('calls getPublicKey for both fromCoin.chain and toCoin.chain (native swap THORChain -> BTC)', async () => {
     const payload = { __mock: 'nativePayload' }
+    const swapQuote = freshNativeQuote(1_000_000_000n, thorCoin, btcCoin)
     mockBuildSwapKeysignPayload.mockResolvedValue(payload)
 
     const result = await prepareSwapTxFromKeys(baseIdentity, {
       fromCoin: thorCoin,
       toCoin: btcCoin,
       amount: 10,
-      swapQuote: swapQuoteStub,
+      swapQuote,
     })
 
     expect(result).toBe(payload)
@@ -103,7 +129,7 @@ describe('prepareSwapTxFromKeys', () => {
       fromCoin: thorCoin,
       toCoin: btcCoin,
       amount: 10,
-      swapQuote: swapQuoteStub,
+      swapQuote,
       vaultId: baseIdentity.ecdsaPublicKey,
       localPartyId: baseIdentity.localPartyId,
       libType: baseIdentity.libType,
@@ -123,7 +149,7 @@ describe('prepareSwapTxFromKeys', () => {
         fromCoin: ethCoin,
         toCoin: btcCoin,
         amount: '1',
-        swapQuote: swapQuoteStub,
+        swapQuote: freshNativeQuote(1_000_000_000_000_000_000n),
       },
       overrideWalletCore as any
     )
@@ -146,7 +172,7 @@ describe('prepareSwapTxFromKeys', () => {
       fromCoin: ethCoin,
       toCoin: btcCoin,
       amount: '1',
-      swapQuote: swapQuoteStub,
+      swapQuote: freshNativeQuote(1_000_000_000_000_000_000n),
     })
 
     expect(mockGetPublicKey).toHaveBeenCalledTimes(2)
@@ -167,7 +193,7 @@ describe('prepareSwapTxFromKeys', () => {
   })
 })
 
-describe('prepareSwapTxFromKeys — quote expiry (native only, ABTS/plan 005)', () => {
+describe('prepareSwapTxFromKeys — quote expiry (ABTS/plan 005)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockGetWalletCore.mockResolvedValue(mockWalletCore)
@@ -175,7 +201,10 @@ describe('prepareSwapTxFromKeys — quote expiry (native only, ABTS/plan 005)', 
   })
 
   it('throws on an expired native quote, before building any payload', async () => {
-    const expiredQuote = { quote: { native: { expiry: Math.floor(Date.now() / 1000) - 1 } } } as any
+    const expiredQuote = bindSwapQuote({ native: { expiry: Math.floor(Date.now() / 1000) - 1 } }, 1_000_000_000n, {
+      fromCoin: thorCoin,
+      toCoin: btcCoin,
+    })
 
     await expect(
       prepareSwapTxFromKeys(baseIdentity, {
@@ -194,7 +223,7 @@ describe('prepareSwapTxFromKeys — quote expiry (native only, ABTS/plan 005)', 
 
   it('does NOT throw on a fresh native quote (expiry in the future)', async () => {
     mockBuildSwapKeysignPayload.mockResolvedValue({ __mock: 'payload' })
-    const freshQuote = { quote: { native: { expiry: Math.floor(Date.now() / 1000) + 600 } } } as any
+    const freshQuote = freshNativeQuote(1_000_000_000n, thorCoin, btcCoin)
 
     await expect(
       prepareSwapTxFromKeys(baseIdentity, {
@@ -206,9 +235,10 @@ describe('prepareSwapTxFromKeys — quote expiry (native only, ABTS/plan 005)', 
     ).resolves.toBeDefined()
   })
 
-  it('does NOT enforce expiry on a non-CoW general quote (evm/solana/transfer carry no expiry field here)', async () => {
-    mockBuildSwapKeysignPayload.mockResolvedValue({ __mock: 'payload' })
-    const generalQuote = { quote: { general: { tx: { evm: {} } } } } as any
+  it('throws on an expired EVM-general quote before building any payload', async () => {
+    const generalQuote = bindSwapQuote({ general: { tx: { evm: {} } } }, 1_000_000_000_000_000_000n, {
+      expiresAt: Date.now() - 1,
+    })
 
     await expect(
       prepareSwapTxFromKeys(baseIdentity, {
@@ -217,12 +247,16 @@ describe('prepareSwapTxFromKeys — quote expiry (native only, ABTS/plan 005)', 
         amount: '1',
         swapQuote: generalQuote,
       })
-    ).resolves.toBeDefined()
+    ).rejects.toThrow(/expired/)
+
+    expect(mockBuildSwapKeysignPayload).not.toHaveBeenCalled()
+    expect(mockGetWalletCore).not.toHaveBeenCalled()
+    expect(mockGetPublicKey).not.toHaveBeenCalled()
   })
 
   it('throws on an expired CoW order (validTo in the past), before building any payload', async () => {
-    const expiredCowQuote = {
-      quote: {
+    const expiredCowQuote = bindSwapQuote(
+      {
         general: {
           tx: {
             cowswap_order: {
@@ -233,7 +267,8 @@ describe('prepareSwapTxFromKeys — quote expiry (native only, ABTS/plan 005)', 
           },
         },
       },
-    } as any
+      1_000_000_000_000_000_000n
+    )
 
     await expect(
       prepareSwapTxFromKeys(baseIdentity, {
@@ -250,8 +285,8 @@ describe('prepareSwapTxFromKeys — quote expiry (native only, ABTS/plan 005)', 
 
   it('does NOT throw on a fresh CoW order (validTo in the future)', async () => {
     mockBuildSwapKeysignPayload.mockResolvedValue({ __mock: 'payload' })
-    const freshCowQuote = {
-      quote: {
+    const freshCowQuote = bindSwapQuote(
+      {
         general: {
           tx: {
             cowswap_order: {
@@ -262,7 +297,8 @@ describe('prepareSwapTxFromKeys — quote expiry (native only, ABTS/plan 005)', 
           },
         },
       },
-    } as any
+      1_000_000_000_000_000_000n
+    )
 
     await expect(
       prepareSwapTxFromKeys(baseIdentity, {
@@ -275,7 +311,7 @@ describe('prepareSwapTxFromKeys — quote expiry (native only, ABTS/plan 005)', 
   })
 })
 
-describe('prepareSwapTxFromKeys — amount vs committed sell amount (ABTS/plan 005)', () => {
+describe('prepareSwapTxFromKeys — amount consistency (ABTS/plan 005)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockGetWalletCore.mockResolvedValue(mockWalletCore)
@@ -286,7 +322,10 @@ describe('prepareSwapTxFromKeys — amount vs committed sell amount (ABTS/plan 0
     // transfer.amount is provider-committed and legitimately diverges from caller input (e.g. 100_000 -> 99_999).
     // Exact comparison is excluded for the transfer variant.
     mockBuildSwapKeysignPayload.mockResolvedValue({ __mock: 'payload' })
-    const quote = { quote: { general: { tx: { transfer: { amount: 500000000000000000n } } } } } as any
+    const quote = bindSwapQuote(
+      { general: { tx: { transfer: { amount: 500000000000000000n } } } },
+      1_000_000_000_000_000_000n
+    )
 
     await expect(
       prepareSwapTxFromKeys(baseIdentity, {
@@ -300,8 +339,8 @@ describe('prepareSwapTxFromKeys — amount vs committed sell amount (ABTS/plan 0
 
   it('throws when the caller amount does not match the CoW gross sell amount (sellAmount + feeAmount)', async () => {
     // gross = 600e15 + 100e15 = 700e15, but requested is 1e18 — mismatch
-    const quote = {
-      quote: {
+    const quote = bindSwapQuote(
+      {
         general: {
           tx: {
             cowswap_order: {
@@ -312,7 +351,8 @@ describe('prepareSwapTxFromKeys — amount vs committed sell amount (ABTS/plan 0
           },
         },
       },
-    } as any
+      1_000_000_000_000_000_000n
+    )
 
     await expect(
       prepareSwapTxFromKeys(baseIdentity, {
@@ -329,8 +369,8 @@ describe('prepareSwapTxFromKeys — amount vs committed sell amount (ABTS/plan 0
   it('builds when the caller amount matches the CoW gross sell amount (sellAmount + feeAmount == requested)', async () => {
     mockBuildSwapKeysignPayload.mockResolvedValue({ __mock: 'payload' })
     // gross = 900e15 + 100e15 = 1e18, matches amount '1'
-    const quote = {
-      quote: {
+    const quote = bindSwapQuote(
+      {
         general: {
           tx: {
             cowswap_order: {
@@ -341,7 +381,8 @@ describe('prepareSwapTxFromKeys — amount vs committed sell amount (ABTS/plan 0
           },
         },
       },
-    } as any
+      1_000_000_000_000_000_000n
+    )
 
     await expect(
       prepareSwapTxFromKeys(baseIdentity, {
@@ -353,23 +394,166 @@ describe('prepareSwapTxFromKeys — amount vs committed sell amount (ABTS/plan 0
     ).resolves.toBeDefined()
   })
 
-  it('does NOT throw for an EVM-general quote (opaque calldata amount, not confidently comparable)', async () => {
-    mockBuildSwapKeysignPayload.mockResolvedValue({ __mock: 'payload' })
-    const quote = { quote: { general: { tx: { evm: { to: '0xrouter', data: '0xdeadbeef', value: '0' } } } } } as any
+  it('throws when an EVM-general quote was fetched for a different source amount', async () => {
+    const quote = bindSwapQuote(
+      {
+        general: {
+          tx: { evm: { to: '0xrouter', data: '0xdeadbeef', value: '0' } },
+        },
+      },
+      1_000_000_000_000_000_000n
+    )
 
     await expect(
       prepareSwapTxFromKeys(baseIdentity, {
         fromCoin: ethCoin,
         toCoin: btcCoin,
-        amount: '999999', // deliberately absurd — must NOT be rejected, since evm calldata isn't decoded
+        amount: '999999',
+        swapQuote: quote,
+      })
+    ).rejects.toThrow(/does not match the quote's requested source amount/)
+
+    expect(mockBuildSwapKeysignPayload).not.toHaveBeenCalled()
+    expect(mockGetWalletCore).not.toHaveBeenCalled()
+    expect(mockGetPublicKey).not.toHaveBeenCalled()
+  })
+
+  it('builds an EVM-general quote when the bound source amount matches', async () => {
+    mockBuildSwapKeysignPayload.mockResolvedValue({ __mock: 'payload' })
+    const quote = bindSwapQuote(
+      {
+        general: {
+          tx: { evm: { to: '0xrouter', data: '0xdeadbeef', value: '0' } },
+        },
+      },
+      1_000_000_000_000_000_000n
+    )
+
+    await expect(
+      prepareSwapTxFromKeys(baseIdentity, {
+        fromCoin: ethCoin,
+        toCoin: btcCoin,
+        amount: '1',
         swapQuote: quote,
       })
     ).resolves.toBeDefined()
   })
 
+  it('rejects a same-amount quote bound to a different coin pair before wallet work', async () => {
+    const quote = bindSwapQuote(
+      {
+        general: {
+          tx: { evm: { to: '0xrouter', data: '0xdeadbeef', value: '0' } },
+        },
+      },
+      1_000_000_000_000_000_000n
+    )
+
+    await expect(
+      prepareSwapTxFromKeys(baseIdentity, {
+        fromCoin: ethCoin,
+        toCoin: { ...btcCoin, id: 'other-bitcoin-asset' },
+        amount: '1',
+        swapQuote: quote,
+      })
+    ).rejects.toThrow(/does not match the requested coins or its original transaction/)
+
+    expect(mockBuildSwapKeysignPayload).not.toHaveBeenCalled()
+    expect(mockGetWalletCore).not.toHaveBeenCalled()
+    expect(mockGetPublicKey).not.toHaveBeenCalled()
+  })
+
+  it('rejects a quote whose EVM transaction changed after binding before wallet work', async () => {
+    const quote = bindSwapQuote(
+      {
+        general: {
+          tx: { evm: { to: '0xrouter', data: '0xdeadbeef', value: '0' } },
+        },
+      },
+      1_000_000_000_000_000_000n
+    )
+    quote.quote.general.tx.evm.data = '0xtampered'
+
+    await expect(
+      prepareSwapTxFromKeys(baseIdentity, {
+        fromCoin: ethCoin,
+        toCoin: btcCoin,
+        amount: '1',
+        swapQuote: quote,
+      })
+    ).rejects.toThrow(/does not match the requested coins or its original transaction/)
+
+    expect(mockBuildSwapKeysignPayload).not.toHaveBeenCalled()
+    expect(mockGetWalletCore).not.toHaveBeenCalled()
+    expect(mockGetPublicKey).not.toHaveBeenCalled()
+  })
+
+  it('uses the validated snapshot when caller-owned quote inputs mutate during wallet resolution', async () => {
+    let resolveWalletCore!: (walletCore: typeof mockWalletCore) => void
+    mockGetWalletCore.mockReturnValue(
+      new Promise<typeof mockWalletCore>(resolve => {
+        resolveWalletCore = resolve
+      })
+    )
+    mockBuildSwapKeysignPayload.mockResolvedValue({ __mock: 'payload' })
+
+    const quote = bindSwapQuote(
+      { general: { tx: { evm: { to: '0xrouter', data: '0xdeadbeef', value: '0' } } } },
+      1_000_000_000_000_000_000n
+    )
+    const params = {
+      fromCoin: ethCoin,
+      toCoin: { ...btcCoin },
+      amount: '1',
+      swapQuote: quote,
+    }
+
+    const pending = prepareSwapTxFromKeys(baseIdentity, params)
+    params.toCoin.id = 'mutated-asset'
+    quote.quote.general.tx.evm.data = '0xtampered-during-await'
+    resolveWalletCore(mockWalletCore)
+
+    await expect(pending).resolves.toBeDefined()
+    expect(mockBuildSwapKeysignPayload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toCoin: expect.not.objectContaining({ id: 'mutated-asset' }),
+        swapQuote: expect.objectContaining({
+          quote: {
+            general: expect.objectContaining({
+              tx: { evm: expect.objectContaining({ data: '0xdeadbeef' }) },
+            }),
+          },
+        }),
+      })
+    )
+  })
+
+  it('fails closed when an EVM-general quote lacks its safety binding', async () => {
+    const quote = {
+      quote: {
+        general: {
+          tx: { evm: { to: '0xrouter', data: '0xdeadbeef', value: '0' } },
+        },
+      },
+    } as any
+
+    await expect(
+      prepareSwapTxFromKeys(baseIdentity, {
+        fromCoin: ethCoin,
+        toCoin: btcCoin,
+        amount: '1',
+        swapQuote: quote,
+      })
+    ).rejects.toThrow(/missing its amount\/expiry safety binding/)
+
+    expect(mockBuildSwapKeysignPayload).not.toHaveBeenCalled()
+    expect(mockGetWalletCore).not.toHaveBeenCalled()
+    expect(mockGetPublicKey).not.toHaveBeenCalled()
+  })
+
   it('does NOT throw for a native quote (no committed-sell-amount field to compare against)', async () => {
     mockBuildSwapKeysignPayload.mockResolvedValue({ __mock: 'payload' })
-    const quote = { quote: { native: { expiry: Math.floor(Date.now() / 1000) + 600 } } } as any
+    const quote = freshNativeQuote(99_999_900_000_000n, thorCoin, btcCoin)
 
     await expect(
       prepareSwapTxFromKeys(baseIdentity, {
@@ -384,7 +568,10 @@ describe('prepareSwapTxFromKeys — amount vs committed sell amount (ABTS/plan 0
   it('accepts a scientific-notation amount on a transfer-route quote (transfer excluded from amount check)', async () => {
     mockBuildSwapKeysignPayload.mockResolvedValue({ __mock: 'payload' })
     // "1e-8" @ 8 decimals == 1 base unit — transfer is excluded, so this should never throw.
-    const quote = { quote: { general: { tx: { transfer: { amount: 999n } } } } } as any
+    const quote = bindSwapQuote({ general: { tx: { transfer: { amount: 999n } } } }, 1n, {
+      fromCoin: btcCoin,
+      toCoin: ethCoin,
+    })
 
     await expect(
       prepareSwapTxFromKeys(baseIdentity, {

--- a/packages/sdk/tests/unit/tools/prep/swap.test.ts
+++ b/packages/sdk/tests/unit/tools/prep/swap.test.ts
@@ -18,7 +18,7 @@ vi.mock('@/context/wasmRuntime', () => ({
   getWalletCore: mockGetWalletCore,
 }))
 
-import { prepareSwapTxFromKeys } from '@/tools/prep/swap'
+import { prepareSwapTxFromKeys, SwapQuoteExpiredError } from '@/tools/prep/swap'
 import type { VaultIdentity } from '@/tools/prep/types'
 
 const baseIdentity: VaultIdentity = {
@@ -247,7 +247,7 @@ describe('prepareSwapTxFromKeys — quote expiry (ABTS/plan 005)', () => {
         amount: '1',
         swapQuote: generalQuote,
       })
-    ).rejects.toThrow(/expired/)
+    ).rejects.toBeInstanceOf(SwapQuoteExpiredError)
 
     expect(mockBuildSwapKeysignPayload).not.toHaveBeenCalled()
     expect(mockGetWalletCore).not.toHaveBeenCalled()
@@ -456,7 +456,7 @@ describe('prepareSwapTxFromKeys — amount consistency (ABTS/plan 005)', () => {
         amount: '1',
         swapQuote: quote,
       })
-    ).rejects.toThrow(/does not match the requested coins or its original transaction/)
+    ).rejects.toThrow(/does not match the requested coins, amount, value types, or original transaction/)
 
     expect(mockBuildSwapKeysignPayload).not.toHaveBeenCalled()
     expect(mockGetWalletCore).not.toHaveBeenCalled()
@@ -472,7 +472,7 @@ describe('prepareSwapTxFromKeys — amount consistency (ABTS/plan 005)', () => {
       },
       1_000_000_000_000_000_000n
     )
-    quote.quote.general.tx.evm.data = '0xtampered'
+    quote.quote.general.tx.evm.data = '0xchanged'
 
     await expect(
       prepareSwapTxFromKeys(baseIdentity, {
@@ -481,7 +481,7 @@ describe('prepareSwapTxFromKeys — amount consistency (ABTS/plan 005)', () => {
         amount: '1',
         swapQuote: quote,
       })
-    ).rejects.toThrow(/does not match the requested coins or its original transaction/)
+    ).rejects.toThrow(/does not match the requested coins, amount, value types, or original transaction/)
 
     expect(mockBuildSwapKeysignPayload).not.toHaveBeenCalled()
     expect(mockGetWalletCore).not.toHaveBeenCalled()
@@ -510,7 +510,7 @@ describe('prepareSwapTxFromKeys — amount consistency (ABTS/plan 005)', () => {
 
     const pending = prepareSwapTxFromKeys(baseIdentity, params)
     params.toCoin.id = 'mutated-asset'
-    quote.quote.general.tx.evm.data = '0xtampered-during-await'
+    quote.quote.general.tx.evm.data = '0xchanged-during-await'
     resolveWalletCore(mockWalletCore)
 
     await expect(pending).resolves.toBeDefined()

--- a/plans/README.md
+++ b/plans/README.md
@@ -15,10 +15,10 @@ live in agent-backend-ts; 004/008 in vultiagent-poc).
 
 ## Execution order & status
 
-| Plan | Title | Priority | Effort | Depends on | Status |
-|------|-------|----------|--------|------------|--------|
-| 003  | Golden-vector-bind the two tx-encoder families (RN pure-JS vs WalletCore) | P1 | M | — | DONE — see note |
-| 005  | Add amount↔quote + expiry checks to the agent-reachable vault-free swap helper | P1 | S | — | DONE (partial) — see note |
+| Plan | Title                                                                          | Priority | Effort | Depends on | Status          |
+| ---- | ------------------------------------------------------------------------------ | -------- | ------ | ---------- | --------------- |
+| 003  | Golden-vector-bind the two tx-encoder families (RN pure-JS vs WalletCore)      | P1       | M      | —          | DONE — see note |
+| 005  | Add amount↔quote + expiry checks to the agent-reachable vault-free swap helper | P1       | S      | —          | DONE — see note |
 
 ## Plan 003 outcome note (2026-07-17, branch fix_encoder_parity_cross_check)
 
@@ -61,6 +61,16 @@ enforcement in the vault-free path — the calldata-amount-decode gap defers bot
 cowswap_order are covered. Follow-up: an EVM calldata amount-decoder (analogous to what would unlock
 decode-based checks elsewhere) is the prerequisite to close it — worth tracking as a named next step,
 not "good enough as-is."
+
+**Follow-up outcome (2026-08-05, issue #1196):** the residual is closed at the canonical quote
+boundary without coupling fund safety to provider-specific router ABIs. `findSwapQuote` now
+integrity-binds every raw quote to the exact source/destination coin identities, requested source
+amount, absolute receive-time expiry, and returned transaction; the vault-free helper fails closed
+when that binding is missing, expired, mismatched, or mutated before wallet-core/key derivation or
+payload construction. Native and CoW embedded deadlines and CoW's committed gross sell amount remain
+defense-in-depth checks. This guards stale/cross-request quote reuse and post-selection transaction
+changes across evolving EVM aggregator calldata shapes while keeping provider response validation at
+each provider's existing trust boundary.
 
 10 new tests (`swap.test.ts`), all green; 3 pre-existing tests' quote fixtures updated (bare mock →
 real `{quote:{native:{expiry}}}` shape) to exercise the real branches rather than break on the new


### PR DESCRIPTION
## Summary

- Bind swap quotes to the requested coin pair, source amount, expiry, and exact returned transaction before vault-free preparation.
- Reject missing, expired, stale, mismatched, or mutated bindings before wallet, key, or payload work.
- Keep the SDK's 60-second quote refresh recommendation separate from the five-minute general-quote preparation window; real provider deadlines still take precedence.
- Preserve `bigint` and `Uint8Array` quote values across Electron structured-clone IPC.
- Expose `SwapQuoteExpiredError` so vault-free callers can catch expiry and requote.

## Compatibility

This is a minor SDK/core-chain change: `prepareSwapTxFromKeys` now requires the `BoundSwapQuote` returned by `findSwapQuote` or `getSwapQuote`.

Keep that bound quote as the live returned object. Structured cloning is supported, but JSON round-tripping is not because it loses required runtime value types such as `bigint`.

## Validation

- Repository-wide typecheck and lint
- Full SDK unit suite: 3,303 tests
- Focused core quote-selection/fingerprint and SDK swap-preparation/service suites
- Live designated-vault Ethereum-to-USDC quote and non-broadcast dry-run
