### PR TITLE
refactor: standardize broadcast result contract

### DIFF
--- a/.changeset/standard-broadcast-result.md
+++ b/.changeset/standard-broadcast-result.md
@@ -1,5 +1,5 @@
 ---
-'@vultisig/core-chain': patch
+'@vultisig/core-chain': major
 '@vultisig/sdk': patch
 ---
 

--- a/.changeset/standard-broadcast-result.md
+++ b/.changeset/standard-broadcast-result.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/sdk': patch
+---
+
+Standardize signed-transaction broadcast adapters on one typed accepted-or-failed result contract.

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "vitest": "^4.1.8"
   },
   "resolutions": {
-    "nanoid@npm:^3.3.16": "^3.3.17",
+    "nanoid@npm:^3.3.16": "^3.3.18",
     "readable-stream": "3.6.2",
     "@grpc/grpc-js": "1.14.4",
     "@cosmjs/encoding/@scure/base": "1.2.6",

--- a/packages/core/chain/tx/broadcast/cosmosDeliverTxRetry.test.ts
+++ b/packages/core/chain/tx/broadcast/cosmosDeliverTxRetry.test.ts
@@ -56,10 +56,10 @@ describe('broadcastTx cosmos DeliverTx-failure retry interlock', () => {
       })
       .mockRejectedValueOnce(new Error('tx already exists in cache'))
 
-    const rejection: unknown = await broadcastTx({ chain, tx }).catch(caught => caught)
+    const result = await broadcastTx({ chain, tx })
 
-    expect(rejection).toBeInstanceOf(DeliverTxFailedError)
-    expect((rejection as Error).message).toMatch(/DEF456/)
+    expect(result).toMatchObject({ status: 'failed', retryable: false, cause: expect.any(DeliverTxFailedError) })
+    expect(result).toHaveProperty('cause.message', expect.stringMatching(/DEF456/))
     expect(mocks.broadcastTx).toHaveBeenCalledTimes(1)
     expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
   })
@@ -78,7 +78,9 @@ describe('broadcastTx cosmos DeliverTx-failure retry interlock', () => {
       })
       .mockRejectedValueOnce(new Error('tx already exists in cache'))
 
-    await expect(broadcastTx({ chain, tx })).rejects.toThrow(/GHI789/)
+    const result = await broadcastTx({ chain, tx })
+    expect(result).toMatchObject({ status: 'failed', retryable: false, cause: expect.any(DeliverTxFailedError) })
+    expect(result).toHaveProperty('cause.message', expect.stringMatching(/GHI789/))
 
     expect(mocks.broadcastTx).toHaveBeenCalledTimes(1)
     expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
@@ -92,7 +94,9 @@ describe('broadcastTx cosmos DeliverTx-failure retry interlock', () => {
       rawLog: 'out of gas',
     })
 
-    await expect(broadcastTx({ chain, tx })).rejects.toThrow(/ABC123/)
+    const result = await broadcastTx({ chain, tx })
+    expect(result).toMatchObject({ status: 'failed', retryable: false, cause: expect.any(DeliverTxFailedError) })
+    expect(result).toHaveProperty('cause.message', expect.stringMatching(/ABC123/))
 
     expect(mocks.broadcastTx).toHaveBeenCalledTimes(1)
     expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()

--- a/packages/core/chain/tx/broadcast/index.test.ts
+++ b/packages/core/chain/tx/broadcast/index.test.ts
@@ -2,49 +2,90 @@ import { HttpResponseError } from '@vultisig/lib-utils/fetch/HttpResponseError'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
-  broadcastBittensorTx: vi.fn(),
-  broadcastCardanoTx: vi.fn(),
-  broadcastCosmosTx: vi.fn(),
-  broadcastEvmTx: vi.fn(),
-  broadcastPolkadotTx: vi.fn(),
-  broadcastQbtcTx: vi.fn(),
-  broadcastRippleTx: vi.fn(),
-  broadcastSolanaTx: vi.fn(),
-  broadcastSuiTx: vi.fn(),
-  broadcastTonTx: vi.fn(),
-  broadcastTronTx: vi.fn(),
-  broadcastUtxoTx: vi.fn(),
+  bittensor: vi.fn(),
+  cardano: vi.fn(),
+  cosmos: vi.fn(),
+  evm: vi.fn(),
+  polkadot: vi.fn(),
+  qbtc: vi.fn(),
+  ripple: vi.fn(),
+  solana: vi.fn(),
+  sui: vi.fn(),
+  ton: vi.fn(),
+  tron: vi.fn(),
+  utxo: vi.fn(),
 }))
 
-vi.mock('./resolvers/bittensor', () => ({
-  broadcastBittensorTx: mocks.broadcastBittensorTx,
-}))
-vi.mock('./resolvers/cardano', () => ({
-  broadcastCardanoTx: mocks.broadcastCardanoTx,
-}))
-vi.mock('./resolvers/cosmos', () => ({
-  broadcastCosmosTx: mocks.broadcastCosmosTx,
-}))
-vi.mock('./resolvers/evm', () => ({ broadcastEvmTx: mocks.broadcastEvmTx }))
-vi.mock('./resolvers/polkadot', () => ({
-  broadcastPolkadotTx: mocks.broadcastPolkadotTx,
-}))
-vi.mock('./resolvers/qbtc', () => ({ broadcastQbtcTx: mocks.broadcastQbtcTx }))
-vi.mock('./resolvers/ripple', () => ({
-  broadcastRippleTx: mocks.broadcastRippleTx,
-}))
-vi.mock('./resolvers/solana', () => ({
-  broadcastSolanaTx: mocks.broadcastSolanaTx,
-}))
-vi.mock('./resolvers/sui', () => ({ broadcastSuiTx: mocks.broadcastSuiTx }))
-vi.mock('./resolvers/ton', () => ({ broadcastTonTx: mocks.broadcastTonTx }))
-vi.mock('./resolvers/tron', () => ({ broadcastTronTx: mocks.broadcastTronTx }))
-vi.mock('./resolvers/utxo', () => ({ broadcastUtxoTx: mocks.broadcastUtxoTx }))
+vi.mock('./resolvers/bittensor', () => ({ broadcastBittensorTx: mocks.bittensor }))
+vi.mock('./resolvers/cardano', () => ({ broadcastCardanoTx: mocks.cardano }))
+vi.mock('./resolvers/cosmos', () => ({ broadcastCosmosTx: mocks.cosmos }))
+vi.mock('./resolvers/evm', () => ({ broadcastEvmTx: mocks.evm }))
+vi.mock('./resolvers/polkadot', () => ({ broadcastPolkadotTx: mocks.polkadot }))
+vi.mock('./resolvers/qbtc', () => ({ broadcastQbtcTx: mocks.qbtc }))
+vi.mock('./resolvers/ripple', () => ({ broadcastRippleTx: mocks.ripple }))
+vi.mock('./resolvers/solana', () => ({ broadcastSolanaTx: mocks.solana }))
+vi.mock('./resolvers/sui', () => ({ broadcastSuiTx: mocks.sui }))
+vi.mock('./resolvers/ton', () => ({ broadcastTonTx: mocks.ton }))
+vi.mock('./resolvers/tron', () => ({ broadcastTronTx: mocks.tron }))
+vi.mock('./resolvers/utxo', () => ({ broadcastUtxoTx: mocks.utxo }))
 
-import { Chain, OtherChain } from '../../Chain'
+import { Chain, CosmosChain, EvmChain, OtherChain, UtxoChain } from '../../Chain'
+import type { ChainKind } from '../../ChainKind'
 import { broadcastTx } from '.'
 import { CosmosSequenceMismatchError } from './cosmosSequenceMismatch'
+import { broadcastAccepted, BroadcastErrorCode, broadcastFailed, isRetryableBroadcastCause } from './resolver'
 import { broadcastRetryMaxAttempts, isTransientBroadcastError } from './transientRetry'
+
+const cases = {
+  bittensor: { chain: OtherChain.Bittensor, resolver: mocks.bittensor },
+  cardano: { chain: OtherChain.Cardano, resolver: mocks.cardano },
+  cosmos: { chain: CosmosChain.Cosmos, resolver: mocks.cosmos },
+  evm: { chain: EvmChain.Ethereum, resolver: mocks.evm },
+  polkadot: { chain: OtherChain.Polkadot, resolver: mocks.polkadot },
+  qbtc: { chain: OtherChain.QBTC, resolver: mocks.qbtc },
+  ripple: { chain: OtherChain.Ripple, resolver: mocks.ripple },
+  solana: { chain: OtherChain.Solana, resolver: mocks.solana },
+  sui: { chain: OtherChain.Sui, resolver: mocks.sui },
+  ton: { chain: OtherChain.Ton, resolver: mocks.ton },
+  tron: { chain: OtherChain.Tron, resolver: mocks.tron },
+  utxo: { chain: UtxoChain.Bitcoin, resolver: mocks.utxo },
+} satisfies Record<ChainKind, { chain: Chain; resolver: ReturnType<typeof vi.fn> }>
+
+describe.each(Object.entries(cases))('broadcastTx %s adapter contract', (kind, { chain, resolver }) => {
+  const tx = {} as any
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns the shared accepted result', async () => {
+    const accepted = broadcastAccepted(`${kind}-hash`)
+    resolver.mockResolvedValue(accepted)
+
+    await expect(broadcastTx({ chain, tx })).resolves.toEqual(accepted)
+    expect(resolver).toHaveBeenCalledWith({ chain, tx })
+  })
+
+  it('returns the shared definitive failure result', async () => {
+    const failed = broadcastFailed(new Error(`${kind} rejected`), false)
+    resolver.mockResolvedValue(failed)
+
+    await expect(broadcastTx({ chain, tx })).resolves.toEqual(failed)
+  })
+
+  it('quarantines raw provider responses under namespaced details', async () => {
+    const rawProviderResponse = { txid: `${kind}-raw`, result: true }
+    resolver.mockResolvedValue(rawProviderResponse)
+
+    await expect(broadcastTx({ chain, tx })).resolves.toEqual({
+      status: 'failed',
+      code: BroadcastErrorCode.Rejected,
+      retryable: false,
+      cause: expect.objectContaining({ message: 'Broadcast resolver returned an invalid result' }),
+      details: { provider: rawProviderResponse },
+    })
+  })
+})
 
 describe('broadcastTx transient retry dispatcher', () => {
   const tx = { encoded: new Uint8Array([1, 2, 3]) } as any
@@ -57,55 +98,123 @@ describe('broadcastTx transient retry dispatcher', () => {
     vi.useRealTimers()
   })
 
-  it('retries transient transport errors for non-Solana/non-EVM resolvers', async () => {
+  it('retries transient result failures for non-Solana/non-EVM resolvers', async () => {
     vi.useFakeTimers()
-    mocks.broadcastCardanoTx.mockRejectedValueOnce(new Error('fetch failed')).mockResolvedValueOnce('hash')
+    const cause = new Error('fetch failed')
+    mocks.cardano.mockResolvedValueOnce(broadcastFailed(cause, true)).mockResolvedValueOnce(broadcastAccepted('hash'))
 
     const promise = broadcastTx({ chain: OtherChain.Cardano, tx })
-
     await vi.advanceTimersByTimeAsync(250)
-    await expect(promise).resolves.toBe('hash')
 
-    expect(mocks.broadcastCardanoTx).toHaveBeenCalledTimes(2)
+    await expect(promise).resolves.toEqual(broadcastAccepted('hash'))
+    expect(mocks.cardano).toHaveBeenCalledTimes(2)
   })
 
-  it('stops after the bounded retry budget for persistent transient errors', async () => {
+  it('stops after the bounded retry budget and returns the last transient failure', async () => {
     vi.useFakeTimers()
-    const error = new Error('socket hang up')
-    mocks.broadcastTonTx.mockRejectedValue(error)
+    const failed = broadcastFailed(new Error('socket hang up'), true)
+    mocks.ton.mockResolvedValue(failed)
 
     const promise = broadcastTx({ chain: OtherChain.Ton, tx })
-    const assertion = expect(promise).rejects.toBe(error)
-
     await vi.advanceTimersByTimeAsync(750)
-    await assertion
 
-    expect(mocks.broadcastTonTx).toHaveBeenCalledTimes(broadcastRetryMaxAttempts)
+    await expect(promise).resolves.toEqual(failed)
+    expect(mocks.ton).toHaveBeenCalledTimes(broadcastRetryMaxAttempts)
   })
 
-  it('does not retry node rejection errors', async () => {
-    const error = new Error('BadInputsUTxO')
-    mocks.broadcastCardanoTx.mockRejectedValue(error)
+  it('does not retry node rejection results', async () => {
+    const failed = broadcastFailed(new Error('BadInputsUTxO'), false)
+    mocks.cardano.mockResolvedValue(failed)
 
-    await expect(broadcastTx({ chain: OtherChain.Cardano, tx })).rejects.toBe(error)
-
-    expect(mocks.broadcastCardanoTx).toHaveBeenCalledTimes(1)
+    await expect(broadcastTx({ chain: OtherChain.Cardano, tx })).resolves.toEqual(failed)
+    expect(mocks.cardano).toHaveBeenCalledTimes(1)
   })
 
-  it('classifies structured HTTP 429 and 5xx errors as transient but not HTTP 400', () => {
+  it('does not add dispatcher retry on top of resolver-owned retry', async () => {
+    const failed = broadcastFailed(new Error('fetch failed'), true)
+    mocks.solana.mockResolvedValueOnce(failed)
+    mocks.evm.mockResolvedValueOnce(failed)
+
+    await expect(broadcastTx({ chain: Chain.Solana, tx })).resolves.toEqual(failed)
+    await expect(broadcastTx({ chain: Chain.Ethereum, tx })).resolves.toEqual(failed)
+    expect(mocks.solana).toHaveBeenCalledTimes(1)
+    expect(mocks.evm).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('broadcast result safety guards', () => {
+  const tx = {} as any
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('normalizes thrown transport failures instead of leaking them', async () => {
+    const cause = new Error('ECONNRESET')
+    mocks.evm.mockRejectedValue(cause)
+
+    await expect(broadcastTx({ chain: EvmChain.Ethereum, tx: {} as any })).resolves.toEqual({
+      status: 'failed',
+      code: BroadcastErrorCode.Transport,
+      retryable: true,
+      cause,
+    })
+  })
+
+  it('does not classify an ambiguous local TypeError as retryable', async () => {
+    const cause = new TypeError('Cannot read properties of undefined')
+    mocks.evm.mockRejectedValue(cause)
+
+    await expect(broadcastTx({ chain: EvmChain.Ethereum, tx: {} as any })).resolves.toEqual({
+      status: 'failed',
+      code: BroadcastErrorCode.Rejected,
+      retryable: false,
+      cause,
+    })
+  })
+
+  it('quarantines contradictory and provider-native result shapes', async () => {
+    const contradictory = {
+      status: 'failed',
+      code: BroadcastErrorCode.Rejected,
+      retryable: true,
+      cause: new Error('rejected'),
+    }
+    mocks.evm.mockResolvedValueOnce(contradictory)
+
+    await expect(broadcastTx({ chain: EvmChain.Ethereum, tx: {} as any })).resolves.toMatchObject({
+      status: 'failed',
+      code: BroadcastErrorCode.Rejected,
+      retryable: false,
+      details: { provider: contradictory },
+    })
+
+    const rawProviderResult = { status: 'accepted', finality: 'pending', txid: 'provider-native-hash' }
+    mocks.evm.mockResolvedValueOnce(rawProviderResult)
+    await expect(broadcastTx({ chain: EvmChain.Ethereum, tx: {} as any })).resolves.toMatchObject({
+      status: 'failed',
+      details: { provider: rawProviderResult },
+    })
+  })
+
+  it('classifies structured HTTP and common fetch transport failures', () => {
     const httpError = (status: number) =>
       new HttpResponseError({
-        message: `HTTP ${status}`,
+        message: 'opaque body',
         status,
         statusText: 'status',
         url: 'https://example.invalid',
         body: null,
       })
 
-    expect(isTransientBroadcastError(httpError(429))).toBe(true)
-    expect(isTransientBroadcastError(httpError(503))).toBe(true)
-    expect(isTransientBroadcastError(httpError(400))).toBe(false)
-    expect(isTransientBroadcastError(httpError(600))).toBe(false)
+    expect(isRetryableBroadcastCause(httpError(408))).toBe(true)
+    expect(isRetryableBroadcastCause(httpError(429))).toBe(true)
+    expect(isRetryableBroadcastCause(httpError(503))).toBe(true)
+    expect(isRetryableBroadcastCause(httpError(400))).toBe(false)
+    expect(isRetryableBroadcastCause(httpError(600))).toBe(false)
+    for (const message of ['fetch failed', 'Failed to fetch', 'Network request failed', 'Load failed']) {
+      expect(isTransientBroadcastError(new TypeError(message))).toBe(true)
+    }
   })
 
   it('terminates when an error cause chain is cyclic', () => {
@@ -115,35 +224,17 @@ describe('broadcastTx transient retry dispatcher', () => {
     expect(isTransientBroadcastError(error)).toBe(false)
   })
 
-  it.each(['fetch failed', 'Failed to fetch', 'Network request failed'])(
-    'classifies common fetch transport error %s as transient',
-    message => {
-      expect(isTransientBroadcastError(new Error(message))).toBe(true)
-    }
-  )
-
-  it('does not add dispatcher retry on top of Solana or EVM resolver-owned retries', async () => {
-    const error = new Error('fetch failed')
-    mocks.broadcastSolanaTx.mockRejectedValueOnce(error)
-    mocks.broadcastEvmTx.mockRejectedValueOnce(error)
-
-    await expect(broadcastTx({ chain: Chain.Solana, tx })).rejects.toBe(error)
-    await expect(broadcastTx({ chain: Chain.Ethereum, tx })).rejects.toBe(error)
-
-    expect(mocks.broadcastSolanaTx).toHaveBeenCalledTimes(1)
-    expect(mocks.broadcastEvmTx).toHaveBeenCalledTimes(1)
-  })
-
   it('does not retry a stale Cosmos sequence that requires re-signing', async () => {
     const error = new CosmosSequenceMismatchError({
       expectedSequence: 255n,
       signedSequence: 254n,
     })
-    mocks.broadcastCosmosTx.mockRejectedValue(error)
+    const failed = broadcastFailed(error, false)
+    mocks.cosmos.mockResolvedValue(failed)
 
-    await expect(broadcastTx({ chain: Chain.Cosmos, tx })).rejects.toBe(error)
+    await expect(broadcastTx({ chain: Chain.Cosmos, tx })).resolves.toEqual(failed)
 
-    expect(mocks.broadcastCosmosTx).toHaveBeenCalledTimes(1)
+    expect(mocks.cosmos).toHaveBeenCalledTimes(1)
   })
 
   it('retries a future Cosmos sequence after its predecessor may have landed', async () => {
@@ -152,12 +243,12 @@ describe('broadcastTx transient retry dispatcher', () => {
       expectedSequence: 254n,
       signedSequence: 255n,
     })
-    mocks.broadcastCosmosTx.mockRejectedValueOnce(error).mockResolvedValueOnce(undefined)
+    mocks.cosmos.mockResolvedValueOnce(broadcastFailed(error, true)).mockResolvedValueOnce(broadcastAccepted())
 
     const promise = broadcastTx({ chain: Chain.Cosmos, tx })
 
     await vi.advanceTimersByTimeAsync(250)
-    await expect(promise).resolves.toBeUndefined()
-    expect(mocks.broadcastCosmosTx).toHaveBeenCalledTimes(2)
+    await expect(promise).resolves.toEqual(broadcastAccepted())
+    expect(mocks.cosmos).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/core/chain/tx/broadcast/index.ts
+++ b/packages/core/chain/tx/broadcast/index.ts
@@ -1,6 +1,6 @@
 import { ChainKind, getChainKind } from '@vultisig/core-chain/ChainKind'
 
-import { BroadcastTxResolver } from './resolver'
+import { broadcastFailed, BroadcastTxResolver, isBroadcastTxResult, isRetryableBroadcastCause } from './resolver'
 import { broadcastBittensorTx } from './resolvers/bittensor'
 import { broadcastCardanoTx } from './resolvers/cardano'
 import { broadcastCosmosTx } from './resolvers/cosmos'
@@ -32,13 +32,49 @@ const resolvers: Record<ChainKind, BroadcastTxResolver<any>> = {
 
 const hasResolverOwnedRetry = (chainKind: ChainKind): boolean => chainKind === 'evm' || chainKind === 'solana'
 
-export const broadcastTx: BroadcastTxResolver = input => {
+export type {
+  BroadcastAcceptedResult,
+  BroadcastFailedResult,
+  BroadcastProviderDetails,
+  BroadcastTxResolver,
+  BroadcastTxResult,
+} from './resolver'
+export { BroadcastErrorCode } from './resolver'
+
+export const broadcastTx: BroadcastTxResolver = async input => {
   const chainKind = getChainKind(input.chain)
   const resolver = resolvers[chainKind]
 
-  if (hasResolverOwnedRetry(chainKind)) {
-    return resolver(input)
+  const resolveOnce = async () => {
+    try {
+      const result = await resolver(input)
+      if (isBroadcastTxResult(result)) return result
+
+      return broadcastFailed(new Error('Broadcast resolver returned an invalid result'), false, {
+        provider: result,
+      })
+    } catch (cause) {
+      return broadcastFailed(cause, isRetryableBroadcastCause(cause))
+    }
   }
 
-  return withTransientBroadcastRetry(() => resolver(input))
+  if (hasResolverOwnedRetry(chainKind)) {
+    return resolveOnce()
+  }
+
+  try {
+    return await withTransientBroadcastRetry(async () => {
+      const result = await resolveOnce()
+      if (result.status === 'failed' && result.retryable) throw result
+
+      return result
+    })
+  } catch (cause) {
+    if (isBroadcastTxResult(cause)) return cause
+    // The public boundary is total even if a future resolver forgets to
+    // normalize an exception. Default to non-retryable unless the cause is a
+    // recognizable transport failure; blindly retrying an ambiguous signed
+    // transaction can double-submit it.
+    return broadcastFailed(cause, isRetryableBroadcastCause(cause))
+  }
 }

--- a/packages/core/chain/tx/broadcast/resolver.ts
+++ b/packages/core/chain/tx/broadcast/resolver.ts
@@ -2,11 +2,102 @@ import { Resolver } from '@vultisig/lib-utils/types/Resolver'
 
 import { Chain } from '../../Chain'
 import { SigningOutput } from '../../tw/signingOutput'
+import { isTransientBroadcastError } from './transientRetry'
+
+export const BroadcastErrorCode = {
+  Rejected: 'BROADCAST_REJECTED',
+  Transport: 'BROADCAST_TRANSPORT_ERROR',
+} as const
+
+export type BroadcastErrorCode = (typeof BroadcastErrorCode)[keyof typeof BroadcastErrorCode]
+
+export type BroadcastProviderDetails = {
+  /** Chain/provider-native data, isolated so it cannot become the common contract by accident. */
+  provider: unknown
+}
+
+/**
+ * The provider accepted (or already knew) the signed transaction.
+ *
+ * `finality: 'pending'` is intentional: a broadcast acknowledgement does not
+ * prove that the transaction executed successfully or reached finality.
+ */
+export type BroadcastAcceptedResult = {
+  status: 'accepted'
+  finality: 'pending'
+  txHash?: string
+  details?: BroadcastProviderDetails
+}
+
+export type BroadcastFailedResult = {
+  status: 'failed'
+  code: BroadcastErrorCode
+  retryable: boolean
+  /** Original provider/transport cause retained for diagnostics and logging. */
+  cause: unknown
+  details?: BroadcastProviderDetails
+}
+
+export type BroadcastTxResult = BroadcastAcceptedResult | BroadcastFailedResult
+
+export const broadcastAccepted = (txHash?: string, details?: BroadcastProviderDetails): BroadcastAcceptedResult => ({
+  status: 'accepted',
+  finality: 'pending',
+  ...(txHash ? { txHash } : {}),
+  ...(details ? { details } : {}),
+})
+
+export const broadcastFailed = (
+  cause: unknown,
+  retryable: boolean,
+  details?: BroadcastProviderDetails
+): BroadcastFailedResult => ({
+  status: 'failed',
+  code: retryable ? BroadcastErrorCode.Transport : BroadcastErrorCode.Rejected,
+  retryable,
+  cause,
+  ...(details ? { details } : {}),
+})
+
+export const isRetryableBroadcastCause = (cause: unknown): boolean => isTransientBroadcastError(cause)
+
+const hasOnlyKeys = (value: object, allowedKeys: readonly string[]): boolean =>
+  Object.keys(value).every(key => allowedKeys.includes(key))
+
+const hasValidDetails = (result: { details?: unknown }): boolean =>
+  result.details === undefined ||
+  (typeof result.details === 'object' &&
+    result.details !== null &&
+    'provider' in result.details &&
+    hasOnlyKeys(result.details, ['provider']))
+
+export const isBroadcastTxResult = (value: unknown): value is BroadcastTxResult => {
+  if (!value || typeof value !== 'object') return false
+
+  const result = value as Partial<BroadcastTxResult>
+  if (result.status === 'accepted') {
+    return (
+      result.finality === 'pending' &&
+      (result.txHash === undefined || (typeof result.txHash === 'string' && result.txHash.length > 0)) &&
+      hasValidDetails(result) &&
+      hasOnlyKeys(result, ['status', 'finality', 'txHash', 'details'])
+    )
+  }
+
+  return (
+    result.status === 'failed' &&
+    ((result.code === BroadcastErrorCode.Rejected && result.retryable === false) ||
+      (result.code === BroadcastErrorCode.Transport && result.retryable === true)) &&
+    'cause' in result &&
+    hasValidDetails(result) &&
+    hasOnlyKeys(result, ['status', 'code', 'retryable', 'cause', 'details'])
+  )
+}
 
 export type BroadcastTxResolver<T extends Chain = Chain> = Resolver<
   {
     chain: T
     tx: SigningOutput<T>
   },
-  Promise<unknown>
+  Promise<BroadcastTxResult>
 >

--- a/packages/core/chain/tx/broadcast/resolvers/bittensor.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/bittensor.test.ts
@@ -19,10 +19,14 @@ describe('broadcastBittensorTx', () => {
 
   beforeEach(() => vi.clearAllMocks())
 
-  it('returns silently when the node accepts the extrinsic', async () => {
+  it('returns the canonical result when the node accepts the extrinsic', async () => {
     mocks.queryUrl.mockResolvedValue({ result: '0xdeadbeef' })
 
-    await expect(broadcastBittensorTx({ chain, tx })).resolves.toBeUndefined()
+    await expect(broadcastBittensorTx({ chain, tx })).resolves.toEqual({
+      status: 'accepted',
+      finality: 'pending',
+      txHash: '0xdeadbeef',
+    })
     expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
   })
 
@@ -31,7 +35,7 @@ describe('broadcastBittensorTx', () => {
       error: { code: 1013, message: 'TRANSACTION ALREADY IMPORTED' },
     })
 
-    await expect(broadcastBittensorTx({ chain, tx })).resolves.toBeUndefined()
+    await expect(broadcastBittensorTx({ chain, tx })).resolves.toEqual({ status: 'accepted', finality: 'pending' })
     expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
   })
 
@@ -40,7 +44,7 @@ describe('broadcastBittensorTx', () => {
       error: { code: 1010, message: 'Invalid Transaction', data: 'Already known' },
     })
 
-    await expect(broadcastBittensorTx({ chain, tx })).resolves.toBeUndefined()
+    await expect(broadcastBittensorTx({ chain, tx })).resolves.toEqual({ status: 'accepted', finality: 'pending' })
     expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
   })
 
@@ -48,9 +52,12 @@ describe('broadcastBittensorTx', () => {
     mocks.queryUrl.mockResolvedValue({
       error: { code: 1010, message: 'Transaction is temporarily banned' },
     })
-    mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+    mocks.verifyBroadcastByHash.mockResolvedValue('0xverified')
 
-    await broadcastBittensorTx({ chain, tx })
+    await expect(broadcastBittensorTx({ chain, tx })).resolves.toMatchObject({
+      status: 'accepted',
+      txHash: '0xverified',
+    })
 
     expect(mocks.verifyBroadcastByHash).toHaveBeenCalledOnce()
     expect((mocks.verifyBroadcastByHash.mock.calls[0]![0].error as Error).message).toBe(
@@ -66,7 +73,7 @@ describe('broadcastBittensorTx', () => {
         data: 'Transaction has a bad signature',
       },
     })
-    mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+    mocks.verifyBroadcastByHash.mockResolvedValue('0xverified')
 
     await broadcastBittensorTx({ chain, tx })
 
@@ -78,7 +85,7 @@ describe('broadcastBittensorTx', () => {
 
   it('routes a response without a result or error through verification', async () => {
     mocks.queryUrl.mockResolvedValue({})
-    mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+    mocks.verifyBroadcastByHash.mockResolvedValue('0xverified')
 
     await broadcastBittensorTx({ chain, tx })
 
@@ -92,19 +99,22 @@ describe('broadcastBittensorTx', () => {
       throw error
     })
 
-    const error = await broadcastBittensorTx({ chain, tx }).catch(caught => caught)
+    const result = await broadcastBittensorTx({ chain, tx })
 
-    expect(error).toBeInstanceOf(Error)
-    expect(error).toHaveProperty('message', 'Bittensor broadcast failed: missing extrinsic hash in RPC response')
-    expect(isTransientBroadcastError(error)).toBe(false)
+    expect(result).toMatchObject({ status: 'failed', retryable: false })
+    expect(result).toHaveProperty('cause.message', 'Bittensor broadcast failed: missing extrinsic hash in RPC response')
+    expect(isTransientBroadcastError(result.status === 'failed' ? result.cause : undefined)).toBe(false)
   })
 
   it('routes transport failures through verification', async () => {
     const error = new Error('ECONNRESET')
     mocks.queryUrl.mockRejectedValue(error)
-    mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+    mocks.verifyBroadcastByHash.mockResolvedValue('0xverified')
 
-    await broadcastBittensorTx({ chain, tx })
+    await expect(broadcastBittensorTx({ chain, tx })).resolves.toMatchObject({
+      status: 'accepted',
+      txHash: '0xverified',
+    })
 
     expect(mocks.verifyBroadcastByHash).toHaveBeenCalledOnce()
     expect(mocks.verifyBroadcastByHash.mock.calls[0]![0].error).toBe(error)

--- a/packages/core/chain/tx/broadcast/resolvers/bittensor.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/bittensor.ts
@@ -3,7 +3,7 @@ import { bittensorRpcUrl } from '@vultisig/core-chain/chains/bittensor/client'
 import { ensureHexPrefix } from '@vultisig/lib-utils/hex/ensureHexPrefix'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
-import { BroadcastTxResolver } from '../resolver'
+import { broadcastAccepted, broadcastFailed, BroadcastTxResolver, isRetryableBroadcastCause } from '../resolver'
 import { verifyBroadcastByHash } from '../verifyBroadcastByHash'
 import { formatSubstrateRpcError, isIdempotentSubstrateBroadcastError, SubstrateRpcError } from './substrate'
 
@@ -14,6 +14,13 @@ type RpcResponse = {
 
 export const broadcastBittensorTx: BroadcastTxResolver<OtherChain.Bittensor> = async ({ chain, tx }) => {
   const hexWithPrefix = ensureHexPrefix(Buffer.from(tx.encoded).toString('hex'))
+  const verify = async (error: unknown, retryable = isRetryableBroadcastCause(error)) => {
+    try {
+      return broadcastAccepted(await verifyBroadcastByHash({ chain, tx, error }))
+    } catch (cause) {
+      return broadcastFailed(cause, retryable)
+    }
+  }
 
   try {
     const response = await queryUrl<RpcResponse>(bittensorRpcUrl, {
@@ -27,15 +34,18 @@ export const broadcastBittensorTx: BroadcastTxResolver<OtherChain.Bittensor> = a
 
     if (response.error) {
       if (isIdempotentSubstrateBroadcastError(response.error)) {
-        return
+        return broadcastAccepted()
       }
-      throw new Error(`Bittensor broadcast failed: ${formatSubstrateRpcError(response.error)}`)
+      const error = new Error(`Bittensor broadcast failed: ${formatSubstrateRpcError(response.error)}`)
+      return verify(error, false)
     }
 
-    if (!response.result) {
-      throw new Error('Bittensor broadcast failed: missing extrinsic hash in RPC response')
+    if (response.result) {
+      return broadcastAccepted(response.result)
     }
-  } catch (error) {
-    await verifyBroadcastByHash({ chain, tx, error })
+
+    return verify(new Error('Bittensor broadcast failed: missing extrinsic hash in RPC response'), false)
+  } catch (cause) {
+    return verify(cause)
   }
 }

--- a/packages/core/chain/tx/broadcast/resolvers/cardano.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/cardano.test.ts
@@ -30,6 +30,7 @@ vi.mock('../verifyBroadcastByHash', () => ({
 
 import { OtherChain } from '@vultisig/core-chain/Chain'
 
+import { BroadcastErrorCode } from '../resolver'
 import { broadcastCardanoTx, getCardanoTtlFreshnessError } from './cardano'
 
 const txWithTtl = (ttl: number) =>
@@ -49,7 +50,11 @@ describe('broadcastCardanoTx', () => {
     mocks.getCardanoCurrentSlot.mockResolvedValue(939n)
     mocks.submitCardanoCbor.mockResolvedValue({ txHash: 'cardano-hash' })
 
-    await expect(broadcastCardanoTx({ chain, tx })).resolves.toBe('cardano-hash')
+    await expect(broadcastCardanoTx({ chain, tx })).resolves.toEqual({
+      status: 'accepted',
+      finality: 'pending',
+      txHash: 'cardano-hash',
+    })
 
     expect(mocks.submitCardanoCbor).toHaveBeenCalledWith(Buffer.from(tx.encoded).toString('hex'))
     expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
@@ -59,7 +64,12 @@ describe('broadcastCardanoTx', () => {
     const tx = txWithTtl(1_000)
     mocks.getCardanoCurrentSlot.mockResolvedValue(940n)
 
-    await expect(broadcastCardanoTx({ chain, tx })).rejects.toThrow(/TTL is expired or too close to expiry/)
+    await expect(broadcastCardanoTx({ chain, tx })).resolves.toMatchObject({
+      status: 'failed',
+      code: BroadcastErrorCode.Rejected,
+      retryable: false,
+      cause: expect.objectContaining({ message: expect.stringMatching(/TTL is expired or too close to expiry/) }),
+    })
 
     expect(mocks.submitCardanoCbor).not.toHaveBeenCalled()
     expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
@@ -70,7 +80,11 @@ describe('broadcastCardanoTx', () => {
     mocks.getCardanoCurrentSlot.mockRejectedValue(new Error('tip route unavailable'))
     mocks.submitCardanoCbor.mockResolvedValue({ txHash: 'cardano-hash' })
 
-    await expect(broadcastCardanoTx({ chain, tx })).resolves.toBe('cardano-hash')
+    await expect(broadcastCardanoTx({ chain, tx })).resolves.toEqual({
+      status: 'accepted',
+      finality: 'pending',
+      txHash: 'cardano-hash',
+    })
 
     expect(mocks.getCardanoCurrentSlot).toHaveBeenCalledTimes(2)
     expect(mocks.submitCardanoCbor).toHaveBeenCalledWith(Buffer.from(tx.encoded).toString('hex'))
@@ -81,7 +95,10 @@ describe('broadcastCardanoTx', () => {
     const tx = txWithTtl(1_000)
     mocks.getCardanoCurrentSlot.mockRejectedValueOnce(new Error('tip route unavailable')).mockResolvedValueOnce(940n)
 
-    await expect(broadcastCardanoTx({ chain, tx })).rejects.toThrow(/TTL is expired or too close to expiry/)
+    await expect(broadcastCardanoTx({ chain, tx })).resolves.toMatchObject({
+      status: 'failed',
+      cause: expect.objectContaining({ message: expect.stringMatching(/TTL is expired or too close to expiry/) }),
+    })
 
     expect(mocks.getCardanoCurrentSlot).toHaveBeenCalledTimes(2)
     expect(mocks.submitCardanoCbor).not.toHaveBeenCalled()
@@ -101,7 +118,12 @@ describe('broadcastCardanoTx', () => {
       encoded: encode([new Map(), new Map(), true, null]),
     } as any
 
-    await expect(broadcastCardanoTx({ chain, tx })).rejects.toThrow(/Invalid Cardano transaction TTL/)
+    await expect(broadcastCardanoTx({ chain, tx })).resolves.toMatchObject({
+      status: 'failed',
+      code: BroadcastErrorCode.Rejected,
+      retryable: false,
+      cause: expect.objectContaining({ message: expect.stringMatching(/Invalid Cardano transaction TTL/) }),
+    })
 
     expect(mocks.getCardanoCurrentSlot).not.toHaveBeenCalled()
     expect(mocks.submitCardanoCbor).not.toHaveBeenCalled()
@@ -111,9 +133,13 @@ describe('broadcastCardanoTx', () => {
     const tx = txWithTtl(1_000)
     mocks.getCardanoCurrentSlot.mockResolvedValue(939n)
     mocks.submitCardanoCbor.mockResolvedValue({ errorMessage: 'request timed out' })
-    mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+    mocks.verifyBroadcastByHash.mockResolvedValue('verified-hash')
 
-    await expect(broadcastCardanoTx({ chain, tx })).resolves.toBeNull()
+    await expect(broadcastCardanoTx({ chain, tx })).resolves.toMatchObject({
+      status: 'accepted',
+      finality: 'pending',
+      txHash: 'verified-hash',
+    })
 
     expect(mocks.verifyBroadcastByHash).toHaveBeenCalledTimes(1)
     expect(mocks.verifyBroadcastByHash).toHaveBeenCalledWith({
@@ -132,7 +158,12 @@ describe('broadcastCardanoTx', () => {
     mocks.submitCardanoCbor.mockResolvedValue({ errorMessage: 'request timed out' })
     mocks.verifyBroadcastByHash.mockRejectedValue(verifyError)
 
-    await expect(broadcastCardanoTx({ chain, tx })).rejects.toBe(verifyError)
+    await expect(broadcastCardanoTx({ chain, tx })).resolves.toEqual({
+      status: 'failed',
+      code: BroadcastErrorCode.Transport,
+      retryable: true,
+      cause: verifyError,
+    })
   })
 
   it('routes an "already known" duplicate through hash verification instead of blanket-swallowing it (false-success fix)', async () => {
@@ -142,9 +173,12 @@ describe('broadcastCardanoTx', () => {
     const tx = txWithTtl(1_000)
     mocks.getCardanoCurrentSlot.mockResolvedValue(939n)
     mocks.submitCardanoCbor.mockResolvedValue({ errorMessage: 'txn-mempool-conflict' })
-    mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+    mocks.verifyBroadcastByHash.mockResolvedValue('verified-hash')
 
-    await expect(broadcastCardanoTx({ chain, tx })).resolves.toBeNull()
+    await expect(broadcastCardanoTx({ chain, tx })).resolves.toMatchObject({
+      status: 'accepted',
+      txHash: 'verified-hash',
+    })
 
     expect(mocks.verifyBroadcastByHash).toHaveBeenCalledTimes(1)
   })
@@ -158,16 +192,24 @@ describe('broadcastCardanoTx', () => {
     // own contract in verifyBroadcastByHash.ts.
     mocks.verifyBroadcastByHash.mockRejectedValue(verifyError)
 
-    await expect(broadcastCardanoTx({ chain, tx })).rejects.toBe(verifyError)
+    await expect(broadcastCardanoTx({ chain, tx })).resolves.toEqual({
+      status: 'failed',
+      code: BroadcastErrorCode.Rejected,
+      retryable: false,
+      cause: verifyError,
+    })
   })
 
   it('still succeeds on a genuine MPC-race "already known" when hash verification confirms the tx IS on chain', async () => {
     const tx = txWithTtl(1_000)
     mocks.getCardanoCurrentSlot.mockResolvedValue(939n)
     mocks.submitCardanoCbor.mockResolvedValue({ errorMessage: 'already known' })
-    mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+    mocks.verifyBroadcastByHash.mockResolvedValue('verified-hash')
 
-    await expect(broadcastCardanoTx({ chain, tx })).resolves.toBeNull()
+    await expect(broadcastCardanoTx({ chain, tx })).resolves.toMatchObject({
+      status: 'accepted',
+      txHash: 'verified-hash',
+    })
 
     expect(mocks.verifyBroadcastByHash).toHaveBeenCalledTimes(1)
   })

--- a/packages/core/chain/tx/broadcast/resolvers/cardano.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/cardano.ts
@@ -6,7 +6,7 @@ import { getCardanoTxHash } from '@vultisig/core-chain/tx/hash/resolvers/cardano
 import { attempt } from '@vultisig/lib-utils/attempt'
 
 import { submitCardanoCbor } from '../../../chains/cardano/submit/submitCardanoCbor'
-import { BroadcastTxResolver } from '../resolver'
+import { broadcastAccepted, broadcastFailed, BroadcastTxResolver, isRetryableBroadcastCause } from '../resolver'
 import { verifyBroadcastByHash } from '../verifyBroadcastByHash'
 import { selectEncodedBytes } from './utxo'
 
@@ -59,26 +59,33 @@ export const assertCardanoTtlFreshForBroadcast = async (encodedBytes: Uint8Array
 }
 
 export const broadcastCardanoTx: BroadcastTxResolver<OtherChain.Cardano> = async ({ chain, tx }) => {
-  const encodedBytes = selectEncodedBytes(chain, tx)
-  await assertCardanoTtlFreshForBroadcast(encodedBytes)
+  try {
+    const encodedBytes = selectEncodedBytes(chain, tx)
+    await assertCardanoTtlFreshForBroadcast(encodedBytes)
 
-  const cborHex = Buffer.from(encodedBytes).toString('hex')
+    const cborHex = Buffer.from(encodedBytes).toString('hex')
 
-  const { txHash, errorMessage, rpcErrorCode } = await submitCardanoCbor(cborHex)
+    const { txHash, errorMessage, rpcErrorCode } = await submitCardanoCbor(cborHex)
 
-  if (txHash) return txHash
+    if (txHash) return broadcastAccepted(txHash)
 
-  if (rpcErrorCode === alreadyCommittedCode) {
-    return (await getCardanoTxHash(tx)).replace(/^0x/i, '')
+    if (rpcErrorCode === alreadyCommittedCode) {
+      return broadcastAccepted((await getCardanoTxHash(tx)).replace(/^0x/i, ''))
+    }
+
+    const error = errorMessage ?? 'unknown broadcast failure'
+
+    // Any submit error past this point is ambiguous — it could be a benign MPC-race duplicate (another
+    // device already broadcast the same signed tx) OR a genuine failure (e.g. BadInputsUTxO: spent/invalid
+    // inputs). String-matching alone can't tell them apart, so verify against the real chain: the hash
+    // either resolves on-chain (the race case — success) or it doesn't (the real failure — returns it).
+    const broadcastError = new Error(`Failed to broadcast transaction: ${error}`)
+    try {
+      return broadcastAccepted(await verifyBroadcastByHash({ chain, tx, error: broadcastError }))
+    } catch (cause) {
+      return broadcastFailed(cause, isRetryableBroadcastCause(broadcastError))
+    }
+  } catch (cause) {
+    return broadcastFailed(cause, isRetryableBroadcastCause(cause))
   }
-
-  const error = errorMessage ?? 'unknown broadcast failure'
-
-  // Any submit error past this point is ambiguous — it could be a benign MPC-race duplicate (another
-  // device already broadcast the same signed tx) OR a genuine failure (e.g. BadInputsUTxO: spent/invalid
-  // inputs). String-matching alone can't tell them apart, so verify against the real chain: the hash
-  // either resolves on-chain (the race case — success) or it doesn't (the real failure — rethrows).
-  const broadcastError = new Error(`Failed to broadcast transaction: ${error}`)
-  await verifyBroadcastByHash({ chain, tx, error: broadcastError })
-  return null
 }

--- a/packages/core/chain/tx/broadcast/resolvers/cosmos.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/cosmos.test.ts
@@ -37,7 +37,11 @@ describe('broadcastCosmosTx', () => {
       rawLog: '',
     })
 
-    await expect(broadcastCosmosTx({ chain, tx })).resolves.toBeUndefined()
+    await expect(broadcastCosmosTx({ chain, tx })).resolves.toMatchObject({
+      status: 'accepted',
+      finality: 'pending',
+      txHash: 'ABC123',
+    })
 
     expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
   })
@@ -56,8 +60,9 @@ describe('broadcastCosmosTx', () => {
       rawLog: 'out of gas',
     })
 
-    await expect(broadcastCosmosTx({ chain, tx })).rejects.toThrow(/DEF456/)
-    await expect(broadcastCosmosTx({ chain, tx })).rejects.toThrow(/out of gas/)
+    const result = await broadcastCosmosTx({ chain, tx })
+    expect(result).toMatchObject({ status: 'failed', retryable: false })
+    expect(result).toHaveProperty('cause.message', expect.stringMatching(/DEF456.*out of gas/))
 
     // The response already proves the tx's on-chain outcome — no need to pay
     // for a redundant hash-verification round trip.
@@ -67,7 +72,7 @@ describe('broadcastCosmosTx', () => {
   it('treats a duplicate in-cache rejection as an idempotent success', async () => {
     mocks.broadcastTx.mockRejectedValue(new Error('tx already exists in cache'))
 
-    await expect(broadcastCosmosTx({ chain, tx })).resolves.toBeUndefined()
+    await expect(broadcastCosmosTx({ chain, tx })).resolves.toEqual({ status: 'accepted', finality: 'pending' })
 
     expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
   })
@@ -79,7 +84,10 @@ describe('broadcastCosmosTx', () => {
     )
     mocks.broadcastTx.mockRejectedValue(timeout)
 
-    await expect(broadcastCosmosTx({ chain, tx })).resolves.toBe('ABC123')
+    await expect(broadcastCosmosTx({ chain, tx })).resolves.toMatchObject({
+      status: 'accepted',
+      txHash: 'ABC123',
+    })
 
     expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
   })
@@ -87,9 +95,12 @@ describe('broadcastCosmosTx', () => {
   it('routes other broadcast errors through hash verification', async () => {
     const rpcError = new Error('request timed out')
     mocks.broadcastTx.mockRejectedValue(rpcError)
-    mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+    mocks.verifyBroadcastByHash.mockResolvedValue('ABC123')
 
-    await expect(broadcastCosmosTx({ chain, tx })).resolves.toBeUndefined()
+    await expect(broadcastCosmosTx({ chain, tx })).resolves.toMatchObject({
+      status: 'accepted',
+      txHash: 'ABC123',
+    })
 
     expect(mocks.verifyBroadcastByHash).toHaveBeenCalledWith({ chain, tx, error: rpcError })
   })

--- a/packages/core/chain/tx/broadcast/resolvers/cosmos.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/cosmos.test.ts
@@ -115,15 +115,19 @@ describe('broadcastCosmosTx', () => {
       throw error
     })
 
-    const rejection = await broadcastCosmosTx({ chain, tx }).catch(error => error)
+    const rejection = await broadcastCosmosTx({ chain, tx })
 
-    expect(rejection).toBeInstanceOf(CosmosSequenceMismatchError)
     expect(rejection).toMatchObject({
-      expectedSequence: 255n,
-      signedSequence: 254n,
-      recovery: 'resign',
-      message: expect.stringContaining('start a new signing ceremony'),
+      status: 'failed',
+      retryable: false,
+      cause: {
+        expectedSequence: 255n,
+        signedSequence: 254n,
+        recovery: 'resign',
+        message: expect.stringContaining('start a new signing ceremony'),
+      },
     })
+    expect(rejection.status === 'failed' && rejection.cause).toBeInstanceOf(CosmosSequenceMismatchError)
     expect(mocks.verifyBroadcastByHash).toHaveBeenCalledOnce()
   })
 
@@ -135,7 +139,7 @@ describe('broadcastCosmosTx', () => {
     )
     mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
 
-    await expect(broadcastCosmosTx({ chain, tx })).resolves.toBeUndefined()
+    await expect(broadcastCosmosTx({ chain, tx })).resolves.toMatchObject({ status: 'accepted' })
 
     expect(mocks.verifyBroadcastByHash).toHaveBeenCalledWith({
       chain,

--- a/packages/core/chain/tx/broadcast/resolvers/cosmos.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/cosmos.ts
@@ -5,7 +5,7 @@ import { attempt } from '@vultisig/lib-utils/attempt'
 import { isInError } from '@vultisig/lib-utils/error/isInError'
 
 import { toCosmosSequenceMismatchError } from '../cosmosSequenceMismatch'
-import { BroadcastTxResolver } from '../resolver'
+import { broadcastAccepted, broadcastFailed, BroadcastTxResolver, isRetryableBroadcastCause } from '../resolver'
 import { DeliverTxFailedError } from '../transientRetry'
 import { verifyBroadcastByHash } from '../verifyBroadcastByHash'
 
@@ -20,44 +20,43 @@ export const getCosmosBroadcastTimeoutTxId = (error: unknown): string | undefine
 }
 
 export const broadcastCosmosTx: BroadcastTxResolver<CosmosChain> = async ({ chain, tx }) => {
-  const { serialized } = tx
-  const { tx_bytes } = JSON.parse(serialized)
-  const decodedTxBytes = Buffer.from(tx_bytes, 'base64')
+  try {
+    const { serialized } = tx
+    const { tx_bytes } = JSON.parse(serialized)
+    const decodedTxBytes = Buffer.from(tx_bytes, 'base64')
 
-  const client = await getCosmosClient(chain)
-  const { data, error } = await attempt(client.broadcastTx(decodedTxBytes))
+    const client = await getCosmosClient(chain)
+    const result = await attempt(client.broadcastTx(decodedTxBytes))
 
-  if (data) {
-    // client.broadcastTx resolves (does not throw) once the tx is INCLUDED in a
-    // block, even when execution itself failed (DeliverTx code !== 0 — e.g.
-    // out-of-gas, wasm revert, a THORChain/Maya deposit-handler rejection). The
-    // tx is on-chain but nothing moved, so this must not be reported as success.
-    try {
-      assertIsDeliverTxSuccess(data)
-    } catch (deliverTxError) {
-      // Marker type, not a bare Error: cosmos has no resolver-owned retry, so
-      // this throws into `withTransientBroadcastRetry`. A rawLog like "wasm
-      // contract aborted" would otherwise match the transient message regex
-      // and get resent, then swallowed as an idempotent "already in cache"
-      // success — reopening the bug this assert exists to close.
-      const message = deliverTxError instanceof Error ? deliverTxError.message : String(deliverTxError)
-      throw new DeliverTxFailedError(message, { cause: deliverTxError })
+    if (result.data !== undefined) {
+      try {
+        assertIsDeliverTxSuccess(result.data)
+      } catch (deliverTxError) {
+        const message = deliverTxError instanceof Error ? deliverTxError.message : String(deliverTxError)
+        return broadcastFailed(new DeliverTxFailedError(message, { cause: deliverTxError }), false, {
+          provider: result.data,
+        })
+      }
+      return broadcastAccepted(result.data.transactionHash, { provider: result.data })
     }
-    return
-  }
 
-  if (isInError(error, 'tx already exists in cache')) {
-    return
-  }
+    const { error } = result
+    if (isInError(error, 'tx already exists in cache')) {
+      return broadcastAccepted()
+    }
 
-  const timeoutTxId = getCosmosBroadcastTimeoutTxId(error)
-  if (timeoutTxId) {
-    return timeoutTxId
-  }
+    const timeoutTxId = getCosmosBroadcastTimeoutTxId(error)
+    if (timeoutTxId) {
+      return broadcastAccepted(timeoutTxId)
+    }
 
-  // Keep the hash-verification safety net first: another MPC participant may
-  // have successfully broadcast these same bytes just before this node returned
-  // a sequence rejection. When the hash is genuinely unknown, replace the raw
-  // code-32 message with direction-aware recovery guidance.
-  await verifyBroadcastByHash({ chain, tx, error: toCosmosSequenceMismatchError(error) ?? error })
+    const verificationError = toCosmosSequenceMismatchError(error) ?? error
+    try {
+      return broadcastAccepted(await verifyBroadcastByHash({ chain, tx, error: verificationError }))
+    } catch (cause) {
+      return broadcastFailed(cause, isRetryableBroadcastCause(cause))
+    }
+  } catch (cause) {
+    return broadcastFailed(cause, isRetryableBroadcastCause(cause))
+  }
 }

--- a/packages/core/chain/tx/broadcast/resolvers/evm.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/evm.ts
@@ -4,25 +4,34 @@ import { attempt } from '@vultisig/lib-utils/attempt'
 import { isInError } from '@vultisig/lib-utils/error/isInError'
 import { ensureHexPrefix } from '@vultisig/lib-utils/hex/ensureHexPrefix'
 
-import { BroadcastTxResolver } from '../resolver'
+import { broadcastAccepted, broadcastFailed, BroadcastTxResolver, isRetryableBroadcastCause } from '../resolver'
 import { verifyBroadcastByHash } from '../verifyBroadcastByHash'
 
 export const broadcastEvmTx: BroadcastTxResolver<EvmChain> = async ({ chain, tx }) => {
-  const client = getEvmClient(chain)
+  try {
+    const client = getEvmClient(chain)
 
-  const { error } = await attempt(
-    client.sendRawTransaction({
-      serializedTransaction: ensureHexPrefix(Buffer.from(tx.encoded).toString('hex')),
-    })
-  )
+    const result = await attempt(
+      client.sendRawTransaction({
+        serializedTransaction: ensureHexPrefix(Buffer.from(tx.encoded).toString('hex')),
+      })
+    )
 
-  if (!error) {
-    return
+    if ('data' in result) {
+      return broadcastAccepted(result.data)
+    }
+
+    const { error } = result
+    if (error && isInError(error, 'already known', 'transaction already exists', 'tx already in mempool')) {
+      return broadcastAccepted()
+    }
+
+    try {
+      return broadcastAccepted(await verifyBroadcastByHash({ chain, tx, error }))
+    } catch (cause) {
+      return broadcastFailed(cause, isRetryableBroadcastCause(error))
+    }
+  } catch (cause) {
+    return broadcastFailed(cause, isRetryableBroadcastCause(cause))
   }
-
-  if (isInError(error, 'already known', 'transaction already exists', 'tx already in mempool')) {
-    return
-  }
-
-  await verifyBroadcastByHash({ chain, tx, error })
 }

--- a/packages/core/chain/tx/broadcast/resolvers/polkadot.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/polkadot.test.ts
@@ -171,6 +171,19 @@ describe('broadcastPolkadotTx', () => {
       expect((callArg.error as Error).message).toContain('missing extrinsic hash')
     })
 
+    it('keeps a malformed response non-retryable when hash verification fails', async () => {
+      const verificationFailure = new Error('verification failed')
+      mocks.queryUrl.mockResolvedValue({})
+      mocks.verifyBroadcastByHash.mockRejectedValue(verificationFailure)
+
+      await expect(broadcastPolkadotTx({ chain, tx })).resolves.toEqual({
+        status: 'failed',
+        code: BroadcastErrorCode.Rejected,
+        retryable: false,
+        cause: verificationFailure,
+      })
+    })
+
     it('routes network-level errors through verifyBroadcastByHash', async () => {
       const networkErr = new Error('ECONNRESET')
       mocks.queryUrl.mockRejectedValue(networkErr)

--- a/packages/core/chain/tx/broadcast/resolvers/polkadot.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/polkadot.test.ts
@@ -14,6 +14,7 @@ vi.mock('../verifyBroadcastByHash', () => ({
 }))
 
 import { OtherChain } from '../../../Chain'
+import { BroadcastErrorCode } from '../resolver'
 import { broadcastPolkadotTx } from './polkadot'
 
 describe('broadcastPolkadotTx', () => {
@@ -24,10 +25,14 @@ describe('broadcastPolkadotTx', () => {
     vi.clearAllMocks()
   })
 
-  it('returns silently when the node accepts the extrinsic', async () => {
+  it('returns the standard accepted result when the node accepts the extrinsic', async () => {
     mocks.queryUrl.mockResolvedValue({ result: '0xdeadbeef' })
 
-    await expect(broadcastPolkadotTx({ chain, tx })).resolves.toBeUndefined()
+    await expect(broadcastPolkadotTx({ chain, tx })).resolves.toEqual({
+      status: 'accepted',
+      finality: 'pending',
+      txHash: '0xdeadbeef',
+    })
     expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
   })
 
@@ -42,7 +47,7 @@ describe('broadcastPolkadotTx', () => {
         error: { code: 1013, message: 'Transaction Already Imported' },
       })
 
-      await expect(broadcastPolkadotTx({ chain, tx })).resolves.toBeUndefined()
+      await expect(broadcastPolkadotTx({ chain, tx })).resolves.toMatchObject({ status: 'accepted' })
       expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
     })
 
@@ -51,7 +56,7 @@ describe('broadcastPolkadotTx', () => {
         error: { code: 1013, message: 'Already known' },
       })
 
-      await expect(broadcastPolkadotTx({ chain, tx })).resolves.toBeUndefined()
+      await expect(broadcastPolkadotTx({ chain, tx })).resolves.toMatchObject({ status: 'accepted' })
       expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
     })
 
@@ -60,7 +65,7 @@ describe('broadcastPolkadotTx', () => {
         error: { code: 1013, message: 'TRANSACTION ALREADY IMPORTED' },
       })
 
-      await expect(broadcastPolkadotTx({ chain, tx })).resolves.toBeUndefined()
+      await expect(broadcastPolkadotTx({ chain, tx })).resolves.toMatchObject({ status: 'accepted' })
     })
   })
 
@@ -89,9 +94,12 @@ describe('broadcastPolkadotTx', () => {
       })
       // verifyBroadcastByHash decides whether to re-throw; here just assert
       // we DID call it (i.e. did not silently swallow a bad-signature error).
-      mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+      mocks.verifyBroadcastByHash.mockResolvedValue('verified-hash')
 
-      await broadcastPolkadotTx({ chain, tx })
+      await expect(broadcastPolkadotTx({ chain, tx })).resolves.toMatchObject({
+        status: 'accepted',
+        txHash: 'verified-hash',
+      })
 
       expect(mocks.verifyBroadcastByHash).toHaveBeenCalledOnce()
       const callArg = mocks.verifyBroadcastByHash.mock.calls[0]![0]
@@ -114,7 +122,7 @@ describe('broadcastPolkadotTx', () => {
           data: 'Transaction is outdated',
         },
       })
-      mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+      mocks.verifyBroadcastByHash.mockResolvedValue('verified-hash')
 
       await broadcastPolkadotTx({ chain, tx })
 
@@ -128,7 +136,7 @@ describe('broadcastPolkadotTx', () => {
       mocks.queryUrl.mockResolvedValue({
         error: { code: 1010, message: 'Invalid Transaction' },
       })
-      mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+      mocks.verifyBroadcastByHash.mockResolvedValue('verified-hash')
 
       await broadcastPolkadotTx({ chain, tx })
 
@@ -148,13 +156,13 @@ describe('broadcastPolkadotTx', () => {
         },
       })
 
-      await expect(broadcastPolkadotTx({ chain, tx })).resolves.toBeUndefined()
+      await expect(broadcastPolkadotTx({ chain, tx })).resolves.toMatchObject({ status: 'accepted' })
       expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
     })
 
     it('routes the missing-result case through verifyBroadcastByHash', async () => {
       mocks.queryUrl.mockResolvedValue({})
-      mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+      mocks.verifyBroadcastByHash.mockResolvedValue('verified-hash')
 
       await broadcastPolkadotTx({ chain, tx })
 
@@ -166,12 +174,53 @@ describe('broadcastPolkadotTx', () => {
     it('routes network-level errors through verifyBroadcastByHash', async () => {
       const networkErr = new Error('ECONNRESET')
       mocks.queryUrl.mockRejectedValue(networkErr)
-      mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+      mocks.verifyBroadcastByHash.mockResolvedValue('verified-hash')
 
       await broadcastPolkadotTx({ chain, tx })
 
       expect(mocks.verifyBroadcastByHash).toHaveBeenCalledOnce()
       expect(mocks.verifyBroadcastByHash.mock.calls[0]![0]!.error).toBe(networkErr)
+    })
+
+    it('returns a definitive failure when a rejected extrinsic is not on chain', async () => {
+      const rejection = new Error('Polkadot broadcast failed: Invalid Transaction')
+      mocks.queryUrl.mockResolvedValue({
+        error: { code: 1010, message: 'Invalid Transaction' },
+      })
+      mocks.verifyBroadcastByHash.mockRejectedValue(rejection)
+
+      await expect(broadcastPolkadotTx({ chain, tx })).resolves.toEqual({
+        status: 'failed',
+        code: BroadcastErrorCode.Rejected,
+        retryable: false,
+        cause: rejection,
+      })
+    })
+
+    it('returns a retryable failure when transport recovery cannot confirm the extrinsic', async () => {
+      const networkError = new Error('ECONNRESET')
+      mocks.queryUrl.mockRejectedValue(networkError)
+      mocks.verifyBroadcastByHash.mockRejectedValue(networkError)
+
+      await expect(broadcastPolkadotTx({ chain, tx })).resolves.toEqual({
+        status: 'failed',
+        code: BroadcastErrorCode.Transport,
+        retryable: true,
+        cause: networkError,
+      })
+    })
+
+    it('does not label an ambiguous local failure as retryable', async () => {
+      const localError = new TypeError('Cannot read properties of undefined')
+      mocks.queryUrl.mockRejectedValue(localError)
+      mocks.verifyBroadcastByHash.mockRejectedValue(localError)
+
+      await expect(broadcastPolkadotTx({ chain, tx })).resolves.toEqual({
+        status: 'failed',
+        code: BroadcastErrorCode.Rejected,
+        retryable: false,
+        cause: localError,
+      })
     })
   })
 })

--- a/packages/core/chain/tx/broadcast/resolvers/polkadot.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/polkadot.ts
@@ -3,7 +3,7 @@ import { ensureHexPrefix } from '@vultisig/lib-utils/hex/ensureHexPrefix'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
 import { polkadotRpcUrl } from '../../../chains/polkadot/client'
-import { BroadcastTxResolver } from '../resolver'
+import { broadcastAccepted, broadcastFailed, BroadcastTxResolver, isRetryableBroadcastCause } from '../resolver'
 import { verifyBroadcastByHash } from '../verifyBroadcastByHash'
 import { formatSubstrateRpcError, isIdempotentSubstrateBroadcastError, SubstrateRpcError } from './substrate'
 
@@ -31,9 +31,14 @@ export const broadcastPolkadotTx: BroadcastTxResolver<OtherChain.Polkadot> = asy
       // (string usually in `message`) or, less commonly, an Invalid
       // Transaction variant whose duplicate signal lives in `data`.
       if (isIdempotentSubstrateBroadcastError(response.error)) {
-        return
+        return broadcastAccepted()
       }
-      throw new Error(`Polkadot broadcast failed: ${formatSubstrateRpcError(response.error)}`)
+      const error = new Error(`Polkadot broadcast failed: ${formatSubstrateRpcError(response.error)}`)
+      try {
+        return broadcastAccepted(await verifyBroadcastByHash({ chain, tx, error }))
+      } catch (cause) {
+        return broadcastFailed(cause, false)
+      }
     }
 
     // Per JSON-RPC 2.0 a valid response must have exactly one of `result` /
@@ -42,7 +47,12 @@ export const broadcastPolkadotTx: BroadcastTxResolver<OtherChain.Polkadot> = asy
     if (!response.result) {
       throw new Error('Polkadot broadcast failed: missing extrinsic hash in RPC response')
     }
+    return broadcastAccepted(response.result)
   } catch (error) {
-    await verifyBroadcastByHash({ chain, tx, error })
+    try {
+      return broadcastAccepted(await verifyBroadcastByHash({ chain, tx, error }))
+    } catch (cause) {
+      return broadcastFailed(cause, isRetryableBroadcastCause(error))
+    }
   }
 }

--- a/packages/core/chain/tx/broadcast/resolvers/polkadot.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/polkadot.ts
@@ -45,7 +45,12 @@ export const broadcastPolkadotTx: BroadcastTxResolver<OtherChain.Polkadot> = asy
     // `error`. If both are missing (malformed gateway response, truncated
     // body, …) do not silently assume success — force hash verification.
     if (!response.result) {
-      throw new Error('Polkadot broadcast failed: missing extrinsic hash in RPC response')
+      const error = new Error('Polkadot broadcast failed: missing extrinsic hash in RPC response')
+      try {
+        return broadcastAccepted(await verifyBroadcastByHash({ chain, tx, error }))
+      } catch (cause) {
+        return broadcastFailed(cause, false)
+      }
     }
     return broadcastAccepted(response.result)
   } catch (error) {

--- a/packages/core/chain/tx/broadcast/resolvers/qbtc.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/qbtc.test.ts
@@ -31,12 +31,13 @@ describe('broadcastQbtcTx — DeliverTx false-success', () => {
     vi.unstubAllGlobals()
   })
 
-  it('throws DeliverTxFailedError when CheckTx passes but DeliverTx fails (out-of-gas)', async () => {
+  it('returns a failed result when CheckTx passes but DeliverTx fails (out-of-gas)', async () => {
     stubFetch({
       checkTx: { tx_response: { code: 0, txhash: 'ABC123' } },
       inclusion: { tx_response: { code: 11, raw_log: 'out of gas' } },
     })
-    await expect(broadcastQbtcTx({ chain: Chain.QBTC, tx })).rejects.toBeInstanceOf(DeliverTxFailedError)
+    const result = await broadcastQbtcTx({ chain: Chain.QBTC, tx })
+    expect(result).toMatchObject({ status: 'failed', retryable: false, cause: expect.any(DeliverTxFailedError) })
   })
 
   it('resolves cleanly when both CheckTx and DeliverTx succeed', async () => {
@@ -44,7 +45,10 @@ describe('broadcastQbtcTx — DeliverTx false-success', () => {
       checkTx: { tx_response: { code: 0, txhash: 'ABC123' } },
       inclusion: { tx_response: { code: 0 } },
     })
-    await expect(broadcastQbtcTx({ chain: Chain.QBTC, tx })).resolves.toBeUndefined()
+    await expect(broadcastQbtcTx({ chain: Chain.QBTC, tx })).resolves.toMatchObject({
+      status: 'accepted',
+      txHash: 'ABC123',
+    })
     expect(mockVerify).not.toHaveBeenCalled()
   })
 
@@ -52,6 +56,19 @@ describe('broadcastQbtcTx — DeliverTx false-success', () => {
     stubFetch({ checkTx: {} })
     await broadcastQbtcTx({ chain: Chain.QBTC, tx })
     expect(mockVerify).toHaveBeenCalledOnce()
+  })
+
+  it('returns a definitive failure when a missing CheckTx hash cannot be verified', async () => {
+    const missingHash = new Error('QBTC broadcast: missing txhash on CheckTx response')
+    stubFetch({ checkTx: { tx_response: { code: 0 } } })
+    mockVerify.mockRejectedValueOnce(missingHash)
+
+    await expect(broadcastQbtcTx({ chain: Chain.QBTC, tx })).resolves.toEqual({
+      status: 'failed',
+      code: 'BROADCAST_REJECTED',
+      retryable: false,
+      cause: missingHash,
+    })
   })
 
   it('verifies by hash on a CheckTx rejection (non-zero code)', async () => {
@@ -67,7 +84,10 @@ describe('broadcastQbtcTx — DeliverTx false-success', () => {
         throw new Error('network down')
       },
     })
-    await expect(broadcastQbtcTx({ chain: Chain.QBTC, tx })).resolves.toBeUndefined()
+    await expect(broadcastQbtcTx({ chain: Chain.QBTC, tx })).resolves.toMatchObject({
+      status: 'accepted',
+      txHash: 'ABC123',
+    })
     expect(mockVerify).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/chain/tx/broadcast/resolvers/qbtc.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/qbtc.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { Chain } from '../../../Chain'
+import { BroadcastErrorCode } from '../resolver'
 import { DeliverTxFailedError } from '../transientRetry'
 
-const { mockVerify } = vi.hoisted(() => ({ mockVerify: vi.fn(async () => {}) }))
+const { mockVerify } = vi.hoisted(() => ({ mockVerify: vi.fn(async (_input: any) => {}) }))
 vi.mock('../verifyBroadcastByHash', () => ({ verifyBroadcastByHash: mockVerify }))
 vi.mock('@vultisig/core-chain/chains/cosmos/qbtc/tendermintRpcUrl', () => ({ qbtcRestUrl: 'https://qbtc.test' }))
 
@@ -68,6 +69,27 @@ describe('broadcastQbtcTx — DeliverTx false-success', () => {
       code: 'BROADCAST_REJECTED',
       retryable: false,
       cause: missingHash,
+    })
+  })
+
+  it('preserves a transient HTTP status in the cause used by the dispatcher retry classifier', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable',
+        url: 'https://qbtc.test/cosmos/tx/v1beta1/txs',
+        text: async () => 'opaque provider body',
+      })
+    )
+    mockVerify.mockImplementationOnce(({ error }) => Promise.reject(error))
+
+    await expect(broadcastQbtcTx({ chain: Chain.QBTC, tx })).resolves.toMatchObject({
+      status: 'failed',
+      code: BroadcastErrorCode.Transport,
+      retryable: true,
+      cause: expect.objectContaining({ status: 503 }),
     })
   })
 

--- a/packages/core/chain/tx/broadcast/resolvers/qbtc.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/qbtc.ts
@@ -3,6 +3,7 @@ import { qbtcRestUrl } from '@vultisig/core-chain/chains/cosmos/qbtc/tendermintR
 import { waitForQbtcTxInclusion } from '@vultisig/core-chain/chains/cosmos/qbtc/waitForQbtcTxInclusion'
 import { attempt } from '@vultisig/lib-utils/attempt'
 import { isInError } from '@vultisig/lib-utils/error/isInError'
+import { HttpResponseError } from '@vultisig/lib-utils/fetch/HttpResponseError'
 
 import { broadcastAccepted, broadcastFailed, BroadcastTxResolver, isRetryableBroadcastCause } from '../resolver'
 import { DeliverTxFailedError } from '../transientRetry'
@@ -32,11 +33,17 @@ export const broadcastQbtcTx: BroadcastTxResolver<typeof Chain.QBTC> = async ({ 
       if (isInError(text, 'tx already exists in cache')) {
         return broadcastAccepted()
       }
-      const err = new Error(`QBTC broadcast failed (${resp.status}): ${text}`)
+      const err = new HttpResponseError({
+        message: `QBTC broadcast failed (${resp.status}): ${text}`,
+        status: resp.status,
+        statusText: resp.statusText,
+        url: resp.url || `${qbtcRestUrl}/cosmos/tx/v1beta1/txs`,
+        body: text,
+      })
       try {
         return broadcastAccepted(await verifyBroadcastByHash({ chain, tx, error: err }))
       } catch (cause) {
-        return broadcastFailed(cause, resp.status === 408 || resp.status === 429 || resp.status >= 500)
+        return broadcastFailed(cause, isRetryableBroadcastCause(err))
       }
     }
 

--- a/packages/core/chain/tx/broadcast/resolvers/qbtc.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/qbtc.ts
@@ -4,7 +4,7 @@ import { waitForQbtcTxInclusion } from '@vultisig/core-chain/chains/cosmos/qbtc/
 import { attempt } from '@vultisig/lib-utils/attempt'
 import { isInError } from '@vultisig/lib-utils/error/isInError'
 
-import { BroadcastTxResolver } from '../resolver'
+import { broadcastAccepted, broadcastFailed, BroadcastTxResolver, isRetryableBroadcastCause } from '../resolver'
 import { DeliverTxFailedError } from '../transientRetry'
 import { verifyBroadcastByHash } from '../verifyBroadcastByHash'
 
@@ -14,72 +14,81 @@ const QBTC_INCLUSION_TIMEOUT_MS = 30_000
 const QBTC_INCLUSION_POLL_INTERVAL_MS = 1_000
 
 export const broadcastQbtcTx: BroadcastTxResolver<typeof Chain.QBTC> = async ({ chain, tx }) => {
-  const { serialized } = tx
-  const { tx_bytes } = JSON.parse(serialized) as { tx_bytes: string }
+  try {
+    const { serialized } = tx
+    const { tx_bytes } = JSON.parse(serialized) as { tx_bytes: string }
 
-  const resp = await fetch(`${qbtcRestUrl}/cosmos/tx/v1beta1/txs`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      tx_bytes,
-      mode: 'BROADCAST_MODE_SYNC',
-    }),
-  })
-
-  if (!resp.ok) {
-    const text = await resp.text()
-    if (isInError(text, 'tx already exists in cache')) {
-      return
-    }
-    const err = new Error(`QBTC broadcast failed (${resp.status}): ${text}`)
-    await verifyBroadcastByHash({ chain, tx, error: err })
-    return
-  }
-
-  const data = (await resp.json()) as {
-    tx_response?: { code?: number; txhash?: string; raw_log?: string; log?: string }
-  }
-  const checkTx = data.tx_response
-
-  // CheckTx (mempool admission). A missing code, or a non-zero code, is NOT a confirmed on-chain
-  // state — verify by hash rather than trusting it. Reading it as `code && code !== 0` (the old
-  // guard) treated a MISSING tx_response as a silent success: half of this false-success bug.
-  if (typeof checkTx?.code !== 'number' || checkTx.code !== 0) {
-    const log = checkTx?.raw_log || checkTx?.log
-    if (log && isInError(log, 'tx already exists in cache')) {
-      return
-    }
-    const err = new Error(`QBTC CheckTx failed: ${log ?? 'missing tx_response.code'}`)
-    await verifyBroadcastByHash({ chain, tx, error: err })
-    return
-  }
-
-  // CheckTx passed — but BROADCAST_MODE_SYNC only surfaces CheckTx. A DeliverTx failure (out-of-gas,
-  // execution revert) still comes back code=0 HERE, so returning now would report an on-chain tx that
-  // moved nothing as a success. Poll for inclusion and re-check the DeliverTx code (mirrors the QBTC
-  // claim helper, broadcastClaimTx). A CONFIRMED DeliverTx failure throws a non-retryable
-  // DeliverTxFailedError; if we cannot confirm within the window (timeout / transient RPC error) the
-  // tx is in the mempool, not failed, so leave it in-flight — the status resolver reports the final
-  // code.
-  const txHash = checkTx.txhash
-  if (!txHash) {
-    await verifyBroadcastByHash({ chain, tx, error: new Error('QBTC broadcast: missing txhash on CheckTx response') })
-    return
-  }
-
-  const { data: included, error: inclusionError } = await attempt(
-    waitForQbtcTxInclusion({
-      txHash,
-      timeoutMs: QBTC_INCLUSION_TIMEOUT_MS,
-      intervalMs: QBTC_INCLUSION_POLL_INTERVAL_MS,
+    const resp = await fetch(`${qbtcRestUrl}/cosmos/tx/v1beta1/txs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tx_bytes,
+        mode: 'BROADCAST_MODE_SYNC',
+      }),
     })
-  )
 
-  if (inclusionError || included === undefined || typeof included.code !== 'number') {
-    return
-  }
+    if (!resp.ok) {
+      const text = await resp.text()
+      if (isInError(text, 'tx already exists in cache')) {
+        return broadcastAccepted()
+      }
+      const err = new Error(`QBTC broadcast failed (${resp.status}): ${text}`)
+      try {
+        return broadcastAccepted(await verifyBroadcastByHash({ chain, tx, error: err }))
+      } catch (cause) {
+        return broadcastFailed(cause, resp.status === 408 || resp.status === 429 || resp.status >= 500)
+      }
+    }
 
-  if (included.code !== 0) {
-    throw new DeliverTxFailedError(`QBTC transaction execution failed: ${included.raw_log || included.log}`)
+    const data = (await resp.json()) as {
+      tx_response?: { code?: number; txhash?: string; raw_log?: string; log?: string }
+    }
+    const checkTx = data.tx_response
+
+    if (typeof checkTx?.code !== 'number' || checkTx.code !== 0) {
+      const log = checkTx?.raw_log || checkTx?.log
+      if (log && isInError(log, 'tx already exists in cache')) {
+        return broadcastAccepted()
+      }
+      const error = new Error(`QBTC CheckTx failed: ${log ?? 'missing tx_response.code'}`)
+      try {
+        return broadcastAccepted(await verifyBroadcastByHash({ chain, tx, error }))
+      } catch (cause) {
+        return broadcastFailed(cause, false)
+      }
+    }
+
+    const txHash = checkTx.txhash
+    if (!txHash) {
+      const error = new Error('QBTC broadcast: missing txhash on CheckTx response')
+      try {
+        return broadcastAccepted(await verifyBroadcastByHash({ chain, tx, error }))
+      } catch (cause) {
+        return broadcastFailed(cause, false)
+      }
+    }
+
+    const { data: included, error: inclusionError } = await attempt(
+      waitForQbtcTxInclusion({
+        txHash,
+        timeoutMs: QBTC_INCLUSION_TIMEOUT_MS,
+        intervalMs: QBTC_INCLUSION_POLL_INTERVAL_MS,
+      })
+    )
+
+    if (inclusionError || included === undefined || typeof included.code !== 'number') {
+      return broadcastAccepted(txHash)
+    }
+
+    if (included.code !== 0) {
+      return broadcastFailed(
+        new DeliverTxFailedError(`QBTC transaction execution failed: ${included.raw_log || included.log}`),
+        false
+      )
+    }
+
+    return broadcastAccepted(txHash, { provider: included })
+  } catch (cause) {
+    return broadcastFailed(cause, isRetryableBroadcastCause(cause))
   }
 }

--- a/packages/core/chain/tx/broadcast/resolvers/resultContract.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/resultContract.test.ts
@@ -200,3 +200,32 @@ describe('broadcast resolver unknown-cause preservation', () => {
     })
   })
 })
+
+describe('TON malformed provider response', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyBroadcastByHash.mockImplementation(({ error }) => Promise.reject(error))
+  })
+
+  it('verifies a successful response that omits its transaction hash instead of throwing', async () => {
+    mocks.queryUrl.mockResolvedValue({ result: {} })
+
+    await expect(broadcastTonTx({ chain: OtherChain.Ton, tx: { encoded: 'boc' } as any })).resolves.toMatchObject({
+      status: 'failed',
+      code: BroadcastErrorCode.Rejected,
+      retryable: false,
+      cause: expect.objectContaining({ message: 'TON broadcast failed: missing transaction hash in response' }),
+    })
+    expect(mocks.verifyBroadcastByHash).toHaveBeenCalledOnce()
+  })
+
+  it('preserves the existing accepted acknowledgement for a duplicate message', async () => {
+    mocks.queryUrl.mockRejectedValue(new Error('duplicate message'))
+
+    await expect(broadcastTonTx({ chain: OtherChain.Ton, tx: { encoded: 'boc' } as any })).resolves.toEqual({
+      status: 'accepted',
+      finality: 'pending',
+    })
+    expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/chain/tx/broadcast/resolvers/resultContract.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/resultContract.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  broadcastCosmos: vi.fn(),
+  executeSui: vi.fn(),
+  queryUrl: vi.fn(),
+  sendEvm: vi.fn(),
+  verifyBroadcastByHash: vi.fn(),
+}))
+
+vi.mock('@vultisig/core-chain/chains/cosmos/client', () => ({
+  getCosmosClient: () => ({ broadcastTx: mocks.broadcastCosmos }),
+}))
+vi.mock('@vultisig/core-chain/chains/evm/client', () => ({
+  getEvmClient: () => ({ sendRawTransaction: mocks.sendEvm }),
+}))
+vi.mock('@vultisig/core-chain/chains/sui/client', () => ({
+  getSuiClient: () => ({ executeTransaction: mocks.executeSui }),
+}))
+vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
+  queryUrl: mocks.queryUrl,
+}))
+vi.mock('../verifyBroadcastByHash', () => ({
+  verifyBroadcastByHash: mocks.verifyBroadcastByHash,
+}))
+
+import { Chain, CosmosChain, EvmChain, OtherChain } from '../../../Chain'
+import type { BroadcastTxResolver } from '../resolver'
+import { BroadcastErrorCode } from '../resolver'
+import { broadcastBittensorTx } from './bittensor'
+import { broadcastCosmosTx } from './cosmos'
+import { broadcastEvmTx } from './evm'
+import { broadcastQbtcTx } from './qbtc'
+import { broadcastSuiTx } from './sui'
+import { broadcastTonTx } from './ton'
+import { broadcastTronTx } from './tron'
+
+const originalFetch = globalThis.fetch
+const encoded = new Uint8Array([0x01, 0x02, 0x03])
+
+type ContractCase = {
+  resolver: BroadcastTxResolver<any>
+  input: { chain: Chain; tx: any }
+  txHash: string
+  accept: () => void
+  reject: () => void
+  failTransient: () => void
+}
+
+const successfulFetch = (body: unknown) =>
+  vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => body,
+  })
+
+const cases: Record<string, ContractCase> = {
+  bittensor: {
+    resolver: broadcastBittensorTx,
+    input: { chain: OtherChain.Bittensor, tx: { encoded } },
+    txHash: '0xbittensor-hash',
+    accept: () => mocks.queryUrl.mockResolvedValue({ result: '0xbittensor-hash' }),
+    reject: () => mocks.queryUrl.mockResolvedValue({ error: { code: 1010, message: 'Invalid Transaction' } }),
+    failTransient: () => mocks.queryUrl.mockRejectedValue(new Error('ECONNRESET')),
+  },
+  cosmos: {
+    resolver: broadcastCosmosTx,
+    input: {
+      chain: CosmosChain.Cosmos,
+      tx: { serialized: JSON.stringify({ tx_bytes: Buffer.from(encoded).toString('base64') }) },
+    },
+    txHash: 'cosmos-hash',
+    accept: () => mocks.broadcastCosmos.mockResolvedValue({ transactionHash: 'cosmos-hash' }),
+    reject: () => mocks.broadcastCosmos.mockRejectedValue(new Error('insufficient fee')),
+    failTransient: () => mocks.broadcastCosmos.mockRejectedValue(new Error('ECONNRESET')),
+  },
+  evm: {
+    resolver: broadcastEvmTx,
+    input: { chain: EvmChain.Ethereum, tx: { encoded } },
+    txHash: '0xevm-hash',
+    accept: () => mocks.sendEvm.mockResolvedValue('0xevm-hash'),
+    reject: () => mocks.sendEvm.mockRejectedValue(new Error('nonce too low')),
+    failTransient: () => mocks.sendEvm.mockRejectedValue(new Error('ECONNRESET')),
+  },
+  qbtc: {
+    resolver: broadcastQbtcTx,
+    input: {
+      chain: OtherChain.QBTC,
+      tx: { serialized: JSON.stringify({ tx_bytes: Buffer.from(encoded).toString('base64') }) },
+    },
+    txHash: 'qbtc-hash',
+    accept: () => {
+      globalThis.fetch = successfulFetch({ tx_response: { code: 0, txhash: 'qbtc-hash' } })
+    },
+    reject: () => {
+      globalThis.fetch = successfulFetch({ tx_response: { code: 5, raw_log: 'signature rejected' } })
+    },
+    failTransient: () => {
+      globalThis.fetch = vi.fn().mockRejectedValue(new Error('ECONNRESET'))
+    },
+  },
+  sui: {
+    resolver: broadcastSuiTx,
+    input: { chain: OtherChain.Sui, tx: { unsignedTx: 'dHgtYmxvY2s=', signature: 'signature' } },
+    txHash: 'sui-hash',
+    accept: () =>
+      mocks.executeSui.mockResolvedValue({
+        $kind: 'Transaction',
+        Transaction: {
+          digest: 'sui-hash',
+          status: { success: true, error: null },
+          effects: { transactionDigest: 'sui-hash' },
+        },
+      }),
+    reject: () => mocks.executeSui.mockRejectedValue(new Error('invalid signature')),
+    failTransient: () => mocks.executeSui.mockRejectedValue(new Error('ECONNRESET')),
+  },
+  ton: {
+    resolver: broadcastTonTx,
+    input: { chain: OtherChain.Ton, tx: { encoded: 'boc' } },
+    txHash: 'ton-hash',
+    accept: () => mocks.queryUrl.mockResolvedValue({ result: { hash: 'ton-hash' } }),
+    reject: () => mocks.queryUrl.mockRejectedValue(new Error('invalid boc')),
+    failTransient: () => mocks.queryUrl.mockRejectedValue(new Error('ECONNRESET')),
+  },
+  tron: {
+    resolver: broadcastTronTx,
+    input: { chain: OtherChain.Tron, tx: { json: { raw_data_hex: '00' } } },
+    txHash: 'tron-hash',
+    accept: () => mocks.queryUrl.mockResolvedValue({ txid: 'tron-hash', result: true }),
+    reject: () =>
+      mocks.queryUrl.mockResolvedValue({
+        txid: 'tron-hash',
+        result: false,
+        code: 'SIGERROR',
+        message: Buffer.from('invalid signature').toString('hex'),
+      }),
+    failTransient: () => mocks.queryUrl.mockRejectedValue(new Error('ECONNRESET')),
+  },
+}
+
+describe.each(Object.entries(cases))('%s broadcast resolver result contract', (_name, contract) => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    globalThis.fetch = originalFetch
+    mocks.verifyBroadcastByHash.mockImplementation(({ error }) => Promise.reject(error))
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('normalizes an accepted provider response and canonical transaction id', async () => {
+    contract.accept()
+
+    await expect(contract.resolver(contract.input as any)).resolves.toMatchObject({
+      status: 'accepted',
+      finality: 'pending',
+      txHash: contract.txHash,
+    })
+  })
+
+  it('normalizes a definitive provider rejection with its original cause', async () => {
+    contract.reject()
+
+    await expect(contract.resolver(contract.input as any)).resolves.toMatchObject({
+      status: 'failed',
+      code: BroadcastErrorCode.Rejected,
+      retryable: false,
+      cause: expect.any(Error),
+    })
+  })
+
+  it('normalizes a transient transport failure as retryable', async () => {
+    contract.failTransient()
+
+    await expect(contract.resolver(contract.input as any)).resolves.toMatchObject({
+      status: 'failed',
+      code: BroadcastErrorCode.Transport,
+      retryable: true,
+      cause: expect.objectContaining({ message: 'ECONNRESET' }),
+    })
+  })
+})
+
+describe('broadcast resolver unknown-cause preservation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyBroadcastByHash.mockRejectedValue(undefined)
+  })
+
+  it('does not mistake a falsy EVM rejection reason for an accepted broadcast', async () => {
+    mocks.sendEvm.mockRejectedValue(undefined)
+
+    await expect(broadcastEvmTx({ chain: EvmChain.Ethereum, tx: { encoded } as any })).resolves.toEqual({
+      status: 'failed',
+      code: BroadcastErrorCode.Rejected,
+      retryable: false,
+      cause: undefined,
+    })
+  })
+})

--- a/packages/core/chain/tx/broadcast/resolvers/ripple.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/ripple.test.ts
@@ -16,6 +16,7 @@ vi.mock('../verifyBroadcastByHash', () => ({
 }))
 
 import { OtherChain } from '../../../Chain'
+import { BroadcastErrorCode } from '../resolver'
 import { broadcastRippleTx, isRippleInFlightEngineResult } from './ripple'
 
 describe('broadcastRippleTx', () => {
@@ -38,10 +39,14 @@ describe('broadcastRippleTx', () => {
   }
 
   describe('engine-level results', () => {
-    it('resolves cleanly on tesSUCCESS (engine_result_code === 0)', async () => {
+    it('returns an accepted result on tesSUCCESS (engine_result_code === 0)', async () => {
       mocks.request.mockResolvedValue(submitResponse('tesSUCCESS', 0))
 
-      await expect(broadcastRippleTx({ chain, tx })).resolves.toBeUndefined()
+      await expect(broadcastRippleTx({ chain, tx })).resolves.toEqual({
+        status: 'accepted',
+        finality: 'pending',
+        txHash: 'DEADBEEF',
+      })
 
       expect(mocks.request).toHaveBeenCalledWith({
         command: 'submit',
@@ -51,49 +56,73 @@ describe('broadcastRippleTx', () => {
       expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
     })
 
-    it('THROWS on temREDUNDANT (self-send) — must NOT be swallowed by verify-by-hash', async () => {
+    it('returns a definitive failure on temREDUNDANT (self-send)', async () => {
       // Regression for the silent-broadcast bug: previously every non-success
       // engine result was caught + sent through verifyBroadcastByHash, which
       // swallows on `getRippleTxStatus` returning 'pending' for txnNotFound.
       // Users saw "Transaction broadcast: HASH" for txs the chain refused.
       mocks.request.mockResolvedValue(submitResponse('temREDUNDANT', -275))
 
-      await expect(broadcastRippleTx({ chain, tx })).rejects.toThrow(/temREDUNDANT/)
+      await expect(broadcastRippleTx({ chain, tx })).resolves.toMatchObject({
+        status: 'failed',
+        code: BroadcastErrorCode.Rejected,
+        retryable: false,
+        cause: expect.objectContaining({ message: expect.stringMatching(/temREDUNDANT/) }),
+      })
 
       // verifyBroadcastByHash MUST NOT be called for authoritative
       // preflight rejections — engine codes are the chain's "no".
       expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
     })
 
-    it('THROWS on tecNO_DST_INSUF_XRP (claim-class failure)', async () => {
+    it('returns a definitive failure on tecNO_DST_INSUF_XRP (claim-class failure)', async () => {
       mocks.request.mockResolvedValue(submitResponse('tecNO_DST_INSUF_XRP', 125))
 
-      await expect(broadcastRippleTx({ chain, tx })).rejects.toThrow(/tecNO_DST_INSUF_XRP/)
+      await expect(broadcastRippleTx({ chain, tx })).resolves.toMatchObject({
+        status: 'failed',
+        code: BroadcastErrorCode.Rejected,
+        retryable: false,
+        cause: expect.objectContaining({ message: expect.stringMatching(/tecNO_DST_INSUF_XRP/) }),
+      })
       expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
     })
 
-    it('THROWS on temBAD_FEE (malformed)', async () => {
+    it('returns a definitive failure on temBAD_FEE (malformed)', async () => {
       mocks.request.mockResolvedValue(submitResponse('temBAD_FEE', -298))
 
-      await expect(broadcastRippleTx({ chain, tx })).rejects.toThrow(/temBAD_FEE/)
+      await expect(broadcastRippleTx({ chain, tx })).resolves.toMatchObject({
+        status: 'failed',
+        code: BroadcastErrorCode.Rejected,
+        retryable: false,
+        cause: expect.objectContaining({ message: expect.stringMatching(/temBAD_FEE/) }),
+      })
       expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
     })
 
-    it('THROWS on terPRE_SEQ (retry-later — not a peer race)', async () => {
+    it('returns a definitive result on terPRE_SEQ (retry-later — not a peer race)', async () => {
       // terPRE_SEQ means our sequence is ahead of the account's current
       // sequence; the gap might fill in later. This is NOT a peer-race
       // duplicate (which is tefALREADY / tefPAST_SEQ). Propagate so the
       // caller knows to retry with a fresh sequence.
       mocks.request.mockResolvedValue(submitResponse('terPRE_SEQ', -396))
 
-      await expect(broadcastRippleTx({ chain, tx })).rejects.toThrow(/terPRE_SEQ/)
+      await expect(broadcastRippleTx({ chain, tx })).resolves.toMatchObject({
+        status: 'failed',
+        code: BroadcastErrorCode.Rejected,
+        retryable: false,
+        cause: expect.objectContaining({ message: expect.stringMatching(/terPRE_SEQ/) }),
+      })
       expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
     })
 
-    it('resolves on terQUEUED because XRPL accepted the tx into the queue', async () => {
+    it('returns accepted on terQUEUED because XRPL accepted the tx into the queue', async () => {
       mocks.request.mockResolvedValue(submitResponse('terQUEUED', -89))
 
-      await expect(broadcastRippleTx({ chain, tx })).resolves.toBeUndefined()
+      await expect(broadcastRippleTx({ chain, tx })).resolves.toEqual({
+        status: 'accepted',
+        finality: 'pending',
+        txHash: 'DEADBEEF',
+      })
 
       expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
     })
@@ -104,7 +133,7 @@ describe('broadcastRippleTx', () => {
       expect(isRippleInFlightEngineResult('tesSUCCESS')).toBe(false)
     })
 
-    it('THROWS with a useful message including engine_result + engine_result_message', async () => {
+    it('retains a useful cause including engine_result + engine_result_message', async () => {
       mocks.request.mockResolvedValue({
         result: {
           engine_result: 'temINVALID_FLAG',
@@ -114,9 +143,14 @@ describe('broadcastRippleTx', () => {
         },
       })
 
-      await expect(broadcastRippleTx({ chain, tx })).rejects.toThrow(
-        /Ripple broadcast rejected: temINVALID_FLAG — The transaction has an invalid flag\./
-      )
+      await expect(broadcastRippleTx({ chain, tx })).resolves.toMatchObject({
+        status: 'failed',
+        cause: expect.objectContaining({
+          message: expect.stringMatching(
+            /Ripple broadcast rejected: temINVALID_FLAG — The transaction has an invalid flag\./
+          ),
+        }),
+      })
     })
   })
 
@@ -129,9 +163,12 @@ describe('broadcastRippleTx', () => {
 
     it('routes tefALREADY through verifyBroadcastByHash (MPC peer-race recovery)', async () => {
       mocks.request.mockResolvedValue(submitResponse('tefALREADY', -198))
-      mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+      mocks.verifyBroadcastByHash.mockResolvedValue('verified-hash')
 
-      await expect(broadcastRippleTx({ chain, tx })).resolves.toBeUndefined()
+      await expect(broadcastRippleTx({ chain, tx })).resolves.toMatchObject({
+        status: 'accepted',
+        txHash: 'verified-hash',
+      })
 
       expect(mocks.verifyBroadcastByHash).toHaveBeenCalledTimes(1)
       expect(mocks.verifyBroadcastByHash).toHaveBeenCalledWith({
@@ -143,9 +180,12 @@ describe('broadcastRippleTx', () => {
 
     it('routes tefPAST_SEQ through verifyBroadcastByHash (peer consumed our sequence)', async () => {
       mocks.request.mockResolvedValue(submitResponse('tefPAST_SEQ', -190))
-      mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+      mocks.verifyBroadcastByHash.mockResolvedValue('verified-hash')
 
-      await expect(broadcastRippleTx({ chain, tx })).resolves.toBeUndefined()
+      await expect(broadcastRippleTx({ chain, tx })).resolves.toMatchObject({
+        status: 'accepted',
+        txHash: 'verified-hash',
+      })
 
       expect(mocks.verifyBroadcastByHash).toHaveBeenCalledTimes(1)
     })
@@ -158,7 +198,12 @@ describe('broadcastRippleTx', () => {
       const verifyError = new Error('Ripple broadcast rejected: tefALREADY — fixture')
       mocks.verifyBroadcastByHash.mockRejectedValue(verifyError)
 
-      await expect(broadcastRippleTx({ chain, tx })).rejects.toBe(verifyError)
+      await expect(broadcastRippleTx({ chain, tx })).resolves.toEqual({
+        status: 'failed',
+        code: BroadcastErrorCode.Rejected,
+        retryable: false,
+        cause: verifyError,
+      })
     })
   })
 
@@ -168,9 +213,12 @@ describe('broadcastRippleTx', () => {
       // peer's broadcast may have landed the tx — verify before failing.
       const networkError = new Error('ECONNRESET')
       mocks.request.mockRejectedValue(networkError)
-      mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+      mocks.verifyBroadcastByHash.mockResolvedValue('verified-hash')
 
-      await expect(broadcastRippleTx({ chain, tx })).resolves.toBeUndefined()
+      await expect(broadcastRippleTx({ chain, tx })).resolves.toMatchObject({
+        status: 'accepted',
+        txHash: 'verified-hash',
+      })
 
       expect(mocks.verifyBroadcastByHash).toHaveBeenCalledTimes(1)
       expect(mocks.verifyBroadcastByHash).toHaveBeenCalledWith({
@@ -186,7 +234,25 @@ describe('broadcastRippleTx', () => {
       const verifyError = new Error('verified: tx not on-chain')
       mocks.verifyBroadcastByHash.mockRejectedValue(verifyError)
 
-      await expect(broadcastRippleTx({ chain, tx })).rejects.toBe(verifyError)
+      await expect(broadcastRippleTx({ chain, tx })).resolves.toEqual({
+        status: 'failed',
+        code: BroadcastErrorCode.Transport,
+        retryable: true,
+        cause: verifyError,
+      })
+    })
+
+    it('does not label an ambiguous local request failure as retryable', async () => {
+      const localError = new TypeError('Cannot read properties of undefined')
+      mocks.request.mockRejectedValue(localError)
+      mocks.verifyBroadcastByHash.mockRejectedValue(localError)
+
+      await expect(broadcastRippleTx({ chain, tx })).resolves.toEqual({
+        status: 'failed',
+        code: BroadcastErrorCode.Rejected,
+        retryable: false,
+        cause: localError,
+      })
     })
   })
 
@@ -199,7 +265,11 @@ describe('broadcastRippleTx', () => {
       // semantics for missing engine_result_code.)
       mocks.request.mockResolvedValue({ result: { tx_json: { hash: 'X' } } })
 
-      await expect(broadcastRippleTx({ chain, tx })).resolves.toBeUndefined()
+      await expect(broadcastRippleTx({ chain, tx })).resolves.toEqual({
+        status: 'accepted',
+        finality: 'pending',
+        txHash: 'X',
+      })
       expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
     })
 
@@ -213,7 +283,12 @@ describe('broadcastRippleTx', () => {
         },
       })
 
-      await expect(broadcastRippleTx({ chain, tx })).rejects.toThrow(/Ripple broadcast rejected: temREDUNDANT$/)
+      await expect(broadcastRippleTx({ chain, tx })).resolves.toMatchObject({
+        status: 'failed',
+        cause: expect.objectContaining({
+          message: expect.stringMatching(/Ripple broadcast rejected: temREDUNDANT$/),
+        }),
+      })
     })
   })
 })

--- a/packages/core/chain/tx/broadcast/resolvers/ripple.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/ripple.ts
@@ -1,7 +1,7 @@
 import { OtherChain } from '@vultisig/core-chain/Chain'
 import { getRippleClient } from '@vultisig/core-chain/chains/ripple/client'
 
-import { BroadcastTxResolver } from '../resolver'
+import { broadcastAccepted, broadcastFailed, BroadcastTxResolver, isRetryableBroadcastCause } from '../resolver'
 import { verifyBroadcastByHash } from '../verifyBroadcastByHash'
 
 /**
@@ -34,7 +34,12 @@ const PEER_RACE_ENGINE_RESULTS = new Set(['tefALREADY', 'tefPAST_SEQ'])
 export const isRippleInFlightEngineResult = (engineResult: string): boolean => engineResult === 'terQUEUED'
 
 export const broadcastRippleTx: BroadcastTxResolver<OtherChain.Ripple> = async ({ chain, tx }) => {
-  const client = await getRippleClient()
+  let client
+  try {
+    client = await getRippleClient()
+  } catch (cause) {
+    return broadcastFailed(cause, isRetryableBroadcastCause(cause))
+  }
 
   // RPC-level errors (network blip, connection drop) get the safety-net
   // verify-by-hash path: another peer's broadcast may have landed the tx.
@@ -45,14 +50,17 @@ export const broadcastRippleTx: BroadcastTxResolver<OtherChain.Ripple> = async (
       tx_blob: Buffer.from(tx.encoded).toString('hex'),
     })
   } catch (error) {
-    await verifyBroadcastByHash({ chain, tx, error })
-    return
+    try {
+      return broadcastAccepted(await verifyBroadcastByHash({ chain, tx, error }))
+    } catch (cause) {
+      return broadcastFailed(cause, isRetryableBroadcastCause(error))
+    }
   }
 
   const engineResultCode = response?.result?.engine_result_code
   if (typeof engineResultCode !== 'number' || engineResultCode === 0) {
     // tesSUCCESS (applied / queued for next ledger). All good.
-    return
+    return broadcastAccepted(response?.result?.tx_json?.hash)
   }
 
   const engineResult = response.result.engine_result ?? 'unknown'
@@ -64,15 +72,18 @@ export const broadcastRippleTx: BroadcastTxResolver<OtherChain.Ripple> = async (
   if (PEER_RACE_ENGINE_RESULTS.has(engineResult)) {
     // Duplicate / past-sequence: fast MPC peer's broadcast may have
     // already landed the tx. Verify before swallowing.
-    await verifyBroadcastByHash({ chain, tx, error })
-    return
+    try {
+      return broadcastAccepted(await verifyBroadcastByHash({ chain, tx, error }))
+    } catch (cause) {
+      return broadcastFailed(cause, false)
+    }
   }
 
   if (isRippleInFlightEngineResult(engineResult)) {
-    return
+    return broadcastAccepted(response?.result?.tx_json?.hash)
   }
 
   // Authoritative rejection at preflight (tem*/tec*/tel*/remaining ter*/remaining tef*).
-  // Propagate so the caller sees the real failure instead of a fake hash.
-  throw error
+  // Return it through the shared contract so callers never receive a raw throw.
+  return broadcastFailed(error, false)
 }

--- a/packages/core/chain/tx/broadcast/resolvers/solana.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/solana.test.ts
@@ -22,6 +22,7 @@ vi.mock('../verifyBroadcastByHash', () => ({
 }))
 
 import { Chain } from '../../../Chain'
+import { BroadcastErrorCode } from '../resolver'
 import { broadcastSolanaTx } from './solana'
 
 describe('broadcastSolanaTx', () => {
@@ -68,7 +69,7 @@ describe('broadcastSolanaTx', () => {
     vi.useFakeTimers()
     const rpcError = new Error('BlockhashNotFound')
     mocks.sendRawTransaction.mockRejectedValue(rpcError)
-    mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+    mocks.verifyBroadcastByHash.mockResolvedValue('verified-hash')
 
     const promise = broadcastSolanaTx({ chain: Chain.Solana, tx })
 
@@ -95,7 +96,7 @@ describe('broadcastSolanaTx', () => {
   it('verifies by hash when standard RPC rejects after JITO acceptance', async () => {
     const rpcError = new Error('rpc rejected')
     mocks.sendRawTransaction.mockRejectedValue(rpcError)
-    mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+    mocks.verifyBroadcastByHash.mockResolvedValue('verified-hash')
 
     await broadcastSolanaTx({ chain: Chain.Solana, tx })
 
@@ -118,7 +119,7 @@ describe('broadcastSolanaTx', () => {
       ],
     })
     mocks.sendRawTransaction.mockRejectedValue(sendError)
-    mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+    mocks.verifyBroadcastByHash.mockResolvedValue('verified-hash')
 
     await broadcastSolanaTx({ chain: Chain.Solana, tx })
 
@@ -129,10 +130,53 @@ describe('broadcastSolanaTx', () => {
     expect(error.message).toContain('insufficient lamports')
   })
 
+  it('returns a definitive failure when standard RPC rejects and hash verification cannot confirm it', async () => {
+    const rejection = new Error('invalid signature')
+    mocks.sendRawTransaction.mockRejectedValue(rejection)
+    mocks.verifyBroadcastByHash.mockRejectedValue(rejection)
+
+    await expect(broadcastSolanaTx({ chain: Chain.Solana, tx })).resolves.toEqual({
+      status: 'failed',
+      code: BroadcastErrorCode.Rejected,
+      retryable: false,
+      cause: rejection,
+    })
+  })
+
+  it('returns a retryable failure after transient blockhash retries cannot be verified', async () => {
+    vi.useFakeTimers()
+    const transientError = new Error('Blockhash not found')
+    mocks.sendRawTransaction.mockRejectedValue(transientError)
+    mocks.verifyBroadcastByHash.mockRejectedValue(transientError)
+
+    const promise = broadcastSolanaTx({ chain: Chain.Solana, tx })
+    await vi.advanceTimersByTimeAsync(1_500)
+
+    await expect(promise).resolves.toEqual({
+      status: 'failed',
+      code: BroadcastErrorCode.Transport,
+      retryable: true,
+      cause: transientError,
+    })
+  })
+
+  it('returns a retryable failure when a transient network error cannot be verified', async () => {
+    const transientError = new Error('ECONNRESET')
+    mocks.sendRawTransaction.mockRejectedValue(transientError)
+    mocks.verifyBroadcastByHash.mockRejectedValue(transientError)
+
+    await expect(broadcastSolanaTx({ chain: Chain.Solana, tx })).resolves.toEqual({
+      status: 'failed',
+      code: BroadcastErrorCode.Transport,
+      retryable: true,
+      cause: transientError,
+    })
+  })
+
   it('treats a duplicate-signature rejection as an idempotent success', async () => {
     mocks.sendRawTransaction.mockRejectedValue(new Error('This transaction has already been processed'))
 
-    await expect(broadcastSolanaTx({ chain: Chain.Solana, tx })).resolves.toBeUndefined()
+    await expect(broadcastSolanaTx({ chain: Chain.Solana, tx })).resolves.toMatchObject({ status: 'accepted' })
 
     expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
   })
@@ -140,7 +184,7 @@ describe('broadcastSolanaTx', () => {
   it('treats an AlreadyProcessed transaction error as an idempotent success', async () => {
     mocks.sendRawTransaction.mockRejectedValue(new Error('Transaction error: AlreadyProcessed'))
 
-    await expect(broadcastSolanaTx({ chain: Chain.Solana, tx })).resolves.toBeUndefined()
+    await expect(broadcastSolanaTx({ chain: Chain.Solana, tx })).resolves.toMatchObject({ status: 'accepted' })
 
     expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
   })
@@ -156,7 +200,7 @@ describe('broadcastSolanaTx', () => {
   it('pins the AlreadyProcessed branch: idempotent success, no re-broadcast, no hash verification', async () => {
     mocks.sendRawTransaction.mockRejectedValue(new Error('This transaction has already been processed'))
 
-    await expect(broadcastSolanaTx({ chain: Chain.Solana, tx })).resolves.toBeUndefined()
+    await expect(broadcastSolanaTx({ chain: Chain.Solana, tx })).resolves.toMatchObject({ status: 'accepted' })
 
     // Single broadcast attempt — the duplicate signature is NOT re-sent.
     expect(mocks.sendRawTransaction).toHaveBeenCalledTimes(1)

--- a/packages/core/chain/tx/broadcast/resolvers/solana.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/solana.ts
@@ -5,7 +5,7 @@ import { sendJitoTransaction } from '@vultisig/core-chain/chains/solana/jito'
 import { isInError } from '@vultisig/lib-utils/error/isInError'
 import base58 from 'bs58'
 
-import { BroadcastTxResolver } from '../resolver'
+import { broadcastAccepted, broadcastFailed, BroadcastTxResolver, isRetryableBroadcastCause } from '../resolver'
 import { verifyBroadcastByHash } from '../verifyBroadcastByHash'
 
 const solanaStandardRpcMaxAttempts = 3
@@ -40,16 +40,15 @@ const withSolanaBroadcastReason = (error: unknown): unknown => {
   return new Error([error.message, ...logs].join('\n'), { cause: error })
 }
 
-const sendSolanaRawTransaction = async (rawTransaction: Uint8Array) => {
+const sendSolanaRawTransaction = async (rawTransaction: Uint8Array): Promise<string> => {
   const client = getSolanaClient()
 
   for (let attempt = 1; attempt <= solanaStandardRpcMaxAttempts; attempt++) {
     try {
-      await client.sendRawTransaction(rawTransaction, {
+      return await client.sendRawTransaction(rawTransaction, {
         skipPreflight: false,
         preflightCommitment: 'confirmed',
       })
-      return
     } catch (error) {
       if (isTransientBlockhashError(error) && attempt < solanaStandardRpcMaxAttempts) {
         await wait(solanaStandardRpcRetryDelayMs * attempt)
@@ -58,10 +57,17 @@ const sendSolanaRawTransaction = async (rawTransaction: Uint8Array) => {
       throw error
     }
   }
+
+  throw new Error('Solana broadcast retry loop exhausted')
 }
 
 export const broadcastSolanaTx: BroadcastTxResolver<OtherChain.Solana> = async ({ chain, tx }) => {
-  const rawTransaction = base58.decode(tx.encoded)
+  let rawTransaction: Uint8Array
+  try {
+    rawTransaction = base58.decode(tx.encoded)
+  } catch (cause) {
+    return broadcastFailed(cause, false)
+  }
 
   // Try JITO first for MEV protection, but still relay through standard RPC.
   // JITO can accept sendTransaction without the signature later appearing in
@@ -73,7 +79,7 @@ export const broadcastSolanaTx: BroadcastTxResolver<OtherChain.Solana> = async (
   }
 
   try {
-    await sendSolanaRawTransaction(rawTransaction)
+    return broadcastAccepted(await sendSolanaRawTransaction(rawTransaction))
   } catch (error) {
     // A duplicate-signature error means the node already accepted this exact
     // signed transaction. Treat it as an idempotent success so a headless
@@ -95,12 +101,13 @@ export const broadcastSolanaTx: BroadcastTxResolver<OtherChain.Solana> = async (
     // raw-SDK consumer that broadcasts and skips that confirmation poll is
     // exposed to the optimistic result; the CLI agent always confirms.
     if (isInError(error, 'already been processed', 'AlreadyProcessed')) {
-      return
+      return broadcastAccepted()
     }
-    await verifyBroadcastByHash({
-      chain,
-      tx,
-      error: withSolanaBroadcastReason(error),
-    })
+    const cause = withSolanaBroadcastReason(error)
+    try {
+      return broadcastAccepted(await verifyBroadcastByHash({ chain, tx, error: cause }))
+    } catch (verifiedCause) {
+      return broadcastFailed(verifiedCause, isTransientBlockhashError(error) || isRetryableBroadcastCause(error))
+    }
   }
 }

--- a/packages/core/chain/tx/broadcast/resolvers/sui.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/sui.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { OtherChain } from '../../../Chain'
-import { isTransientBroadcastError, withTransientBroadcastRetry } from '../transientRetry'
+import { DeliverTxFailedError, isTransientBroadcastError, withTransientBroadcastRetry } from '../transientRetry'
 
 const { mockExecute, mockVerify } = vi.hoisted(() => ({
   mockExecute: vi.fn(),
@@ -43,21 +43,25 @@ const succeeded = {
 describe('broadcastSuiTx — sdk#1398 MoveAbort false-success', () => {
   afterEach(() => vi.clearAllMocks())
 
-  it('requests effects and throws when the tx aborts on-chain (FailedTransaction arm)', async () => {
+  it('requests effects and returns failure when the tx aborts on-chain (FailedTransaction arm)', async () => {
     mockExecute.mockResolvedValueOnce(failed('MoveAbort'))
-    await expect(broadcastSuiTx({ chain: OtherChain.Sui, tx })).rejects.toThrow(/failed on-chain/i)
+    const result = await broadcastSuiTx({ chain: OtherChain.Sui, tx })
+    expect(result).toMatchObject({ status: 'failed', retryable: false, cause: expect.any(DeliverTxFailedError) })
+    expect(result).toHaveProperty('cause.message', expect.stringMatching(/failed on-chain/i))
     expect(mockExecute).toHaveBeenCalledWith(expect.objectContaining({ include: { effects: true } }))
     // A genuinely-failed Move is NOT fed back into verifyBroadcastByHash (it's on-chain, not un-broadcast).
     expect(mockVerify).not.toHaveBeenCalled()
   })
 
-  it('throws on a Transaction arm whose execution status says failure', async () => {
+  it('returns failure on a Transaction arm whose execution status says failure', async () => {
     // The union arm and the status must BOTH say success; a mismatched pair is not proven success.
     mockExecute.mockResolvedValueOnce({
       $kind: 'Transaction',
       Transaction: { digest: '0xabc', status: { success: false, error: { message: 'InsufficientGas' } } },
     })
-    await expect(broadcastSuiTx({ chain: OtherChain.Sui, tx })).rejects.toThrow(/InsufficientGas/)
+    const result = await broadcastSuiTx({ chain: OtherChain.Sui, tx })
+    expect(result).toMatchObject({ status: 'failed', retryable: false, cause: expect.any(DeliverTxFailedError) })
+    expect(result).toHaveProperty('cause.message', expect.stringMatching(/InsufficientGas/))
     expect(mockVerify).not.toHaveBeenCalled()
   })
 
@@ -65,7 +69,11 @@ describe('broadcastSuiTx — sdk#1398 MoveAbort false-success', () => {
     // With effects requested a real endpoint always returns a status; a response WITHOUT an
     // explicit success is not proven execution success and must NOT be reported as one.
     mockExecute.mockResolvedValueOnce({ $kind: 'Transaction', Transaction: { digest: '0xabc' } })
-    await expect(broadcastSuiTx({ chain: OtherChain.Sui, tx })).rejects.toThrow()
+    await expect(broadcastSuiTx({ chain: OtherChain.Sui, tx })).resolves.toMatchObject({
+      status: 'failed',
+      retryable: false,
+      cause: expect.any(DeliverTxFailedError),
+    })
     expect(mockVerify).not.toHaveBeenCalled()
   })
 
@@ -78,8 +86,9 @@ describe('broadcastSuiTx — sdk#1398 MoveAbort false-success', () => {
     // regex-matching: with a message that matches nothing, the assertion passes on a bare Error too
     // and the guard goes inert.
     mockExecute.mockResolvedValueOnce(failed(moveAbort))
-    const err = await broadcastSuiTx({ chain: OtherChain.Sui, tx }).catch((e: unknown) => e)
-    expect(isTransientBroadcastError(err)).toBe(false)
+    const result = await broadcastSuiTx({ chain: OtherChain.Sui, tx })
+    expect(result.status).toBe('failed')
+    expect(isTransientBroadcastError(result.status === 'failed' ? result.cause : undefined)).toBe(false)
     // Red-on-revert anchor: prove the fixture really does trip the message regex, so the assertion
     // above can only be passing because of the marker.
     expect(isTransientBroadcastError(new Error(`Sui transaction failed on-chain: ${moveAbort}`))).toBe(true)
@@ -93,17 +102,22 @@ describe('broadcastSuiTx — sdk#1398 MoveAbort false-success', () => {
     // this pass on a bare Error and prove nothing about the wrapper.
     mockExecute.mockResolvedValue(failed(moveAbort))
 
-    await expect(withTransientBroadcastRetry(() => broadcastSuiTx({ chain: OtherChain.Sui, tx }))).rejects.toThrow(
-      /failed on-chain/i
-    )
+    await expect(
+      withTransientBroadcastRetry(() => broadcastSuiTx({ chain: OtherChain.Sui, tx }))
+    ).resolves.toMatchObject({ status: 'failed', retryable: false, cause: expect.any(DeliverTxFailedError) })
     // Called exactly once = the wrapper did NOT retry the aborted tx (marker short-circuited).
     expect(mockExecute).toHaveBeenCalledTimes(1)
     expect(mockVerify).not.toHaveBeenCalled()
   })
 
-  it('returns the response when the tx executes successfully', async () => {
+  it('returns the canonical result when the tx executes successfully', async () => {
     mockExecute.mockResolvedValueOnce(succeeded)
-    await expect(broadcastSuiTx({ chain: OtherChain.Sui, tx })).resolves.toBe(succeeded)
+    await expect(broadcastSuiTx({ chain: OtherChain.Sui, tx })).resolves.toEqual({
+      status: 'accepted',
+      finality: 'pending',
+      txHash: '0xabc',
+      details: { provider: succeeded },
+    })
     expect(mockVerify).not.toHaveBeenCalled()
   })
 

--- a/packages/core/chain/tx/broadcast/resolvers/sui.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/sui.ts
@@ -3,12 +3,13 @@ import { OtherChain } from '@vultisig/core-chain/Chain'
 import { getSuiClient } from '@vultisig/core-chain/chains/sui/client'
 import {
   describeSuiExecutionFailure,
+  getSuiResultTransaction,
   isSuiExecutionSuccess,
   SuiTransactionResultLike,
 } from '@vultisig/core-chain/chains/sui/transactionResult'
 import { attempt } from '@vultisig/lib-utils/attempt'
 
-import { BroadcastTxResolver } from '../resolver'
+import { broadcastAccepted, broadcastFailed, BroadcastTxResolver, isRetryableBroadcastCause } from '../resolver'
 import { DeliverTxFailedError } from '../transientRetry'
 import { verifyBroadcastByHash } from '../verifyBroadcastByHash'
 
@@ -19,25 +20,26 @@ export const assertSuiTxSucceeded = (result: SuiTransactionResultLike | null | u
 }
 
 export const broadcastSuiTx: BroadcastTxResolver<OtherChain.Sui> = async ({ chain, tx }) => {
-  const { data: response, error } = await attempt(
-    getSuiClient().executeTransaction({
-      transaction: fromBase64(tx.unsignedTx),
-      signatures: [tx.signature],
-      // sdk#1398: without requesting effects, execution resolves with a digest even when the tx
-      // executed but ABORTED (MoveAbort / InsufficientGas) — an RPC-level success that is NOT
-      // execution success. Ask for effects so we can tell the two apart.
-      include: { effects: true },
-    })
+  const result = await attempt(
+    Promise.resolve().then(() =>
+      getSuiClient().executeTransaction({
+        transaction: fromBase64(tx.unsignedTx),
+        signatures: [tx.signature],
+        include: { effects: true },
+      })
+    )
   )
 
-  if (error) {
-    await verifyBroadcastByHash({ chain, tx, error })
-    return
+  if ('error' in result) {
+    const { error } = result
+    try {
+      return broadcastAccepted(await verifyBroadcastByHash({ chain, tx, error }))
+    } catch (cause) {
+      return broadcastFailed(cause, isRetryableBroadcastCause(error))
+    }
   }
 
-  if (!response) {
-    return
-  }
+  const response = result.data
 
   // Mirror the status resolver (status/resolvers/sui.ts): ONLY an explicit `$kind: 'Transaction'`
   // with `status.success === true` is execution success. A `FailedTransaction` (MoveAbort /
@@ -49,7 +51,11 @@ export const broadcastSuiTx: BroadcastTxResolver<OtherChain.Sui> = async ({ chai
   // `instanceof` BEFORE its message-regex runs: a Sui abort error string routinely contains
   // "aborted"/"timed out", which the transient patterns match — a bare Error would be misclassified
   // as transient and the aborted tx re-sent by withTransientBroadcastRetry.
-  assertSuiTxSucceeded(response)
+  try {
+    assertSuiTxSucceeded(response)
+  } catch (cause) {
+    return broadcastFailed(cause, false, { provider: response })
+  }
 
-  return response
+  return broadcastAccepted(getSuiResultTransaction(response)?.digest, { provider: response })
 }

--- a/packages/core/chain/tx/broadcast/resolvers/ton.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/ton.ts
@@ -11,16 +11,20 @@ export const broadcastTonTx: BroadcastTxResolver<OtherChain.Ton> = async ({ chai
   const url = `${rootApiUrl}/ton/v2/sendBocReturnHash`
 
   const result = await attempt(
-    queryUrl<{ result: { hash: string } }>(url, {
+    queryUrl<{ result?: { hash?: string } }>(url, {
       body: { boc: tx.encoded },
     })
   )
 
-  if (result.data !== undefined) {
-    return broadcastAccepted(result.data.result.hash)
+  const hash = result.data?.result?.hash
+  if (hash) {
+    return broadcastAccepted(hash)
   }
 
-  const { error } = result
+  const responseMissingHash = result.data !== undefined
+  const error = responseMissingHash
+    ? new Error('TON broadcast failed: missing transaction hash in response')
+    : result.error
   if (isInError(error, 'duplicate message', 'duplicate msg_seqno')) {
     return broadcastAccepted()
   }
@@ -28,6 +32,6 @@ export const broadcastTonTx: BroadcastTxResolver<OtherChain.Ton> = async ({ chai
   try {
     return broadcastAccepted(await verifyBroadcastByHash({ chain, tx, error }))
   } catch (cause) {
-    return broadcastFailed(cause, isRetryableBroadcastCause(error))
+    return broadcastFailed(cause, responseMissingHash ? false : isRetryableBroadcastCause(error))
   }
 }

--- a/packages/core/chain/tx/broadcast/resolvers/ton.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/ton.ts
@@ -4,25 +4,30 @@ import { attempt } from '@vultisig/lib-utils/attempt'
 import { isInError } from '@vultisig/lib-utils/error/isInError'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
-import { BroadcastTxResolver } from '../resolver'
+import { broadcastAccepted, broadcastFailed, BroadcastTxResolver, isRetryableBroadcastCause } from '../resolver'
 import { verifyBroadcastByHash } from '../verifyBroadcastByHash'
 
 export const broadcastTonTx: BroadcastTxResolver<OtherChain.Ton> = async ({ chain, tx }) => {
   const url = `${rootApiUrl}/ton/v2/sendBocReturnHash`
 
-  const { error } = await attempt(
+  const result = await attempt(
     queryUrl<{ result: { hash: string } }>(url, {
       body: { boc: tx.encoded },
     })
   )
 
-  if (!error) {
-    return
+  if (result.data !== undefined) {
+    return broadcastAccepted(result.data.result.hash)
   }
 
+  const { error } = result
   if (isInError(error, 'duplicate message', 'duplicate msg_seqno')) {
-    return
+    return broadcastAccepted()
   }
 
-  await verifyBroadcastByHash({ chain, tx, error })
+  try {
+    return broadcastAccepted(await verifyBroadcastByHash({ chain, tx, error }))
+  } catch (cause) {
+    return broadcastFailed(cause, isRetryableBroadcastCause(error))
+  }
 }

--- a/packages/core/chain/tx/broadcast/resolvers/tron.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/tron.ts
@@ -2,7 +2,7 @@ import { OtherChain } from '@vultisig/core-chain/Chain'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
 import { tronRpcUrl } from '../../../chains/tron/config'
-import { BroadcastTxResolver } from '../resolver'
+import { broadcastAccepted, broadcastFailed, BroadcastTxResolver, isRetryableBroadcastCause } from '../resolver'
 import { verifyBroadcastByHash } from '../verifyBroadcastByHash'
 
 export const broadcastTronTx: BroadcastTxResolver<OtherChain.Tron> = async ({ chain, tx }) => {
@@ -18,14 +18,20 @@ export const broadcastTronTx: BroadcastTxResolver<OtherChain.Tron> = async ({ ch
       const msg = result.message
         ? Buffer.from(result.message, 'hex').toString('utf8')
         : (result.code ?? 'Unknown error')
-      throw new Error(`Tron broadcast failed: ${msg}`)
+      const error = new Error(`Tron broadcast failed: ${msg}`)
+      try {
+        return broadcastAccepted(await verifyBroadcastByHash({ chain, tx, error }))
+      } catch (cause) {
+        return broadcastFailed(cause, false)
+      }
     }
 
-    // Return the tx hash string, consistent with the other broadcast resolvers (which return a hash
-    // or void) rather than the full RPC envelope. The SDK's BroadcastService discards this return and
-    // derives the hash itself, so no consumer reads the object — this is a shape-consistency fix.
-    return result.txid
+    return broadcastAccepted(result.txid)
   } catch (error) {
-    await verifyBroadcastByHash({ chain, tx, error })
+    try {
+      return broadcastAccepted(await verifyBroadcastByHash({ chain, tx, error }))
+    } catch (cause) {
+      return broadcastFailed(cause, isRetryableBroadcastCause(error))
+    }
   }
 }

--- a/packages/core/chain/tx/broadcast/resolvers/utxo.test.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/utxo.test.ts
@@ -14,6 +14,7 @@ vi.mock('../verifyBroadcastByHash', () => ({
 }))
 
 import { UtxoChain } from '../../../Chain'
+import { BroadcastErrorCode } from '../resolver'
 import { broadcastUtxoTx } from './utxo'
 
 describe('broadcastUtxoTx', () => {
@@ -24,14 +25,29 @@ describe('broadcastUtxoTx', () => {
     vi.clearAllMocks()
   })
 
+  it('returns the canonical transaction hash when Blockchair accepts the transaction', async () => {
+    mocks.queryUrl.mockResolvedValue({ data: { transaction_hash: 'bitcoin-hash' } })
+
+    await expect(broadcastUtxoTx({ chain, tx })).resolves.toEqual({
+      status: 'accepted',
+      finality: 'pending',
+      txHash: 'bitcoin-hash',
+    })
+    expect(mocks.verifyBroadcastByHash).not.toHaveBeenCalled()
+  })
+
   it('routes timeout responses through verifyBroadcastByHash before swallowing', async () => {
     mocks.queryUrl.mockResolvedValue({
       data: null,
       context: { error: 'request timed out' },
     })
-    mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+    mocks.verifyBroadcastByHash.mockResolvedValue('verified-hash')
 
-    await expect(broadcastUtxoTx({ chain, tx })).resolves.toBeNull()
+    await expect(broadcastUtxoTx({ chain, tx })).resolves.toMatchObject({
+      status: 'accepted',
+      finality: 'pending',
+      txHash: 'verified-hash',
+    })
 
     expect(mocks.verifyBroadcastByHash).toHaveBeenCalledTimes(1)
     expect(mocks.verifyBroadcastByHash).toHaveBeenCalledWith({
@@ -51,7 +67,12 @@ describe('broadcastUtxoTx', () => {
     })
     mocks.verifyBroadcastByHash.mockRejectedValue(verifyError)
 
-    await expect(broadcastUtxoTx({ chain, tx })).rejects.toBe(verifyError)
+    await expect(broadcastUtxoTx({ chain, tx })).resolves.toEqual({
+      status: 'failed',
+      code: BroadcastErrorCode.Transport,
+      retryable: true,
+      cause: verifyError,
+    })
   })
 
   it('routes an "already known" duplicate through hash verification instead of blanket-swallowing it (false-success fix)', async () => {
@@ -62,9 +83,9 @@ describe('broadcastUtxoTx', () => {
       data: null,
       context: { error: 'txn-mempool-conflict' },
     })
-    mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+    mocks.verifyBroadcastByHash.mockResolvedValue('verified-hash')
 
-    await expect(broadcastUtxoTx({ chain, tx })).resolves.toBeNull()
+    await expect(broadcastUtxoTx({ chain, tx })).resolves.toMatchObject({ status: 'accepted', txHash: 'verified-hash' })
 
     expect(mocks.verifyBroadcastByHash).toHaveBeenCalledTimes(1)
   })
@@ -79,7 +100,12 @@ describe('broadcastUtxoTx', () => {
     // own contract in verifyBroadcastByHash.ts.
     mocks.verifyBroadcastByHash.mockRejectedValue(verifyError)
 
-    await expect(broadcastUtxoTx({ chain, tx })).rejects.toBe(verifyError)
+    await expect(broadcastUtxoTx({ chain, tx })).resolves.toEqual({
+      status: 'failed',
+      code: BroadcastErrorCode.Rejected,
+      retryable: false,
+      cause: verifyError,
+    })
   })
 
   it('still succeeds on a genuine MPC-race "already known" when hash verification confirms the tx IS on chain', async () => {
@@ -87,9 +113,9 @@ describe('broadcastUtxoTx', () => {
       data: null,
       context: { error: 'already known' },
     })
-    mocks.verifyBroadcastByHash.mockResolvedValue(undefined)
+    mocks.verifyBroadcastByHash.mockResolvedValue('verified-hash')
 
-    await expect(broadcastUtxoTx({ chain, tx })).resolves.toBeNull()
+    await expect(broadcastUtxoTx({ chain, tx })).resolves.toMatchObject({ status: 'accepted', txHash: 'verified-hash' })
 
     expect(mocks.verifyBroadcastByHash).toHaveBeenCalledTimes(1)
   })

--- a/packages/core/chain/tx/broadcast/resolvers/utxo.ts
+++ b/packages/core/chain/tx/broadcast/resolvers/utxo.ts
@@ -6,7 +6,7 @@ import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 import { getChainKind } from '../../../ChainKind'
 import { getBlockchairBaseUrl } from '../../../chains/utxo/client/getBlockchairBaseUrl'
 import { SigningOutput } from '../../../tw/signingOutput'
-import { BroadcastTxResolver } from '../resolver'
+import { broadcastAccepted, broadcastFailed, BroadcastTxResolver, isRetryableBroadcastCause } from '../resolver'
 import { verifyBroadcastByHash } from '../verifyBroadcastByHash'
 
 type UtxoBasedDecodedTx = SigningOutput<UtxoChain> | SigningOutput<OtherChain.Cardano>
@@ -25,28 +25,35 @@ type BlockchairBroadcastResponse =
     }
 
 export const broadcastUtxoTx: BroadcastTxResolver<UtxoBasedChain> = async ({ chain, tx }) => {
-  const url = `${getBlockchairBaseUrl(chain)}/push/transaction`
-  const encodedBytes = selectEncodedBytes(chain, tx as UtxoBasedDecodedTx)
+  try {
+    const url = `${getBlockchairBaseUrl(chain)}/push/transaction`
+    const encodedBytes = selectEncodedBytes(chain, tx as UtxoBasedDecodedTx)
 
-  const response = await queryUrl<BlockchairBroadcastResponse>(url, {
-    body: {
-      data: Buffer.from(encodedBytes).toString('hex'),
-    },
-  })
+    const response = await queryUrl<BlockchairBroadcastResponse>(url, {
+      body: {
+        data: Buffer.from(encodedBytes).toString('hex'),
+      },
+    })
 
-  if (response.data) {
-    return response.data.transaction_hash
+    if (response.data) {
+      return broadcastAccepted(response.data.transaction_hash)
+    }
+
+    const error = 'context' in response ? response.context.error : extractErrorMsg(response)
+
+    // Any submit error past this point is ambiguous — it could be a benign MPC-race duplicate (another
+    // device already broadcast the same signed tx) OR a genuine failure (e.g. BadInputsUTxO: spent/invalid
+    // inputs). String-matching alone can't tell them apart, so verify against the real chain: the hash
+    // either resolves on-chain (the race case — success) or it doesn't (the real failure — returns it).
+    const broadcastError = new Error(`Failed to broadcast transaction: ${extractErrorMsg(error)}`)
+    try {
+      return broadcastAccepted(await verifyBroadcastByHash({ chain, tx, error: broadcastError }))
+    } catch (cause) {
+      return broadcastFailed(cause, isRetryableBroadcastCause(broadcastError))
+    }
+  } catch (cause) {
+    return broadcastFailed(cause, isRetryableBroadcastCause(cause))
   }
-
-  const error = 'context' in response ? response.context.error : extractErrorMsg(response)
-
-  // Any submit error past this point is ambiguous — it could be a benign MPC-race duplicate (another
-  // device already broadcast the same signed tx) OR a genuine failure (e.g. BadInputsUTxO: spent/invalid
-  // inputs). String-matching alone can't tell them apart, so verify against the real chain: the hash
-  // either resolves on-chain (the race case — success) or it doesn't (the real failure — rethrows).
-  const broadcastError = new Error(`Failed to broadcast transaction: ${extractErrorMsg(error)}`)
-  await verifyBroadcastByHash({ chain, tx, error: broadcastError })
-  return null
 }
 
 const hasSigningResultV2 = (

--- a/packages/core/chain/tx/broadcast/transientRetry.ts
+++ b/packages/core/chain/tx/broadcast/transientRetry.ts
@@ -68,8 +68,10 @@ const decodeTransportMessage = (message: string): string => {
 }
 
 const transientMessagePatterns = [
+  /\b(?:ECONNRESET|ECONNREFUSED|ECONNABORTED|ETIMEDOUT|ENETRESET|ENETUNREACH|EHOSTUNREACH|EAI_AGAIN)\b/i,
   /\bfetch failed\b/i,
   /\bfailed to fetch\b/i,
+  /\bload failed\b/i,
   /\bnetwork error\b/i,
   /\bnetwork request failed\b/i,
   /\brequest timed out\b/i,
@@ -112,7 +114,7 @@ export const isTransientBroadcastError = (error: unknown): boolean => {
     }
 
     if (current instanceof HttpResponseError) {
-      return current.status === 429 || (current.status >= 500 && current.status <= 599)
+      return current.status === 408 || current.status === 429 || (current.status >= 500 && current.status <= 599)
     }
 
     if (typeof current === 'object') {
@@ -122,7 +124,7 @@ export const isTransientBroadcastError = (error: unknown): boolean => {
       }
 
       const status = (current as { status?: unknown }).status
-      if (typeof status === 'number' && (status === 429 || (status >= 500 && status <= 599))) {
+      if (typeof status === 'number' && (status === 408 || status === 429 || (status >= 500 && status <= 599))) {
         return true
       }
     }

--- a/packages/core/chain/tx/broadcast/verifyBroadcastByHash.test.ts
+++ b/packages/core/chain/tx/broadcast/verifyBroadcastByHash.test.ts
@@ -32,12 +32,12 @@ describe('verifyBroadcastByHash', () => {
     vi.clearAllMocks()
   })
 
-  it("swallows error when status is 'pending'", async () => {
+  it("returns the canonical hash when status is 'pending'", async () => {
     const originalError = new Error('duplicate tx')
     getTxHashMock.mockResolvedValue('0xdeadbeef')
     getTxStatusMock.mockResolvedValue({ status: 'pending' })
 
-    await expect(verifyBroadcastByHash({ chain, tx, error: originalError })).resolves.toBeUndefined()
+    await expect(verifyBroadcastByHash({ chain, tx, error: originalError })).resolves.toBe('0xdeadbeef')
 
     expect(getTxHashMock).toHaveBeenCalledTimes(1)
     expect(getTxHashMock).toHaveBeenCalledWith({ chain, tx })
@@ -66,7 +66,7 @@ describe('verifyBroadcastByHash', () => {
       status: 'success',
     })
 
-    await expect(verifyBroadcastByHash({ chain, tx, error: originalError })).resolves.toBeUndefined()
+    await expect(verifyBroadcastByHash({ chain, tx, error: originalError })).resolves.toBe('0xeb475a')
 
     expect(getTxHashMock).toHaveBeenCalledTimes(1)
     expect(getTxStatusMock).toHaveBeenCalledTimes(2)
@@ -93,18 +93,18 @@ describe('verifyBroadcastByHash', () => {
       isKnown: true,
     })
 
-    await expect(verifyBroadcastByHash({ chain, tx, error: originalError })).resolves.toBeUndefined()
+    await expect(verifyBroadcastByHash({ chain, tx, error: originalError })).resolves.toBe('0xpending')
 
     expect(getTxStatusMock).toHaveBeenCalledTimes(2)
     expect(sleepMock).toHaveBeenCalledOnce()
   })
 
-  it("swallows error when status is 'success'", async () => {
+  it("returns the canonical hash when status is 'success'", async () => {
     const originalError = new Error('duplicate tx')
     getTxHashMock.mockResolvedValue('0xabc')
     getTxStatusMock.mockResolvedValue({ status: 'success' })
 
-    await expect(verifyBroadcastByHash({ chain, tx, error: originalError })).resolves.toBeUndefined()
+    await expect(verifyBroadcastByHash({ chain, tx, error: originalError })).resolves.toBe('0xabc')
   })
 
   it("rethrows original error when status is 'error'", async () => {

--- a/packages/core/chain/tx/broadcast/verifyBroadcastByHash.ts
+++ b/packages/core/chain/tx/broadcast/verifyBroadcastByHash.ts
@@ -35,7 +35,7 @@ export const broadcastVerificationBaseDelayMs = 500
  * before the original error is rethrown. Verification is a safety net, never
  * a new failure mode.
  */
-export const verifyBroadcastByHash = async <T extends Chain>({ chain, tx, error }: VerifyInput<T>): Promise<void> => {
+export const verifyBroadcastByHash = async <T extends Chain>({ chain, tx, error }: VerifyInput<T>): Promise<string> => {
   let hash: string
 
   try {
@@ -57,7 +57,7 @@ export const verifyBroadcastByHash = async <T extends Chain>({ chain, tx, error 
       const isKnownPending = result.status === 'pending' && result.isKnown !== false
 
       if (result.status === 'success' || isKnownPending) {
-        return
+        return hash
       }
 
       if (result.status === 'error') {

--- a/packages/sdk/src/vault/services/BroadcastService.ts
+++ b/packages/sdk/src/vault/services/BroadcastService.ts
@@ -16,29 +16,6 @@ import type { Signature } from '../../types'
 import { convertToKeysignSignatures } from '../utils/convertSignature'
 import { VaultError, VaultErrorCode } from '../VaultError'
 
-/**
- * Broadcast resolvers return `Promise<unknown>` and are inconsistent in shape: utxo/cardano
- * resolve a bare hash string, tron resolves the raw RPC response object (`{ txid, ... }`), and
- * most others (evm/cosmos/sui/ripple/ton/polkadot/bittensor) resolve void. When the resolver DID
- * echo back a hash, prefer it over a locally re-derived one - it is the node's own authoritative
- * value, not a client-side guess about what the node will have computed.
- */
-const extractResolverTxHash = (broadcastResult: unknown): string | undefined => {
-  if (typeof broadcastResult === 'string' && broadcastResult.length > 0) {
-    return broadcastResult
-  }
-  if (
-    broadcastResult &&
-    typeof broadcastResult === 'object' &&
-    'txid' in broadcastResult &&
-    typeof (broadcastResult as { txid?: unknown }).txid === 'string' &&
-    (broadcastResult as { txid: string }).txid.length > 0
-  ) {
-    return (broadcastResult as { txid: string }).txid
-  }
-  return undefined
-}
-
 type BroadcastPartialFailureInput = {
   chain: Chain
   broadcastedTxHashes: string[]
@@ -189,7 +166,7 @@ export class BroadcastService {
         })
 
         const signingOutput = decodeSigningOutput(chain, compiledTx)
-        let broadcastResult: unknown
+        let broadcastResult: Awaited<ReturnType<typeof coreBroadcastTx>>
         try {
           broadcastResult = await this.broadcastTransaction({
             chain,
@@ -207,7 +184,27 @@ export class BroadcastService {
           throw error
         }
 
-        const inputTxHash = extractResolverTxHash(broadcastResult) ?? (await getTxHash({ chain, tx: signingOutput }))
+        if (broadcastResult.status === 'failed') {
+          const cause =
+            broadcastResult.cause instanceof Error ? broadcastResult.cause : new Error(String(broadcastResult.cause))
+          const error = new Error(
+            `${broadcastResult.code} (retryable=${broadcastResult.retryable}): ${cause.message}`,
+            {
+              cause,
+            }
+          )
+          if (broadcastedTxHashes.length > 0) {
+            throw new BroadcastPartialFailureError({
+              chain,
+              broadcastedTxHashes,
+              failedInputIndex: index,
+              cause: error,
+            })
+          }
+          throw error
+        }
+
+        const inputTxHash = broadcastResult.txHash ?? (await getTxHash({ chain, tx: signingOutput }))
         broadcastedTxHashes.push(inputTxHash)
         txHash = inputTxHash
 

--- a/packages/sdk/tests/unit/vault/services/BroadcastService.test.ts
+++ b/packages/sdk/tests/unit/vault/services/BroadcastService.test.ts
@@ -1,5 +1,6 @@
 import { Chain } from '@vultisig/core-chain/Chain'
 import { CosmosSequenceMismatchError } from '@vultisig/core-chain/tx/broadcast/cosmosSequenceMismatch'
+import { broadcastAccepted, broadcastFailed } from '@vultisig/core-chain/tx/broadcast/resolver'
 import type { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -108,8 +109,8 @@ describe('BroadcastService', () => {
     mockGetTxStatus.mockResolvedValue({ status: 'success' })
   })
 
-  it('falls back to the locally computed hash when the resolver returns void (evm/cosmos/sui/ripple/ton/polkadot/bittensor)', async () => {
-    mockCoreBroadcastTx.mockResolvedValue(undefined)
+  it('falls back to the locally computed hash when the accepted result has no hash', async () => {
+    mockCoreBroadcastTx.mockResolvedValue(broadcastAccepted())
     mockGetTxHash.mockResolvedValue('0xlocally-computed-hash')
 
     const hash = await service.broadcastTx({
@@ -122,8 +123,8 @@ describe('BroadcastService', () => {
     expect(mockGetTxHash).toHaveBeenCalledOnce()
   })
 
-  it('prefers the resolver-returned hash over the local computation when the resolver returns a bare string (utxo/cardano)', async () => {
-    mockCoreBroadcastTx.mockResolvedValue('node-returned-hash')
+  it('prefers the canonical hash from the accepted result over local computation', async () => {
+    mockCoreBroadcastTx.mockResolvedValue(broadcastAccepted('node-returned-hash'))
     mockGetTxHash.mockResolvedValue('should-never-be-used')
 
     const hash = await service.broadcastTx({
@@ -136,11 +137,8 @@ describe('BroadcastService', () => {
     expect(mockGetTxHash).not.toHaveBeenCalled()
   })
 
-  it('prefers the resolver-returned txid over the local computation for the Tron response shape', async () => {
-    mockCoreBroadcastTx.mockResolvedValue({
-      txid: 'tron-node-hash',
-      result: true,
-    })
+  it('uses the normalized canonical Tron hash', async () => {
+    mockCoreBroadcastTx.mockResolvedValue(broadcastAccepted('tron-node-hash'))
     mockGetTxHash.mockResolvedValue('should-never-be-used')
 
     const hash = await service.broadcastTx({
@@ -153,8 +151,8 @@ describe('BroadcastService', () => {
     expect(mockGetTxHash).not.toHaveBeenCalled()
   })
 
-  it('falls back to the local hash when the resolver returns an empty string', async () => {
-    mockCoreBroadcastTx.mockResolvedValue('')
+  it('falls back to the local hash when the accepted result omits a hash', async () => {
+    mockCoreBroadcastTx.mockResolvedValue(broadcastAccepted())
     mockGetTxHash.mockResolvedValue('local-fallback-hash')
 
     const hash = await service.broadcastTx({
@@ -166,8 +164,8 @@ describe('BroadcastService', () => {
     expect(hash).toBe('local-fallback-hash')
   })
 
-  it('falls back to the local hash when the resolver returns an object without a usable txid', async () => {
-    mockCoreBroadcastTx.mockResolvedValue({ result: true })
+  it('falls back to the local hash when accepted provider details contain no canonical hash', async () => {
+    mockCoreBroadcastTx.mockResolvedValue(broadcastAccepted(undefined, { provider: { result: true } }))
     mockGetTxHash.mockResolvedValue('local-fallback-hash')
 
     const hash = await service.broadcastTx({
@@ -181,7 +179,9 @@ describe('BroadcastService', () => {
 
   it('resolves each broadcast input independently and returns the last transaction hash (approve + swap)', async () => {
     mockGetEncodedSigningInputs.mockResolvedValue(['approve-input', 'swap-input'])
-    mockCoreBroadcastTx.mockResolvedValueOnce(undefined).mockResolvedValueOnce('swap-node-hash')
+    mockCoreBroadcastTx
+      .mockResolvedValueOnce(broadcastAccepted())
+      .mockResolvedValueOnce(broadcastAccepted('swap-node-hash'))
     mockGetTxHash.mockResolvedValue('approve-local-hash')
 
     const hash = await service.broadcastTx({
@@ -191,14 +191,14 @@ describe('BroadcastService', () => {
     })
 
     expect(hash).toBe('swap-node-hash')
-    // Only the first (void-resolver) iteration needed the local fallback.
+    // Only the first hashless accepted result needed the local fallback.
     expect(mockGetTxHash).toHaveBeenCalledOnce()
   })
 
   it('uses an injected broadcaster without calling the network broadcaster', async () => {
     mockGetEncodedSigningInputs.mockResolvedValue(['approve-input', 'swap-input'])
     mockGetTxHash.mockResolvedValueOnce('approve-local-hash').mockResolvedValueOnce('swap-local-hash')
-    const injectedBroadcaster = vi.fn().mockResolvedValue(undefined)
+    const injectedBroadcaster = vi.fn().mockResolvedValue(broadcastAccepted())
     const injectedService = new BroadcastService(extractMessageHashes, wasmProvider, injectedBroadcaster)
 
     await injectedService.broadcastTx({ chain: Chain.Ethereum, keysignPayload, signature })
@@ -209,7 +209,7 @@ describe('BroadcastService', () => {
 
   it('carries already-broadcast hashes when a later input fails', async () => {
     mockGetEncodedSigningInputs.mockResolvedValue(['approve-input', 'swap-input'])
-    mockCoreBroadcastTx.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('swap rejected'))
+    mockCoreBroadcastTx.mockResolvedValueOnce(broadcastAccepted()).mockRejectedValueOnce(new Error('swap rejected'))
     mockGetTxHash.mockResolvedValueOnce('approve-local-hash')
 
     const promise = service.broadcastTx({ chain: Chain.Ethereum, keysignPayload, signature })
@@ -233,6 +233,19 @@ describe('BroadcastService', () => {
     })
   })
 
+  it('maps a failed broadcast result while retaining its original cause', async () => {
+    const cause = new Error('RPC rejected the transaction')
+    mockCoreBroadcastTx.mockResolvedValue(broadcastFailed(cause, false))
+
+    const error = await service.broadcastTx({ chain: Chain.Ethereum, keysignPayload, signature }).catch(value => value)
+
+    expect(error).toMatchObject({
+      code: VaultErrorCode.BroadcastFailed,
+      message: expect.stringContaining('BROADCAST_REJECTED'),
+    })
+    expect(error.originalError.cause).toBe(cause)
+  })
+
   it('waits for ERC-20 approval confirmation before broadcasting the swap input', async () => {
     const events: string[] = []
     mockGetEncodedSigningInputs.mockResolvedValue(['approval-input', 'swap-input'])
@@ -240,6 +253,7 @@ describe('BroadcastService', () => {
     mockDecodeSigningOutput.mockImplementation((_chain, tx) => tx)
     const injectedBroadcaster = vi.fn(async () => {
       events.push('broadcast')
+      return broadcastAccepted()
     })
     mockGetTxHash.mockImplementation(async ({ tx }) => (tx.includes('approval-input') ? '0xapproval' : '0xswap'))
     mockGetTxStatus.mockImplementation(async ({ hash }) => {
@@ -272,7 +286,7 @@ describe('BroadcastService', () => {
     mockGetEncodedSigningInputs.mockResolvedValue(['approval-input', 'swap-input'])
     mockCompileTx.mockImplementation(({ txInputData }) => txInputData)
     mockDecodeSigningOutput.mockImplementation((_chain, tx) => tx)
-    mockCoreBroadcastTx.mockResolvedValue(undefined)
+    mockCoreBroadcastTx.mockResolvedValue(broadcastAccepted())
     mockGetTxHash.mockImplementation(async ({ tx }) => (tx.includes('approval-input') ? '0xapproval' : '0xswap'))
     mockGetTxStatus.mockResolvedValue({ status: 'error' })
 
@@ -303,7 +317,7 @@ describe('BroadcastService', () => {
     mockGetEncodedSigningInputs.mockResolvedValue(['approval-input', 'swap-input'])
     mockCompileTx.mockImplementation(({ txInputData }) => txInputData)
     mockDecodeSigningOutput.mockImplementation((_chain, tx) => tx)
-    mockCoreBroadcastTx.mockResolvedValue(undefined)
+    mockCoreBroadcastTx.mockResolvedValue(broadcastAccepted())
     mockGetTxHash.mockImplementation(async ({ tx }) => (tx.includes('approval-input') ? '0xapproval' : '0xswap'))
     mockGetTxStatus.mockResolvedValue({ status: 'pending' })
 
@@ -334,7 +348,7 @@ describe('BroadcastService', () => {
     mockGetEncodedSigningInputs.mockResolvedValue(['approval-input', 'swap-input'])
     mockCompileTx.mockImplementation(({ txInputData }) => txInputData)
     mockDecodeSigningOutput.mockImplementation((_chain, tx) => tx)
-    mockCoreBroadcastTx.mockResolvedValue(undefined)
+    mockCoreBroadcastTx.mockResolvedValue(broadcastAccepted())
     mockGetTxHash.mockResolvedValue('0xapproval')
     mockGetTxStatus.mockReturnValue(new Promise(() => {}))
 
@@ -364,7 +378,7 @@ describe('BroadcastService', () => {
 
   it('does not wait between multiple inputs without an ERC-20 approval payload', async () => {
     mockGetEncodedSigningInputs.mockResolvedValue(['first-input', 'second-input'])
-    mockCoreBroadcastTx.mockResolvedValue(undefined)
+    mockCoreBroadcastTx.mockResolvedValue(broadcastAccepted())
     mockGetTxHash.mockResolvedValueOnce('0xfirst').mockResolvedValueOnce('0xsecond')
 
     await service.broadcastTx({
@@ -382,12 +396,12 @@ describe('BroadcastService', () => {
       expectedSequence: 255n,
       signedSequence: 254n,
     })
-    mockCoreBroadcastTx.mockRejectedValue(mismatch)
+    mockCoreBroadcastTx.mockResolvedValue(broadcastFailed(mismatch, false))
 
     await expect(service.broadcastTx({ chain: Chain.Cosmos, keysignPayload, signature })).rejects.toMatchObject({
       code: VaultErrorCode.BroadcastFailed,
       message: expect.stringContaining('start a new signing ceremony'),
-      originalError: mismatch,
+      originalError: expect.objectContaining({ cause: mismatch }),
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -15442,7 +15442,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.17":
+"nanoid@npm:^3.3.18":
   version: 3.3.18
   resolution: "nanoid@npm:3.3.18"
   bin:


### PR DESCRIPTION
Closes #1610
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized transaction broadcasting across supported networks with clear accepted or failed outcomes.
  * Accepted broadcasts consistently include transaction hashes, finality status, and provider details where available.
  * Ambiguous submissions can be verified on-chain before being marked successful or failed.
* **Bug Fixes**
  * Improved retry handling for transient transport failures while preventing retries for definitive transaction failures.
  * Broadcast errors preserve actionable failure codes, retryability, and original causes.
  * SDK services reliably consume normalized broadcast results and fall back to locally derived hashes when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->