### PR TITLE
fix(rn): export pure helper parity on SDK RN entry

### DIFF
--- a/.changeset/r140-rn-pure-exports.md
+++ b/.changeset/r140-rn-pure-exports.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Export the root SDK's pure address-format, validate-normalizer, and Station import helper families from `@vultisig/sdk/react-native`, and pin them with RN entrypoint coverage.

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -715,6 +715,16 @@ export { decodeCosmosTx, decodeEvmTx, decodeFromToolResult } from '../../tools/d
 // hand-curated-gap class as the rest of this section (sdk#1224) — so RN
 // consumers (Station) couldn't format high-decimal balances exactly or link
 // out to a block explorer without deep-importing core-chain.
+export {
+  canonicalChainTag,
+  classifyAddress,
+  isAddressValidForChain,
+  isSolanaAddress,
+  supportedChainTags,
+} from '../../utils/addressFormat'
+export type { AddressFamily, AddressRole, ChainPrefixResult } from '../../utils/addressValidation'
+export { address, validate } from '../../utils/addressValidation'
+export { checkChainPrefix } from '../../utils/chainPrefix'
 export { computeNotificationVaultId } from '../../utils/computeNotificationVaultId'
 export type {
   AmountDirection,
@@ -731,20 +741,6 @@ export {
   toHumanUnits,
 } from '../../utils/convertAmount'
 export { FiatToAmountError } from '../../utils/fiatToAmount'
-export { fromChainAmountExact } from '@vultisig/core-chain/amount/fromChainAmountExact'
-export { ChainAmountParseError, toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'
-export type { ChainKind } from '@vultisig/core-chain/ChainKind'
-export { getChainKind, isChainOfKind } from '@vultisig/core-chain/ChainKind'
-export {
-  canonicalChainTag,
-  classifyAddress,
-  isAddressValidForChain,
-  isSolanaAddress,
-  supportedChainTags,
-} from '../../utils/addressFormat'
-export type { AddressFamily, AddressRole, ChainPrefixResult } from '../../utils/addressValidation'
-export { address, validate } from '../../utils/addressValidation'
-export { checkChainPrefix } from '../../utils/chainPrefix'
 export {
   amountMatches,
   computeEvmFee,
@@ -757,6 +753,21 @@ export {
   tokenDecimals,
   ValidateNormalizerError,
 } from '../../utils/validateNormalizers'
+export { fromChainAmountExact } from '@vultisig/core-chain/amount/fromChainAmountExact'
+export { ChainAmountParseError, toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'
+export type { ChainKind } from '@vultisig/core-chain/ChainKind'
+export { getChainKind, isChainOfKind } from '@vultisig/core-chain/ChainKind'
+export type {
+  BlockExplorerEntity,
+  ChainDescriptor,
+  ChainDescriptorRegistry,
+  ChainExplorerDescriptor,
+  ChainExtensionRecord,
+  ExtendedChainRegistry,
+} from '@vultisig/core-chain/chainRegistry'
+export { chainRegistry, deriveFromChainRegistry, extendChainRegistry } from '@vultisig/core-chain/chainRegistry'
+export { getThorchainInboundAddress } from '@vultisig/core-chain/chains/cosmos/thor/getThorchainInboundAddress'
+export * from '@vultisig/core-chain/chains/cosmos/thor/lp'
 export type {
   StationImportSource,
   StationMnemonicImportSource,
@@ -774,17 +785,6 @@ export {
   stationTerraCoinTypes,
   validateStationPrivateKeyHex,
 } from '@vultisig/core-chain/station/importPrimitives'
-export type {
-  BlockExplorerEntity,
-  ChainDescriptor,
-  ChainDescriptorRegistry,
-  ChainExplorerDescriptor,
-  ChainExtensionRecord,
-  ExtendedChainRegistry,
-} from '@vultisig/core-chain/chainRegistry'
-export { chainRegistry, deriveFromChainRegistry, extendChainRegistry } from '@vultisig/core-chain/chainRegistry'
-export { getThorchainInboundAddress } from '@vultisig/core-chain/chains/cosmos/thor/getThorchainInboundAddress'
-export * from '@vultisig/core-chain/chains/cosmos/thor/lp'
 export type { GetSwapExplorerUrlInput, SwapExplorerProvider } from '@vultisig/core-chain/swap/utils/getSwapExplorerUrl'
 export { getSwapExplorerUrl, swapExplorerProviders } from '@vultisig/core-chain/swap/utils/getSwapExplorerUrl'
 export { getBlockExplorerUrl } from '@vultisig/core-chain/utils/getBlockExplorerUrl'

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -735,6 +735,45 @@ export { fromChainAmountExact } from '@vultisig/core-chain/amount/fromChainAmoun
 export { ChainAmountParseError, toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'
 export type { ChainKind } from '@vultisig/core-chain/ChainKind'
 export { getChainKind, isChainOfKind } from '@vultisig/core-chain/ChainKind'
+export {
+  canonicalChainTag,
+  classifyAddress,
+  isAddressValidForChain,
+  isSolanaAddress,
+  supportedChainTags,
+} from '../../utils/addressFormat'
+export type { AddressFamily, AddressRole, ChainPrefixResult } from '../../utils/addressValidation'
+export { address, validate } from '../../utils/addressValidation'
+export { checkChainPrefix } from '../../utils/chainPrefix'
+export {
+  amountMatches,
+  computeEvmFee,
+  decimalsFor,
+  feeMatches,
+  isValidTokenSymbolFormat,
+  normalizeTokenSymbol,
+  scaleHumanToRaw,
+  scaleRawToHuman,
+  tokenDecimals,
+  ValidateNormalizerError,
+} from '../../utils/validateNormalizers'
+export type {
+  StationImportSource,
+  StationMnemonicImportSource,
+  StationPrivateKeyImportSource,
+  StationSeedImportSource,
+  StationTerraChain,
+  StationTerraChainPublicData,
+  StationTerraCoinType,
+  StationTerraKeyMaterial,
+} from '@vultisig/core-chain/station/importPrimitives'
+export {
+  deriveStationTerraKeyMaterial,
+  getStationTerraDerivationPath,
+  normalizeStationPrivateKeyHex,
+  stationTerraCoinTypes,
+  validateStationPrivateKeyHex,
+} from '@vultisig/core-chain/station/importPrimitives'
 export type {
   BlockExplorerEntity,
   ChainDescriptor,

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -68,6 +68,18 @@ describe('RN entry wires configureCrypto and configureDefaultStorage', () => {
     expect(typeof sdk.deriveStationTerraKeyMaterial).toBe('function')
     expect(typeof sdk.getStationTerraDerivationPath).toBe('function')
     expect(typeof sdk.validateStationPrivateKeyHex).toBe('function')
+    expect(typeof sdk.decimalsFor).toBe('function')
+    expect(typeof sdk.feeMatches).toBe('function')
+    expect(typeof sdk.isValidTokenSymbolFormat).toBe('function')
+    expect(typeof sdk.normalizeTokenSymbol).toBe('function')
+    expect(typeof sdk.scaleHumanToRaw).toBe('function')
+    expect(typeof sdk.scaleRawToHuman).toBe('function')
+    expect(sdk.tokenDecimals).toBeDefined()
+    expect(typeof sdk.isAddressValidForChain).toBe('function')
+    expect(typeof sdk.isSolanaAddress).toBe('function')
+    expect(typeof sdk.supportedChainTags).toBe('function')
+    expect(sdk.address).toBeDefined()
+    expect(sdk.validate).toBeDefined()
   })
 
   it('exports default chain canonicals on the RN entrypoint', async () => {
@@ -76,6 +88,7 @@ describe('RN entry wires configureCrypto and configureDefaultStorage', () => {
     expect(Array.isArray(rn.DEFAULT_CHAINS)).toBe(true)
     expect(Array.isArray(rn.defaultChains)).toBe(true)
     expect(rn.DEFAULT_CHAINS).toEqual(['Bitcoin', 'Ethereum', 'THORChain', 'Solana', 'BSC'])
+    expect(rn.DEFAULT_CHAINS).toBe(rn.defaultChains)
   })
 
   it('exports the canonical Cosmos fee helpers and gas-limit tables from the RN entry', async () => {

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -51,7 +51,7 @@ describe('RN entry wires configureCrypto and configureDefaultStorage', () => {
   })
 
   it('registers crypto + storage on module load so Vultisig({}) does not throw', async () => {
-    const rn = await import('../../../../src/platforms/react-native/index')
+    const sdk = await import('../../../../src/platforms/react-native/index')
     const { randomUUID } = await import('../../../../src/crypto')
     const { getDefaultStorage } = await import('../../../../src/context/defaultStorage')
 
@@ -59,7 +59,15 @@ describe('RN entry wires configureCrypto and configureDefaultStorage', () => {
     const storage = getDefaultStorage()
     expect(storage).toBeDefined()
     expect(typeof storage.get).toBe('function')
-    expect(rn.DEFAULT_CHAINS).toBe(rn.defaultChains)
+
+    expect(typeof sdk.amountMatches).toBe('function')
+    expect(typeof sdk.computeEvmFee).toBe('function')
+    expect(typeof sdk.canonicalChainTag).toBe('function')
+    expect(typeof sdk.classifyAddress).toBe('function')
+    expect(typeof sdk.checkChainPrefix).toBe('function')
+    expect(typeof sdk.deriveStationTerraKeyMaterial).toBe('function')
+    expect(typeof sdk.getStationTerraDerivationPath).toBe('function')
+    expect(typeof sdk.validateStationPrivateKeyHex).toBe('function')
   })
 
   it('exports default chain canonicals on the RN entrypoint', async () => {


### PR DESCRIPTION
## Summary
- export the root SDK's pure address-format, validate-normalizer, and Station import helper families from `@vultisig/sdk/react-native`
- pin those exports in the RN entrypoint test so future root-only additions fail loudly
- add a changeset for the additive RN public-surface fix

Closes #1922

## Verification
- `VULTISIG_STRICT_SINGLETON=0 corepack yarn workspace @vultisig/sdk vitest run tests/unit/utils/publicExports.test.ts tests/unit/platforms/react-native/entry.test.ts --testTimeout=15000` ✅
- `corepack yarn build:sdk` ❌ pre-existing mainline blocker: `packages/core/mpc/keysign/signingInputs/resolvers/cardano.ts(72,5): error TS2353: 'auxiliaryData' does not exist in type 'ISigningInput'`
- `corepack yarn workspace @vultisig/sdk typecheck` ❌ same pre-existing Cardano blocker (`packages/core/mpc/.../cardano.ts`, `packages/core/mpc/tx/compile/compileTx.golden.test.ts`)
- `corepack yarn workspace @vultisig/sdk pack --out /tmp/vultisig-sdk-r140.tgz` ✅
- downstream tarball import receipt is currently blocked because the pre-existing build failure leaves the packed RN entry without `dist/index.react-native.js`

## Notes
- This is intentionally additive and low-risk: the helpers are already public from the root SDK entry and are pure / RN-safe.
- I kept the PR draft because broader build/typecheck/dist receipts are still blocked on the unrelated Cardano `ISigningInput` drift already present on main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the React Native SDK with address formatting and validation utilities.
  * Added token, fee, and chain normalization helpers.
  * Added Station Terra import and key-derivation helpers.

* **Tests**
  * Updated React Native entrypoint coverage to verify the newly available utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->