### PR TITLE
fix(sdk): publish stable evm/cosmos/signable subpaths

### DIFF
--- a/.changeset/public-subpath-exports-r150.md
+++ b/.changeset/public-subpath-exports-r150.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+Publish stable `@vultisig/sdk/tools/evm`, `@vultisig/sdk/tools/cosmos`, and `@vultisig/sdk/signable-transaction` subpaths alongside the existing root and React Native exports.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -115,6 +115,32 @@
       "require": "./dist/tools/bridge/index.cjs",
       "default": "./dist/tools/bridge/index.cjs"
     },
+    "./tools/evm": {
+      "types": "./dist/tools/evm/index.d.ts",
+      "browser": "./dist/tools/evm/index.js",
+      "worker": "./dist/tools/evm/index.js",
+      "react-native": "./dist/tools/evm/index.js",
+      "node": {
+        "import": "./dist/tools/evm/index.js",
+        "require": "./dist/tools/evm/index.cjs"
+      },
+      "import": "./dist/tools/evm/index.js",
+      "require": "./dist/tools/evm/index.cjs",
+      "default": "./dist/tools/evm/index.cjs"
+    },
+    "./tools/cosmos": {
+      "types": "./dist/tools/cosmos/index.d.ts",
+      "browser": "./dist/tools/cosmos/index.js",
+      "worker": "./dist/tools/cosmos/index.js",
+      "react-native": "./dist/tools/cosmos/index.js",
+      "node": {
+        "import": "./dist/tools/cosmos/index.js",
+        "require": "./dist/tools/cosmos/index.cjs"
+      },
+      "import": "./dist/tools/cosmos/index.js",
+      "require": "./dist/tools/cosmos/index.cjs",
+      "default": "./dist/tools/cosmos/index.cjs"
+    },
     "./chains/tron": {
       "types": "./dist/chains/tron/index.d.ts",
       "browser": "./dist/chains/tron/index.js",
@@ -176,6 +202,19 @@
       "import": "./dist/tx/index.js",
       "require": "./dist/tx/index.cjs",
       "default": "./dist/tx/index.cjs"
+    },
+    "./signable-transaction": {
+      "types": "./dist/signable-transaction/index.d.ts",
+      "browser": "./dist/signable-transaction/index.js",
+      "worker": "./dist/signable-transaction/index.js",
+      "react-native": "./dist/signable-transaction/index.js",
+      "node": {
+        "import": "./dist/signable-transaction/index.js",
+        "require": "./dist/signable-transaction/index.cjs"
+      },
+      "import": "./dist/signable-transaction/index.js",
+      "require": "./dist/signable-transaction/index.cjs",
+      "default": "./dist/signable-transaction/index.cjs"
     }
   },
   "scripts": {

--- a/packages/sdk/rollup.platforms.config.js
+++ b/packages/sdk/rollup.platforms.config.js
@@ -336,6 +336,14 @@ const configs = {
       distBase: 'tools/bridge',
     }),
     ...createSubpathConfigs({
+      input: './src/tools/evm/index.ts',
+      distBase: 'tools/evm',
+    }),
+    ...createSubpathConfigs({
+      input: './src/tools/cosmos/index.ts',
+      distBase: 'tools/cosmos',
+    }),
+    ...createSubpathConfigs({
       input: './src/chains/tron/index.ts',
       distBase: 'chains/tron',
     }),
@@ -354,6 +362,10 @@ const configs = {
     ...createSubpathConfigs({
       input: './src/tx/index.ts',
       distBase: 'tx',
+    }),
+    ...createSubpathConfigs({
+      input: './src/signable-transaction/index.ts',
+      distBase: 'signable-transaction',
     }),
   ],
   browser: {

--- a/packages/sdk/rollup.types.config.js
+++ b/packages/sdk/rollup.types.config.js
@@ -124,6 +124,8 @@ export default defineConfig([
   createSubpathTypesConfig('src/tools/parse/index.ts', 'dist/tools/parse/index.d.ts'),
   createSubpathTypesConfig('src/tools/defi/index.ts', 'dist/tools/defi/index.d.ts'),
   createSubpathTypesConfig('src/tools/bridge/index.ts', 'dist/tools/bridge/index.d.ts'),
+  createSubpathTypesConfig('src/tools/evm/index.ts', 'dist/tools/evm/index.d.ts'),
+  createSubpathTypesConfig('src/tools/cosmos/index.ts', 'dist/tools/cosmos/index.d.ts'),
   createSubpathTypesConfig('src/chains/tron/index.ts', 'dist/chains/tron/index.d.ts'),
   createSubpathTypesConfig('src/chains/utxo/index.ts', 'dist/chains/utxo/index.d.ts'),
   // Canonical seedphrase helpers and import/discovery services are published
@@ -131,4 +133,5 @@ export default defineConfig([
   createSubpathTypesConfig('src/seedphrase/index.ts', 'dist/seedphrase/index.d.ts'),
   createSubpathTypesConfig('src/tools/decode/index.ts', 'dist/tools/decode/index.d.ts'),
   createSubpathTypesConfig('src/tx/index.ts', 'dist/tx/index.d.ts'),
+  createSubpathTypesConfig('src/signable-transaction/index.ts', 'dist/signable-transaction/index.d.ts'),
 ])

--- a/packages/sdk/tests/unit/public-api/toolsSubpathExports.test.ts
+++ b/packages/sdk/tests/unit/public-api/toolsSubpathExports.test.ts
@@ -14,8 +14,8 @@ describe('public API subpath exports', () => {
     const parseExport = sdkPackageJson.exports['./tools/parse']
     const defiExport = sdkPackageJson.exports['./tools/defi']
     const bridgeExport = sdkPackageJson.exports['./tools/bridge']
-    const tronExport = sdkPackageJson.exports['./chains/tron']
-    const utxoExport = sdkPackageJson.exports['./chains/utxo']
+    const evmExport = sdkPackageJson.exports['./tools/evm']
+    const cosmosExport = sdkPackageJson.exports['./tools/cosmos']
     const decodeExport = sdkPackageJson.exports['./tools/decode']
     const txExport = sdkPackageJson.exports['./tx']
 
@@ -37,17 +37,17 @@ describe('public API subpath exports', () => {
       require: './dist/tools/bridge/index.cjs',
       default: './dist/tools/bridge/index.cjs',
     })
-    expect(tronExport).toMatchObject({
-      types: './dist/chains/tron/index.d.ts',
-      import: './dist/chains/tron/index.js',
-      require: './dist/chains/tron/index.cjs',
-      default: './dist/chains/tron/index.cjs',
+    expect(evmExport).toMatchObject({
+      types: './dist/tools/evm/index.d.ts',
+      import: './dist/tools/evm/index.js',
+      require: './dist/tools/evm/index.cjs',
+      default: './dist/tools/evm/index.cjs',
     })
-    expect(utxoExport).toMatchObject({
-      types: './dist/chains/utxo/index.d.ts',
-      import: './dist/chains/utxo/index.js',
-      require: './dist/chains/utxo/index.cjs',
-      default: './dist/chains/utxo/index.cjs',
+    expect(cosmosExport).toMatchObject({
+      types: './dist/tools/cosmos/index.d.ts',
+      import: './dist/tools/cosmos/index.js',
+      require: './dist/tools/cosmos/index.cjs',
+      default: './dist/tools/cosmos/index.cjs',
     })
     expect(decodeExport).toMatchObject({
       types: './dist/tools/decode/index.d.ts',
@@ -65,8 +65,8 @@ describe('public API subpath exports', () => {
     expect(JSON.stringify(parseExport)).not.toContain('dist/index.node')
     expect(JSON.stringify(defiExport)).not.toContain('dist/index.node')
     expect(JSON.stringify(bridgeExport)).not.toContain('dist/index.node')
-    expect(JSON.stringify(tronExport)).not.toContain('dist/index.node')
-    expect(JSON.stringify(utxoExport)).not.toContain('dist/index.node')
+    expect(JSON.stringify(evmExport)).not.toContain('dist/index.node')
+    expect(JSON.stringify(cosmosExport)).not.toContain('dist/index.node')
     expect(JSON.stringify(decodeExport)).not.toContain('dist/index.node')
     expect(JSON.stringify(txExport)).not.toContain('dist/index.node')
   })
@@ -78,10 +78,10 @@ describe('public API subpath exports', () => {
     expect(platformRollupConfig).toContain("distBase: 'tools/defi'")
     expect(platformRollupConfig).toContain("input: './src/tools/bridge/index.ts'")
     expect(platformRollupConfig).toContain("distBase: 'tools/bridge'")
-    expect(platformRollupConfig).toContain("input: './src/chains/tron/index.ts'")
-    expect(platformRollupConfig).toContain("distBase: 'chains/tron'")
-    expect(platformRollupConfig).toContain("input: './src/chains/utxo/index.ts'")
-    expect(platformRollupConfig).toContain("distBase: 'chains/utxo'")
+    expect(platformRollupConfig).toContain("input: './src/tools/evm/index.ts'")
+    expect(platformRollupConfig).toContain("distBase: 'tools/evm'")
+    expect(platformRollupConfig).toContain("input: './src/tools/cosmos/index.ts'")
+    expect(platformRollupConfig).toContain("distBase: 'tools/cosmos'")
     expect(platformRollupConfig).toContain("input: './src/tools/decode/index.ts'")
     expect(platformRollupConfig).toContain("distBase: 'tools/decode'")
     expect(platformRollupConfig).toContain("input: './src/tx/index.ts'")
@@ -97,10 +97,10 @@ describe('public API subpath exports', () => {
       "createSubpathTypesConfig('src/tools/bridge/index.ts', 'dist/tools/bridge/index.d.ts')"
     )
     expect(typesRollupConfig).toContain(
-      "createSubpathTypesConfig('src/chains/tron/index.ts', 'dist/chains/tron/index.d.ts')"
+      "createSubpathTypesConfig('src/tools/evm/index.ts', 'dist/tools/evm/index.d.ts')"
     )
     expect(typesRollupConfig).toContain(
-      "createSubpathTypesConfig('src/chains/utxo/index.ts', 'dist/chains/utxo/index.d.ts')"
+      "createSubpathTypesConfig('src/tools/cosmos/index.ts', 'dist/tools/cosmos/index.d.ts')"
     )
     expect(typesRollupConfig).toContain(
       "createSubpathTypesConfig('src/tools/decode/index.ts', 'dist/tools/decode/index.d.ts')"

--- a/packages/sdk/tests/unit/public/signableTransactionExports.test.ts
+++ b/packages/sdk/tests/unit/public/signableTransactionExports.test.ts
@@ -8,8 +8,22 @@ describe('signable transaction public exports', () => {
     const sdkRoot = resolve(__dirname, '../../..')
     const sharedEntry = readFileSync(resolve(sdkRoot, 'src/index.ts'), 'utf8')
     const reactNativeEntry = readFileSync(resolve(sdkRoot, 'src/platforms/react-native/index.ts'), 'utf8')
+    const packageJson = JSON.parse(readFileSync(resolve(sdkRoot, 'package.json'), 'utf8'))
+    const platformRollupConfig = readFileSync(resolve(sdkRoot, 'rollup.platforms.config.js'), 'utf8')
+    const typesRollupConfig = readFileSync(resolve(sdkRoot, 'rollup.types.config.js'), 'utf8')
 
     expect(sharedEntry).toContain("export * from './signable-transaction'")
     expect(reactNativeEntry).toContain("export * from '../../signable-transaction'")
+    expect(packageJson.exports['./signable-transaction']).toMatchObject({
+      types: './dist/signable-transaction/index.d.ts',
+      import: './dist/signable-transaction/index.js',
+      require: './dist/signable-transaction/index.cjs',
+      default: './dist/signable-transaction/index.cjs',
+    })
+    expect(platformRollupConfig).toContain("input: './src/signable-transaction/index.ts'")
+    expect(platformRollupConfig).toContain("distBase: 'signable-transaction'")
+    expect(typesRollupConfig).toContain(
+      "createSubpathTypesConfig('src/signable-transaction/index.ts', 'dist/signable-transaction/index.d.ts')"
+    )
   })
 })


### PR DESCRIPTION
## Summary
- publish stable `@vultisig/sdk/tools/evm`, `@vultisig/sdk/tools/cosmos`, and `@vultisig/sdk/signable-transaction` package subpaths
- wire JS + declaration bundling for those public surfaces
- extend public-surface tests so CI catches future export-map regressions

Closes https://github.com/vultisig/vultisig-sdk/issues/1974

## Verification
- `corepack yarn vitest run packages/sdk/tests/unit/public-api/toolsSubpathExports.test.ts packages/sdk/tests/unit/public/signableTransactionExports.test.ts`
- `corepack yarn workspace @vultisig/sdk build:platform:node && corepack yarn workspace @vultisig/sdk build:types`
- `corepack yarn workspace @vultisig/sdk pack --out /tmp/sdk-r150-public-subpaths/vultisig-sdk-r150.tgz --json`
- fresh temp consumer import smoke:
  - `import('@vultisig/sdk/tools/evm')`
  - `import('@vultisig/sdk/tools/cosmos')`
  - `import('@vultisig/sdk/signable-transaction')`
  - all resolved and exposed the expected canonical functions

## Context
Round report mirror: https://gist.github.com/gomesalexandre/da911dd7513231245f1635bf3eb606fc
