### PR TITLE
chore(rujira): inert expired merge balance service

### DIFF
--- a/.changeset/remove-expired-rujira-merge.md
+++ b/.changeset/remove-expired-rujira-merge.md
@@ -1,5 +1,6 @@
 ---
 '@vultisig/core-chain': patch
+'@vultisig/sdk': patch
 ---
 
 Make the expired, zero-caller Rujira merge-balance service inert. The KUJI-to-RUJI merge window closed on 2026-04-05, so the compatibility shim now returns an empty result without querying GraphQL.

--- a/.changeset/remove-expired-rujira-merge.md
+++ b/.changeset/remove-expired-rujira-merge.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/core-chain': patch
+---
+
+Make the expired, zero-caller Rujira merge-balance service inert. The KUJI-to-RUJI merge window closed on 2026-04-05, so the compatibility shim now returns an empty result without querying GraphQL.

--- a/packages/core/chain/chains/thorchain/ruji/services/fetchMergeableTokenBalances.test.ts
+++ b/packages/core/chain/chains/thorchain/ruji/services/fetchMergeableTokenBalances.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+
+import { fetchMergeableTokenBalances } from './fetchMergeableTokenBalances'
+
+describe('fetchMergeableTokenBalances', () => {
+  it('stays inert after the KUJI-to-RUJI merge window closed', async () => {
+    await expect(fetchMergeableTokenBalances('thor1unused')).resolves.toEqual([])
+  })
+})

--- a/packages/core/chain/chains/thorchain/ruji/services/fetchMergeableTokenBalances.ts
+++ b/packages/core/chain/chains/thorchain/ruji/services/fetchMergeableTokenBalances.ts
@@ -1,64 +1,12 @@
-import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
-
-import { rujiraGraphQlEndpoint } from '../../../cosmos/thor/rujira/config'
-
-type MergeAccount = {
-  shares: string
-  size: { amount: string }
-  pool: { mergeAsset: { metadata: { symbol: string } } }
-}
-
-type Gql = {
-  data?: {
-    node?: {
-      merge?: {
-        accounts: MergeAccount[]
-      }
-    }
-  }
-  errors?: unknown[]
-}
-
 type TokenBalance = {
   symbol: string
   sharesChain: string
   sizeAmountChain: string
 }
 
-export const fetchMergeableTokenBalances = async (thorAddr: string): Promise<TokenBalance[]> => {
-  const { data, errors } = await queryUrl<Gql>(rujiraGraphQlEndpoint, {
-    body: {
-      query: `
-        query ($id: ID!) {
-          node(id: $id) {
-            ... on Account {
-              merge {
-                accounts {
-                  shares
-                  size { amount }
-                  pool {
-                    mergeAsset { metadata { symbol } }
-                  }
-                }
-              }
-            }
-          }}`,
-      variables: { id: btoa(`Account:${thorAddr}`) },
-    },
-  })
-
-  if (errors) {
-    throw new Error(`GraphQL errors: ${JSON.stringify(errors)}`)
-  }
-
-  const accounts = data?.node?.merge?.accounts ?? []
-
-  return accounts.map(account => {
-    return {
-      symbol: account.pool.mergeAsset.metadata.symbol,
-
-      sharesChain: account.shares,
-      sizeAmountChain: account.size.amount,
-    }
-  })
-}
+/**
+ * @deprecated The KUJI-to-RUJI merge window closed on 2026-04-05.
+ *
+ * Kept as an inert compatibility shim for the published package subpath.
+ */
+export const fetchMergeableTokenBalances = async (_thorAddr: string): Promise<TokenBalance[]> => []


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Expired KUJI-to-RUJI merge-balance lookups now return no results instead of attempting unavailable queries.
  - Prevents outdated mergeable-token balances from being displayed.

- **Tests**
  - Added coverage confirming empty results after the merge window closed.

- **Chores**
  - Marked the expired merge-balance service as inactive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->