### PR TITLE
fix: sync supportedIbcDestinationsFrom source-chain acceptance with prepareIbcTransfer

### DIFF
--- a/.changeset/ibc-canonical-names-sync.md
+++ b/.changeset/ibc-canonical-names-sync.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Fix `supportedIbcDestinationsFrom()` rejecting canonical Vultisig chain names (`Osmosis`, `Cosmos`, etc.) that `prepareIbcTransfer()` already accepts for the same `fromChain` input. Both entry points now route the source chain through `normaliseIbcChainId()`, so route discovery and transfer building agree on what counts as a valid source chain.

--- a/packages/sdk/src/tools/prep/ibcTransfer.ts
+++ b/packages/sdk/src/tools/prep/ibcTransfer.ts
@@ -128,10 +128,17 @@ function resolveSourceChannelByDestChain(fromChain: string, toChainId: string): 
   return IBC_CHANNEL_BY_ROUTE.get(`${fromChain}→${toChainId}`) ?? null
 }
 
-/** Supported destination chain-IDs reachable FROM the given source chain. */
+/**
+ * Supported destination chain-IDs reachable FROM the given source chain.
+ * Accepts both Vultisig canonical names ("Osmosis") and plain IBC chain-IDs
+ * ("osmosis-1") — normalised through the same `normaliseIbcChainId()` alias
+ * table `prepareIbcTransfer()` uses, so the two functions never disagree on
+ * what counts as a valid source chain for the same input.
+ */
 export function supportedIbcDestinationsFrom(fromChain: string): string[] {
+  const normalised = normaliseIbcChainId(fromChain)
   return Array.from(IBC_CHANNEL_BY_ROUTE.keys())
-    .filter(routeKey => routeKey.startsWith(`${fromChain}→`))
+    .filter(routeKey => routeKey.startsWith(`${normalised}→`))
     .map(routeKey => routeKey.split('→')[1]!)
     .sort()
 }

--- a/packages/sdk/tests/unit/cosmos/ibcTransfer.test.ts
+++ b/packages/sdk/tests/unit/cosmos/ibcTransfer.test.ts
@@ -286,4 +286,24 @@ describe('prepareIbcTransfer', () => {
     expect(dests).toContain('noble-1')
     expect(dests).toEqual([...dests].sort())
   })
+
+  it('supportedIbcDestinationsFrom accepts canonical Vultisig names, matching the chain-ID result', () => {
+    expect(supportedIbcDestinationsFrom('Osmosis')).toEqual(supportedIbcDestinationsFrom('osmosis-1'))
+    expect(supportedIbcDestinationsFrom('Cosmos')).toEqual(supportedIbcDestinationsFrom('cosmoshub-4'))
+    expect(supportedIbcDestinationsFrom('Osmosis')).toContain('cosmoshub-4')
+    expect(supportedIbcDestinationsFrom('Cosmos')).toContain('osmosis-1')
+  })
+
+  it('agrees with prepareIbcTransfer on which canonical source names resolve to a route', () => {
+    // Cross-consistency guard: every canonical name that prepareIbcTransfer
+    // resolves to a chain-ID with at least one route must also be recognised
+    // by supportedIbcDestinationsFrom for that same canonical input — catches
+    // future drift between the two entry points.
+    for (const name of ['Cosmos', 'Osmosis', 'Terra', 'TerraClassic', 'Kujira', 'Akash', 'Noble', 'Dydx', 'Stride']) {
+      const chainId = normaliseIbcChainId(name)
+      const byChainId = supportedIbcDestinationsFrom(chainId)
+      const byCanonicalName = supportedIbcDestinationsFrom(name)
+      expect(byCanonicalName).toEqual(byChainId)
+    }
+  })
 })


### PR DESCRIPTION
Closes #1917

## what

`supportedIbcDestinationsFrom()` filtered route keys against the raw `fromChain` string, so canonical Vultisig chain names like `"Osmosis"` and `"Cosmos"` returned an empty destination list even though `prepareIbcTransfer()` already normalizes those same aliases through `normaliseIbcChainId()` and builds the transfer successfully.

## why

Two functions that both accept a "source chain" parameter drifted apart on what counts as a valid input for that parameter. A consumer using `supportedIbcDestinationsFrom()` to populate a destination picker (the documented use case) got either pushed into re-implementing alias normalization locally, or shown an incomplete/empty route list for a chain that `prepareIbcTransfer()` handles fine.

## how

Route `fromChain` through the existing `normaliseIbcChainId()` helper inside `supportedIbcDestinationsFrom()` before filtering `IBC_CHANNEL_BY_ROUTE`, mirroring what `prepareIbcTransfer()` already does. Single source of truth for source-chain normalization, no new alias table.

## tests

- `supportedIbcDestinationsFrom('Osmosis')` now equals `supportedIbcDestinationsFrom('osmosis-1')` (same for `Cosmos`/`cosmoshub-4`)
- Cross-consistency regression test: for every canonical Vultisig name, `supportedIbcDestinationsFrom(name)` matches `supportedIbcDestinationsFrom(normaliseIbcChainId(name))` — catches future drift between the two entry points
- Full existing suite still green (16 pre-existing + 2 new = 18 passing)

## verification

- `yarn workspace @vultisig/sdk vitest run packages/sdk/tests/unit/cosmos/ibcTransfer.test.ts` — 18/18 pass
- `yarn typecheck` — 2 pre-existing failures in `packages/core/mpc/keysign/signingInputs/resolvers/cardano.ts` / `compileTx.golden.test.ts` (unrelated `ISigningInput.auxiliaryData` type gap, confirmed present on `main` via `git stash`, not touched by this PR)
- `node_modules/.bin/eslint` + `node_modules/.bin/prettier --check` on both touched files — clean
- `yarn npm audit --recursive --all --severity high` — clean, no lockfile changes
- Changeset added: `@vultisig/sdk` patch

🤖 Agent-generated