### PR TITLE
fix(cli): resolve --max to a numeric amount in JSON output

### DIFF
--- a/.changeset/bright-pandas-resolve.md
+++ b/.changeset/bright-pandas-resolve.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/cli': patch
+---
+
+Resolve max send and swap quote amounts to numeric strings in JSON output.

--- a/clients/cli/src/commands/__tests__/sendDryRunFee.test.ts
+++ b/clients/cli/src/commands/__tests__/sendDryRunFee.test.ts
@@ -26,6 +26,7 @@ function makeVault(opts: {
   fee: string
   total: string
   balance: string
+  resolvedAmount?: string
   payloadMemo?: string
   payloadDestinationTag?: number
 }) {
@@ -36,6 +37,8 @@ function makeVault(opts: {
       feeSymbol: 'ETH',
       total: opts.total,
       keysignPayload: {
+        coin: { decimals: 18 },
+        toAmount: opts.resolvedAmount ?? '1000000000000000000',
         memo: opts.payloadMemo,
         blockchainSpecific:
           opts.payloadDestinationTag === undefined
@@ -73,7 +76,10 @@ function makeTokenVault(opts: {
       feeSymbol: 'ETH',
       total: opts.total,
       contractAddress: opts.contractAddress,
-      keysignPayload: { some: 'payload' },
+      keysignPayload: {
+        coin: { decimals: 6 },
+        toAmount: '50000000',
+      },
     })),
     balance: vi.fn(async (_chain: unknown, tokenId?: string) =>
       tokenId
@@ -158,6 +164,43 @@ describe('send --dry-run preview', () => {
       balance: '5.0',
     })
     expect(data).not.toHaveProperty('contractAddress')
+  })
+
+  it('serializes the resolved amount and max flag for a max send', async () => {
+    const data = await sendJson(
+      makeVault({
+        fee: '0.0021',
+        total: '1.5021',
+        balance: '2.0',
+        resolvedAmount: '1500000000000000000',
+      }),
+      { ...(params as object), amount: 'max' } as never
+    )
+
+    expect(data.amount).toBe('1.5')
+    expect(data.isMax).toBe(true)
+  })
+
+  it('leaves a non-max send amount unchanged and omits the max flag', async () => {
+    const data = await sendJson(makeVault({ fee: '0.0021', total: '1.0021', balance: '5.0' }))
+
+    expect(data.amount).toBe('1.0')
+    expect(data).not.toHaveProperty('isMax')
+  })
+
+  it('leaves the human max-send preview unchanged', async () => {
+    configureOutput({ format: 'table', silent: false })
+    const logs: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      logs.push(args.map(String).join(' '))
+    })
+
+    await sendTransaction(
+      makeVault({ fee: '0.0021', total: '1.5021', balance: '2.0', resolvedAmount: '1500000000000000000' }),
+      { ...(params as object), amount: 'max' } as never
+    )
+
+    expect(logs.join('\n')).toContain('Amount:  max ETH')
   })
 
   it('surfaces the signable payload memo in JSON instead of echoing the input', async () => {

--- a/clients/cli/src/commands/__tests__/sendSwapDupGuard.test.ts
+++ b/clients/cli/src/commands/__tests__/sendSwapDupGuard.test.ts
@@ -46,6 +46,7 @@ import { computeFingerprint, reserveBroadcast } from '../../agent/broadcastJourn
 import { AgentExecutor } from '../../agent/executor'
 import { buildSendBroadcastIntent } from '../../core/broadcastGuard'
 import { classifyError, ExitCode } from '../../core/errors'
+import { outputJson } from '../../lib/output'
 import { executeSwap } from '../swap'
 import { sendTransaction } from '../transaction'
 
@@ -335,6 +336,22 @@ describe('send — broadcast dedupe guard', () => {
         dryRun: true,
       })
     ).rejects.toThrow(/Conflicting XRP destination tags/)
+  })
+
+  it('keeps the executed max-send JSON result limited to transaction fields', async () => {
+    const realSends = { count: 0 }
+    const { vault } = makeDriftingMaxVault({
+      payloads: [nativeSendPayload('0xrecipient', '1000000000000000000')],
+      txHash: '0xmax-json',
+      realSends,
+    })
+
+    await sendTransaction(vault, { chain: Chain.Ethereum, to: '0xrecipient', amount: 'max', yes: true })
+
+    const jsonResult = vi.mocked(outputJson).mock.calls.at(-1)?.[0] as Record<string, unknown>
+    expect(jsonResult).toMatchObject({ txHash: '0xmax-json', chain: Chain.Ethereum })
+    expect(jsonResult).not.toHaveProperty('amount')
+    expect(jsonResult).not.toHaveProperty('isMax')
   })
 
   it('refuses an identical second send within the window (no second broadcast, exit 9)', async () => {

--- a/clients/cli/src/commands/swap.ts
+++ b/clients/cli/src/commands/swap.ts
@@ -63,10 +63,10 @@ export async function executeSwapQuote(ctx: CommandContext, options: SwapQuoteOp
   spinner.succeed('Quote received')
 
   const quote = result.quote
-  const semanticAmount = isMax ? amount : normalizeSwapAmount(amount, quote.fromCoin.decimals)
-  const fromAmountDisplay = isMax
-    ? `${formatBigintAmount(quote.maxSwapable, quote.fromCoin.decimals)} (max)`
-    : semanticAmount
+  const semanticAmount = isMax
+    ? formatBigintAmount(quote.maxSwapable, quote.fromCoin.decimals)
+    : normalizeSwapAmount(amount, quote.fromCoin.decimals)
+  const fromAmountDisplay = isMax ? `${semanticAmount} (max)` : semanticAmount
 
   if (isJsonOutput()) {
     outputJson({

--- a/clients/cli/src/commands/swapAmount.test.ts
+++ b/clients/cli/src/commands/swapAmount.test.ts
@@ -1,6 +1,6 @@
 import type { VaultBase } from '@vultisig/sdk'
 import { Chain } from '@vultisig/sdk'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../lib/output', () => ({
   createSpinner: () => ({
@@ -20,22 +20,23 @@ vi.mock('../ui', () => ({
   displaySwapChains: vi.fn(),
   displaySwapPreview: vi.fn(),
   displaySwapResult: vi.fn(),
-  formatBigintAmount: (value: bigint) => String(value),
+  formatBigintAmount: (value: bigint, decimals: number) => String(Number(value) / 10 ** decimals),
 }))
 
 import type { CommandContext } from '../core'
+import { outputJson } from '../lib/output'
 import { executeSwap, executeSwapQuote, normalizeSwapAmount } from './swap'
 
 const exactAmount = '0.123456789123456789'
 
-function makeContext() {
+function makeContext({ fromDecimals = 18, maxSwapable = 0n } = {}) {
   const swap = vi.fn().mockResolvedValue({
     dryRun: true,
     quote: {
-      fromCoin: { decimals: 18, ticker: 'ETH' },
+      fromCoin: { decimals: fromDecimals, ticker: 'ETH' },
       toCoin: { decimals: 8, ticker: 'BTC' },
       estimatedOutput: 100n,
-      maxSwapable: 0n,
+      maxSwapable,
       provider: 'thorchain',
     },
   })
@@ -47,6 +48,10 @@ function makeContext() {
 }
 
 describe('CLI swap amount precision', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('preserves an exact decimal string in swap quote requests', async () => {
     const { ctx, swap } = makeContext()
 
@@ -57,6 +62,30 @@ describe('CLI swap amount precision', () => {
     })
 
     expect(swap).toHaveBeenCalledWith(expect.objectContaining({ amount: exactAmount, dryRun: true }))
+  })
+
+  it('serializes the resolved amount and max flag for a max swap quote', async () => {
+    const { ctx } = makeContext({ fromDecimals: 6, maxSwapable: 1500000n })
+
+    await executeSwapQuote(ctx, {
+      fromChain: Chain.Ethereum,
+      toChain: Chain.Bitcoin,
+      amount: 'max',
+    })
+
+    expect(outputJson).toHaveBeenCalledWith(expect.objectContaining({ amount: '1.5', isMax: true }))
+  })
+
+  it('leaves a non-max swap quote amount unchanged and clears the max flag', async () => {
+    const { ctx } = makeContext()
+
+    await executeSwapQuote(ctx, {
+      fromChain: Chain.Ethereum,
+      toChain: Chain.Bitcoin,
+      amount: '1.2500',
+    })
+
+    expect(outputJson).toHaveBeenCalledWith(expect.objectContaining({ amount: '1.25', isMax: false }))
   })
 
   it('preserves an exact decimal string in swap dry-run requests and output', async () => {

--- a/clients/cli/src/commands/transaction.ts
+++ b/clients/cli/src/commands/transaction.ts
@@ -10,7 +10,13 @@ import type { CommandContext, SendDryRunResult, SendParams, TransactionResult } 
 import { buildSendBroadcastIntent, ensureVaultUnlocked, guardedBroadcast } from '../core'
 import { ConfirmationRequiredError } from '../core/errors'
 import { createSpinner, info, isJsonOutput, isNonInteractive, outputJson, warn } from '../lib/output'
-import { confirmTransaction, displayTransactionPreview, displayTransactionResult, escapeTerminalControls } from '../ui'
+import {
+  confirmTransaction,
+  displayTransactionPreview,
+  displayTransactionResult,
+  escapeTerminalControls,
+  formatBigintAmount,
+} from '../ui'
 
 const getSendPreviewDetails = (
   chain: Chain,
@@ -139,8 +145,20 @@ async function previewDryRun(
   }
 
   if (isJsonOutput()) {
-    outputJson(result)
-    return result
+    if (params.amount !== 'max') {
+      outputJson(result)
+      return result
+    }
+
+    const decimals = dryResult.keysignPayload.coin?.decimals
+    if (decimals === undefined) throw new Error('Prepared transaction is missing coin decimals')
+    const jsonResult = {
+      ...result,
+      amount: formatBigintAmount(BigInt(dryResult.keysignPayload.toAmount), decimals),
+      isMax: true,
+    }
+    outputJson(jsonResult)
+    return jsonResult
   }
 
   info(`\nDry-run preview:`)

--- a/clients/cli/src/core/types.ts
+++ b/clients/cli/src/core/types.ts
@@ -28,6 +28,8 @@ export type SendDryRunResult = {
   chain: string
   to: string
   amount: string
+  /** True when `amount` was resolved from the `max` input sentinel. */
+  isMax?: boolean
   symbol: string
   /** Resolved token contract address / chain-specific asset id. Omitted for native sends. */
   contractAddress?: string


### PR DESCRIPTION
## Summary

- resolve max send dry-run JSON amounts from the prepared signable payload using the coin decimals
- resolve max swap-quote JSON amounts from maxSwapable using the source coin decimals
- preserve non-max amounts, human output, and executed-send JSON while retaining isMax as the machine-readable flag
- add a patch changeset for @vultisig/cli

## Verification

- revert-check: the new send and swap-quote max regressions failed before the implementation with amount equal to max
- yarn test:cli --maxWorkers=2 (79 files, 1181 tests passed)
- yarn lint
- yarn typecheck
- yarn quality:complexity
- yarn format:check
- yarn build:all
- yarn test
- bundled CLI live backend dry-run: send Ethereum to the active vault own address with --max --dry-run --output json returned success true, a resolved decimal amount, isMax true, and dryRun true
- executed max-send regression confirms its JSON still omits amount and isMax


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected JSON output for maximum send and swap amounts by resolving values using the asset’s decimal precision.
  * Added an `isMax` indicator for dry-run results when the maximum amount is selected.
  * Preserved clean transaction output without duplicate or unformatted amount fields.
  * Kept non-maximum amount formatting and human-readable previews unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->