### PR TITLE
fix: decode bytes32 ERC-20 symbol/name for legacy tokens like MKR

### DIFF
--- a/.changeset/evm-balance-bytes32-symbol.md
+++ b/.changeset/evm-balance-bytes32-symbol.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Fix `getEvmBalances()` rejecting the whole balance read when a requested ERC-20 returns its `symbol()` as a raw right-padded bytes32 instead of the canonical ABI `string` (legacy tokens like MKR, SAI). `symbol()` is now read over a raw `eth_call` and decoded as a `string` first, falling back to bytes32 decoding, matching the tolerant readers already used by `resolveContract()` and the Uniswap ERC-20 helpers.

--- a/packages/sdk/src/tools/evm/balanceEvm.ts
+++ b/packages/sdk/src/tools/evm/balanceEvm.ts
@@ -1,7 +1,9 @@
 import { EvmChain } from '@vultisig/core-chain/Chain'
 import { getEvmClient } from '@vultisig/core-chain/chains/evm/client'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
-import { erc20Abi } from 'viem'
+import { decodeAbiParameters, erc20Abi, parseAbiParameters } from 'viem'
+
+import { evmCall } from './evmCall'
 
 /** Format a raw base-unit bigint to a human-readable decimal string (no precision loss). */
 const formatUnits = (raw: bigint, decimals: number): string => {
@@ -10,6 +12,42 @@ const formatUnits = (raw: bigint, decimals: number): string => {
   const frac = raw % divisor
   if (frac === 0n) return whole.toString()
   return `${whole}.${frac.toString().padStart(decimals, '0').replace(/0+$/, '')}`
+}
+
+const SYMBOL_SELECTOR = '0x95d89b41' as const
+
+/**
+ * Decode a right-NULL-padded bytes32 string. Legacy ERC-20s (MKR, SAI class)
+ * return `symbol()` as a raw bytes32 instead of the canonical ABI `string`,
+ * which viem's typed `readContract` decoder rejects outright.
+ */
+const decodeBytes32Symbol = (data: `0x${string}`): string => {
+  const hex = data.slice(2)
+  let end = hex.length
+  while (end >= 2 && hex.slice(end - 2, end) === '00') end -= 2
+  if (end === 0) return 'UNKNOWN'
+  let out = ''
+  for (let i = 0; i < end; i += 2) {
+    out += String.fromCharCode(parseInt(hex.slice(i, i + 2), 16))
+  }
+  return out
+}
+
+/**
+ * Read an ERC-20 `symbol()`, tolerating both the canonical ABI `string`
+ * return and the legacy right-padded `bytes32` return (MKR / SAI class).
+ * `readContract` decodes strictly against the ABI and throws for the bytes32
+ * shape, so we go through a raw `eth_call` and try both decodings.
+ */
+const readSymbol = async (chain: EvmChain, address: `0x${string}`): Promise<string> => {
+  const data = await evmCall(chain, { to: address, data: SYMBOL_SELECTOR })
+  if (data === '0x') return 'UNKNOWN'
+  try {
+    const [symbol] = decodeAbiParameters(parseAbiParameters('string'), data)
+    return symbol
+  } catch {
+    return decodeBytes32Symbol(data)
+  }
 }
 
 export type EvmBalance = {
@@ -77,11 +115,7 @@ export const getEvmBalances = async (chain: EvmChain, params: GetEvmBalancesPara
           abi: erc20Abi,
           functionName: 'decimals',
         }),
-        client.readContract({
-          address: contractAddress,
-          abi: erc20Abi,
-          functionName: 'symbol',
-        }),
+        readSymbol(chain, contractAddress),
       ])
 
       return {

--- a/packages/sdk/tests/unit/tools/evm/balanceEvm.test.ts
+++ b/packages/sdk/tests/unit/tools/evm/balanceEvm.test.ts
@@ -1,10 +1,12 @@
+import { encodeAbiParameters, parseAbiParameters, stringToHex } from 'viem'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockGetBalance = vi.fn()
 const mockReadContract = vi.fn()
+const mockCall = vi.fn()
 
 vi.mock('@vultisig/core-chain/chains/evm/client', () => ({
-  getEvmClient: () => ({ getBalance: mockGetBalance, readContract: mockReadContract }),
+  getEvmClient: () => ({ getBalance: mockGetBalance, readContract: mockReadContract, call: mockCall }),
 }))
 
 import { getEvmBalances } from '@/tools/evm/balanceEvm'
@@ -12,6 +14,13 @@ import { getEvmBalances } from '@/tools/evm/balanceEvm'
 const HOLDER = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045' as const
 const USDC = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' as const
 const DAI = '0x6B175474E89094C44Da98b954EedeAC495271d0F' as const
+const MKR = '0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2' as const
+
+/** ABI-encode a `string` return value, as a well-behaved ERC-20 `symbol()` would. */
+const encodeSymbolString = (symbol: string) => encodeAbiParameters(parseAbiParameters('string'), [symbol])
+
+/** Right-padded bytes32 return, as legacy ERC-20s (MKR, SAI class) return from `symbol()`. */
+const encodeSymbolBytes32 = (symbol: string) => stringToHex(symbol, { size: 32 })
 
 describe('getEvmBalances', () => {
   beforeEach(() => {
@@ -33,7 +42,7 @@ describe('getEvmBalances', () => {
     mockReadContract
       .mockResolvedValueOnce(500_000n) // balanceOf -> 0.5 USDC
       .mockResolvedValueOnce(6) // decimals
-      .mockResolvedValueOnce('USDC') // symbol
+    mockCall.mockResolvedValueOnce({ data: encodeSymbolString('USDC') }) // symbol
 
     const result = await getEvmBalances('Ethereum', { address: HOLDER, tokens: [USDC] })
 
@@ -41,7 +50,36 @@ describe('getEvmBalances', () => {
       { symbol: 'ETH', decimals: 18, raw: 0n, balance: '0' },
       { contractAddress: USDC, symbol: 'USDC', decimals: 6, raw: 500_000n, balance: '0.5' },
     ])
-    expect(mockReadContract).toHaveBeenCalledTimes(3)
+    expect(mockReadContract).toHaveBeenCalledTimes(2)
+    expect(mockCall).toHaveBeenCalledTimes(1)
+  })
+
+  it('decodes a bytes32-returning symbol() for legacy tokens like MKR', async () => {
+    // MKR predates the ABI `string` convention and returns symbol() as a raw
+    // right-padded bytes32. A strict ABI-string decode throws on this shape,
+    // which used to reject the whole getEvmBalances() call.
+    mockGetBalance.mockResolvedValueOnce(0n)
+    mockReadContract
+      .mockResolvedValueOnce(2_000_000_000_000_000_000n) // balanceOf -> 2 MKR
+      .mockResolvedValueOnce(18) // decimals
+    mockCall.mockResolvedValueOnce({ data: encodeSymbolBytes32('MKR') }) // bytes32 symbol
+
+    const result = await getEvmBalances('Ethereum', { address: HOLDER, tokens: [MKR] })
+
+    expect(result).toEqual([
+      { symbol: 'ETH', decimals: 18, raw: 0n, balance: '0' },
+      { contractAddress: MKR, symbol: 'MKR', decimals: 18, raw: 2_000_000_000_000_000_000n, balance: '2' },
+    ])
+  })
+
+  it('does not disturb standard string-returning symbol() decoding', async () => {
+    mockGetBalance.mockResolvedValueOnce(0n)
+    mockReadContract.mockResolvedValueOnce(500_000n).mockResolvedValueOnce(6)
+    mockCall.mockResolvedValueOnce({ data: encodeSymbolString('USDC') })
+
+    const [, usdc] = await getEvmBalances('Ethereum', { address: HOLDER, tokens: [USDC] })
+
+    expect(usdc.symbol).toBe('USDC')
   })
 
   it('formats sub-unit balances without precision loss', async () => {
@@ -70,10 +108,11 @@ describe('getEvmBalances', () => {
     mockReadContract
       .mockResolvedValueOnce(1_500_000n) // USDC balanceOf
       .mockResolvedValueOnce(6) // USDC decimals
-      .mockResolvedValueOnce('USDC') // USDC symbol
       .mockResolvedValueOnce(1_500_000_000_000_000_000n) // DAI balanceOf
       .mockResolvedValueOnce(18) // DAI decimals
-      .mockResolvedValueOnce('DAI') // DAI symbol
+    mockCall
+      .mockResolvedValueOnce({ data: encodeSymbolString('USDC') }) // USDC symbol
+      .mockResolvedValueOnce({ data: encodeSymbolString('DAI') }) // DAI symbol
 
     const [, usdc, dai] = await getEvmBalances('Ethereum', { address: HOLDER, tokens: [USDC, DAI] })
 
@@ -95,7 +134,7 @@ describe('getEvmBalances', () => {
     mockReadContract
       .mockResolvedValueOnce(123n) // balanceOf ok
       .mockRejectedValueOnce(new Error('execution reverted')) // decimals reverts
-      .mockResolvedValueOnce('???')
+    mockCall.mockResolvedValueOnce({ data: encodeSymbolString('???') })
 
     await expect(getEvmBalances('Ethereum', { address: HOLDER, tokens: [USDC] })).rejects.toThrow('execution reverted')
   })


### PR DESCRIPTION
Closes #1946

## what
`getEvmBalances()` rejected the whole balance read (native + every requested token, not just the offender) whenever a requested ERC-20 returned `symbol()` as a raw right-padded bytes32 instead of the canonical ABI `string`. MKR is the classic example - it predates the ABI-string convention and has never migrated.

## why
`symbol()` went through viem's typed `readContract()` against `erc20Abi`, which decodes strictly as a `string`. A bytes32 return doesn't decode as a `string`, so viem throws, `Promise.all()` rejects, and the caller gets nothing back for a wallet that happens to hold MKR (or SAI, or any other bytes32-symbol legacy token).

## how
`symbol()` now goes through a raw `eth_call` and tries the ABI-string decode first, falling back to bytes32 decoding (right-null-trimmed) on failure. Same tolerant pattern already established in `resolveContract()` (`packages/sdk/src/tools/token/resolveContract.ts`) and the Uniswap ERC-20 readers (`packages/sdk/src/tools/dex/_erc20.ts`) - kept it self-contained in `balanceEvm.ts` rather than importing from `dex/` to avoid introducing the first `evm -> dex` reverse dependency in the tools layer.

`balanceOf`/`decimals` are untouched - those are `uint256`/`uint8`, not affected by the legacy-string issue.

## test plan
- New regression test: MKR-shaped bytes32 `symbol()` return decodes to `'MKR'` instead of throwing.
- New test confirming standard string-returning `symbol()` (USDC) is unaffected.
- Updated existing tests to mock the raw `eth_call` path instead of `readContract` for symbol.
- `yarn workspace @vultisig/sdk vitest run tests/unit/tools/evm/balanceEvm.test.ts` - 8/8 pass
- `yarn workspace @vultisig/sdk vitest run tests/unit/tools/evm tests/unit/tools/dex tests/unit/tools/token` - 102/102 pass
- `npx tsc --project .config/tsconfig.json --noEmit` - clean
- eslint + prettier on touched files - clean
- `yarn npm audit --recursive --all --severity high` - clean, no lockfile changes

Risk: low, additive decode fallback isolated to `getEvmBalances()`'s ERC-20 symbol read.