### PR TITLE
Export Cosmos custom-signing payload builders

### DIFF
--- a/.changeset/bright-cosmos-builders.md
+++ b/.changeset/bright-cosmos-builders.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': minor
+---
+
+Export the canonical Cosmos SignAmino and SignDirect keysign payload builders from the root and React Native SDK surfaces.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -285,6 +285,12 @@ export {
   isCosmosMemoWithinCap,
 } from '@vultisig/core-chain/chains/cosmos/cosmosMemoCap'
 
+// Canonical Cosmos custom-message signing payload builders. Export these from
+// the SDK boundary so consumers do not have to assemble KeysignPayload values
+// themselves or import from internal vault-service paths.
+export type { BuildSignAminoPayloadInput, BuildSignDirectPayloadInput } from './vault/services/cosmos'
+export { buildSignAminoKeysignPayload, buildSignDirectKeysignPayload } from './vault/services/cosmos'
+
 // Fiat currency types
 export type { FiatCurrency } from '@vultisig/core-config/FiatCurrency'
 export {

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -109,6 +109,12 @@ export {
   parseThorchainSecuredAssets,
   thorchainSecuredAssetFallback,
 } from '@vultisig/core-chain/chains/cosmos/thor/securedAssets'
+
+// Canonical Cosmos custom-message signing payload builders. Keep this
+// hand-curated RN surface aligned with the root SDK entrypoint.
+export type { BuildSignAminoPayloadInput, BuildSignDirectPayloadInput } from '../../vault/services/cosmos'
+export { buildSignAminoKeysignPayload, buildSignDirectKeysignPayload } from '../../vault/services/cosmos'
+
 // XRP Ledger issued-currency canonicals — pure helpers/tables that are safe on
 // the RN graph and should stay in parity with the root SDK entrypoint.
 export {

--- a/packages/sdk/src/vault/services/cosmos/buildCosmosPayload.ts
+++ b/packages/sdk/src/vault/services/cosmos/buildCosmosPayload.ts
@@ -6,7 +6,7 @@
  */
 
 import { create } from '@bufbuild/protobuf'
-import { PublicKey } from '@trustwallet/wallet-core/dist/src/wallet-core'
+import type { PublicKey } from '@trustwallet/wallet-core/dist/src/wallet-core'
 import { CosmosChain, IbcEnabledCosmosChain } from '@vultisig/core-chain/Chain'
 import { getCosmosAccountInfo } from '@vultisig/core-chain/chains/cosmos/account/getCosmosAccountInfo'
 import { cosmosGasRecord, getCosmosFeeAmount } from '@vultisig/core-chain/chains/cosmos/gas'

--- a/packages/sdk/src/vault/services/cosmos/buildCosmosPayload.ts
+++ b/packages/sdk/src/vault/services/cosmos/buildCosmosPayload.ts
@@ -6,7 +6,6 @@
  */
 
 import { create } from '@bufbuild/protobuf'
-import type { PublicKey } from '@trustwallet/wallet-core/dist/src/wallet-core'
 import { CosmosChain, IbcEnabledCosmosChain } from '@vultisig/core-chain/Chain'
 import { getCosmosAccountInfo } from '@vultisig/core-chain/chains/cosmos/account/getCosmosAccountInfo'
 import { cosmosGasRecord, getCosmosFeeAmount } from '@vultisig/core-chain/chains/cosmos/gas'
@@ -31,12 +30,23 @@ import {
 import type { CosmosFeeInput, CosmosMsgInput, SignAminoInput, SignDirectInput } from '../../../types/cosmos'
 
 /**
+ * Minimal public-key contract the Cosmos payload builders need — just the raw
+ * key bytes, via `.data()`. Deliberately narrower than @trustwallet/wallet-core's
+ * `PublicKey` so it's structurally compatible with both that type and RN's
+ * `NativePublicKeyInstance` (@vultisig/walletcore-native), letting RN consumers
+ * pass their native public key without a cast.
+ */
+export type CosmosBuilderPublicKey = {
+  data(): Uint8Array
+}
+
+/**
  * Input parameters for building SignAmino keysign payload
  */
 export type BuildSignAminoPayloadInput = SignAminoInput & {
   vaultId: string
   localPartyId: string
-  publicKey: PublicKey
+  publicKey: CosmosBuilderPublicKey
   libType: KeysignLibType
   skipChainSpecificFetch?: boolean
 }
@@ -47,7 +57,7 @@ export type BuildSignAminoPayloadInput = SignAminoInput & {
 export type BuildSignDirectPayloadInput = SignDirectInput & {
   vaultId: string
   localPartyId: string
-  publicKey: PublicKey
+  publicKey: CosmosBuilderPublicKey
   libType: KeysignLibType
   skipChainSpecificFetch?: boolean
 }

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -262,6 +262,54 @@ describe('RN entry wires configureCrypto and configureDefaultStorage', () => {
     expect(rn.buildSignDirectKeysignPayload).toBe(canonical.buildSignDirectKeysignPayload)
   })
 
+  // sdk#1657 - buildSignAminoKeysignPayload/buildSignDirectKeysignPayload only
+  // ever call `publicKey.data()`, but their exported `publicKey` type was
+  // pinned to @trustwallet/wallet-core's `PublicKey`. RN consumers hold a
+  // @vultisig/walletcore-native `NativePublicKeyInstance` instead, which is
+  // not that class, so the RN-published type forced a cast. This test assigns
+  // a `NativePublicKeyInstance`-typed value directly to `publicKey` with no
+  // `as` — it fails to compile (not just fails at runtime) if the export ever
+  // narrows back to the TrustWallet WASM type.
+  it('accepts a React Native NativePublicKeyInstance as publicKey with no cast', async () => {
+    const rn = await import('../../../../src/platforms/react-native/index')
+
+    const nativePublicKey: import('@vultisig/walletcore-native').NativePublicKeyInstance = {
+      _handle: 1,
+      data: () => new Uint8Array([1, 2, 3]),
+      uncompressed() {
+        return this
+      },
+      compressed() {
+        return this
+      },
+      verify: () => true,
+      verifyAsDER: () => true,
+      delete: () => {},
+    }
+
+    const payload = await rn.buildSignAminoKeysignPayload({
+      chain: rn.Chain.Cosmos,
+      coin: {
+        chain: rn.Chain.Cosmos,
+        address: 'cosmos1abcdef',
+        decimals: 6,
+        ticker: 'ATOM',
+      },
+      msgs: [],
+      fee: {
+        amount: [{ denom: 'uatom', amount: '5000' }],
+        gas: '200000',
+      },
+      vaultId: 'vault-ecdsa',
+      localPartyId: 'device-1',
+      publicKey: nativePublicKey,
+      libType: 'DKLS',
+      skipChainSpecificFetch: true,
+    })
+
+    expect(payload.coin?.hexPublicKey).toBe('010203')
+  })
+
   it('exports the generic CosmWasm execute message builder from the RN root surface', async () => {
     const sdk = await import('../../../../src/platforms/react-native/index')
 

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -254,6 +254,14 @@ describe('RN entry wires configureCrypto and configureDefaultStorage', () => {
     expect(rn.isCosmosMemoWithinCap(rn.Chain.Osmosis, 'a'.repeat(257))).toBe(false)
   })
 
+  it('exports the canonical Cosmos custom-signing payload builders from the RN entry', async () => {
+    const rn = await import('../../../../src/platforms/react-native/index')
+    const canonical = await import('../../../../src/vault/services/cosmos')
+
+    expect(rn.buildSignAminoKeysignPayload).toBe(canonical.buildSignAminoKeysignPayload)
+    expect(rn.buildSignDirectKeysignPayload).toBe(canonical.buildSignDirectKeysignPayload)
+  })
+
   it('exports the generic CosmWasm execute message builder from the RN root surface', async () => {
     const sdk = await import('../../../../src/platforms/react-native/index')
 

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -5,6 +5,10 @@ import { describe, expect, it } from 'vitest'
 
 import * as sdk from '../../../src/index'
 import * as dangerousAddresses from '../../../src/utils/dangerousAddresses'
+import {
+  buildSignAminoKeysignPayload as canonicalBuildSignAminoKeysignPayload,
+  buildSignDirectKeysignPayload as canonicalBuildSignDirectKeysignPayload,
+} from '../../../src/vault/services/cosmos'
 import { cosmosTxFeeGasParityCases } from '../../fixtures/cosmosTxFeeGasParity'
 
 const dangerousAddressCanonicalExports = [
@@ -357,6 +361,11 @@ describe('@vultisig/sdk public exports', () => {
     const requiredFee = (gasLimit * 28_325n) / 1000n
     expect(sdk.TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS).toBeGreaterThanOrEqual(requiredFee)
     expect(msg.typeUrl).toBe('/cosmos.staking.v1beta1.MsgBeginRedelegate')
+  })
+
+  it('exports the canonical Cosmos custom-signing payload builders', () => {
+    expect(sdk.buildSignAminoKeysignPayload).toBe(canonicalBuildSignAminoKeysignPayload)
+    expect(sdk.buildSignDirectKeysignPayload).toBe(canonicalBuildSignDirectKeysignPayload)
   })
 
   it('exports seedphrase import chain support policy for consumers', () => {

--- a/packages/sdk/tests/unit/vault/services/cosmos/buildCosmosPayload.test.ts
+++ b/packages/sdk/tests/unit/vault/services/cosmos/buildCosmosPayload.test.ts
@@ -26,9 +26,9 @@ import { buildSignAminoKeysignPayload, buildSignDirectKeysignPayload } from '@/v
 
 const libType: KeysignLibType = 'DKLS'
 
-const fakePublicKey = {
+const fakePublicKey: import('@/vault/services/cosmos/buildCosmosPayload').CosmosBuilderPublicKey = {
   data: () => new Uint8Array([1, 2, 3]),
-} as import('@trustwallet/wallet-core/dist/src/wallet-core').PublicKey
+}
 
 const accountInfoFixture = {
   address: 'cosmos1testaddr',

--- a/scripts/check-sdk-package-exports.mjs
+++ b/scripts/check-sdk-package-exports.mjs
@@ -283,6 +283,16 @@ assert.equal(typeof root?.fiatToAmount, 'function', 'root import exports fiatToA
 assert.equal(typeof root?.normalizeChain, 'function', 'root import exports normalizeChain')
 assert.equal(typeof root?.fromChainAmountExact, 'function', 'root import exports fromChainAmountExact')
 assert.equal(typeof root?.getBlockExplorerUrl, 'function', 'root import exports getBlockExplorerUrl')
+assert.equal(
+  typeof root?.buildSignAminoKeysignPayload,
+  'function',
+  'root import exports buildSignAminoKeysignPayload'
+)
+assert.equal(
+  typeof root?.buildSignDirectKeysignPayload,
+  'function',
+  'root import exports buildSignDirectKeysignPayload'
+)
 assert.ok(root?.chainRegistry !== undefined, 'root import exports chainRegistry')
 assert.equal(typeof root?.deriveFromChainRegistry, 'function', 'root import exports deriveFromChainRegistry')
 assert.equal(typeof root?.extendChainRegistry, 'function', 'root import exports extendChainRegistry')
@@ -348,8 +358,17 @@ void ${alias}Keys`
     path.join(consumerRoot, 'verify-types.ts'),
     `${typeImports}
 ${declarationAssertions}
-import { Chain, chainRegistry, deriveFromChainRegistry, extendChainRegistry } from '@vultisig/sdk'
+import {
+  Chain,
+  buildSignAminoKeysignPayload,
+  buildSignDirectKeysignPayload,
+  chainRegistry,
+  deriveFromChainRegistry,
+  extendChainRegistry,
+} from '@vultisig/sdk'
 import type {
+  BuildSignAminoPayloadInput,
+  BuildSignDirectPayloadInput,
   ChainDescriptor,
   ChainDescriptorRegistry,
   ChainExplorerDescriptor,
@@ -360,6 +379,12 @@ import type {
 import type {
   ChainDescriptor as ReactNativeChainDescriptor,
   ExtendedChainRegistry as ReactNativeExtendedChainRegistry,
+} from '@vultisig/sdk/react-native'
+import {
+  buildSignAminoKeysignPayload as buildSignAminoKeysignPayloadReactNative,
+  buildSignDirectKeysignPayload as buildSignDirectKeysignPayloadReactNative,
+  type BuildSignAminoPayloadInput as BuildSignAminoPayloadInputReactNative,
+  type BuildSignDirectPayloadInput as BuildSignDirectPayloadInputReactNative,
 } from '@vultisig/sdk/react-native'
 import type { Vultisig } from '@vultisig/sdk/node'
 import type { ElectronMainCrypto, Vultisig as ElectronMainVultisig } from '@vultisig/sdk/electron/main'
@@ -381,6 +406,14 @@ export type ExplorerShape = typeof explorer
 export type ExtendedShape = typeof extended
 export type ReactNativeDescriptor = ReactNativeChainDescriptor
 export type ReactNativeExtended = ReactNativeExtendedChainRegistry<typeof extension>
+export type CosmosAminoInput = BuildSignAminoPayloadInput
+export type CosmosDirectInput = BuildSignDirectPayloadInput
+export type CosmosAminoInputReactNative = BuildSignAminoPayloadInputReactNative
+export type CosmosDirectInputReactNative = BuildSignDirectPayloadInputReactNative
+export type CosmosAminoBuilder = typeof buildSignAminoKeysignPayload
+export type CosmosDirectBuilder = typeof buildSignDirectKeysignPayload
+export type CosmosAminoBuilderReactNative = typeof buildSignAminoKeysignPayloadReactNative
+export type CosmosDirectBuilderReactNative = typeof buildSignDirectKeysignPayloadReactNative
 `
   )
 

--- a/scripts/check-sdk-package-exports.mjs
+++ b/scripts/check-sdk-package-exports.mjs
@@ -100,6 +100,18 @@ export function validatePackedExportTargets(manifest, packageRoot) {
   return targets
 }
 
+function validatePackedReactNativeCosmosPayloadExports(packageRoot) {
+  const runtimePath = path.join(packageRoot, 'dist/index.react-native.js')
+  const declarationsPath = path.join(packageRoot, 'dist/index.react-native.d.ts')
+  const runtimeSource = readFileSync(runtimePath, 'utf8')
+  const declarationSource = readFileSync(declarationsPath, 'utf8')
+
+  for (const symbol of ['buildSignAminoKeysignPayload', 'buildSignDirectKeysignPayload']) {
+    assert.ok(runtimeSource.includes(symbol), `react-native bundle exports ${symbol}`)
+    assert.ok(declarationSource.includes(symbol), `react-native types export ${symbol}`)
+  }
+}
+
 export function resolveConditionalTarget(value, activeConditions) {
   if (typeof value === 'string') return value
   if (Array.isArray(value)) {
@@ -497,6 +509,7 @@ export async function checkSdkPackageExports({
     )
 
     const targets = validatePackedExportTargets(sourceManifest, packageRoot)
+    validatePackedReactNativeCosmosPayloadExports(packageRoot)
     const importCases = collectNodeRuntimeCases(sourceManifest, 'import')
     const requireCases = collectNodeRuntimeCases(sourceManifest, 'require')
     if (!importCases.length || !requireCases.length) {


### PR DESCRIPTION
Closes #1657
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SDK support for building canonical Cosmos Amino and Direct signing payloads.
  * Builders are available through the main and React Native SDK entrypoints.
  * Added TypeScript input types for signing payload builders.
  * Improved compatibility with supported public key implementations.

* **Tests**
  * Added coverage for exports across SDK entrypoints and generated signing payload data.
  * Added package-consumer checks for JavaScript and TypeScript integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->