### PR TITLE
fix(cli): interactive chat renders the terminal message, not the delta buffer

### DIFF
--- a/.changeset/cli-terminal-message.md
+++ b/.changeset/cli-terminal-message.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/cli': patch
+---
+
+Render the authoritative terminal assistant message in interactive chat when it replaces streamed text.

--- a/clients/cli/src/agent/tui.test.ts
+++ b/clients/cli/src/agent/tui.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ChatTUI } from './tui'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('ChatTUI terminal assistant messages', () => {
+  function captureTurn(deltas: string[], content: string) {
+    const writes: string[] = []
+    const logs: string[] = []
+    vi.spyOn(process.stdout, 'write').mockImplementation(chunk => {
+      writes.push(String(chunk))
+      return true
+    })
+    vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      logs.push(args.map(String).join(' ') + '\n')
+    })
+
+    const tui = Object.create(ChatTUI.prototype) as ChatTUI
+    const callbacks = tui.getCallbacks()
+    for (const delta of deltas) callbacks.onTextDelta?.(delta)
+    callbacks.onAssistantMessage?.(content)
+
+    return { logs, output: [...writes, ...logs].join(''), writes }
+  }
+
+  it('renders the authoritative refusal instead of replaced streamed prose', () => {
+    const { output } = captureTurn(
+      ['Here are your balances:\n', '- Cosmos: 42 ATOM\n'],
+      "I can't complete that safely -- I could not verify the balances I was about to show. Retrying usually resolves this."
+    )
+
+    expect(output).toContain(
+      "I can't complete that safely -- I could not verify the balances I was about to show. Retrying usually resolves this."
+    )
+    expect(output).not.toContain('Here are your balances')
+    expect(output).not.toContain('42 ATOM')
+  })
+
+  it('renders matching terminal content exactly once', () => {
+    const content = 'Your ETH balance is 1.5 ETH.'
+    const { logs, output, writes } = captureTurn([content], content)
+
+    expect(output.split(content)).toHaveLength(2)
+    expect(writes).toHaveLength(2)
+    expect(writes[1]).toBe(`${content}\n`)
+    expect(logs).toEqual([])
+  })
+
+  it('falls back to streamed text when the terminal content is empty', () => {
+    const buffered = 'Fallback streamed response.'
+    const { writes } = captureTurn([buffered], '')
+
+    expect(writes[1]).toBe(`${buffered}\n`)
+  })
+})

--- a/clients/cli/src/agent/tui.test.ts
+++ b/clients/cli/src/agent/tui.test.ts
@@ -22,6 +22,10 @@ describe('ChatTUI terminal assistant messages', () => {
     const callbacks = tui.getCallbacks()
     for (const delta of deltas) callbacks.onTextDelta?.(delta)
     callbacks.onAssistantMessage?.(content)
+    // Complete the turn like production does (session.ts calls onDone after the
+    // terminal message) — if the render path ever leaves isStreaming set, onDone
+    // re-flushes the buffer and the exactly-once assertions below catch it.
+    callbacks.onDone?.()
 
     return { logs, output: [...writes, ...logs].join(''), writes }
   }

--- a/clients/cli/src/agent/tui.ts
+++ b/clients/cli/src/agent/tui.ts
@@ -195,8 +195,8 @@ export class ChatTUI {
 
       onAssistantMessage: (content: string) => {
         if (this.isStreaming) {
-          // Deltas were collected; render the full text with markdown
-          process.stdout.write(renderMarkdown(this.currentStreamText) + '\n')
+          // Prefer the authoritative terminal message over collected deltas
+          process.stdout.write(renderMarkdown(content || this.currentStreamText) + '\n')
           this.isStreaming = false
         } else if (content && content !== this.currentStreamText) {
           // Print full message with markdown rendering


### PR DESCRIPTION
The interactive agent chat (`vultisig agent`) discards the authoritative terminal message whenever streaming deltas were collected: `onAssistantMessage` renders its accumulated delta buffer (`this.currentStreamText`) instead of the resolved `content`, even though `session.ts` already resolves the display text correctly ("final message event wins over streamed deltas").

On a guardrail-blocked turn the buffer is `<pre-block model prose><refusal>` while `content` is the refusal alone — so the interactive user sees the unverified prose the backend deliberately replaced. Runtime-observed:

```
[22:26:41] Agent: Here are your balances:
- Cosmos: 42 ATOM
I can't complete that safely — I could not verify the balances I was about to show. Retrying usually resolves this.
```

The headless path (`agent ask`) already prefers the terminal message, which is why it renders the refusal alone for the same turn.

## Fix

Render `content` when the turn produced one, falling back to the delta buffer only when it's empty:

```ts
process.stdout.write(renderMarkdown(content || this.currentStreamText) + '\n')
```

The `onDone` flush is deliberately unchanged — it handles turns that end with no terminal message at all, where the buffer is the only text there is.

## Tests

Three regressions in `tui.test.ts`: the blocked shape (deltas carry fabricated prose, content is refusal-only → output contains the refusal and none of the prose), matching content renders exactly once (no double print on normal turns), and empty content falls back to the buffer. The blocked-shape test fails against the unfixed renderer (revert-verified).

Changeset included (`@vultisig/cli` patch).


## Behavior note (ordinary turns)

On tool-interleaved turns (text → tool → text), the pre-tool prose now prints after the tool lines under the final `Agent:` label, because the terminal message carries the whole turn while the old buffer held only the last segment. Nothing is duplicated — previously that prose was silently dropped (the buffer is abandoned when a tool call starts), so this is strictly recovered output, in a different position.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal assistant message rendering to display the complete authoritative response when available.
  * Added a fallback to streamed text when no final response content is provided.

* **Tests**
  * Added coverage for final-content rendering, duplicate prevention, and streamed-text fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->