### PR TITLE
fix(tx): splitMultiTx drops camelCase metadata on transactions[] legs

### DIFF
--- a/packages/sdk/src/tx/normalize.ts
+++ b/packages/sdk/src/tx/normalize.ts
@@ -173,6 +173,23 @@ const LEG_METADATA_KEYS = [
   'to_decimals',
 ] as const
 
+// camelCase aliases some newer SDK-native builders emit for the same concepts (e.g.
+// buildCctpBridge.ts returns chainId/fromChain/toChain/fromSymbol/toSymbol, not the snake_case
+// shape below). Output legs stay snake_case (matches Go wrapSingleTx and downstream consumers),
+// but source lookup falls back to the camelCase key when the snake_case one is absent, so a
+// camelCase-emitting parent doesn't silently lose its leg metadata.
+const LEG_METADATA_CAMEL_ALIASES: Partial<Record<(typeof LEG_METADATA_KEYS)[number], string>> = {
+  chain_id: 'chainId',
+  from_chain: 'fromChain',
+  to_chain: 'toChain',
+  from_symbol: 'fromSymbol',
+  to_symbol: 'toSymbol',
+  from_address: 'fromAddress',
+  to_address: 'toAddress',
+  from_decimals: 'fromDecimals',
+  to_decimals: 'toDecimals',
+}
+
 /**
  * Wrap a single child tx under `txKey` and copy routing metadata from the
  * parent envelope. Mirrors Go `wrapSingleTx`.
@@ -180,7 +197,12 @@ const LEG_METADATA_KEYS = [
 const wrapSingleTx = (txKey: string, txData: unknown, parent: JsonObject): NormalizedTx => {
   const leg: JsonObject = { [txKey]: txData }
   for (const key of LEG_METADATA_KEYS) {
-    if (key in parent) leg[key] = parent[key]
+    if (key in parent) {
+      leg[key] = parent[key]
+      continue
+    }
+    const camelKey = LEG_METADATA_CAMEL_ALIASES[key]
+    if (camelKey && camelKey in parent) leg[key] = parent[camelKey]
   }
   return leg as NormalizedTx
 }

--- a/packages/sdk/tests/unit/tx/normalize.test.ts
+++ b/packages/sdk/tests/unit/tx/normalize.test.ts
@@ -250,4 +250,44 @@ describe('splitMultiTx', () => {
       expect(leg['approval_tx']).toBeUndefined()
     }
   })
+
+  // #1715: newer SDK-native builders (e.g. buildCctpBridge.ts) emit camelCase routing metadata
+  // (chainId/fromChain/toChain/fromSymbol/toSymbol) instead of the snake_case shape LEG_METADATA_KEYS
+  // originally only looked for, so every multi-leg CCTP (and similar) split silently lost its
+  // chain/routing/display context on each wrapped leg.
+  it('falls back to camelCase source keys so a camelCase parent (e.g. CCTP bridge) keeps its leg metadata', () => {
+    const legs = splitMultiTx({
+      chain: 'Ethereum',
+      chainId: 1,
+      provider: 'cctp',
+      fromChain: 'Ethereum',
+      toChain: 'Base',
+      fromSymbol: 'USDC',
+      toSymbol: 'USDC',
+      transactions: [
+        { to: '0xtoken', value: '0', data: '0xapprove', action: 'approve' },
+        { to: '0xmessenger', value: '0', data: '0xburn', action: 'burn' },
+      ],
+    })
+    expect(legs).toHaveLength(2)
+    for (const leg of legs) {
+      expect(leg.chain).toBe('Ethereum')
+      expect(leg.chain_id).toBe(1)
+      expect(leg.provider).toBe('cctp')
+      expect(leg.from_chain).toBe('Ethereum')
+      expect(leg.to_chain).toBe('Base')
+      expect(leg.from_symbol).toBe('USDC')
+      expect(leg.to_symbol).toBe('USDC')
+    }
+  })
+
+  it('prefers an existing snake_case key over a camelCase alias when both are present', () => {
+    const legs = splitMultiTx({
+      chain: 'Ethereum',
+      chain_id: '1',
+      chainId: 999, // must be ignored: snake_case wins when both are present
+      transactions: [{ to: '0xrouter' }],
+    })
+    expect(legs[0].chain_id).toBe('1')
+  })
 })

--- a/packages/sdk/tests/unit/tx/normalize.test.ts
+++ b/packages/sdk/tests/unit/tx/normalize.test.ts
@@ -264,6 +264,10 @@ describe('splitMultiTx', () => {
       toChain: 'Base',
       fromSymbol: 'USDC',
       toSymbol: 'USDC',
+      fromAddress: '0xsource',
+      toAddress: '0xdestination',
+      fromDecimals: 6,
+      toDecimals: 6,
       transactions: [
         { to: '0xtoken', value: '0', data: '0xapprove', action: 'approve' },
         { to: '0xmessenger', value: '0', data: '0xburn', action: 'burn' },
@@ -278,6 +282,10 @@ describe('splitMultiTx', () => {
       expect(leg.to_chain).toBe('Base')
       expect(leg.from_symbol).toBe('USDC')
       expect(leg.to_symbol).toBe('USDC')
+      expect(leg.from_address).toBe('0xsource')
+      expect(leg.to_address).toBe('0xdestination')
+      expect(leg.from_decimals).toBe(6)
+      expect(leg.to_decimals).toBe(6)
     }
   })
 


### PR DESCRIPTION
closes vultisig/vultisig-sdk#1715

## what

`splitMultiTx`'s `wrapSingleTx` only looked up `LEG_METADATA_KEYS` in their snake_case form (`chain_id`, `from_chain`, `from_symbol`, ...), matching the Go backend's `wrapSingleTx` shape. Newer SDK-native builders emit camelCase instead - `buildCctpBridge.ts` returns `chainId`/`fromChain`/`toChain`/`fromSymbol`/`toSymbol` - so every multi-leg CCTP bridge split (approve + burn legs) silently dropped routing/display metadata on each wrapped leg.

## why it matters

Downstream consumers of a split leg (UI display, chain resolution for signing) rely on `chain`/`chain_id`/`from_chain`/`to_chain` etc riding along on every leg. A camelCase-emitting parent meant those fields were just... missing, on both legs of every CCTP bridge tx.

## fix

`wrapSingleTx` now falls back to a camelCase alias when the snake_case key is absent from the parent envelope. Output legs stay snake_case (no downstream contract change) - only the *source* lookup gained the camelCase fallback, and an existing snake_case value always wins over its alias when both are present (covered by a test).

## testing

- New regression test reproducing the CCTP-shaped bug (camelCase parent -> legs lose all metadata) - confirmed it fails on unmodified `normalize.ts` (via `git stash`) and passes with the fix.
- New test confirming snake_case still takes priority when both forms are present.
- Full `tests/unit/tx/normalize.test.ts` suite: 22/22 passing.
- Typecheck: 29 pre-existing `@vultisig/mpc-types` resolution errors present identically before and after this change (unrelated - this worktree hasn't run the `build:shared` step CI runs first; none reference `normalize.ts`).
- Lint: clean on both changed files.

## risk

Low - additive fallback only, existing snake_case behavior unchanged, scoped to one function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata handling for multi-leg transactions.
  * CamelCase routing metadata is now recognized and correctly propagated to transaction legs.
  * When both camelCase and snake_case values are provided, snake_case values take precedence.
  * Existing snake_case metadata remains available in normalized transaction output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->