### PR TITLE
fix(cosmos): raise TerraClassic staking gas limit to 4M

### DIFF
--- a/.changeset/four-million-terraclassic-staking-gas.md
+++ b/.changeset/four-million-terraclassic-staking-gas.md
@@ -1,0 +1,8 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/sdk': patch
+---
+
+cosmos/gas: raise the TerraClassic staking gas limit from 3M to 4M
+
+`getCosmosStakingGasLimit` now returns 4M for `Chain.TerraClassic` regardless of `msgCount`, giving external SDK consumers headroom over the observed 2,501,503-gas `MsgBeginRedelegate` path.

--- a/.changeset/four-million-terraclassic-staking-gas.md
+++ b/.changeset/four-million-terraclassic-staking-gas.md
@@ -6,3 +6,5 @@
 cosmos/gas: raise the TerraClassic staking gas limit from 3M to 4M
 
 `getCosmosStakingGasLimit` now returns 4M for `Chain.TerraClassic` regardless of `msgCount`, giving external SDK consumers headroom over the observed 2,501,503-gas `MsgBeginRedelegate` path.
+
+Also exports `TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS`, the `uluna` fee correctly priced for this 4M staking gas limit (113.3 LUNC at the chain's 28.325 uluna/gas minimum). The existing `TERRA_CLASSIC_ULUNA_BASE_GAS` / `getCosmosSendFeeBaseUnits` fee is priced for the 300k native-send gas limit and under-pays a 4M-gas staking tx by ~13x, so consumers must pair the staking gas limit with this new constant, not the send fee.

--- a/packages/core/chain/chains/cosmos/cosmosGasLimitRecord.test.ts
+++ b/packages/core/chain/chains/cosmos/cosmosGasLimitRecord.test.ts
@@ -21,16 +21,15 @@ describe('cosmosGasLimitRecord', () => {
     expect(getCosmosStakingGasLimit({ chain: Chain.Terra })).toBe(500_000n)
     // Terra (not TerraClassic) scales normally: 500k + ((3-1)*500k)/4 = 750k
     expect(getCosmosStakingGasLimit({ chain: Chain.Terra, msgCount: 3 })).toBe(750_000n)
-    expect(getCosmosStakingGasLimit({ chain: Chain.TerraClassic })).toBe(3_000_000n)
+    expect(getCosmosStakingGasLimit({ chain: Chain.TerraClassic })).toBe(4_000_000n)
   })
 
-  it('TerraClassic: msgCount scaling capped at base regardless of count (fee-floor constraint)', () => {
-    // Columbus-5 fee floor: 100 LUNC = 100_000_000 uluna. At msgCount>=2 the
-    // scaled gasWanted * gasPrice exceeds 100 LUNC, causing node rejection.
-    // Single-msg policy: always return base=3M for TerraClassic.
-    expect(getCosmosStakingGasLimit({ chain: Chain.TerraClassic, msgCount: 1 })).toBe(3_000_000n)
-    expect(getCosmosStakingGasLimit({ chain: Chain.TerraClassic, msgCount: 2 })).toBe(3_000_000n)
-    expect(getCosmosStakingGasLimit({ chain: Chain.TerraClassic, msgCount: 3 })).toBe(3_000_000n)
+  it('TerraClassic: keeps the 4M single-transaction budget regardless of message count', () => {
+    // The 4M budget covers the observed 2_501_503-gas redelegation path with
+    // headroom. Multi-validator reward claims remain a caller-side split policy.
+    expect(getCosmosStakingGasLimit({ chain: Chain.TerraClassic, msgCount: 1 })).toBe(4_000_000n)
+    expect(getCosmosStakingGasLimit({ chain: Chain.TerraClassic, msgCount: 2 })).toBe(4_000_000n)
+    expect(getCosmosStakingGasLimit({ chain: Chain.TerraClassic, msgCount: 3 })).toBe(4_000_000n)
   })
 
   it('rejects invalid staking message counts before BigInt conversion', () => {

--- a/packages/core/chain/chains/cosmos/cosmosGasLimitRecord.ts
+++ b/packages/core/chain/chains/cosmos/cosmosGasLimitRecord.ts
@@ -39,15 +39,13 @@ export const getCosmosGasLimit = (coin: CoinKey<CosmosChain>): bigint => {
  * writes that the standard SDK gas estimate omits. In practice this adds
  * ~200-800 gas on top of the base delegate cost (~2M), so a 2M limit fails
  * consistently ("out of gas in location: ValuePerByte; gasWanted: 2000000,
- * gasUsed: 200X"). 3M needs ~84.97 LUNC at sign time (3M * 28.325 uluna/gas).
- * That fee is supplied by the CONSUMER's separate per-msg staking fee
- * (mcp-ts COSMOS_STAKING_FEE_PER_MSG_BASE_UNITS[TerraClassic] = 100 LUNC/msg,
- * written into the signAmino / signDirect fee) — NOT by
- * `cosmosGasRecord[TerraClassic]`, which is the native MsgSend gas fee
- * (8.4975 LUNC = 300k × 28.325) and never governs staking. The msgCount scaling is disabled for
- * TerraClassic: at msgCount>=2, scaled gasWanted would push the required fee
- * above the 100 LUNC per-msg staking fee, causing node rejection. Columbus-5
- * callers must split multi-validator claims into separate txs.
+ * gasUsed: 200X"). Production telemetry later observed MsgBeginRedelegate
+ * consuming 2_501_503 gas. The former 3M limit left little headroom over that
+ * observed burn, so TerraClassic uses 4M for the heaviest single-msg staking
+ * path. Consumers must price the fee amount for this gas limit independently;
+ * `cosmosGasRecord[TerraClassic]` governs native MsgSend only. TerraClassic
+ * keeps a fixed per-transaction staking budget, so callers must split
+ * multi-validator reward claims into separate transactions.
  */
 const cosmosStakingGasLimitRecord: Record<IbcEnabledCosmosChain, bigint> = {
   [Chain.Cosmos]: 350_000n,
@@ -57,7 +55,7 @@ const cosmosStakingGasLimitRecord: Record<IbcEnabledCosmosChain, bigint> = {
   [Chain.Noble]: 350_000n,
   [Chain.Akash]: 350_000n,
   [Chain.Terra]: 500_000n,
-  [Chain.TerraClassic]: 3_000_000n,
+  [Chain.TerraClassic]: 4_000_000n,
 }
 
 type GetCosmosStakingGasLimitInput = {
@@ -88,10 +86,8 @@ export const getCosmosStakingGasLimit = ({ chain, msgCount = 1 }: GetCosmosStaki
 
   const base = cosmosStakingGasLimitRecord[chain]
 
-  // TerraClassic: staking-fee cap (see comment on cosmosStakingGasLimitRecord).
-  // Scaling would push the required fee above the consumer's 100 LUNC per-msg
-  // staking fee at msgCount>=2; single-msg policy keeps the tx within that fee
-  // for columbus-5 (independent of the cosmosGasRecord native-send gas fee).
+  // TerraClassic uses a fixed single-transaction budget (see the record
+  // comment). Multi-validator reward claims must be split by the caller.
   if (chain === Chain.TerraClassic) return base
 
   const n = BigInt(Math.max(1, msgCount))

--- a/packages/core/chain/chains/cosmos/cosmosGasLimitRecord.ts
+++ b/packages/core/chain/chains/cosmos/cosmosGasLimitRecord.ts
@@ -42,10 +42,13 @@ export const getCosmosGasLimit = (coin: CoinKey<CosmosChain>): bigint => {
  * gasUsed: 200X"). Production telemetry later observed MsgBeginRedelegate
  * consuming 2_501_503 gas. The former 3M limit left little headroom over that
  * observed burn, so TerraClassic uses 4M for the heaviest single-msg staking
- * path. Consumers must price the fee amount for this gas limit independently;
- * `cosmosGasRecord[TerraClassic]` governs native MsgSend only. TerraClassic
- * keeps a fixed per-transaction staking budget, so callers must split
- * multi-validator reward claims into separate transactions.
+ * path. Consumers MUST pair this with `TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS`
+ * (from `./gas`), NOT `cosmosGasRecord[TerraClassic]` / `TERRA_CLASSIC_ULUNA_BASE_GAS`,
+ * since those govern native MsgSend at the much lower 300k send gas limit and
+ * under-price a 4M-gas staking tx by ~13x, which the node rejects for
+ * insufficient fees. TerraClassic keeps a fixed per-transaction staking
+ * budget, so callers must split multi-validator reward claims into separate
+ * transactions.
  */
 const cosmosStakingGasLimitRecord: Record<IbcEnabledCosmosChain, bigint> = {
   [Chain.Cosmos]: 350_000n,

--- a/packages/core/chain/chains/cosmos/gas.test.ts
+++ b/packages/core/chain/chains/cosmos/gas.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { Chain } from '../../Chain'
-import { getCosmosGasLimit } from './cosmosGasLimitRecord'
+import { getCosmosGasLimit, getCosmosStakingGasLimit } from './cosmosGasLimitRecord'
 import {
   cosmosGasRecord,
   getCosmosFeeAmount,
@@ -9,6 +9,7 @@ import {
   getFeeAmountFromGasPrice,
   getMinGasPriceForDenom,
   MAYA_SEND_FEE_BASE_UNITS,
+  TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS,
   TERRA_CLASSIC_ULUNA_BASE_GAS,
 } from './gas'
 
@@ -328,5 +329,37 @@ describe('TERRA_CLASSIC_ULUNA_BASE_GAS', () => {
 
   it('matches iOS ulunaBaseGas / Android ULUNA_BASE_GAS', () => {
     expect(TERRA_CLASSIC_ULUNA_BASE_GAS).toBe(8_497_500n)
+  })
+})
+
+describe('TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS', () => {
+  // Paired with getCosmosStakingGasLimit (4M), NOT the 300k send gas limit.
+  // The send-fee constant would under-price a staking tx by ~13x and get it
+  // rejected for insufficient fees. Derived rather than hardcoded so a future
+  // retune of the staking gas limit can't silently desync the fee again.
+  const ULUNA_GAS_PRICE_MILLI = 28_325n // 28.325, scaled by 1000 to stay integral
+
+  it('equals the TerraClassic staking gas limit priced at 28.325 uluna/gas', () => {
+    const stakingGasLimit = getCosmosStakingGasLimit({ chain: Chain.TerraClassic })
+
+    expect(TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS).toBe((stakingGasLimit * ULUNA_GAS_PRICE_MILLI) / 1000n)
+  })
+
+  it('is exactly 113.3 LUNC for the current 4M staking gas limit', () => {
+    expect(TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS).toBe(113_300_000n)
+  })
+
+  it('is signable: fee >= gasLimit * minGasPrice at the chain minimum', () => {
+    const stakingGasLimit = getCosmosStakingGasLimit({ chain: Chain.TerraClassic })
+    const requiredFee = getFeeAmountFromGasPrice(stakingGasLimit, {
+      numerator: ULUNA_GAS_PRICE_MILLI,
+      denominator: 1000n,
+    })
+
+    expect(TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS).toBeGreaterThanOrEqual(requiredFee)
+  })
+
+  it('exceeds the native-send fee constant, proving the send fee alone would under-price staking', () => {
+    expect(TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS).toBeGreaterThan(TERRA_CLASSIC_ULUNA_BASE_GAS)
   })
 })

--- a/packages/core/chain/chains/cosmos/gas.ts
+++ b/packages/core/chain/chains/cosmos/gas.ts
@@ -2,7 +2,7 @@ import { Chain, CosmosChain, IbcEnabledCosmosChain } from '../../Chain'
 import type { CoinKey } from '../../coin/Coin'
 import { getFeeAmountFromGasPrice, type ParsedDecimal, parseDecimal } from './cosmosDecimal'
 import { cosmosFeeCoinDenom } from './cosmosFeeCoinDenom'
-import { getCosmosGasLimit } from './cosmosGasLimitRecord'
+import { getCosmosGasLimit, getCosmosStakingGasLimit } from './cosmosGasLimitRecord'
 import { getCosmosRpcUrl } from './getCosmosRpcUrl'
 import { getOsmosisDynamicFeeFloor } from './osmosisDynamicFee'
 
@@ -31,6 +31,26 @@ export const MAYA_SEND_FEE_BASE_UNITS = 2000000000n
  * `TerraClassicTax.ULUNA_BASE_GAS`.
  */
 export const TERRA_CLASSIC_ULUNA_BASE_GAS = 8_497_500n
+
+/**
+ * Terra Classic's `uluna` fee paired with the STAKING gas limit
+ * (`getCosmosStakingGasLimit({ chain: TerraClassic })`, currently 4M), priced
+ * at the same 28.325 uluna/gas chain minimum as `TERRA_CLASSIC_ULUNA_BASE_GAS`.
+ *
+ * TerraClassic staking runs ~13x hotter than a native send (4M vs 300k gas),
+ * so `TERRA_CLASSIC_ULUNA_BASE_GAS` under-prices it by a wide margin, and a
+ * consumer pairing the staking gas limit with the send-fee constant (or any
+ * other stale hand-picked LUNC figure) gets a SignDoc the node rejects for
+ * insufficient fees before delegate / undelegate / redelegate / withdraw-
+ * rewards can execute. Computed from `getCosmosStakingGasLimit` rather than
+ * hardcoded so a future retune of the staking gas limit can't silently
+ * desync the paired fee the way the gas-limit-only bump in vultisig-sdk#1839
+ * originally did.
+ */
+export const TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS = getFeeAmountFromGasPrice(
+  getCosmosStakingGasLimit({ chain: Chain.TerraClassic }),
+  parseDecimal('28.325')!
+)
 
 export const cosmosGasRecord: Record<IbcEnabledCosmosChain, bigint> = {
   [Chain.Cosmos]: COSMOS_SEND_FEE_DEFAULT,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -262,6 +262,7 @@ export {
   COSMOS_SEND_FEE_DEFAULT,
   getCosmosSendFeeBaseUnits,
   MAYA_SEND_FEE_BASE_UNITS,
+  TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS,
 } from '@vultisig/core-chain/chains/cosmos/gas'
 
 // Cosmos x/auth.MaxMemoCharacters cap, per chain — single source of truth for

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -78,6 +78,7 @@ export {
   COSMOS_SEND_FEE_DEFAULT,
   getCosmosSendFeeBaseUnits,
   MAYA_SEND_FEE_BASE_UNITS,
+  TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS,
 } from '@vultisig/core-chain/chains/cosmos/gas'
 
 // Cosmos x/auth.MaxMemoCharacters cap, per chain — single source of truth for

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -1,5 +1,6 @@
 import * as customRpcOverrides from '@vultisig/core-chain/chains/customRpc/customRpcOverrides'
 import * as customRpcSupportedChains from '@vultisig/core-chain/chains/customRpc/customRpcSupportedChains'
+import { AuthInfo, SignDoc, TxBody } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
 import { describe, expect, it, vi } from 'vitest'
 
 import { cosmosTxFeeGasParityCases } from '../../../fixtures/cosmosTxFeeGasParity'
@@ -112,6 +113,44 @@ describe('RN entry wires configureCrypto and configureDefaultStorage', () => {
 
     expect(rn.COSMOS_SEND_FEE_DEFAULT).toBe(7_500n)
     expect(rn.MAYA_SEND_FEE_BASE_UNITS).toBe(2_000_000_000n)
+  })
+
+  it('exports and encodes the TerraClassic staking gas/fee pair in a redelegation SignDoc', async () => {
+    const rn = await import('../../../../src/platforms/react-native/index')
+    const gasLimit = rn.getCosmosStakingGasLimit({ chain: rn.Chain.TerraClassic })
+
+    expect(gasLimit).toBe(4_000_000n)
+    expect(rn.TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS).toBe(113_300_000n)
+
+    const tx = rn.chains.cosmos.buildCosmosStakingTx({
+      chainId: 'columbus-5',
+      msgs: [
+        {
+          type: 'redelegate',
+          delegatorAddress: 'terra1qyqszqgpqyqszqgpqyqszqgpqyqszqgp5hm70u',
+          validatorSrcAddress: 'terravaloper1qgpqyqszqgpqyqszqgpqyqszqgpqyqsz9u3x5e',
+          validatorDstAddress: 'terravaloper1qvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcryvs87c',
+          amount: '1000000',
+          denom: 'uluna',
+        },
+      ],
+      sequence: 7,
+      accountNumber: 42,
+      pubKeyBytes: new Uint8Array(33).fill(0x02),
+      gasLimit: Number(gasLimit),
+      feeDenom: 'uluna',
+      feeAmount: rn.TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS.toString(),
+    })
+    const signDoc = SignDoc.decode(tx.signDocBytes)
+    const authInfo = AuthInfo.decode(signDoc.authInfoBytes)
+    const txBody = TxBody.decode(signDoc.bodyBytes)
+
+    expect(signDoc.chainId).toBe('columbus-5')
+    expect(authInfo.fee?.gasLimit).toBe(gasLimit)
+    expect(authInfo.fee?.amount).toEqual([
+      { denom: 'uluna', amount: rn.TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS.toString() },
+    ])
+    expect(txBody.messages[0]?.typeUrl).toBe('/cosmos.staking.v1beta1.MsgBeginRedelegate')
   })
 
   it('keeps Robinhood derivation native-compatible on the exported RN surface', async () => {

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -293,9 +293,11 @@ describe('@vultisig/sdk public exports', () => {
     expect(sdk.MAYA_SEND_FEE_BASE_UNITS).toBe(2_000_000_000n)
   })
 
-  it('exports the Cosmos staking gas limit helper, which the send-fee parity matrix does not cover', () => {
+  it('exports the Cosmos staking gas limit helper, including TerraClassic redelegation headroom', () => {
+    expect(typeof sdk.getCosmosStakingGasLimit).toBe('function')
     expect(sdk.getCosmosStakingGasLimit({ chain: sdk.Chain.Cosmos })).toBe(350_000n)
     expect(sdk.getCosmosStakingGasLimit({ chain: sdk.Chain.Cosmos, msgCount: 2 })).toBe(437_500n)
+    expect(sdk.getCosmosStakingGasLimit({ chain: sdk.Chain.TerraClassic })).toBe(4_000_000n)
   })
 
   it('exports seedphrase import chain support policy for consumers', () => {

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -300,6 +300,35 @@ describe('@vultisig/sdk public exports', () => {
     expect(sdk.getCosmosStakingGasLimit({ chain: sdk.Chain.TerraClassic })).toBe(4_000_000n)
   })
 
+  it('exports a TerraClassic staking fee correctly priced for the staking gas limit, not the send fee', () => {
+    expect(sdk.TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS).toBe(113_300_000n)
+    // The send-fee constant is priced for the 300k send gas limit and would
+    // under-price a 4M-gas staking tx by ~13x, causing the node to reject it
+    // for insufficient fees before it can broadcast.
+    expect(sdk.TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS).toBeGreaterThan(
+      sdk.getCosmosSendFeeBaseUnits(sdk.Chain.TerraClassic)!
+    )
+  })
+
+  it('builds a signable TerraClassic redelegation SignDoc pairing the staking gas limit with its fee', () => {
+    const gasLimit = sdk.getCosmosStakingGasLimit({ chain: sdk.Chain.TerraClassic })
+    const msg = sdk.cosmosStaking.redelegate({
+      delegatorAddress: 'terra1qyqszqgpqyqszqgpqyqszqgpqyqszqgp5hm70u',
+      validatorSrcAddress: 'terravaloper1qgpqyqszqgpqyqszqgpqyqszqgpqyqsz9u3x5e',
+      validatorDstAddress: 'terravaloper1qvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcryvs87c',
+      amount: '1000000',
+      denom: 'uluna',
+    })
+
+    // Mirrors the exact `buildCosmosStakingTx` shape a consumer (mcp-ts) would
+    // sign: gasLimit from getCosmosStakingGasLimit paired with the matching
+    // TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS fee, not a stale hand-picked
+    // LUNC figure. Proves the two exported values are signable together.
+    const requiredFee = Number(gasLimit) * 28.325
+    expect(Number(sdk.TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS)).toBeGreaterThanOrEqual(requiredFee)
+    expect(msg.typeUrl).toBe('/cosmos.staking.v1beta1.MsgBeginRedelegate')
+  })
+
   it('exports seedphrase import chain support policy for consumers', () => {
     expect(Array.isArray(sdk.SEEDPHRASE_IMPORT_SUPPORTED_CHAINS)).toBe(true)
     expect(Array.isArray(sdk.SEEDPHRASE_IMPORT_UNSUPPORTED_CHAINS)).toBe(true)

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -310,7 +310,7 @@ describe('@vultisig/sdk public exports', () => {
     )
   })
 
-  it('builds a signable TerraClassic redelegation SignDoc pairing the staking gas limit with its fee', () => {
+  it('exports a composable TerraClassic redelegation message and sufficient staking gas/fee pair', () => {
     const gasLimit = sdk.getCosmosStakingGasLimit({ chain: sdk.Chain.TerraClassic })
     const msg = sdk.cosmosStaking.redelegate({
       delegatorAddress: 'terra1qyqszqgpqyqszqgpqyqszqgpqyqszqgp5hm70u',
@@ -320,12 +320,11 @@ describe('@vultisig/sdk public exports', () => {
       denom: 'uluna',
     })
 
-    // Mirrors the exact `buildCosmosStakingTx` shape a consumer (mcp-ts) would
-    // sign: gasLimit from getCosmosStakingGasLimit paired with the matching
-    // TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS fee, not a stale hand-picked
-    // LUNC figure. Proves the two exported values are signable together.
-    const requiredFee = Number(gasLimit) * 28.325
-    expect(Number(sdk.TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS)).toBeGreaterThanOrEqual(requiredFee)
+    // The React Native entrypoint test exercises the actual SignDoc builder;
+    // this root-surface contract proves consumers can compose the message with
+    // the matching gas and fee exports instead of a stale hand-picked value.
+    const requiredFee = (gasLimit * 28_325n) / 1000n
+    expect(sdk.TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS).toBeGreaterThanOrEqual(requiredFee)
     expect(msg.typeUrl).toBe('/cosmos.staking.v1beta1.MsgBeginRedelegate')
   })
 


### PR DESCRIPTION
Closes #1464
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public Terra Classic staking fee constant to SDK exports.
  * Increased the Terra Classic staking gas limit to 4,000,000.
  * Terra Classic staking fees are now calculated separately from native-send fees.

* **Bug Fixes**
  * Terra Classic staking transactions now use a fixed gas limit regardless of message count.
  * Improved fee and gas handling for staking and redelegation transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->