### PR TITLE
fix(tron): bound trc-20 fee_limit to protobuf int64

### DIFF
--- a/.changeset/fix-tron-fee-limit-int64-bound.md
+++ b/.changeset/fix-tron-fee-limit-int64-bound.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Fix Tron `fee_limit` silently corrupting above protobuf `int64` range. `prepareTrc20TransferFromKeys` and `buildTrc20TransferTx` accepted any positive `feeLimitSun` / `feeLimit`, and `encodeInt64Varint` passed values >= 2^63 straight to the unsigned varint encoder - so the bytes a node decodes back were a different number entirely (2^63 read back as `-9223372036854775808`, 2^70 read back as `0`, the latter silently re-entering the zero-fee_limit `OUT_OF_ENERGY` case the `> 0` guard exists to prevent). All three now fail closed at the int64 bound; `int64` max itself remains valid and round-trips unchanged.

--- a/packages/sdk/src/chains/tron/proto.ts
+++ b/packages/sdk/src/chains/tron/proto.ts
@@ -38,6 +38,10 @@ export function encodeVarint(value: number | bigint): Uint8Array {
   return new Uint8Array(bytes)
 }
 
+/** Inclusive bounds of a protobuf `int64`. */
+export const INT64_MAX = (1n << 63n) - 1n
+export const INT64_MIN = -(1n << 63n)
+
 /**
  * Protobuf int64 varint — two's-complement encoding for negatives.
  *
@@ -47,8 +51,19 @@ export function encodeVarint(value: number | bigint): Uint8Array {
  * reinterpreting a negative int64 as uint64 always leaves bit 63 set, and
  * a varint for a value ≥ 2^63 always takes 10 bytes (9 continuation bytes
  * + 1 final byte with the high bit of the original 64-bit integer).
+ *
+ * sdk#1828: an `int64` field must actually fit in an int64. A positive value
+ * >= 2^63 used to fall straight through to `encodeVarint`, which happily emits
+ * its UNSIGNED varint — and the node decodes those same bytes back as a SIGNED
+ * 64-bit integer. `2^63` comes back as `-9223372036854775808`; `2^70` comes
+ * back as `0`. Every caller here encodes a value-adjacent field (amount,
+ * fee_limit, expiration, timestamp), so emitting bytes that do not mean what
+ * the caller asked for is never the right answer. Fail closed at the encoder.
  */
 export function encodeInt64Varint(value: bigint): Uint8Array {
+  if (value > INT64_MAX || value < INT64_MIN) {
+    throw new Error(`encodeInt64Varint: value does not fit in an int64, got ${value}`)
+  }
   if (value >= 0n) return encodeVarint(value)
   // Two's-complement mask — BigInt.asUintN(64, x) is mathematically
   // `x + 2^64` for negative x in [-2^63, -1]. Output is in [2^63, 2^64-1],

--- a/packages/sdk/src/chains/tron/tx.ts
+++ b/packages/sdk/src/chains/tron/tx.ts
@@ -49,7 +49,7 @@
 import { sha256 } from '@noble/hashes/sha2.js'
 import bs58check from 'bs58check'
 
-import { concatProtoBytes, fieldBytes, fieldInt64, fieldString, fieldVarint } from './proto'
+import { concatProtoBytes, fieldBytes, fieldInt64, fieldString, fieldVarint, INT64_MAX } from './proto'
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -456,6 +456,15 @@ export function buildTrc20TransferTx(opts: BuildTrc20TransferOptions): TronTxBui
   // broadcast.
   if (opts.feeLimit <= 0n) {
     throw new Error(`buildTrc20TransferTx: feeLimit must be > 0, got ${opts.feeLimit}`)
+  }
+  // sdk#1828: and it must fit in the protobuf int64 it is encoded into. Above
+  // that the varint the node decodes is a DIFFERENT number — 2^63 reads back
+  // as negative, 2^70 reads back as 0, which silently re-enters the exact
+  // zero-fee_limit OUT_OF_ENERGY case the check above exists to prevent.
+  if (opts.feeLimit > INT64_MAX) {
+    throw new Error(
+      `buildTrc20TransferTx: feeLimit must fit in an int64 (max ${INT64_MAX}), got ${opts.feeLimit}`
+    )
   }
   const callData = buildTrc20CallData(opts.to, opts.amount)
   const contractValue = buildTriggerSmartContract(opts.from, opts.tokenAddress, callData)

--- a/packages/sdk/src/chains/tron/tx.ts
+++ b/packages/sdk/src/chains/tron/tx.ts
@@ -462,9 +462,7 @@ export function buildTrc20TransferTx(opts: BuildTrc20TransferOptions): TronTxBui
   // as negative, 2^70 reads back as 0, which silently re-enters the exact
   // zero-fee_limit OUT_OF_ENERGY case the check above exists to prevent.
   if (opts.feeLimit > INT64_MAX) {
-    throw new Error(
-      `buildTrc20TransferTx: feeLimit must fit in an int64 (max ${INT64_MAX}), got ${opts.feeLimit}`
-    )
+    throw new Error(`buildTrc20TransferTx: feeLimit must fit in an int64 (max ${INT64_MAX}), got ${opts.feeLimit}`)
   }
   const callData = buildTrc20CallData(opts.to, opts.amount)
   const contractValue = buildTriggerSmartContract(opts.from, opts.tokenAddress, callData)

--- a/packages/sdk/src/tools/prep/trc20.ts
+++ b/packages/sdk/src/tools/prep/trc20.ts
@@ -58,6 +58,12 @@ export type UnsignedTrc20Transfer = {
 const DEFAULT_FEE_LIMIT_SUN = '100000000' // 100 TRX
 
 /**
+ * `fee_limit` is a protobuf `int64` on the Tron wire (raw_data field 18), so
+ * its ceiling is int64 max, not "any positive integer". sdk#1828.
+ */
+const TRON_FEE_LIMIT_MAX_SUN = (1n << 63n) - 1n
+
+/**
  * Vault-free, pure-crypto builder for an unsigned TRON TRC-20 transfer.
  *
  * Ported from the mcp-ts `build_trc20_transfer` tool so the SDK is the single
@@ -125,6 +131,14 @@ export const prepareTrc20TransferFromKeys = (params: PrepareTrc20TransferFromKey
     const feeBig = BigInt(feeLimitSun)
     if (feeBig <= 0n) {
       throw new Error(`prepareTrc20TransferFromKeys: feeLimitSun must be greater than zero, got ${feeLimitSun}`)
+    }
+    // sdk#1828: anything above int64 max serialises to bytes the node decodes
+    // as a DIFFERENT number (2^63 -> negative, 2^70 -> 0), so bound it here
+    // rather than emit a descriptor whose fee ceiling cannot survive the wire.
+    if (feeBig > TRON_FEE_LIMIT_MAX_SUN) {
+      throw new Error(
+        `prepareTrc20TransferFromKeys: feeLimitSun must fit in an int64 (max ${TRON_FEE_LIMIT_MAX_SUN}), got ${feeLimitSun}`
+      )
     }
     canonicalFeeLimit = feeBig.toString()
   }

--- a/packages/sdk/tests/unit/chains/tron-tx.test.ts
+++ b/packages/sdk/tests/unit/chains/tron-tx.test.ts
@@ -82,6 +82,22 @@ describe('tron / encodeInt64Varint', () => {
     expect(enc.length).toBe(10)
     expect(enc[9]).toBe(0x01)
   })
+
+  it('refuses values that do not fit in an int64 (sdk#1828)', () => {
+    const max = (1n << 63n) - 1n
+    const min = -(1n << 63n)
+
+    // Both inclusive bounds stay encodable.
+    expect(() => encodeInt64Varint(max)).not.toThrow()
+    expect(() => encodeInt64Varint(min)).not.toThrow()
+
+    // One past either bound used to encode SILENTLY: 2^63 emitted the unsigned
+    // varint, which a node decodes back as -9223372036854775808, and 2^70
+    // decoded back as 0. Corrupting a value-adjacent field must fail closed.
+    expect(() => encodeInt64Varint(max + 1n)).toThrow(/does not fit in an int64/)
+    expect(() => encodeInt64Varint(1n << 70n)).toThrow(/does not fit in an int64/)
+    expect(() => encodeInt64Varint(min - 1n)).toThrow(/does not fit in an int64/)
+  })
 })
 
 describe('tron / buildTronSendTx', () => {
@@ -193,6 +209,31 @@ describe('tron / buildTrc20TransferTx', () => {
         timestamp: 1_699_999_940_000n,
       })
     ).toThrow(/feeLimit must be > 0/)
+  })
+
+  it('rejects a feeLimit above protobuf int64 max (sdk#1828)', () => {
+    const INT64_MAX = (1n << 63n) - 1n
+    const build = (feeLimit: bigint) =>
+      buildTrc20TransferTx({
+        from: FROM,
+        to: TO,
+        tokenAddress: USDT,
+        amount: 1n,
+        feeLimit,
+        refBlockBytes: REF_BLOCK_BYTES,
+        refBlockHash: REF_BLOCK_HASH,
+        expiration: 1_700_000_000_000n,
+        timestamp: 1_699_999_940_000n,
+      })
+
+    // int64 max is legal and the field survives serialisation unchanged.
+    expect(() => build(INT64_MAX)).not.toThrow()
+
+    // Above it, the emitted varint decodes to a different number entirely
+    // (2^63 -> negative, 2^70 -> 0). Fail closed rather than sign a tx whose
+    // fee ceiling is not the one the caller asked for.
+    expect(() => build(INT64_MAX + 1n)).toThrow(/feeLimit must fit in an int64/)
+    expect(() => build(1n << 70n)).toThrow(/feeLimit must fit in an int64/)
   })
 })
 

--- a/packages/sdk/tests/unit/prepareTrc20TransferFromKeys.test.ts
+++ b/packages/sdk/tests/unit/prepareTrc20TransferFromKeys.test.ts
@@ -179,6 +179,36 @@ describe('prepareTrc20TransferFromKeys', () => {
     ).toThrow(/feeLimitSun must be a plain decimal/)
   })
 
+  it('rejects a feeLimitSun above protobuf int64 max (sdk#1828)', () => {
+    const INT64_MAX = (1n << 63n) - 1n
+
+    // int64 max itself is legal and must still round-trip.
+    expect(
+      prepareTrc20TransferFromKeys({
+        contractAddress: USDT_CONTRACT,
+        from: FROM,
+        to: TO,
+        amount: '1',
+        feeLimitSun: INT64_MAX.toString(),
+      }).feeLimitSun
+    ).toBe(INT64_MAX.toString())
+
+    // One past it encodes to a varint the node reads back as NEGATIVE, and
+    // 2^70 reads back as 0 (silently re-entering the OUT_OF_ENERGY case the
+    // "> 0" guard exists to prevent). Both must fail closed here instead.
+    for (const over of [INT64_MAX + 1n, 1n << 70n]) {
+      expect(() =>
+        prepareTrc20TransferFromKeys({
+          contractAddress: USDT_CONTRACT,
+          from: FROM,
+          to: TO,
+          amount: '1',
+          feeLimitSun: over.toString(),
+        })
+      ).toThrow(/feeLimitSun must fit in an int64/)
+    }
+  })
+
   it('canonicalizes a valid feeLimitSun', () => {
     const tx = prepareTrc20TransferFromKeys({
       contractAddress: USDT_CONTRACT,


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#1828

## what

`fee_limit` is a protobuf `int64` on the Tron wire (`raw_data` field 18), but nothing
enforced that bound. The issue reported that oversized values were merely "accepted" -
driving it at runtime showed it is worse than that: the emitted bytes decode back as a
**different number**.

`encodeInt64Varint` handed any non-negative value straight to `encodeVarint`, which emits
the UNSIGNED varint. The node decodes the same bytes as a SIGNED int64:

| `feeLimit` in | what the node reads back |
|---|---|
| `2^63 - 1` (int64 max) | `9223372036854775807` - faithful |
| `2^63` | **`-9223372036854775808`** - a negative fee ceiling |
| `2^70` | **`0`** |

That last row is the sharp one: a zero `fee_limit` is exactly the `OUT_OF_ENERGY` case the
existing `feeLimit > 0` guard in `buildTrc20TransferTx` was written to prevent, and
overflow walks straight back into it while passing that guard.

## how

Fail closed at all three layers, so the error names the parameter the caller actually
passed:

- `encodeInt64Varint` - root cause. Rejects anything outside `[INT64_MIN, INT64_MAX]`
  instead of emitting bytes that do not mean what the caller asked for.
- `buildTrc20TransferTx` - `feeLimit` ceiling next to the existing `> 0` check.
- `prepareTrc20TransferFromKeys` - `feeLimitSun` ceiling next to the existing positive check.

`int64` max itself stays valid and still round-trips byte-identically, so no legitimate
caller changes behaviour.

## receipts

Pure offline crypto - no HTTP surface, so no curl transcript applies. Receipt is a runtime
transcript against the real modules via `tsx`, driven by temporary uncommitted QA
instrumentation (`packages/sdk/qa-trc20-repro.ts`, deleted before commit - not in this
diff). It builds the tx and then **re-decodes field 18 back out of the raw_data hex** to
show what a node would actually read.

**BEFORE (on main):**

```
--- prepareTrc20TransferFromKeys(feeLimitSun = <n>) ---
int64 max       -> ACCEPTED, descriptor.feeLimitSun = 9223372036854775807
int64 max + 1   -> ACCEPTED, descriptor.feeLimitSun = 9223372036854775808
2^70            -> ACCEPTED, descriptor.feeLimitSun = 1180591620717411303424

--- buildTrc20TransferTx(feeLimit = <n>) and what the wire bytes MEAN ---
int64 max       -> BUILT | wire uint=9223372036854775807 | as int64=9223372036854775807 | faithful
int64 max + 1   -> BUILT | wire uint=9223372036854775808 | as int64=-9223372036854775808 | CORRUPTED -> node reads -9223372036854775808
2^70            -> BUILT | wire uint=1180591620717411303424 | as int64=0 | CORRUPTED -> node reads 0
```

**AFTER (this branch):**

```
--- prepareTrc20TransferFromKeys(feeLimitSun = <n>) ---
int64 max       -> ACCEPTED, descriptor.feeLimitSun = 9223372036854775807
int64 max + 1   -> rejected: prepareTrc20TransferFromKeys: feeLimitSun must fit in an int64 (max 9223372036854775807), got 9223372036854775808
2^70            -> rejected: prepareTrc20TransferFromKeys: feeLimitSun must fit in an int64 (max 9223372036854775807), got 1180591620717411303424

--- buildTrc20TransferTx(feeLimit = <n>) and what the wire bytes MEAN ---
int64 max       -> BUILT | wire uint=9223372036854775807 | as int64=9223372036854775807 | faithful
int64 max + 1   -> rejected: buildTrc20TransferTx: feeLimit must fit in an int64 (max 9223372036854775807), got 9223372036854775808
2^70            -> rejected: buildTrc20TransferTx: feeLimit must fit in an int64 (max 9223372036854775807), got 1180591620717411303424
```

**The 3 new tests are not vacuous** - reverting only the src changes fails exactly them:

```
 × rejects a feeLimitSun above protobuf int64 max (sdk#1828)
 × refuses values that do not fit in an int64 (sdk#1828)
 × rejects a feeLimit above protobuf int64 max (sdk#1828)
      Tests  3 failed | 72 passed (75)
```

**Full SDK unit suite + lint, green on this branch:**

```
$ yarn workspace @vultisig/sdk test:unit
 Test Files  220 passed (220)
      Tests  3397 passed (3397)

$ yarn lint
exit 0
```

Notably the byte-parity tests that cross-check our encoder against WalletCore's own output
are in that suite and still pass, so the new bound does not move any real-world encoding.

## notes for the reviewer

- **Scope call worth challenging:** the issue's fix sketch asked only for ceilings in the
  two TRC-20 entry points. I also bounded `encodeInt64Varint` itself, because that is the
  actual root cause and the same corruption is reachable through every other `int64` field
  it encodes (`amount`, `expiration`, `timestamp`, `call_value`). It fails closed and the
  full suite is green, but if you would rather keep this PR to the two TRC-20 guards, say
  so and I will split the encoder bound into its own PR.
- **`yarn typecheck` passes on this branch (exit 0).** An earlier revision of this PR
  body reported it failing with `Cannot find module '@vultisig/sdk'`; that was only a
  missing build step on my checkout, not a real failure. After `yarn build:shared`,
  `build:sdk:bundle`, `build:client-shared` and `build:rujira`, typecheck is clean.
- No emulator screenshot: pure library function with no user-facing surface, and the
  `vultiagent-app` debug build is currently blocked on an expired `TRUSTWALLET_PAT`
  (`com.trustwallet:wallet-core` 401s from GitHub Packages).

