### PR TITLE
fix(polkadot): bound asset-send amount to u128

### DIFF
--- a/.changeset/fix-polkadot-asset-amount-u128-bound.md
+++ b/.changeset/fix-polkadot-asset-amount-u128-bound.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Fix `preparePolkadotAssetSend` accepting an `amount` above `u128`. `pallet_assets.transferKeepAlive` encodes `amount` as a `u128`, but only a `> 0` check was applied - past `2^128-1` `compactToU8a` silently switches to compact big-integer mode and emits a payload wider than the slot the runtime decodes, so the on-device signer would sign a call body that cannot execute. Now bounded at `2^128-1`, mirroring the existing `ASSET_ID_MAX` guard in the same builder.

--- a/packages/sdk/src/tools/prep/polkadotAssetSend.ts
+++ b/packages/sdk/src/tools/prep/polkadotAssetSend.ts
@@ -43,6 +43,19 @@ const METHOD_TRANSFER_KEEP_ALIVE = 2
 const ASSET_ID_MAX = 0x3fffffff // 2^30 - 1, the largest non-big-integer compact
 
 /**
+ * `pallet_assets.transferKeepAlive` takes its `amount` as a `u128` (the
+ * pallet's `Balance` type), so that is the real ceiling of the field.
+ *
+ * sdk#1827: `compactToU8a` does NOT stop at u128 — past that it silently
+ * switches to compact big-integer mode and happily produces a 17+ byte payload
+ * for a slot the runtime decodes as a 16-byte u128. The resulting call body is
+ * not a decodable `transferKeepAlive`, so the on-device signer would be signing
+ * bytes that cannot execute. Same failure class the ASSET_ID_MAX guard above
+ * already covers for the asset id.
+ */
+const AMOUNT_MAX = (1n << 128n) - 1n
+
+/**
  * SS58 address-prefix for Polkadot relay chain + Asset Hub. Substrate chains
  * (Bittensor prefix=42 → `5xxx`, Kusama prefix=2 → `H/J`, Acala prefix=10 →
  * `2xxx`, etc.) all share the same 32-byte AccountId under different SS58
@@ -176,6 +189,13 @@ export const preparePolkadotAssetSend = (params: PreparePolkadotAssetSendParams)
   }
   if (amount <= 0n) {
     throw new Error('Amount must be greater than zero')
+  }
+  if (amount > AMOUNT_MAX) {
+    throw new Error(
+      `Invalid Polkadot asset amount ${amount}: must be <= ${AMOUNT_MAX} (2^128-1). ` +
+        `pallet_assets encodes amount as a u128; larger values SCALE-encode in compact ` +
+        `big-integer mode and do not decode back as a valid transferKeepAlive call.`
+    )
   }
   if (!from) {
     throw new Error('Sender address (from) is required')

--- a/packages/sdk/tests/unit/preparePolkadotAssetSend.test.ts
+++ b/packages/sdk/tests/unit/preparePolkadotAssetSend.test.ts
@@ -105,6 +105,23 @@ describe('preparePolkadotAssetSend', () => {
     )
   })
 
+  it('rejects an amount above u128, which pallet_assets cannot decode (sdk#1827)', () => {
+    const U128_MAX = (1n << 128n) - 1n
+
+    // u128 max is a legal Balance and must still build.
+    const ok = preparePolkadotAssetSend({ assetId: 1984, from: BOB, to: ALICE, amount: U128_MAX })
+    expect(ok.amount).toBe(U128_MAX.toString())
+
+    // Past it, compactToU8a silently switches to big-integer mode and emits a
+    // payload wider than the u128 slot the runtime decodes — the same failure
+    // class the assetId ceiling above already guards against.
+    for (const over of [U128_MAX + 1n, 1n << 200n]) {
+      expect(() => preparePolkadotAssetSend({ assetId: 1984, from: BOB, to: ALICE, amount: over })).toThrow(
+        /Invalid Polkadot asset amount/
+      )
+    }
+  })
+
   it('rejects non-u32 / non-positive asset ids', () => {
     expect(() => preparePolkadotAssetSend({ assetId: 0, from: BOB, to: ALICE, amount: 1n })).toThrow(
       /Invalid Polkadot asset id/


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#1827

## what

`pallet_assets.transferKeepAlive` takes its `amount` as a `u128` (the pallet's `Balance`
type), but `preparePolkadotAssetSend` only enforced `amount > 0`.

`compactToU8a` does not stop at u128. Past `2^128-1` it silently switches to **compact
big-integer mode** and happily emits a payload wider than the 16-byte slot the runtime
decodes - so the builder returns a `callHex` that is not a decodable `transferKeepAlive`,
and the on-device signer would be signing bytes that cannot execute.

This is the same failure class the file **already guards against for the asset id**
(`ASSET_ID_MAX = 2^30-1`, whose comment says outright that big-integer-mode compacts are
"what the on-device signer refuses to sign"). The amount just never got the parallel bound.

## how

Bound `amount` at `2^128-1` next to the existing `> 0` check, with an error that names the
pallet type. `u128` max itself stays valid and still builds.

## receipts

Pure offline SCALE encoding - no HTTP surface, so no curl transcript applies. Receipt is a
runtime transcript against the real builder via `tsx`, driven by temporary uncommitted QA
instrumentation (`packages/sdk/qa-polkadot-repro.ts`, deleted before commit - not in this
diff). It builds the call and then **decodes the trailing compact back out of `callHex`**
to show the encoder really did go wide.

**BEFORE (on main):**

```
--- preparePolkadotAssetSend({ amount }) ---
1 USDT         -> ACCEPTED | callHex 82 hex chars  | legal u128
u128 max       -> ACCEPTED | callHex 108 hex chars | legal u128
u128 max + 1   -> ACCEPTED | callHex 110 hex chars | OVER u128 - signer/runtime decodes this field as u128, encoded 340282366920938463463374607431768211456
2^200          -> ACCEPTED | callHex 128 hex chars | OVER u128 - signer/runtime decodes this field as u128, encoded 1606938044258990275541962092341162602522202993782792835301376
```

Note the widening `callHex`: 108 hex chars at u128 max, 110 one past it, 128 at 2^200.
The amount field is physically outgrowing its slot.

**AFTER (this branch):**

```
--- preparePolkadotAssetSend({ amount }) ---
1 USDT         -> ACCEPTED | callHex 82 hex chars  | legal u128
u128 max       -> ACCEPTED | callHex 108 hex chars | legal u128
u128 max + 1   -> rejected: Invalid Polkadot asset amount 340282366920938463463374607431768211456: must be <= 340282366920938463463374607431768211455 (2^128-1). pallet_assets encodes amount as a u128; larger values SCALE-encode in compact big-integer mode and do not decode back as a valid transferKeepAlive call.
2^200          -> rejected: Invalid Polkadot asset amount 1606938044258990275541962092341162602522202993782792835301376: must be <= 340282366920938463463374607431768211455 (2^128-1). ...
```

**The new test is not vacuous** - reverting only the src change fails exactly it:

```
 × rejects an amount above u128, which pallet_assets cannot decode (sdk#1827)
      Tests  1 failed | 16 passed (17)
```

**Full SDK unit suite + lint, green on this branch:**

```
$ yarn workspace @vultisig/sdk test:unit
 Test Files  220 passed (220)
      Tests  3395 passed (3395)

$ yarn lint
exit 0
```

## notes for the reviewer

- **`yarn typecheck` passes on this branch (exit 0).** An earlier revision of this PR
  body reported it failing with `Cannot find module '@vultisig/sdk'`; that was only a
  missing build step on my checkout, not a real failure. After `yarn build:shared`,
  `build:sdk:bundle`, `build:client-shared` and `build:rujira`, typecheck is clean.
- Sibling to #1970 (Tron `fee_limit` int64 bound) - same "the prep layer never enforced the
  wire type's own range" shape, different chain. They touch disjoint files.
- No emulator screenshot: pure library function with no user-facing surface, and the
  `vultiagent-app` debug build is currently blocked on an expired `TRUSTWALLET_PAT`
  (`com.trustwallet:wallet-core` 401s from GitHub Packages).

