### PR TITLE
feat(sdk): publish seedphrase helper subpath

### DIFF
--- a/.changeset/public-seedphrase-subpath.md
+++ b/.changeset/public-seedphrase-subpath.md
@@ -1,5 +1,5 @@
 ---
-'@vultisig/sdk': patch
+'@vultisig/sdk': minor
 ---
 
 Publish the canonical seedphrase normalization, validation, key-derivation, and chain-discovery helpers through the supported `@vultisig/sdk/seedphrase` subpath.

--- a/.changeset/public-seedphrase-subpath.md
+++ b/.changeset/public-seedphrase-subpath.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Publish the canonical seedphrase normalization, validation, key-derivation, and chain-discovery helpers through the supported `@vultisig/sdk/seedphrase` subpath.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -114,6 +114,16 @@
       "import": "./dist/tools/bridge/index.js",
       "require": "./dist/tools/bridge/index.cjs",
       "default": "./dist/tools/bridge/index.cjs"
+    },
+    "./seedphrase": {
+      "types": "./dist/seedphrase/index.d.ts",
+      "node": {
+        "import": "./dist/seedphrase/index.js",
+        "require": "./dist/seedphrase/index.cjs"
+      },
+      "import": "./dist/seedphrase/index.js",
+      "require": "./dist/seedphrase/index.cjs",
+      "default": "./dist/seedphrase/index.cjs"
     }
   },
   "scripts": {

--- a/packages/sdk/rollup.platforms.config.js
+++ b/packages/sdk/rollup.platforms.config.js
@@ -144,7 +144,10 @@ const rnOverridePlugin = () => ({
   name: 'vultisig-rn-path-override',
   async resolveId(source, importer, options) {
     if (options?.isEntry) return null
-    const resolved = await this.resolve(source, importer, { ...options, skipSelf: true })
+    const resolved = await this.resolve(source, importer, {
+      ...options,
+      skipSelf: true,
+    })
     if (!resolved || resolved.external) return null
     const id = resolved.id.replace(/\\/g, '/')
     for (const [suffix, override] of Object.entries(rnOverrideMap)) {
@@ -238,7 +241,7 @@ const createPlugins = (platformOptions = {}) => {
   ]
 }
 
-const createToolsSubpathConfigs = ({ input, distBase }) => [
+const createSubpathConfigs = ({ input, distBase }) => [
   {
     input,
     output: {
@@ -320,17 +323,21 @@ const configs = {
         },
       }),
     },
-    ...createToolsSubpathConfigs({
+    ...createSubpathConfigs({
       input: './src/tools/parse/index.ts',
       distBase: 'tools/parse',
     }),
-    ...createToolsSubpathConfigs({
+    ...createSubpathConfigs({
       input: './src/tools/defi/index.ts',
       distBase: 'tools/defi',
     }),
-    ...createToolsSubpathConfigs({
+    ...createSubpathConfigs({
       input: './src/tools/bridge/index.ts',
       distBase: 'tools/bridge',
+    }),
+    ...createSubpathConfigs({
+      input: './src/seedphrase/index.ts',
+      distBase: 'seedphrase',
     }),
   ],
   browser: {

--- a/packages/sdk/rollup.types.config.js
+++ b/packages/sdk/rollup.types.config.js
@@ -124,4 +124,7 @@ export default defineConfig([
   createSubpathTypesConfig('src/tools/parse/index.ts', 'dist/tools/parse/index.d.ts'),
   createSubpathTypesConfig('src/tools/defi/index.ts', 'dist/tools/defi/index.d.ts'),
   createSubpathTypesConfig('src/tools/bridge/index.ts', 'dist/tools/bridge/index.d.ts'),
+  // Canonical seedphrase helpers and import/discovery services are published
+  // as a narrow declaration surface alongside their dedicated runtime bundle.
+  createSubpathTypesConfig('src/seedphrase/index.ts', 'dist/seedphrase/index.d.ts'),
 ])

--- a/packages/sdk/tests/unit/public-api/seedphraseSubpathExports.test.ts
+++ b/packages/sdk/tests/unit/public-api/seedphraseSubpathExports.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import * as seedphrase from '../../../src/seedphrase'
+
+const sdkRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..')
+const sdkPackageJson = JSON.parse(readFileSync(path.join(sdkRoot, 'package.json'), 'utf8'))
+const platformRollupConfig = readFileSync(path.join(sdkRoot, 'rollup.platforms.config.js'), 'utf8')
+const typesRollupConfig = readFileSync(path.join(sdkRoot, 'rollup.types.config.js'), 'utf8')
+
+describe('@vultisig/sdk/seedphrase public surface', () => {
+  it('publishes a dedicated conditional export instead of a root-bundle alias', () => {
+    const seedphraseExport = sdkPackageJson.exports['./seedphrase']
+
+    expect(seedphraseExport).toMatchObject({
+      types: './dist/seedphrase/index.d.ts',
+      node: {
+        import: './dist/seedphrase/index.js',
+        require: './dist/seedphrase/index.cjs',
+      },
+      import: './dist/seedphrase/index.js',
+      require: './dist/seedphrase/index.cjs',
+      default: './dist/seedphrase/index.cjs',
+    })
+    expect(JSON.stringify(seedphraseExport)).not.toContain('dist/index.node')
+    expect(seedphraseExport).not.toHaveProperty('browser')
+    expect(seedphraseExport).not.toHaveProperty('worker')
+    expect(seedphraseExport).not.toHaveProperty('react-native')
+  })
+
+  it('keeps dedicated runtime and declaration bundle generation wired', () => {
+    expect(platformRollupConfig).toContain("input: './src/seedphrase/index.ts'")
+    expect(platformRollupConfig).toContain("distBase: 'seedphrase'")
+    expect(typesRollupConfig).toContain(
+      "createSubpathTypesConfig('src/seedphrase/index.ts', 'dist/seedphrase/index.d.ts')"
+    )
+  })
+
+  it('exposes the canonical runtime helper and import/discovery family', () => {
+    expect(Object.keys(seedphrase).sort()).toEqual(
+      [
+        'BIP39_LANGUAGES',
+        'BIP39_WORDLISTS',
+        'ChainDiscoveryService',
+        'MasterKeyDeriver',
+        'SEEDPHRASE_IMPORT_SUPPORTED_CHAINS',
+        'SEEDPHRASE_IMPORT_UNSUPPORTED_CHAINS',
+        'SEEDPHRASE_WORD_COUNTS',
+        'SeedphraseValidator',
+        'TransportError',
+        'assertSeedphraseImportSupportsChains',
+        'cleanMnemonic',
+        'detectMnemonicLanguage',
+        'findInvalidWords',
+        'findInvalidWordsAcrossAllLanguages',
+        'getUnsupportedSeedphraseImportChains',
+        'getWordlist',
+        'isSeedphraseImportSupportedChain',
+        'normalizeMnemonic',
+        'validateSeedphrase',
+      ].sort()
+    )
+    expect(seedphrase.normalizeMnemonic('  ABANDON\nABANDON  ')).toBe('abandon abandon')
+    expect(
+      seedphrase.detectMnemonicLanguage(
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+      )
+    ).toBe('english')
+  })
+})

--- a/scripts/quality-contracts.mjs
+++ b/scripts/quality-contracts.mjs
@@ -304,6 +304,7 @@ function packedConsumerSmoke(workRoot, tgzPath) {
 import * as root from '@vultisig/sdk'
 import * as node from '@vultisig/sdk/node'
 import * as browser from '@vultisig/sdk/browser'
+import * as seedphrase from '@vultisig/sdk/seedphrase'
 import * as vite from '@vultisig/sdk/vite'
 import { existsSync, readFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
@@ -314,7 +315,9 @@ const entry = require.resolve('@vultisig/sdk')
 const pkgDir = path.resolve(path.dirname(entry), '..')
 const electronMainEntry = require.resolve('@vultisig/sdk/electron/main')
 const reactNativeEntry = require.resolve('@vultisig/sdk/react-native')
+const seedphraseEntry = require.resolve('@vultisig/sdk/seedphrase')
 const electronMain = require('@vultisig/sdk/electron/main')
+const seedphraseRequire = require('@vultisig/sdk/seedphrase')
 const electronMainImport = await import('@vultisig/sdk/electron/main')
 
 assert.equal(typeof root.Vultisig, 'function', 'root exports Vultisig')
@@ -360,6 +363,23 @@ assert.equal(
   node.prepareCosmosVote,
   '@vultisig/sdk/node exposes sdk.cosmos.gov'
 )
+
+assert.equal(
+  path.basename(seedphraseEntry),
+  'index.cjs',
+  '@vultisig/sdk/seedphrase resolves the dedicated CommonJS bundle'
+)
+assert.equal(typeof seedphraseRequire.normalizeMnemonic, 'function', 'CommonJS seedphrase subpath loads')
+assert.equal(seedphrase.normalizeMnemonic('  ABANDON   ABANDON  '), 'abandon abandon')
+assert.equal(
+  seedphrase.detectMnemonicLanguage(
+    'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+  ),
+  'english'
+)
+assert.equal(typeof seedphrase.SeedphraseValidator, 'function')
+assert.equal(typeof seedphrase.MasterKeyDeriver, 'function')
+assert.equal(typeof seedphrase.ChainDiscoveryService, 'function')
 
 assert.ok(browser.Chain !== undefined, '@vultisig/sdk/browser resolves')
 assert.equal(browser.evm.encodeErc20Approve, browser.encodeErc20Approve, '@vultisig/sdk/browser exposes sdk.evm')
@@ -454,6 +474,12 @@ import type {
 import type { Vultisig } from '@vultisig/sdk/node'
 import type { ElectronMainCrypto, Vultisig as ElectronMainVultisig } from '@vultisig/sdk/electron/main'
 import { cosmos, evm, token } from '@vultisig/sdk'
+import {
+  normalizeMnemonic,
+  type Bip39Language,
+  type ChainDiscoveryResult,
+  type SeedphraseValidation,
+} from '@vultisig/sdk/seedphrase'
 import '@vultisig/sdk/browser'
 import '@vultisig/sdk/vite'
 
@@ -494,6 +520,10 @@ export type EvmNamespace = typeof evm
 export type TokenNamespace = typeof token
 export type RootUtxoBrandResult = typeof rootUtxoBrandValid
 export type ReactNativeUtxoBrandResult = typeof reactNativeUtxoBrandValid
+export type SeedphraseLanguage = Bip39Language
+export type SeedphraseDiscovery = ChainDiscoveryResult
+export type SeedphraseValidationResult = SeedphraseValidation
+export const normalizedMnemonic: string = normalizeMnemonic(' ABANDON  ABOUT ')
 `
     )
     run(process.execPath, [tscBin, '-p', path.join(consumer, 'tsconfig.json')], {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15280,11 +15280,11 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:^3.3.17":
-  version: 3.3.17
-  resolution: "nanoid@npm:3.3.17"
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/06f7949c7cce5c92c6aea66022f29a1eae7f56e05acbfddf1e049e819b4bf234c44a765cc44da7163482b111677948514012e27acdfa56f95309295768bdae32
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `@vultisig/sdk/seedphrase` public subpath.
  - Provides seedphrase normalization, validation, language detection, key derivation, and chain discovery helpers.
  - Supports JavaScript and TypeScript usage across supported module environments.

- **Tests**
  - Added coverage for runtime exports, TypeScript declarations, mnemonic normalization, language detection, and packaged consumer usage.

- **Documentation**
  - Documented publication of the new seedphrase subpath in the SDK release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->