### PR TITLE
test(sdk): extend Cosmos fee and gas parity coverage

### DIFF
--- a/packages/sdk/tests/fixtures/cosmosTxFeeGasParity.ts
+++ b/packages/sdk/tests/fixtures/cosmosTxFeeGasParity.ts
@@ -1,0 +1,19 @@
+import type { CosmosChain } from '@vultisig/core-chain/Chain'
+
+export const cosmosTxFeeGasParityCases = [
+  { chain: 'THORChain', feeDenom: 'rune', feeAmount: undefined, gasLimit: 20_000_000n },
+  { chain: 'Cosmos', feeDenom: 'uatom', feeAmount: 7_500n, gasLimit: 200_000n },
+  { chain: 'Osmosis', feeDenom: 'uosmo', feeAmount: 9_000n, gasLimit: 300_000n },
+  { chain: 'MayaChain', feeDenom: 'cacao', feeAmount: 2_000_000_000n, gasLimit: 2_000_000_000n },
+  { chain: 'Dydx', feeDenom: 'adydx', feeAmount: 2_500_000_000_000_000n, gasLimit: 200_000n },
+  { chain: 'Kujira', feeDenom: 'ukuji', feeAmount: 7_500n, gasLimit: 200_000n },
+  { chain: 'Terra', feeDenom: 'uluna', feeAmount: 7_500n, gasLimit: 300_000n },
+  { chain: 'TerraClassic', feeDenom: 'uluna', feeAmount: 8_497_500n, gasLimit: 300_000n },
+  { chain: 'Noble', feeDenom: 'uusdc', feeAmount: 30_000n, gasLimit: 200_000n },
+  { chain: 'Akash', feeDenom: 'uakt', feeAmount: 200_000n, gasLimit: 200_000n },
+] as const satisfies ReadonlyArray<{
+  chain: CosmosChain
+  feeDenom: string
+  feeAmount: bigint | undefined
+  gasLimit: bigint
+}>

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import { cosmosTxFeeGasParityCases } from '../../../fixtures/cosmosTxFeeGasParity'
+
 vi.mock('expo-crypto', () => ({
   randomUUID: () => '00000000-0000-4000-8000-000000000000',
   getRandomValues: <T extends ArrayBufferView | null>(a: T) => a,
@@ -58,14 +60,29 @@ describe('RN entry wires configureCrypto and configureDefaultStorage', () => {
     expect(rn.resolveChainReference('8453')).toBe(rn.Chain.Base)
   })
 
-  it('exports the canonical IBC Cosmos send-fee floors from the RN entry', async () => {
+  it.each(cosmosTxFeeGasParityCases)(
+    'exports the canonical $chain fee denom, fee amount, and gas limit together',
+    async ({ chain, feeDenom, feeAmount, gasLimit }) => {
+      const rn = await import('../../../../src/platforms/react-native/index')
+
+      expect(rn.getCosmosAllowedFeeDenoms(chain)[0]).toBe(feeDenom)
+      expect(rn.getCosmosSendFeeBaseUnits(chain)).toBe(feeAmount)
+      expect(rn.getCosmosGasLimit({ chain })).toBe(gasLimit)
+    }
+  )
+
+  it('covers every Cosmos chain exposed by the RN entry', async () => {
+    const rn = await import('../../../../src/platforms/react-native/index')
+    const exposedCosmosChains = Object.values(rn.Chain).filter(chain => rn.getChainKind(chain) === 'cosmos')
+
+    expect(new Set(cosmosTxFeeGasParityCases.map(({ chain }) => chain))).toEqual(new Set(exposedCosmosChains))
+  })
+
+  it('exports the shared Cosmos send-fee constants used by the parity matrix', async () => {
     const rn = await import('../../../../src/platforms/react-native/index')
 
-    expect(rn.COSMOS_SEND_FEE_DEFAULT).toBe(7500n)
-    expect(rn.getCosmosSendFeeBaseUnits(rn.Chain.Cosmos)).toBe(7500n)
-    expect(rn.getCosmosSendFeeBaseUnits(rn.Chain.TerraClassic)).toBe(8_497_500n)
-    expect(rn.getCosmosSendFeeBaseUnits(rn.Chain.MayaChain)).toBe(2_000_000_000n)
-    expect(rn.getCosmosSendFeeBaseUnits(rn.Chain.THORChain)).toBeUndefined()
+    expect(rn.COSMOS_SEND_FEE_DEFAULT).toBe(7_500n)
+    expect(rn.MAYA_SEND_FEE_BASE_UNITS).toBe(2_000_000_000n)
   })
 
   it('keeps Robinhood derivation native-compatible on the exported RN surface', async () => {

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import * as sdk from '../../../src/index'
+import { cosmosTxFeeGasParityCases } from '../../fixtures/cosmosTxFeeGasParity'
 
 describe('@vultisig/sdk public exports', () => {
   it('exports fiatToAmount, toChainAmount, and chain-reference normalization utilities', () => {
@@ -190,12 +191,24 @@ describe('@vultisig/sdk public exports', () => {
     expect(typeof sdk.getChainGasPriceGwei).toBe('function')
   })
 
-  it('exports canonical Cosmos send-fee floors for first-party consumers', () => {
-    expect(sdk.COSMOS_SEND_FEE_DEFAULT).toBe(7500n)
-    expect(sdk.getCosmosSendFeeBaseUnits(sdk.Chain.Cosmos)).toBe(7500n)
-    expect(sdk.getCosmosSendFeeBaseUnits(sdk.Chain.TerraClassic)).toBe(8_497_500n)
-    expect(sdk.getCosmosSendFeeBaseUnits(sdk.Chain.MayaChain)).toBe(sdk.MAYA_SEND_FEE_BASE_UNITS)
-    expect(sdk.getCosmosSendFeeBaseUnits(sdk.Chain.THORChain)).toBeUndefined()
+  it.each(cosmosTxFeeGasParityCases)(
+    'exports the canonical $chain fee denom, fee amount, and gas limit together',
+    ({ chain, feeDenom, feeAmount, gasLimit }) => {
+      expect(sdk.cosmosFeeCoinDenom[chain]).toBe(feeDenom)
+      expect(sdk.getCosmosSendFeeBaseUnits(chain)).toBe(feeAmount)
+      expect(sdk.getCosmosGasLimit({ chain })).toBe(gasLimit)
+    }
+  )
+
+  it('covers every Cosmos chain exposed by the root SDK entry', () => {
+    const exposedCosmosChains = Object.values(sdk.Chain).filter(chain => sdk.getChainKind(chain) === 'cosmos')
+
+    expect(new Set(cosmosTxFeeGasParityCases.map(({ chain }) => chain))).toEqual(new Set(exposedCosmosChains))
+  })
+
+  it('exports the shared Cosmos send-fee constants used by the parity matrix', () => {
+    expect(sdk.COSMOS_SEND_FEE_DEFAULT).toBe(7_500n)
+    expect(sdk.MAYA_SEND_FEE_BASE_UNITS).toBe(2_000_000_000n)
   })
 
   it('exports seedphrase import chain support policy for consumers', () => {


### PR DESCRIPTION
Closes #1466

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded Cosmos transaction fee and gas coverage across all supported chains.
  - Added validation for fee denominations, fee amounts, gas limits, and shared send-fee constants.
  - Verified consistency between exported Cosmos chain lists and platform-specific configurations.
  - Included coverage for chains with undefined transaction fees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->