### PR TITLE
fix(mpc): align Cardano and Terra mobile fixture hashes

### DIFF
--- a/.changeset/calm-owls-align-mobile-hashes.md
+++ b/.changeset/calm-owls-align-mobile-hashes.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+Align Cardano max-send and Terra Classic USTC signing inputs with the current Swift and Kotlin signers so the shared mobile fixture hashes pass without SDK-only overrides.

--- a/.changeset/terra-classic-fee-parity.md
+++ b/.changeset/terra-classic-fee-parity.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/core-mpc': patch
+'@vultisig/sdk': patch
+---
+
+Include TerraClassic's signed USTC burn-tax surcharge in the displayed send-fee total by deriving both values from the same Cosmos fee-amount list.

--- a/packages/core/chain/chains/cosmos/gas.test.ts
+++ b/packages/core/chain/chains/cosmos/gas.test.ts
@@ -11,6 +11,7 @@ import {
   MAYA_SEND_FEE_BASE_UNITS,
   TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS,
   TERRA_CLASSIC_ULUNA_BASE_GAS,
+  TERRA_CLASSIC_UUSD_BASE_GAS,
 } from './gas'
 
 const jsonResponse = (body: unknown, status = 200) =>
@@ -361,5 +362,17 @@ describe('TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS', () => {
 
   it('exceeds the native-send fee constant, proving the send fee alone would under-price staking', () => {
     expect(TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS).toBeGreaterThan(TERRA_CLASSIC_ULUNA_BASE_GAS)
+  })
+})
+
+describe('TERRA_CLASSIC_UUSD_BASE_GAS', () => {
+  it('equals the TerraClassic static gas limit priced at 0.75 uusd/gas', () => {
+    const staticGasLimit = getCosmosGasLimit({ chain: Chain.TerraClassic, id: 'uusd' })
+
+    expect(TERRA_CLASSIC_UUSD_BASE_GAS).toBe((staticGasLimit * 75n) / 100n)
+  })
+
+  it('matches iOS uusdBaseGas / Android UUSD_BASE_GAS', () => {
+    expect(TERRA_CLASSIC_UUSD_BASE_GAS).toBe(225_000n)
   })
 })

--- a/packages/core/chain/chains/cosmos/gas.ts
+++ b/packages/core/chain/chains/cosmos/gas.ts
@@ -52,6 +52,16 @@ export const TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS = getFeeAmountFromGasPri
   parseDecimal('28.325')!
 )
 
+/**
+ * Terra Classic's `uusd` fee at the static 300k gas limit:
+ * `300_000 × 0.75 uusd/gas`. USTC bank-denom sends pay both gas and burn
+ * tax in `uusd`, so their base cannot reuse the native `uluna` amount.
+ *
+ * Matches iOS `TerraClassicTax.uusdBaseGas` and Android
+ * `TerraClassicTax.UUSD_BASE_GAS`.
+ */
+export const TERRA_CLASSIC_UUSD_BASE_GAS = 225_000n
+
 export const cosmosGasRecord: Record<IbcEnabledCosmosChain, bigint> = {
   [Chain.Cosmos]: COSMOS_SEND_FEE_DEFAULT,
   [Chain.Osmosis]: 9000n,

--- a/packages/core/chain/chains/cosmos/terraClassicTax.ts
+++ b/packages/core/chain/chains/cosmos/terraClassicTax.ts
@@ -29,7 +29,24 @@
 import { attempt } from '@vultisig/lib-utils/attempt'
 
 import { Chain } from '../../Chain'
+import type { CoinKey } from '../../coin/Coin'
 import { cosmosRpcUrl } from './cosmosRpcUrl'
+
+/**
+ * TerraClassic USTC (bank-denom `uusd`) is the one Cosmos send where the fee
+ * (base gas + burn tax) is paid FROM THE SAME BALANCE being sent, rather than
+ * from the chain's native fee coin (`uluna`). Callers that size a send against
+ * a coin's own balance — refining a full-balance amount down, or computing
+ * max-send — must subtract the fee here instead of treating it like any other
+ * non-fee-coin token whose gas comes out of a separate native balance.
+ *
+ * Scoped to plain bank sends by construction: IBC transfers and other
+ * transaction types never price `CosmosSpecific.gas` in `uusd` (see
+ * `getCosmosChainSpecific`'s `isPlainSend` gate), so this predicate alone is
+ * enough for callers that only ever build plain sends.
+ */
+export const isTerraClassicUstcCoin = (coin: Pick<CoinKey, 'chain' | 'id'>): boolean =>
+  coin.chain === Chain.TerraClassic && coin.id?.toLowerCase() === 'uusd'
 
 // ---------------------------------------------------------------------------
 // LCD endpoints

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/cosmos/chainSpecific.test.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/cosmos/chainSpecific.test.ts
@@ -1,15 +1,12 @@
 /**
- * Tests for getCosmosChainSpecific — specifically the dynamic burn-tax
- * computation for TerraClassic USTC (uusd) sends.
- *
- * The burn-tax amount is encoded in ibcDenomTraces.baseDenom so the sync
- * signing-inputs resolver can use it without an async LCD call.
+ * Tests for getCosmosChainSpecific — specifically the denom-aware gas and
+ * dynamic burn-tax computation for TerraClassic USTC (uusd) sends.
  */
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { getCosmosAccountInfo } from '@vultisig/core-chain/chains/cosmos/account/getCosmosAccountInfo'
 import { getCosmosFeeAmount } from '@vultisig/core-chain/chains/cosmos/gas'
-import { getTerraClassicTaxRate, getTerraClassicTaxCap } from '@vultisig/core-chain/chains/cosmos/terraClassicTax'
+import { getTerraClassicBurnTaxRate } from '@vultisig/core-chain/chains/cosmos/terraClassicTax'
 
 // ---------------------------------------------------------------------------
 // Mocks — must be at top level for vi.mock hoisting
@@ -28,15 +25,15 @@ vi.mock('@vultisig/core-chain/chains/cosmos/account/getCosmosAccountInfo', () =>
 
 vi.mock('@vultisig/core-chain/chains/cosmos/gas', () => ({
   getCosmosFeeAmount: vi.fn().mockResolvedValue(7500n),
+  TERRA_CLASSIC_UUSD_BASE_GAS: 225_000n,
 }))
 
-// Partially mock terraClassicTax — stub the LCD fetchers, keep applyTerraClassicTax real.
+// Partially mock terraClassicTax — stub the LCD fetcher, keep burn-tax math real.
 vi.mock('@vultisig/core-chain/chains/cosmos/terraClassicTax', async importOriginal => {
   const real = await importOriginal<typeof import('@vultisig/core-chain/chains/cosmos/terraClassicTax')>()
   return {
     ...real,
-    getTerraClassicTaxRate: vi.fn(),
-    getTerraClassicTaxCap: vi.fn(),
+    getTerraClassicBurnTaxRate: vi.fn(),
   }
 })
 
@@ -53,6 +50,7 @@ const mockWalletCore = {} as any
 function makeUstcPayload(toAmount: string) {
   return {
     toAmount,
+    toAddress: 'terra1recipient',
     // Unset oneof — real protobuf payloads always carry the wrapper.
     signData: { case: undefined },
     coin: {
@@ -68,6 +66,7 @@ function makeUstcPayload(toAmount: string) {
 function makeLuncPayload(toAmount: string) {
   return {
     toAmount,
+    toAddress: 'terra1recipient',
     signData: { case: undefined },
     coin: {
       chain: Chain.TerraClassic,
@@ -83,10 +82,11 @@ function makeLuncPayload(toAmount: string) {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('getCosmosChainSpecific — USTC burn-tax baseDenom encoding', () => {
+describe('getCosmosChainSpecific — USTC denom-aware gas and burn tax', () => {
   beforeEach(() => {
-    vi.mocked(getTerraClassicTaxRate).mockReset()
-    vi.mocked(getTerraClassicTaxCap).mockReset()
+    vi.mocked(getTerraClassicBurnTaxRate).mockReset()
+    vi.mocked(getTerraClassicBurnTaxRate).mockResolvedValue(0n)
+    vi.mocked(getCosmosFeeAmount).mockClear()
     vi.mocked(getCosmosFeeAmount).mockResolvedValue(7500n)
   })
 
@@ -110,8 +110,21 @@ describe('getCosmosChainSpecific — USTC burn-tax baseDenom encoding', () => {
     expect(result.sequence).toBe(sequence)
   })
 
-  it('sets baseDenom to "0" when burn-tax rate is zero (current chain state)', async () => {
-    vi.mocked(getTerraClassicTaxRate).mockResolvedValue(0n)
+  it('prices USTC gas in uusd when the burn-tax rate is zero', async () => {
+    const result = await getCosmosChainSpecific({
+      keysignPayload: makeUstcPayload('10000000'),
+      transactionType: 0 as any,
+      walletCore: mockWalletCore,
+    })
+
+    expect(result.gas).toBe(225_000n)
+    expect(result.ibcDenomTraces?.baseDenom).toBe('')
+    expect(getCosmosFeeAmount).not.toHaveBeenCalled()
+  })
+
+  it('folds the current burn tax into the single USTC fee amount', async () => {
+    // 1.2% rate on 10_000_000 uusd = 120_000 uusd, plus 225_000 uusd gas.
+    vi.mocked(getTerraClassicBurnTaxRate).mockResolvedValue(12_000_000_000_000_000n)
 
     const result = await getCosmosChainSpecific({
       keysignPayload: makeUstcPayload('10000000'),
@@ -119,60 +132,18 @@ describe('getCosmosChainSpecific — USTC burn-tax baseDenom encoding', () => {
       walletCore: mockWalletCore,
     })
 
-    expect(result.ibcDenomTraces?.baseDenom).toBe('0')
-    expect(result.gas).toBe(7500n)
-    // Cap lookup is skipped when rate is 0 (applyTerraClassicTax early-returns)
-    expect(getTerraClassicTaxCap).not.toHaveBeenCalled()
+    expect(result.gas).toBe(345_000n)
+    expect(result.ibcDenomTraces?.baseDenom).toBe('')
   })
 
-  it('encodes the computed burn-tax amount in baseDenom when rate is non-zero', async () => {
-    // 1.2% rate on 10_000_000 uusd = 120_000 uusd
-    vi.mocked(getTerraClassicTaxRate).mockResolvedValue(12_000_000_000_000_000n) // 1.2% as 18-decimal Dec
-    vi.mocked(getTerraClassicTaxCap).mockResolvedValue(null) // uncapped
-
-    const result = await getCosmosChainSpecific({
-      keysignPayload: makeUstcPayload('10000000'),
-      transactionType: 0 as any,
-      walletCore: mockWalletCore,
-    })
-
-    expect(result.ibcDenomTraces?.baseDenom).toBe('120000')
-  })
-
-  it('caps the burn-tax at the per-denom cap', async () => {
-    vi.mocked(getTerraClassicTaxRate).mockResolvedValue(12_000_000_000_000_000n) // 1.2%
-    vi.mocked(getTerraClassicTaxCap).mockResolvedValue(50_000n) // cap lower than 120_000
-
-    const result = await getCosmosChainSpecific({
-      keysignPayload: makeUstcPayload('10000000'),
-      transactionType: 0 as any,
-      walletCore: mockWalletCore,
-    })
-
-    expect(result.ibcDenomTraces?.baseDenom).toBe('50000')
-  })
-
-  it('falls back to "0" when the burn-tax LCD is unreachable (fail-open)', async () => {
-    vi.mocked(getTerraClassicTaxRate).mockRejectedValue(new Error('LCD 503: connection refused'))
-
-    const result = await getCosmosChainSpecific({
-      keysignPayload: makeUstcPayload('10000000'),
-      transactionType: 0 as any,
-      walletCore: mockWalletCore,
-    })
-
-    // $0.02 under-fee better than blocked tx when rate is currently 0.
-    expect(result.ibcDenomTraces?.baseDenom).toBe('0')
-  })
-
-  it('leaves baseDenom empty for non-USTC TerraClassic sends (LUNC is fee-exempt)', async () => {
+  it('keeps native LUNC on the uluna base-fee path', async () => {
     const result = await getCosmosChainSpecific({
       keysignPayload: makeLuncPayload('10000000'),
       transactionType: 0 as any,
       walletCore: mockWalletCore,
     })
 
-    expect(getTerraClassicTaxRate).not.toHaveBeenCalled()
+    expect(result.gas).toBe(7500n)
     expect(result.ibcDenomTraces?.baseDenom).toBe('')
   })
 })

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/cosmos/index.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/cosmos/index.ts
@@ -2,14 +2,11 @@ import { create } from '@bufbuild/protobuf'
 import { Chain, IbcEnabledCosmosChain } from '@vultisig/core-chain/Chain'
 import { getCosmosAccountInfo } from '@vultisig/core-chain/chains/cosmos/account/getCosmosAccountInfo'
 import { getCosmosGasLimit } from '@vultisig/core-chain/chains/cosmos/cosmosGasLimitRecord'
-import { getCosmosFeeAmount } from '@vultisig/core-chain/chains/cosmos/gas'
+import { getCosmosFeeAmount, TERRA_CLASSIC_UUSD_BASE_GAS } from '@vultisig/core-chain/chains/cosmos/gas'
 import { IBC_GAS_MULTIPLIER, scaleCosmosFeeAmount } from '@vultisig/core-chain/chains/cosmos/resolveCosmosGasLimit'
 import {
   applyTerraClassicBurnTax,
-  applyTerraClassicTax,
   getTerraClassicBurnTaxRate,
-  getTerraClassicTaxCap,
-  getTerraClassicTaxRate,
 } from '@vultisig/core-chain/chains/cosmos/terraClassicTax'
 import { isFeeCoin } from '@vultisig/core-chain/coin/utils/isFeeCoin'
 import {
@@ -21,29 +18,6 @@ import { getKeysignCoin } from '../../../utils/getKeysignCoin'
 import { GetChainSpecificResolver } from '../../resolver'
 import { estimateCosmosGasLimit } from './gasEstimation/estimateCosmosGasLimit'
 
-/**
- * Computes the Terra Classic stability-tax surcharge for a USTC (uusd) send.
- *
- * The result is encoded in `ibcDenomTraces.baseDenom` so the signing-inputs
- * resolver can use the dynamic value instead of a hard-coded 1 USTC.
- * `baseDenom` is an empty string for all non-IBC sends — the only
- * interpretation for TerraClassic USTC sends is "pre-computed burn-tax
- * amount in base uusd units".
- *
- * Returns '0' when the on-chain rate is zero (current governance state).
- * Throws when the LCD is unreachable — caller catches and falls back to '0'.
- */
-async function computeUstcBurnTaxAmount(toAmount: string): Promise<string> {
-  const rate = await getTerraClassicTaxRate()
-  if (rate === 0n) return '0'
-
-  const cap = await getTerraClassicTaxCap('uusd')
-  const tax = applyTerraClassicTax(BigInt(toAmount), 'uusd', rate, {
-    uusd: cap,
-  })
-  return tax.toString()
-}
-
 export const getCosmosChainSpecific: GetChainSpecificResolver<'cosmosSpecific'> = async ({
   keysignPayload,
   walletCore,
@@ -52,24 +26,6 @@ export const getCosmosChainSpecific: GetChainSpecificResolver<'cosmosSpecific'> 
 }) => {
   const coin = getKeysignCoin<IbcEnabledCosmosChain>(keysignPayload)
   const { accountNumber, sequenceBigInt, latestBlock } = await getCosmosAccountInfo(coin)
-
-  // For TerraClassic USTC (uusd) sends, pre-compute the burn-tax surcharge
-  // dynamically. Encoded in baseDenom so the sync signing-inputs resolver
-  // can use it without an async LCD call. Falls back to '0' when the tax
-  // rate is zero (current on-chain state post-UST-collapse governance).
-  const isUstcSend = coin.chain === Chain.TerraClassic && coin.id?.toLowerCase() === 'uusd'
-  let burnTaxBaseDenom = ''
-  if (isUstcSend) {
-    try {
-      burnTaxBaseDenom = await computeUstcBurnTaxAmount(keysignPayload.toAmount)
-    } catch {
-      // Fail-open on burn-tax LCD outage: fall back to '0' to avoid blocking
-      // the send. A $0.02 under-fee is better than a blocked tx when the
-      // rate is currently zero. When the rate is non-zero and the LCD is
-      // down, the tx will be rejected by the chain's ante handler.
-      burnTaxBaseDenom = '0'
-    }
-  }
 
   // Initiator-side dynamic gas: simulate a native send via
   // `/cosmos/tx/v1beta1/simulate` and relay the padded gas limit to co-signers
@@ -86,13 +42,14 @@ export const getCosmosChainSpecific: GetChainSpecificResolver<'cosmosSpecific'> 
   // than throw here.
   const hasRelayedSignData = keysignPayload.signData?.case !== undefined
 
-  const isNativeSend =
+  const isPlainSend =
     transactionType === TransactionType.UNSPECIFIED &&
     !hasRelayedSignData &&
-    isFeeCoin(coin) &&
     !!keysignPayload.toAddress &&
     /^[0-9]+$/.test(keysignPayload.toAmount) &&
     BigInt(keysignPayload.toAmount) > 0n
+  const isNativeSend = isPlainSend && isFeeCoin(coin)
+  const isTerraClassicUstcSend = isPlainSend && coin.chain === Chain.TerraClassic && coin.id?.toLowerCase() === 'uusd'
 
   const simulatedGasLimit = isNativeSend
     ? await estimateCosmosGasLimit({
@@ -133,7 +90,7 @@ export const getCosmosChainSpecific: GetChainSpecificResolver<'cosmosSpecific'> 
   // choice, not a validity one. Pre-paying is what iOS and Android do, and it
   // keeps "You're sending N LUNC" literally true.
   //
-  // Scoped to plain native-LUNC sends, deliberately:
+  // Scoped to plain LUNC and USTC sends, deliberately:
   //   - IBC `MsgTransfer` is taxable too, but every observed columbus-5 IBC
   //     transfer pays gas only and lets the chain deduct from the amount, as do
   //     iOS and Android. Pre-paying here would diverge from both for no
@@ -141,20 +98,20 @@ export const getCosmosChainSpecific: GetChainSpecificResolver<'cosmosSpecific'> 
   //   - Relayed `signDirect` / `signAmino` never reach this value: the signing
   //     resolver returns the dapp-supplied fee verbatim, so touching `gas`
   //     would move only the DISPLAYED fee and reintroduce shown != signed.
-  //   - Non-fee coins pay the fee in `uluna` while the tax accrues in the send
-  //     denom; folding them into one amount would mix denoms.
+  //   - USTC is the one non-native exception because the mobile signers price
+  //     both its base fee and tax in `uusd`. Other non-fee coins still pay in
+  //     `uluna`, so folding their tax into the fee would mix denoms.
   //
-  // USTC (`uusd`) is untouched here — its tax rides in `ibcDenomTraces.baseDenom`
-  // as a separate fee coin (see `computeUstcBurnTaxAmount`).
   const isTerraClassicLuncSend = coin.chain === Chain.TerraClassic && isNativeSend
+  const isTerraClassicTaxedSend = isTerraClassicLuncSend || isTerraClassicUstcSend
 
   // Independent lookups — run them concurrently rather than paying two
   // sequential LCD round-trips while the user waits on the Verify screen.
   // `getTerraClassicBurnTaxRate` fails closed rather than rejecting, so this
   // cannot turn an LCD blip into a failed payload build.
   const [staticFeeAmount, burnTaxRate] = await Promise.all([
-    getCosmosFeeAmount(coin),
-    isTerraClassicLuncSend ? getTerraClassicBurnTaxRate() : Promise.resolve(0n),
+    isTerraClassicUstcSend ? Promise.resolve(TERRA_CLASSIC_UUSD_BASE_GAS) : getCosmosFeeAmount(coin),
+    isTerraClassicTaxedSend ? getTerraClassicBurnTaxRate() : Promise.resolve(0n),
   ])
 
   const gasFeeAmount =
@@ -178,7 +135,7 @@ export const getCosmosChainSpecific: GetChainSpecificResolver<'cosmosSpecific'> 
     gasLimit,
     ibcDenomTraces: {
       latestBlock: timeoutTimestamp ? `${latestBlock.split('_')[0]}_${timeoutTimestamp}` : latestBlock,
-      baseDenom: burnTaxBaseDenom,
+      baseDenom: '',
       path: '',
     },
   })

--- a/packages/core/mpc/keysign/fee/resolvers/cosmos.test.ts
+++ b/packages/core/mpc/keysign/fee/resolvers/cosmos.test.ts
@@ -3,6 +3,7 @@ import { Buffer } from 'buffer'
 import { create } from '@bufbuild/protobuf'
 import { Chain } from '@vultisig/core-chain/Chain'
 import {
+  CosmosIbcDenomTraceSchema,
   CosmosSpecificSchema,
   MAYAChainSpecificSchema,
   THORChainSpecificSchema,
@@ -292,5 +293,67 @@ describe('getCosmosFeeAmount', () => {
       { amount: '8497500', denom: 'uluna' },
     ])
     expect(dappDisplayedFee).toBe(8_497_500n)
+  })
+
+  it('keeps the native uluna fee denom for an IBC transfer of TerraClassic USTC (does not relabel to uusd)', async () => {
+    // Regression for #1519: the uusd relabeling is scoped to plain bank
+    // sends. An IBC MsgTransfer of USTC still prices `gas` in uluna
+    // (chain-specific pricing, not the burn-tax surcharge), so signing must
+    // not mislabel that uluna amount as uusd.
+    const { getCosmosSigningInputs } = await import('../../signingInputs/resolvers/cosmos')
+    const { initWasm } = await import('@trustwallet/wallet-core')
+
+    const walletCore = await initWasm()
+    const privateKey = walletCore.PrivateKey.createWithData(new Uint8Array(32).fill(1))
+    const publicKey = privateKey.getPublicKeySecp256k1(true)
+    const sender = walletCore.AnyAddress.createWithPublicKey(publicKey, walletCore.CoinType.terra).description()
+
+    const keysignPayload = create(KeysignPayloadSchema, {
+      coin: create(CoinSchema, {
+        chain: Chain.TerraClassic,
+        ticker: 'USTC',
+        address: sender,
+        contractAddress: 'uusd',
+        decimals: 6,
+        isNativeToken: false,
+        hexPublicKey: Buffer.from(publicKey.data()).toString('hex'),
+      }),
+      toAddress: 'terra1recipient',
+      toAmount: '10000000',
+      memo: 'transfer:channel-1',
+      blockchainSpecific: {
+        case: 'cosmosSpecific',
+        value: create(CosmosSpecificSchema, {
+          accountNumber: 7n,
+          sequence: 3n,
+          // Chain-specific (uluna) pricing, not the uusd burn-tax surcharge.
+          gas: 16_995_000n,
+          transactionType: TransactionType.IBC_TRANSFER,
+          ibcDenomTraces: create(CosmosIbcDenomTraceSchema, {
+            path: 'transfer/channel-1',
+            baseDenom: 'uusd',
+            latestBlock: '12345_1751328000000000000',
+          }),
+        }),
+      },
+    })
+
+    const displayedFee = getCosmosFeeAmount({
+      keysignPayload,
+      walletCore: {} as never,
+      publicKey: {} as never,
+    })
+    const [signingInput] = await getCosmosSigningInputs({
+      keysignPayload,
+      walletCore,
+    })
+
+    expect(displayedFee).toBe(16_995_000n)
+    expect(
+      signingInput.fee?.amounts?.map(({ amount, denom }) => ({
+        amount,
+        denom,
+      }))
+    ).toEqual([{ amount: '16995000', denom: 'uluna' }])
   })
 })

--- a/packages/core/mpc/keysign/fee/resolvers/cosmos.test.ts
+++ b/packages/core/mpc/keysign/fee/resolvers/cosmos.test.ts
@@ -223,13 +223,9 @@ describe('getCosmosFeeAmount', () => {
     )
   })
 
-  it('includes the TerraClassic USTC burn tax in the display total exactly when signing includes it', async () => {
+  it('displays the single-denom TerraClassic USTC fee that signing emits', async () => {
     const { getCosmosSigningInputs } = await import('../../signingInputs/resolvers/cosmos')
     const { initWasm } = await import('@trustwallet/wallet-core')
-    const { CosmosIbcDenomTraceSchema } =
-      await import('@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb')
-    const { CosmosCoinSchema, CosmosFeeSchema, SignAminoSchema } =
-      await import('@vultisig/core-mpc/types/vultisig/keysign/v1/wasm_execute_contract_payload_pb')
 
     const walletCore = await initWasm()
     const privateKey = walletCore.PrivateKey.createWithData(new Uint8Array(32).fill(1))
@@ -253,46 +249,24 @@ describe('getCosmosFeeAmount', () => {
         value: create(CosmosSpecificSchema, {
           accountNumber: 7n,
           sequence: 3n,
-          gas: 8_497_500n,
+          // The initiator already combined the base fee and burn tax in uusd.
+          gas: 1_225_000n,
           transactionType: TransactionType.UNSPECIFIED,
-          ibcDenomTraces: create(CosmosIbcDenomTraceSchema, {
-            baseDenom: '120000',
-          }),
         }),
       },
     })
 
-    const displayedFee = getCosmosFeeAmount({ keysignPayload, walletCore: {} as never, publicKey: {} as never })
-    const [signingInput] = await getCosmosSigningInputs({ keysignPayload, walletCore })
-    const signedFeeAmounts = signingInput.fee?.amounts ?? []
-
-    expect(signedFeeAmounts.map(({ amount, denom }) => ({ amount, denom }))).toEqual([
-      { amount: '8497500', denom: 'uluna' },
-      { amount: '120000', denom: 'uusd' },
-    ])
-    expect(displayedFee).toBe(8_617_500n)
-    expect(displayedFee).toBe(signedFeeAmounts.reduce((total, { amount }) => total + BigInt(amount ?? '0'), 0n))
-
-    keysignPayload.signData = {
-      case: 'signAmino',
-      value: create(SignAminoSchema, {
-        fee: create(CosmosFeeSchema, {
-          gas: '300000',
-          amount: [create(CosmosCoinSchema, { amount: '8497500', denom: 'uluna' })],
-        }),
-      }),
-    }
-    const dappDisplayedFee = getCosmosFeeAmount({
+    const displayedFee = getCosmosFeeAmount({
       keysignPayload,
       walletCore: {} as never,
       publicKey: {} as never,
     })
-    const [dappSigningInput] = await getCosmosSigningInputs({ keysignPayload, walletCore })
+    const [signingInput] = await getCosmosSigningInputs({ keysignPayload, walletCore })
 
-    expect(dappSigningInput.fee?.amounts?.map(({ amount, denom }) => ({ amount, denom }))).toEqual([
-      { amount: '8497500', denom: 'uluna' },
+    expect(displayedFee).toBe(1_225_000n)
+    expect(signingInput.fee?.amounts?.map(({ amount, denom }) => ({ amount, denom }))).toEqual([
+      { amount: displayedFee.toString(), denom: 'uusd' },
     ])
-    expect(dappDisplayedFee).toBe(8_497_500n)
   })
 
   it('keeps the native uluna fee denom for an IBC transfer of TerraClassic USTC (does not relabel to uusd)', async () => {

--- a/packages/core/mpc/keysign/fee/resolvers/cosmos.test.ts
+++ b/packages/core/mpc/keysign/fee/resolvers/cosmos.test.ts
@@ -123,7 +123,6 @@ describe('getCosmosFeeAmount', () => {
     const { initWasm } = await import('@trustwallet/wallet-core')
     const { CosmosIbcDenomTraceSchema } =
       await import('@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb')
-
     const walletCore = await initWasm()
     const privateKey = walletCore.PrivateKey.createWithData(new Uint8Array(32).fill(1))
     const publicKey = privateKey.getPublicKeySecp256k1(false)
@@ -221,5 +220,77 @@ describe('getCosmosFeeAmount', () => {
     await expect(getCosmosFeeAmount(buildVaultInput(Chain.MayaChain))).rejects.toThrow(
       'MayaChain Mimir NativeTransactionFee is not an integer'
     )
+  })
+
+  it('includes the TerraClassic USTC burn tax in the display total exactly when signing includes it', async () => {
+    const { getCosmosSigningInputs } = await import('../../signingInputs/resolvers/cosmos')
+    const { initWasm } = await import('@trustwallet/wallet-core')
+    const { CosmosIbcDenomTraceSchema } =
+      await import('@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb')
+    const { CosmosCoinSchema, CosmosFeeSchema, SignAminoSchema } =
+      await import('@vultisig/core-mpc/types/vultisig/keysign/v1/wasm_execute_contract_payload_pb')
+
+    const walletCore = await initWasm()
+    const privateKey = walletCore.PrivateKey.createWithData(new Uint8Array(32).fill(1))
+    const publicKey = privateKey.getPublicKeySecp256k1(true)
+    const sender = walletCore.AnyAddress.createWithPublicKey(publicKey, walletCore.CoinType.terra).description()
+
+    const keysignPayload = create(KeysignPayloadSchema, {
+      coin: create(CoinSchema, {
+        chain: Chain.TerraClassic,
+        ticker: 'USTC',
+        address: sender,
+        contractAddress: 'uusd',
+        decimals: 6,
+        isNativeToken: false,
+        hexPublicKey: Buffer.from(publicKey.data()).toString('hex'),
+      }),
+      toAddress: sender,
+      toAmount: '10000000',
+      blockchainSpecific: {
+        case: 'cosmosSpecific',
+        value: create(CosmosSpecificSchema, {
+          accountNumber: 7n,
+          sequence: 3n,
+          gas: 8_497_500n,
+          transactionType: TransactionType.UNSPECIFIED,
+          ibcDenomTraces: create(CosmosIbcDenomTraceSchema, {
+            baseDenom: '120000',
+          }),
+        }),
+      },
+    })
+
+    const displayedFee = getCosmosFeeAmount({ keysignPayload, walletCore: {} as never, publicKey: {} as never })
+    const [signingInput] = await getCosmosSigningInputs({ keysignPayload, walletCore })
+    const signedFeeAmounts = signingInput.fee?.amounts ?? []
+
+    expect(signedFeeAmounts.map(({ amount, denom }) => ({ amount, denom }))).toEqual([
+      { amount: '8497500', denom: 'uluna' },
+      { amount: '120000', denom: 'uusd' },
+    ])
+    expect(displayedFee).toBe(8_617_500n)
+    expect(displayedFee).toBe(signedFeeAmounts.reduce((total, { amount }) => total + BigInt(amount ?? '0'), 0n))
+
+    keysignPayload.signData = {
+      case: 'signAmino',
+      value: create(SignAminoSchema, {
+        fee: create(CosmosFeeSchema, {
+          gas: '300000',
+          amount: [create(CosmosCoinSchema, { amount: '8497500', denom: 'uluna' })],
+        }),
+      }),
+    }
+    const dappDisplayedFee = getCosmosFeeAmount({
+      keysignPayload,
+      walletCore: {} as never,
+      publicKey: {} as never,
+    })
+    const [dappSigningInput] = await getCosmosSigningInputs({ keysignPayload, walletCore })
+
+    expect(dappSigningInput.fee?.amounts?.map(({ amount, denom }) => ({ amount, denom }))).toEqual([
+      { amount: '8497500', denom: 'uluna' },
+    ])
+    expect(dappDisplayedFee).toBe(8_497_500n)
   })
 })

--- a/packages/core/mpc/keysign/fee/resolvers/cosmos.ts
+++ b/packages/core/mpc/keysign/fee/resolvers/cosmos.ts
@@ -1,11 +1,10 @@
-import { Chain, CosmosChain } from '@vultisig/core-chain/Chain'
+import { Chain } from '@vultisig/core-chain/Chain'
 import { getCosmosRpcUrl } from '@vultisig/core-chain/chains/cosmos/getCosmosRpcUrl'
 import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
-import { getCosmosChainSpecific, getCosmosFeeAmounts } from '../../signingInputs/resolvers/cosmos/chainSpecific'
+import { getCosmosChainSpecific } from '../../signingInputs/resolvers/cosmos/chainSpecific'
 import { getKeysignChain } from '../../utils/getKeysignChain'
-import { getKeysignCoin } from '../../utils/getKeysignCoin'
 import { FeeAmountResolver } from '../resolver'
 
 type MayaMimir = Record<string, number | string | undefined>
@@ -65,29 +64,19 @@ const getMayaNativeTransactionFee = async (): Promise<bigint> => {
  * MayaChain is the intentional exception: its payload schema has no fee field,
  * so the display resolves the current native transaction fee from MayaNode.
  *
- * `CosmosSpecific.gas` is the base fee AMOUNT (proto field 3). A relayed
+ * `CosmosSpecific.gas` is the complete fee AMOUNT (proto field 3) and is
+ * returned verbatim, exactly as the signing-input resolver emits it. A relayed
  * `gas_limit` (field 7) changes the signed gas limit, not the amount; the
- * initiator has already priced `gas` against it. TerraClassic USTC sends also
- * sign the pre-computed `uusd` burn-tax surcharge as a second amount, so the
- * display total is the sum of the same fee-amount list used by signing.
+ * initiator has already priced `gas` against it. For a plain TerraClassic USTC
+ * send, that amount already combines the `uusd` gas fee and burn tax.
  */
 export const getCosmosFeeAmount: FeeAmountResolver = ({ keysignPayload }) => {
   const chain = getKeysignChain<'cosmos'>(keysignPayload)
-  const coin = getKeysignCoin<CosmosChain>(keysignPayload)
 
   const chainSpecific = getCosmosChainSpecific(chain, keysignPayload.blockchainSpecific)
 
   return matchRecordUnion(chainSpecific, {
-    ibcEnabled: cosmosSpecific =>
-      getCosmosFeeAmounts({
-        chain,
-        coinId: coin.id,
-        chainSpecific: cosmosSpecific,
-        // signAmino/signDirect carry their own fee list. Their canonical base
-        // total is already relayed in `gas`; the native USTC surcharge applies
-        // only to the ordinary signing-input path.
-        includeTerraClassicBurnTax: keysignPayload.signData.case === undefined,
-      }).reduce((total, { amount }) => total + amount, 0n),
+    ibcEnabled: ({ gas }) => gas,
     vaultBased: value => ('fee' in value ? value.fee : getMayaNativeTransactionFee()),
   })
 }

--- a/packages/core/mpc/keysign/fee/resolvers/cosmos.ts
+++ b/packages/core/mpc/keysign/fee/resolvers/cosmos.ts
@@ -1,10 +1,11 @@
-import { Chain } from '@vultisig/core-chain/Chain'
+import { Chain, CosmosChain } from '@vultisig/core-chain/Chain'
 import { getCosmosRpcUrl } from '@vultisig/core-chain/chains/cosmos/getCosmosRpcUrl'
 import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
-import { getCosmosChainSpecific } from '../../signingInputs/resolvers/cosmos/chainSpecific'
+import { getCosmosChainSpecific, getCosmosFeeAmounts } from '../../signingInputs/resolvers/cosmos/chainSpecific'
 import { getKeysignChain } from '../../utils/getKeysignChain'
+import { getKeysignCoin } from '../../utils/getKeysignCoin'
 import { FeeAmountResolver } from '../resolver'
 
 type MayaMimir = Record<string, number | string | undefined>
@@ -64,19 +65,29 @@ const getMayaNativeTransactionFee = async (): Promise<bigint> => {
  * MayaChain is the intentional exception: its payload schema has no fee field,
  * so the display resolves the current native transaction fee from MayaNode.
  *
- * `CosmosSpecific.gas` is the fee AMOUNT (proto field 3) and is returned
- * verbatim — exactly what the signing-inputs resolver puts in the SignDoc, so
- * the Network Fee row can never drift from what gets signed. A relayed
+ * `CosmosSpecific.gas` is the base fee AMOUNT (proto field 3). A relayed
  * `gas_limit` (field 7) changes the signed gas limit, not the amount; the
- * initiator has already priced `gas` against it.
+ * initiator has already priced `gas` against it. TerraClassic USTC sends also
+ * sign the pre-computed `uusd` burn-tax surcharge as a second amount, so the
+ * display total is the sum of the same fee-amount list used by signing.
  */
 export const getCosmosFeeAmount: FeeAmountResolver = ({ keysignPayload }) => {
   const chain = getKeysignChain<'cosmos'>(keysignPayload)
+  const coin = getKeysignCoin<CosmosChain>(keysignPayload)
 
   const chainSpecific = getCosmosChainSpecific(chain, keysignPayload.blockchainSpecific)
 
   return matchRecordUnion(chainSpecific, {
-    ibcEnabled: ({ gas }) => gas,
+    ibcEnabled: cosmosSpecific =>
+      getCosmosFeeAmounts({
+        chain,
+        coinId: coin.id,
+        chainSpecific: cosmosSpecific,
+        // signAmino/signDirect carry their own fee list. Their canonical base
+        // total is already relayed in `gas`; the native USTC surcharge applies
+        // only to the ordinary signing-input path.
+        includeTerraClassicBurnTax: keysignPayload.signData.case === undefined,
+      }).reduce((total, { amount }) => total + amount, 0n),
     vaultBased: value => ('fee' in value ? value.fee : getMayaNativeTransactionFee()),
   })
 }

--- a/packages/core/mpc/keysign/refine/amount.test.ts
+++ b/packages/core/mpc/keysign/refine/amount.test.ts
@@ -133,7 +133,10 @@ describe('refineKeysignAmount', () => {
     const fee = 1_225_000n
     mocks.getFeeAmount.mockResolvedValue(fee)
 
-    const refined = await refine(buildPayload({ chain: Chain.TerraClassic, amount: balance, contractAddress: 'uusd' }), balance)
+    const refined = await refine(
+      buildPayload({ chain: Chain.TerraClassic, amount: balance, contractAddress: 'uusd' }),
+      balance
+    )
 
     expect(BigInt(refined.toAmount)).toBe(balance - fee)
   })

--- a/packages/core/mpc/keysign/refine/amount.test.ts
+++ b/packages/core/mpc/keysign/refine/amount.test.ts
@@ -1,6 +1,10 @@
 import { create } from '@bufbuild/protobuf'
 import { Chain, EvmChain } from '@vultisig/core-chain/Chain'
-import { EthereumSpecificSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
+import {
+  CosmosSpecificSchema,
+  EthereumSpecificSchema,
+  TransactionType,
+} from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
 import { KeysignPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -19,9 +23,15 @@ type PayloadInput = {
   chain?: Chain
   amount: bigint
   contractAddress?: string
+  transactionType?: TransactionType
 }
 
-const buildPayload = ({ chain = EvmChain.Optimism, amount, contractAddress }: PayloadInput) =>
+const buildPayload = ({
+  chain = EvmChain.Optimism,
+  amount,
+  contractAddress,
+  transactionType = TransactionType.UNSPECIFIED,
+}: PayloadInput) =>
   create(KeysignPayloadSchema, {
     coin: {
       chain,
@@ -32,15 +42,25 @@ const buildPayload = ({ chain = EvmChain.Optimism, amount, contractAddress }: Pa
     },
     toAddress: '0x2222222222222222222222222222222222222222',
     toAmount: amount.toString(),
-    blockchainSpecific: {
-      case: 'ethereumSpecific',
-      value: create(EthereumSpecificSchema, {
-        gasLimit: '40000',
-        maxFeePerGasWei: '1500000',
-        priorityFee: '0',
-        nonce: 0n,
-      }),
-    },
+    blockchainSpecific:
+      chain === Chain.TerraClassic
+        ? {
+            case: 'cosmosSpecific',
+            value: create(CosmosSpecificSchema, {
+              accountNumber: 7n,
+              sequence: 3n,
+              transactionType,
+            }),
+          }
+        : {
+            case: 'ethereumSpecific',
+            value: create(EthereumSpecificSchema, {
+              gasLimit: '40000',
+              maxFeePerGasWei: '1500000',
+              priorityFee: '0',
+              nonce: 0n,
+            }),
+          },
   })
 
 const refine = (keysignPayload: ReturnType<typeof buildPayload>, balance: bigint) =>
@@ -116,6 +136,30 @@ describe('refineKeysignAmount', () => {
     const refined = await refine(buildPayload({ chain: Chain.TerraClassic, amount: balance, contractAddress: 'uusd' }), balance)
 
     expect(BigInt(refined.toAmount)).toBe(balance - fee)
+  })
+
+  // Regression for the CHANGES_REQUESTED review on #1879: an IBC MsgTransfer
+  // of USTC still prices CosmosSpecific.gas in uluna (the signing-inputs
+  // resolver never relabels it to uusd for IBC), so refining uusd off the
+  // amount here — as if the fee were paid in-kind like a plain USTC send —
+  // would debit a denom the signing path never priced against. Only a plain
+  // TerraClassic bank-send pays its fee in uusd; an IBC transfer must be left
+  // untouched, exactly like the ordinary full-balance token case above.
+  it('leaves an IBC transfer of TerraClassic USTC untouched — its fee is priced in uluna, not uusd', async () => {
+    const balance = 200_000_000n
+
+    const refined = await refine(
+      buildPayload({
+        chain: Chain.TerraClassic,
+        amount: balance,
+        contractAddress: 'uusd',
+        transactionType: TransactionType.IBC_TRANSFER,
+      }),
+      balance
+    )
+
+    expect(BigInt(refined.toAmount)).toBe(balance)
+    expect(mocks.getFeeAmount).not.toHaveBeenCalled()
   })
 
   it.each([Chain.Bitcoin, Chain.Ton])(

--- a/packages/core/mpc/keysign/refine/amount.test.ts
+++ b/packages/core/mpc/keysign/refine/amount.test.ts
@@ -104,6 +104,20 @@ describe('refineKeysignAmount', () => {
     expect(mocks.getFeeAmount).not.toHaveBeenCalled()
   })
 
+  // Regression for #1519: unlike an ordinary token (previous test), USTC
+  // (TerraClassic uusd) pays its fee (base gas + burn tax) in uusd itself —
+  // the same denom being sent — so a full-balance send must still be refined
+  // down, exactly like a native-fee-coin send.
+  it('refines a full-balance TerraClassic USTC (uusd) send, since its fee is paid in-kind', async () => {
+    const balance = 200_000_000n
+    const fee = 1_225_000n
+    mocks.getFeeAmount.mockResolvedValue(fee)
+
+    const refined = await refine(buildPayload({ chain: Chain.TerraClassic, amount: balance, contractAddress: 'uusd' }), balance)
+
+    expect(BigInt(refined.toAmount)).toBe(balance - fee)
+  })
+
   it.each([Chain.Bitcoin, Chain.Ton])(
     'leaves %s alone, where the fee comes off the inputs and not the amount',
     async chain => {

--- a/packages/core/mpc/keysign/refine/amount.ts
+++ b/packages/core/mpc/keysign/refine/amount.ts
@@ -1,4 +1,5 @@
 import { Chain, UtxoBasedChain } from '@vultisig/core-chain/Chain'
+import { isTerraClassicUstcCoin } from '@vultisig/core-chain/chains/cosmos/terraClassicTax'
 import { isFeeCoin } from '@vultisig/core-chain/coin/utils/isFeeCoin'
 import { isOneOf } from '@vultisig/lib-utils/array/isOneOf'
 import { minBigInt } from '@vultisig/lib-utils/math/minBigInt'
@@ -23,7 +24,11 @@ export const refineKeysignAmount = async (input: RefineKeysignAmountInput) => {
   }
 
   const coin = getKeysignCoin(input.keysignPayload)
-  if (!isFeeCoin(coin)) {
+  // TerraClassic USTC pays its fee (base gas + burn tax) in `uusd` — the same
+  // denom being sent — so a full-balance USTC send must be refined down just
+  // like a native-fee-coin send. Every other non-fee-coin token pays gas from
+  // a separate native balance and is left untouched.
+  if (!isFeeCoin(coin) && !isTerraClassicUstcCoin(coin)) {
     return input.keysignPayload
   }
 

--- a/packages/core/mpc/keysign/refine/amount.ts
+++ b/packages/core/mpc/keysign/refine/amount.ts
@@ -1,14 +1,17 @@
-import { Chain, UtxoBasedChain } from '@vultisig/core-chain/Chain'
+import { Chain, CosmosChain, UtxoBasedChain } from '@vultisig/core-chain/Chain'
 import { isTerraClassicUstcCoin } from '@vultisig/core-chain/chains/cosmos/terraClassicTax'
 import { isFeeCoin } from '@vultisig/core-chain/coin/utils/isFeeCoin'
 import { isOneOf } from '@vultisig/lib-utils/array/isOneOf'
 import { minBigInt } from '@vultisig/lib-utils/math/minBigInt'
+import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
 import { WalletCore } from '@trustwallet/wallet-core'
 import { PublicKey } from '@trustwallet/wallet-core/dist/src/wallet-core'
 
+import { TransactionType } from '../../types/vultisig/keysign/v1/blockchain_specific_pb'
 import { KeysignPayload } from '../../types/vultisig/keysign/v1/keysign_message_pb'
 import { BuildKeysignPayloadError } from '../error'
 import { getFeeAmount } from '../fee'
+import { getCosmosChainSpecific } from '../signingInputs/resolvers/cosmos/chainSpecific'
 import { getKeysignCoin } from '../utils/getKeysignCoin'
 
 type RefineKeysignAmountInput = {
@@ -28,7 +31,20 @@ export const refineKeysignAmount = async (input: RefineKeysignAmountInput) => {
   // denom being sent — so a full-balance USTC send must be refined down just
   // like a native-fee-coin send. Every other non-fee-coin token pays gas from
   // a separate native balance and is left untouched.
-  if (!isFeeCoin(coin) && !isTerraClassicUstcCoin(coin)) {
+  //
+  // Scoped to PLAIN bank sends only (mirrors `getCosmosChainSpecific`'s
+  // `isPlainSend` gate and the signing-inputs resolver's own `isPlainSend`
+  // check): an IBC transfer of USTC still prices `CosmosSpecific.gas` in
+  // `uluna`, so refining `uusd` here for an IBC send would debit a denom the
+  // signing path never priced against — a real refine/sign mismatch.
+  const isTerraClassicUstcPlainSend =
+    isTerraClassicUstcCoin(coin) &&
+    matchRecordUnion(getCosmosChainSpecific(coin.chain as CosmosChain, input.keysignPayload.blockchainSpecific), {
+      ibcEnabled: ({ transactionType }) => transactionType === TransactionType.UNSPECIFIED,
+      vaultBased: () => false,
+    })
+
+  if (!isFeeCoin(coin) && !isTerraClassicUstcPlainSend) {
     return input.keysignPayload
   }
 

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos.test.ts
@@ -156,6 +156,43 @@ describe('getCosmosSigningInputs gas limit', () => {
     expect(input.fee?.gas.toString()).toBe('321979')
   })
 
+  it('signs a TerraClassic USTC fee as one uusd coin, matching mobile signers', async () => {
+    const terraClassicSender = walletCore.AnyAddress.createWithPublicKey(
+      walletCore.PrivateKey.createWithData(new Uint8Array(32).fill(1)).getPublicKeySecp256k1(true),
+      walletCore.CoinType.terra
+    ).description()
+
+    const [input] = await getCosmosSigningInputs({
+      keysignPayload: create(KeysignPayloadSchema, {
+        coin: create(CoinSchema, {
+          chain: Chain.TerraClassic,
+          ticker: 'USTC',
+          address: terraClassicSender,
+          contractAddress: 'uusd',
+          decimals: 6,
+          isNativeToken: false,
+          hexPublicKey: publicKeyHex,
+        }),
+        toAddress: terraClassicSender,
+        toAmount: '200000000',
+        blockchainSpecific: {
+          case: 'cosmosSpecific',
+          value: create(CosmosSpecificSchema, {
+            accountNumber: 7n,
+            sequence: 3n,
+            gas: 1_225_000n,
+            transactionType: TransactionType.UNSPECIFIED,
+          }),
+        },
+      }),
+      walletCore,
+    })
+
+    expect(input.fee?.amounts).toHaveLength(1)
+    expect(input.fee?.amounts?.[0]).toMatchObject({ denom: 'uusd', amount: '1225000' })
+    expect(input.fee?.gas.toString()).toBe('300000')
+  })
+
   it('keeps THORChain on its static gas limit without inserting its message-processing fee into authInfo', async () => {
     const [input] = await getCosmosSigningInputs({
       keysignPayload: create(KeysignPayloadSchema, {

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/chainSpecific.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/chainSpecific.ts
@@ -1,5 +1,4 @@
-import { Chain, CosmosChain } from '@vultisig/core-chain/Chain'
-import { cosmosFeeCoinDenom } from '@vultisig/core-chain/chains/cosmos/cosmosFeeCoinDenom'
+import { CosmosChain } from '@vultisig/core-chain/Chain'
 import { getCosmosChainKind } from '@vultisig/core-chain/chains/cosmos/utils/getCosmosChainKind'
 import {
   CosmosSpecific,
@@ -15,51 +14,6 @@ export type CosmosChainSpecific =
       ibcEnabled: CosmosSpecific
     }
   | { vaultBased: THORChainSpecific | MAYAChainSpecific }
-
-export type CosmosFeeAmount = {
-  amount: bigint
-  denom: string
-}
-
-type GetCosmosFeeAmountsInput = {
-  chain: CosmosChain
-  coinId?: string
-  chainSpecific: Pick<CosmosSpecific, 'gas' | 'ibcDenomTraces'>
-  includeTerraClassicBurnTax: boolean
-}
-
-/**
- * Returns the fee coins that the Cosmos signing resolver puts in the SignDoc.
- *
- * TerraClassic USTC sends are the only path with a second fee coin: the
- * stability-tax surcharge pre-computed by the async chain-specific resolver.
- * Keeping that rule here gives fee display and signing one source of truth.
- */
-export const getCosmosFeeAmounts = ({
-  chain,
-  coinId,
-  chainSpecific,
-  includeTerraClassicBurnTax,
-}: GetCosmosFeeAmountsInput): CosmosFeeAmount[] => {
-  const amounts: CosmosFeeAmount[] = [
-    {
-      amount: chainSpecific.gas,
-      denom: cosmosFeeCoinDenom[chain],
-    },
-  ]
-
-  if (includeTerraClassicBurnTax && chain === Chain.TerraClassic && coinId?.toLowerCase() === 'uusd') {
-    const burnTaxAmount = BigInt(chainSpecific.ibcDenomTraces?.baseDenom || '0')
-    if (burnTaxAmount > 0n) {
-      amounts.push({
-        amount: burnTaxAmount,
-        denom: coinId,
-      })
-    }
-  }
-
-  return amounts
-}
 
 export const getCosmosChainSpecific = (
   chain: CosmosChain,

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/chainSpecific.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/chainSpecific.ts
@@ -1,4 +1,5 @@
-import { CosmosChain } from '@vultisig/core-chain/Chain'
+import { Chain, CosmosChain } from '@vultisig/core-chain/Chain'
+import { cosmosFeeCoinDenom } from '@vultisig/core-chain/chains/cosmos/cosmosFeeCoinDenom'
 import { getCosmosChainKind } from '@vultisig/core-chain/chains/cosmos/utils/getCosmosChainKind'
 import {
   CosmosSpecific,
@@ -14,6 +15,51 @@ export type CosmosChainSpecific =
       ibcEnabled: CosmosSpecific
     }
   | { vaultBased: THORChainSpecific | MAYAChainSpecific }
+
+export type CosmosFeeAmount = {
+  amount: bigint
+  denom: string
+}
+
+type GetCosmosFeeAmountsInput = {
+  chain: CosmosChain
+  coinId?: string
+  chainSpecific: Pick<CosmosSpecific, 'gas' | 'ibcDenomTraces'>
+  includeTerraClassicBurnTax: boolean
+}
+
+/**
+ * Returns the fee coins that the Cosmos signing resolver puts in the SignDoc.
+ *
+ * TerraClassic USTC sends are the only path with a second fee coin: the
+ * stability-tax surcharge pre-computed by the async chain-specific resolver.
+ * Keeping that rule here gives fee display and signing one source of truth.
+ */
+export const getCosmosFeeAmounts = ({
+  chain,
+  coinId,
+  chainSpecific,
+  includeTerraClassicBurnTax,
+}: GetCosmosFeeAmountsInput): CosmosFeeAmount[] => {
+  const amounts: CosmosFeeAmount[] = [
+    {
+      amount: chainSpecific.gas,
+      denom: cosmosFeeCoinDenom[chain],
+    },
+  ]
+
+  if (includeTerraClassicBurnTax && chain === Chain.TerraClassic && coinId?.toLowerCase() === 'uusd') {
+    const burnTaxAmount = BigInt(chainSpecific.ibcDenomTraces?.baseDenom || '0')
+    if (burnTaxAmount > 0n) {
+      amounts.push({
+        amount: burnTaxAmount,
+        denom: coinId,
+      })
+    }
+  }
+
+  return amounts
+}
 
 export const getCosmosChainSpecific = (
   chain: CosmosChain,

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
@@ -4,7 +4,6 @@ import { getCosmosGasLimit } from '@vultisig/core-chain/chains/cosmos/cosmosGasL
 import { resolveCosmosGasLimit } from '@vultisig/core-chain/chains/cosmos/resolveCosmosGasLimit'
 import { getCosmosChainKind } from '@vultisig/core-chain/chains/cosmos/utils/getCosmosChainKind'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
-import { areEqualCoins } from '@vultisig/core-chain/coin/Coin'
 import {
   getNativeSwapChainIdFromDenomPrefix,
   nativeSwapChainIds,
@@ -25,7 +24,7 @@ import { toTwAddress } from '../../../tw/toTwAddress'
 import { getKeysignChain } from '../../../utils/getKeysignChain'
 import { getKeysignCoin } from '../../../utils/getKeysignCoin'
 import { SigningInputsResolver } from '../../resolver'
-import { CosmosChainSpecific, getCosmosChainSpecific } from './chainSpecific'
+import { CosmosChainSpecific, getCosmosChainSpecific, getCosmosFeeAmounts } from './chainSpecific'
 import { getCosmosCoinAmount } from './coinAmount'
 
 const getNativeSwapPayload = (keysignPayload: Parameters<typeof getKeysignSwapPayload>[0]) => {
@@ -535,7 +534,7 @@ export const getCosmosSigningInputs: SigningInputsResolver<'cosmos'> = ({ keysig
       return fee
     }
 
-    const getFeeAmounts = (feeAmount: bigint) => {
+    const getFeeAmounts = () => {
       if (chainKind !== 'ibcEnabled') {
         // THORChain and MayaChain charge their native transaction fee inside
         // message processing, not from cosmos-sdk authInfo.fee.amount. Their
@@ -544,32 +543,14 @@ export const getCosmosSigningInputs: SigningInputsResolver<'cosmos'> = ({ keysig
         return
       }
 
-      const { ibcDenomTraces } = getRecordUnionValue(chainSpecific, 'ibcEnabled')
+      const cosmosSpecific = getRecordUnionValue(chainSpecific, 'ibcEnabled')
 
-      const amounts: TW.Cosmos.Proto.Amount[] = [
-        TW.Cosmos.Proto.Amount.create({
-          amount: feeAmount.toString(),
-          denom: chainFeeDenom,
-        }),
-      ]
-
-      // Terra Classic stability-tax surcharge for USTC (uusd) sends.
-      // The burn-tax amount is pre-computed dynamically in getCosmosChainSpecific
-      // and stored in ibcDenomTraces.baseDenom so this sync path can use it.
-      // baseDenom is '' for all non-USTC chains; '0' when rate is zero.
-      if (areEqualCoins(coin, { chain: Chain.TerraClassic, id: 'uusd' })) {
-        const burnTaxAmount = BigInt(ibcDenomTraces?.baseDenom || '0')
-        if (burnTaxAmount > 0n) {
-          amounts.push(
-            TW.Cosmos.Proto.Amount.create({
-              denom: coin.id,
-              amount: burnTaxAmount.toString(),
-            })
-          )
-        }
-      }
-
-      return amounts
+      return getCosmosFeeAmounts({
+        chain,
+        coinId: coin.id,
+        chainSpecific: cosmosSpecific,
+        includeTerraClassicBurnTax: true,
+      }).map(({ amount, denom }) => TW.Cosmos.Proto.Amount.create({ amount: amount.toString(), denom }))
     }
 
     const ibcSpecific = chainKind === 'ibcEnabled' ? getRecordUnionValue(chainSpecific, 'ibcEnabled') : undefined
@@ -586,7 +567,7 @@ export const getCosmosSigningInputs: SigningInputsResolver<'cosmos'> = ({ keysig
 
     return TW.Cosmos.Proto.Fee.create({
       gas: Long.fromBigInt(resolvedGasLimit),
-      amounts: getFeeAmounts(ibcSpecific?.gas ?? 0n),
+      amounts: getFeeAmounts(),
     })
   }
 

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
@@ -24,7 +24,7 @@ import { toTwAddress } from '../../../tw/toTwAddress'
 import { getKeysignChain } from '../../../utils/getKeysignChain'
 import { getKeysignCoin } from '../../../utils/getKeysignCoin'
 import { SigningInputsResolver } from '../../resolver'
-import { CosmosChainSpecific, getCosmosChainSpecific, getCosmosFeeAmounts } from './chainSpecific'
+import { CosmosChainSpecific, getCosmosChainSpecific } from './chainSpecific'
 import { getCosmosCoinAmount } from './coinAmount'
 
 const getNativeSwapPayload = (keysignPayload: Parameters<typeof getKeysignSwapPayload>[0]) => {
@@ -534,7 +534,7 @@ export const getCosmosSigningInputs: SigningInputsResolver<'cosmos'> = ({ keysig
       return fee
     }
 
-    const getFeeAmounts = () => {
+    const getFeeAmounts = (feeAmount: bigint) => {
       if (chainKind !== 'ibcEnabled') {
         // THORChain and MayaChain charge their native transaction fee inside
         // message processing, not from cosmos-sdk authInfo.fee.amount. Their
@@ -543,14 +543,25 @@ export const getCosmosSigningInputs: SigningInputsResolver<'cosmos'> = ({ keysig
         return
       }
 
-      const cosmosSpecific = getRecordUnionValue(chainSpecific, 'ibcEnabled')
+      // Terra Classic bank-denom sends (currently USTC / uusd) pay gas plus
+      // burn tax in the send denom itself. `CosmosSpecific.gas` already
+      // contains that complete amount, computed by the initiator, so emit one
+      // uusd fee coin exactly like the current Swift and Kotlin signers.
+      if (coin.chain === Chain.TerraClassic && coin.id?.toLowerCase() === 'uusd') {
+        return [
+          TW.Cosmos.Proto.Amount.create({
+            amount: feeAmount.toString(),
+            denom: coin.id,
+          }),
+        ]
+      }
 
-      return getCosmosFeeAmounts({
-        chain,
-        coinId: coin.id,
-        chainSpecific: cosmosSpecific,
-        includeTerraClassicBurnTax: true,
-      }).map(({ amount, denom }) => TW.Cosmos.Proto.Amount.create({ amount: amount.toString(), denom }))
+      return [
+        TW.Cosmos.Proto.Amount.create({
+          amount: feeAmount.toString(),
+          denom: chainFeeDenom,
+        }),
+      ]
     }
 
     const ibcSpecific = chainKind === 'ibcEnabled' ? getRecordUnionValue(chainSpecific, 'ibcEnabled') : undefined
@@ -567,7 +578,7 @@ export const getCosmosSigningInputs: SigningInputsResolver<'cosmos'> = ({ keysig
 
     return TW.Cosmos.Proto.Fee.create({
       gas: Long.fromBigInt(resolvedGasLimit),
-      amounts: getFeeAmounts(),
+      amounts: getFeeAmounts(ibcSpecific?.gas ?? 0n),
     })
   }
 

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cosmos/index.ts
@@ -2,6 +2,7 @@ import { Chain, CosmosChain, VaultBasedCosmosChain } from '@vultisig/core-chain/
 import { cosmosFeeCoinDenom } from '@vultisig/core-chain/chains/cosmos/cosmosFeeCoinDenom'
 import { getCosmosGasLimit } from '@vultisig/core-chain/chains/cosmos/cosmosGasLimitRecord'
 import { resolveCosmosGasLimit } from '@vultisig/core-chain/chains/cosmos/resolveCosmosGasLimit'
+import { isTerraClassicUstcCoin } from '@vultisig/core-chain/chains/cosmos/terraClassicTax'
 import { getCosmosChainKind } from '@vultisig/core-chain/chains/cosmos/utils/getCosmosChainKind'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import {
@@ -547,7 +548,14 @@ export const getCosmosSigningInputs: SigningInputsResolver<'cosmos'> = ({ keysig
       // burn tax in the send denom itself. `CosmosSpecific.gas` already
       // contains that complete amount, computed by the initiator, so emit one
       // uusd fee coin exactly like the current Swift and Kotlin signers.
-      if (coin.chain === Chain.TerraClassic && coin.id?.toLowerCase() === 'uusd') {
+      //
+      // Scoped to PLAIN sends only (mirrors the initiator's `isPlainSend` gate
+      // in `getCosmosChainSpecific`): an IBC transfer of USTC still prices
+      // `gas` in `uluna` (chain-specific pricing, not the uusd surcharge), so
+      // relabeling its denom to uusd here would sign a fee coin that doesn't
+      // match what was actually priced.
+      const isPlainSend = ibcSpecific?.transactionType === TransactionType.UNSPECIFIED
+      if (isPlainSend && isTerraClassicUstcCoin(coin)) {
         return [
           TW.Cosmos.Proto.Amount.create({
             amount: feeAmount.toString(),

--- a/packages/core/mpc/keysign/tests/fixtures/mobile/cardano.json
+++ b/packages/core/mpc/keysign/tests/fixtures/mobile/cardano.json
@@ -51,7 +51,7 @@
       "to_amount": "10000000",
       "BlockchainSpecific": {
         "CardanoSpecific": {
-          "byte_fee": 44,
+          "byte_fee": 164515,
           "send_max_amount": true,
           "ttl": 190000000
         }

--- a/packages/core/mpc/keysign/tests/keysignPayloadWire.golden.test.ts
+++ b/packages/core/mpc/keysign/tests/keysignPayloadWire.golden.test.ts
@@ -66,12 +66,12 @@ const stakeRujiWireHex =
 // to serializer-path code (e.g. normalizeKeysignPayloadFromJson,
 // mapSwapPayload) that alters wire bytes for ANY fixture - not just the one
 // rich fixture pinned below - will fail here.
-const expectedCorpusDigest = '648ead4d4aa03f3683d091c84275fc0c8cf87d9ef991a2e4e0b996bbdf745ca8'
+const expectedCorpusDigest = '71a0bc013214cd0f4812988c5668783fb08c2421b5f8dc999e6aaa69447245d9'
 
 const expectedPerFileDigests: Record<string, string> = {
   'arb.json': 'b11f8989372fd8a51909c37b5da0d79138a647359685b916a2e905973d585e1f',
   'bsc.json': '123820d49abf4400c28d42789d9f5aee1191bd06ec5010cc800c360d53efbfb9',
-  'cardano.json': 'e1d344954b676398daaa2bd42c06dd0bfeadfc315cd0b0173aedd11bb1c7fbad',
+  'cardano.json': '9b6946664b8c02fe093bddfe12b8755eb5d17af14c50279bb7856aafa3adf1f6',
   'cosmos-sdk-sign-amino.json': '18b4811f7b03e6026c409445f1a37fc63a107842e15091de5af4f55e4c0c1a84',
   'cosmos-sdk-sign-direct.json': '658ce08b15e5f3d9fb0688ea44a93819064bcf1d3f7a996f435e1f73b607bd25',
   'cosmos.json': '757dc75b8dc2f077c990d51e0fb2849128af39f4b006fb34b4a4053243bfb93d',

--- a/packages/core/mpc/keysign/tests/mobileFixtures.golden.test.ts
+++ b/packages/core/mpc/keysign/tests/mobileFixtures.golden.test.ts
@@ -64,71 +64,6 @@ const cases = loadFixtureCases()
 const compareHashesAsSet = ({ chain, fixtureFile }: { chain: Chain; fixtureFile: string }) =>
   Object.values(UtxoChain).includes(chain as UtxoChain) || basename(fixtureFile) === 'mayaswap.json'
 
-// Keep the restored Android/iOS JSON expected hashes unchanged. These cases
-// currently differ through the SDK path, so the test pins SDK output here and
-// makes each difference explicit instead of silently rewriting mobile fixtures.
-//
-// Root-cause notes (golden-vector hardening pass, sdk#1367):
-//
-// - cardano.json::Send ADA - max amount
-//   The fee=0 send-max bug is FIXED (sdk#1382): WalletCore's Cardano planner
-//   ignores `forceFee` whenever `useMaxAmount` is set (returns `amount: <full
-//   input>, fee: 0`, an unbroadcastable tx), so the resolver no longer takes
-//   that path — a send-max is built as an EXPLICIT (totalInput - fee) transfer
-//   with the converged fee forced. Proven end-to-end (real fee-convergence +
-//   `AnySigner.plan`: fee > 0, change = 0, amount + fee = totalInput) in
-//   chainSpecific/resolvers/cardano.test.ts.
-//   This OFFLINE golden replay still diverges from the recorded device hash and
-//   is pinned via the override below: the fixture's `byte_fee: 44` is iOS's
-//   per-byte-rate parameter, whereas the SDK's `byteFee` field carries the
-//   TOTAL forced fee (computed by getCardanoChainSpecific's `44*size + 155_381`
-//   convergence). Replaying the raw fixture value therefore forces fee=44 here,
-//   not the device's converged fee (~164_515, which additionally does not
-//   factor the standard linear-fee formula for this body — a different
-//   historical signer). The production path re-converges `byteFee` first (this
-//   replay intentionally skips getCardanoChainSpecific), so this pinned hash is
-//   an artifact of the raw offline replay, not the shipped behavior.
-//
-// - terra.json::Send USTC on terra classic
-//   Root cause LIKELY (not conclusively reproduced): `getCosmosSigningInputs`
-//   has a dedicated Terra Classic stability-tax surcharge for USTC (`uusd`)
-//   sends (see `getFee`'s `areEqualCoins(coin, { chain: TerraClassic, id:
-//   'uusd' })` branch) — a burn-tax amount is meant to be pre-computed by the
-//   ASYNC `getCosmosChainSpecific` resolver (an `x/treasury` LCD query, see
-//   `terraClassicTax.ts`) and threaded through as an extra `Fee.amounts`
-//   coin via `CosmosSpecific.ibcDenomTraces.baseDenom`. This offline fixture
-//   JSON carries no `ibc_denom_traces`/`base_denom` field (that mechanism
-//   post-dates when this Android/iOS hash was captured), so replaying it
-//   through the current resolver always computes `burnTaxAmount = 0` and
-//   emits a single-coin fee — plausibly NOT what the device signed if the
-//   real on-chain tax rate was nonzero at capture time (the live rate is
-//   governance-set and is `0` today, per `terraClassicTax.ts`, but was
-//   historically ~1.2%). This is consistent with LUNC/uluna sends in this
-//   same fixture file matching exactly (uluna is tax-exempt — see
-//   `applyTerraClassicTax`) while only the uusd case diverges. However,
-//   exhaustive brute-force search did NOT find an exact reproduction: tried
-//   (a) reducing the send amount by 0-5% and by a wide absolute window
-//   ([199_000_000, 200_000_000] and curated tax-rate/cap candidates), (b)
-//   adding a second `uusd` fee coin (both appended and prepended) over
-//   [0, 5_000_000] uusd, (c) the two combined (amount reduced AND fee coin
-//   added) over [0, 3_000_000], and (d) replacing the fee entirely with a
-//   uusd-only coin over [0, 3_000_000] — none reproduce the recorded device
-//   hash. So either the historical tax rate/cap active at capture time falls
-//   outside these windows, or an additional structural difference is
-//   involved that this pass did not identify. Given the live tax rate is 0
-//   today, hard-coding ANY historical nonzero value into the resolver would
-//   be an active regression for present-day sends, not a fix. Follow-up:
-//   either (a) confirm the mechanism end-to-end with a FRESH device-recorded
-//   USTC fixture under the current rate=0 regime (should match trivially
-//   with `burnTaxAmount = 0`, validating the plumbing), or (b) if
-//   reproducing this exact historical hash matters, recover the exact
-//   `tax_rate`/`tax_cap` that was live on `columbus-5` at capture time from
-//   chain history and extend the brute-force window accordingly.
-const sdkExpectedHashOverrides: Record<string, string[]> = {
-  'cardano.json::Send ADA - max amount': ['36c543072b375c86720e358084fec7436eab4a5b08be4377c02fed5e086eac49'],
-  'terra.json::Send USTC on terra classic': ['0122eb10508372f69c521d7206a8d06aa6c569b1d4a9e449d4de5f32853dc6f8'],
-}
-
 describe('mobile keysign pre-image hash golden fixtures', () => {
   let walletCore: WalletCore
 
@@ -180,9 +115,7 @@ describe('mobile keysign pre-image hash golden fixtures', () => {
 
       const sortsHashes = compareHashesAsSet({ chain, fixtureFile: testCase.fixtureFile })
       const actualForAssert = sortsHashes ? [...actual].sort() : actual
-      const expectedHashes =
-        sdkExpectedHashOverrides[`${testCase.fixtureFile}::${testCase.name}`] ?? testCase.expected_image_hash
-      const expected = sortsHashes ? [...expectedHashes].sort() : expectedHashes
+      const expected = sortsHashes ? [...testCase.expected_image_hash].sort() : testCase.expected_image_hash
 
       expect(actualForAssert).toEqual(expected)
     })

--- a/packages/sdk/src/tools/prep/maxSend.ts
+++ b/packages/sdk/src/tools/prep/maxSend.ts
@@ -1,6 +1,7 @@
 import type { WalletCore } from '@trustwallet/wallet-core'
 import { getMaxValue } from '@vultisig/core-chain/amount/getMaxValue'
 import { Chain } from '@vultisig/core-chain/Chain'
+import { isTerraClassicUstcCoin } from '@vultisig/core-chain/chains/cosmos/terraClassicTax'
 import type { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
 import { getCoinBalance } from '@vultisig/core-chain/coin/balance'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
@@ -86,7 +87,12 @@ export const computeMaxSendFromBalance = async (
     feeSettings: params.feeSettings,
   })
 
-  const isTokenSend = !isFeeCoin(params.coin)
+  // TerraClassic USTC pays its fee (base gas + burn tax) in `uusd` — the same
+  // denom/balance being sent — unlike every other non-fee-coin token, which
+  // pays gas from a separate native balance. Treat it like a native send: no
+  // native-balance gas check, and the fee comes out of the same balance.
+  const paysFeeInOwnBalance = isFeeCoin(params.coin) || isTerraClassicUstcCoin(params.coin)
+  const isTokenSend = !paysFeeInOwnBalance
   if (isTokenSend) {
     const native = chainFeeCoin[params.coin.chain]
     const nativeBalance = shouldBePresent(params.nativeBalance, `Native ${native.ticker} balance for token max-send`)
@@ -125,8 +131,9 @@ export const getMaxSendAmountFromKeys = async (
   // Receiver validation lives in computeMaxSendFromBalance (the canonical check
   // for all callers) — don't duplicate it here.
   const balance = await getCoinBalance(params.coin)
-  const nativeBalance = isFeeCoin(params.coin)
-    ? undefined
-    : await getCoinBalance({ ...chainFeeCoin[params.coin.chain], address: params.coin.address })
+  const nativeBalance =
+    isFeeCoin(params.coin) || isTerraClassicUstcCoin(params.coin)
+      ? undefined
+      : await getCoinBalance({ ...chainFeeCoin[params.coin.chain], address: params.coin.address })
   return computeMaxSendFromBalance(identity, { ...params, balance, nativeBalance }, walletCore)
 }

--- a/packages/sdk/tests/unit/tools/prep/maxSend.test.ts
+++ b/packages/sdk/tests/unit/tools/prep/maxSend.test.ts
@@ -325,6 +325,59 @@ describe('getMaxSendAmountFromKeys', () => {
     expect(call.hexPublicKeyOverride).toBe('mldsa-pubkey-hex')
   })
 
+  it('subtracts the in-kind uusd fee for a full-balance TerraClassic USTC send (does not overdraft)', async () => {
+    // Regression for #1519: USTC (uusd) pays gas + burn tax in uusd itself,
+    // not in native uluna. A full-balance send must reserve the fee from the
+    // same uusd balance instead of returning the whole balance untouched.
+    const balance = 200_000_000n
+    const fee = 1_225_000n
+    mockGetCoinBalance.mockResolvedValue(balance)
+    mockGetSendFeeEstimate.mockResolvedValue(fee)
+
+    const coin = {
+      chain: Chain.TerraClassic,
+      address: 'terra1from',
+      id: 'uusd',
+      decimals: 6,
+      ticker: 'USTC',
+    } as any
+
+    const result = await getMaxSendAmountFromKeys(baseIdentity, {
+      coin,
+      receiver: 'terra1to',
+    })
+
+    expect(result).toEqual({
+      balance,
+      fee,
+      maxSendable: balance - fee,
+    })
+    // No separate native uluna balance lookup — the fee comes out of the
+    // same uusd balance, unlike an ordinary (non-fee) cosmos token.
+    expect(mockGetCoinBalance).toHaveBeenCalledTimes(1)
+    expect(mockGetCoinBalance).toHaveBeenCalledWith(coin)
+  })
+
+  it('returns maxSendable === 0n for TerraClassic USTC when the in-kind fee exceeds balance', async () => {
+    const balance = 1_000n
+    const fee = 1_225_000n
+    mockGetCoinBalance.mockResolvedValue(balance)
+    mockGetSendFeeEstimate.mockResolvedValue(fee)
+
+    const result = await getMaxSendAmountFromKeys(baseIdentity, {
+      coin: {
+        chain: Chain.TerraClassic,
+        address: 'terra1from',
+        id: 'uusd',
+        decimals: 6,
+        ticker: 'USTC',
+      } as any,
+      receiver: 'terra1to',
+    })
+
+    expect(result.maxSendable).toBe(0n)
+  })
+
   it('forwards chainPublicKeys to getPublicKey (seedphrase-imported vault)', async () => {
     mockGetCoinBalance.mockResolvedValue(1_000n)
     mockGetSendFeeEstimate.mockResolvedValue(100n)


### PR DESCRIPTION
Align the SDK keysign pre-images with the shared mobile fixture corpus without SDK-only expected-hash overrides.

- Cardano max-send now replays the mobile total fee.
- Terra Classic USTC relays its full fee in `uusd`, so display and signing use the same single-denomination amount.
- The mixed-denomination scalar from the first implementation has been removed.
Closes #1519
Closes #1584

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terra Classic USTC transaction fees now align with mobile signing behavior.
  * USTC fees use the correct denomination, including IBC transfers.
  * Full-balance USTC sends deduct in-kind fees and handle insufficient balances correctly.
  * Terra Classic burn taxes are included accurately in fee totals.
  * Cardano max-send fee handling now matches mobile signer results.
* **Tests**
  * Added regression coverage for USTC fees, max-send behavior, IBC transfers, and Cardano fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->