### PR TITLE
Fail closed on SDK signature count mismatches

### DIFF
--- a/.changeset/guard-multi-input-signature-count.md
+++ b/.changeset/guard-multi-input-signature-count.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Fail closed when multi-input signing returns a different number of signatures than message hashes.

--- a/.changeset/guard-multi-input-signature-count.md
+++ b/.changeset/guard-multi-input-signature-count.md
@@ -2,4 +2,4 @@
 '@vultisig/sdk': patch
 ---
 
-Fail closed when multi-input signing returns a different number of signatures than message hashes.
+Fail closed when multi-input signature counts differ from message hashes or a single signature is paired with multiple message hashes.

--- a/packages/sdk/src/vault/utils/convertSignature.ts
+++ b/packages/sdk/src/vault/utils/convertSignature.ts
@@ -75,6 +75,12 @@ export function convertToKeysignSignatures(
 
   if (signature.signatures && signature.signatures.length > 0) {
     // Multi-message case (UTXO inputs, bundled approvals, and similar flows)
+    if (signature.signatures.length !== messageHashes.length) {
+      throw new Error(
+        `Signature count ${signature.signatures.length} does not match message hash count ${messageHashes.length}`
+      )
+    }
+
     signature.signatures.forEach((sig, index) => {
       const messageHash = messageHashes[index]
       if (!messageHash) {
@@ -91,6 +97,10 @@ export function convertToKeysignSignatures(
     })
   } else {
     // Single signature case (most chains)
+    if (messageHashes.length > 1) {
+      throw new Error(`Signature count 1 does not match message hash count ${messageHashes.length}`)
+    }
+
     const messageHash = messageHashes[0]
     if (!messageHash) {
       throw new Error('No message hash provided for signature')

--- a/packages/sdk/tests/unit/vault/utils/convertSignature.test.ts
+++ b/packages/sdk/tests/unit/vault/utils/convertSignature.test.ts
@@ -261,7 +261,7 @@ describe('convertToKeysignSignatures', () => {
       )
     })
 
-    it('should throw error when message hash is missing for multi-signature', () => {
+    it('should throw error when there are more signatures than message hashes', () => {
       const signature: Signature = {
         signature: '',
         format: 'ECDSA',
@@ -281,7 +281,56 @@ describe('convertToKeysignSignatures', () => {
       const messageHashes = ['0x1111111111111111111111111111111111111111111111111111111111111111'] // Only 1 hash but 2 signatures
 
       expect(() => convertToKeysignSignatures(signature, messageHashes)).toThrow(
-        'Missing message hash for signature at index 1'
+        'Signature count 2 does not match message hash count 1'
+      )
+    })
+
+    it('should throw error when there are fewer signatures than message hashes', () => {
+      const signature: Signature = {
+        signature: '',
+        format: 'ECDSA',
+        signatures: [
+          {
+            r: '0xab3c7b6a9e8f2c1d5e4a3f2b1c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d',
+            s: '0x7f6e5d4c3b2a1f0e9d8c7b6a5f4e3d2c1b0a9f8e7d6c5b4a3f2e1d0c9b8a7f6e',
+            der: '0x3045022100ab3c7b6a9e8f2c1d5e4a3f2b1c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d02207f6e5d4c3b2a1f0e9d8c7b6a5f4e3d2c1b0a9f8e7d6c5b4a3f2e1d0c9b8a7f6e',
+          },
+        ],
+      }
+      const messageHashes = [
+        '0x1111111111111111111111111111111111111111111111111111111111111111',
+        '0x2222222222222222222222222222222222222222222222222222222222222222',
+      ]
+
+      expect(() => convertToKeysignSignatures(signature, messageHashes)).toThrow(
+        'Signature count 1 does not match message hash count 2'
+      )
+    })
+
+    it('should throw error when an empty signatures array is paired with multiple message hashes', () => {
+      const signature: Signature = {
+        signature:
+          '0x3045022100ab3c7b6a9e8f2c1d5e4a3f2b1c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d02207f6e5d4c3b2a1f0e9d8c7b6a5f4e3d2c1b0a9f8e7d6c5b4a3f2e1d0c9b8a7f6e',
+        format: 'ECDSA',
+        signatures: [],
+      }
+      const messageHashes = ['0xfirst', '0xsecond']
+
+      expect(() => convertToKeysignSignatures(signature, messageHashes)).toThrow(
+        'Signature count 1 does not match message hash count 2'
+      )
+    })
+
+    it('should throw error when a single signature is paired with multiple message hashes', () => {
+      const signature: Signature = {
+        signature:
+          '0x3045022100ab3c7b6a9e8f2c1d5e4a3f2b1c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d02207f6e5d4c3b2a1f0e9d8c7b6a5f4e3d2c1b0a9f8e7d6c5b4a3f2e1d0c9b8a7f6e',
+        format: 'ECDSA',
+      }
+      const messageHashes = ['0xfirst', '0xsecond']
+
+      expect(() => convertToKeysignSignatures(signature, messageHashes)).toThrow(
+        'Signature count 1 does not match message hash count 2'
       )
     })
   })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signature validation during signing.
  * Signing now fails safely when the number of signatures does not match the number of message hashes.
  * Added handling for empty signature lists and single signatures paired with multiple message hashes.
* **Documentation**
  * Documented the fail-closed behavior for mismatched multi-input signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->