### PR TITLE
feat(stakekit): export the action preflight validators publicly

### DIFF
--- a/.changeset/feat-export-stakekit-action-validators.md
+++ b/.changeset/feat-export-stakekit-action-validators.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': minor
+---
+
+Export `validateStakekitActionAddress` and `validateStakekitActionInput` from the public SDK surfaces (root, `tools`, and the React Native entry). Both are pure canonicals already used internally by the StakeKit builders and already test-covered, but they were stranded inside the module - so consumers kept re-declaring the same address/amount preflight rules after the SDK had ported them.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1041,6 +1041,8 @@ export {
   token,
   TRC20_TRANSFER_SELECTOR,
   utxoFeeRate,
+  validateStakekitActionAddress,
+  validateStakekitActionInput,
   VerifierClient,
 } from './tools'
 

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -489,6 +489,8 @@ export {
   stakekitBuildManage,
   stakekitDetails,
   stakekitSearch,
+  validateStakekitActionAddress,
+  validateStakekitActionInput,
 } from '../../tools/defi/stakekit'
 export type {
   BuildThreeJaneSupplyUsdcParams,

--- a/packages/sdk/src/tools/index.ts
+++ b/packages/sdk/src/tools/index.ts
@@ -294,6 +294,8 @@ export {
   stakekitDetails,
   stakekitSearch,
   stripChainPrefix,
+  validateStakekitActionAddress,
+  validateStakekitActionInput,
 } from './defi'
 
 // Verifier client

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -312,6 +312,9 @@ describe('RN entry exposes pure chain helpers and registry', () => {
     expect(rn.parseActionDisplay).toBe(stakekit.parseActionDisplay)
     expect(rn.buildYieldActionScanRequest).toBe(stakekit.buildYieldActionScanRequest)
     expect(rn.buildYieldStepScanRequest).toBe(stakekit.buildYieldStepScanRequest)
+    // sdk#1902: the action preflight validators belong to the same canonical set.
+    expect(rn.validateStakekitActionAddress).toBe(stakekit.validateStakekitActionAddress)
+    expect(rn.validateStakekitActionInput).toBe(stakekit.validateStakekitActionInput)
   })
 })
 

--- a/packages/sdk/tests/unit/public/stakekitValidatorExports.test.ts
+++ b/packages/sdk/tests/unit/public/stakekitValidatorExports.test.ts
@@ -1,0 +1,52 @@
+/**
+ * sdk#1902: the StakeKit action preflight validators are pure SDK canonicals and are
+ * already used internally by the builders, but they were stranded inside the module —
+ * absent from every public entrypoint. Downstream consumers therefore re-declared the
+ * same address/amount rules even after the SDK owned them.
+ *
+ * Identity assertions (`toBe`, not `typeof`) so a re-implementation on any surface —
+ * rather than a re-export of the one canonical — fails here.
+ *
+ * The react-native entry is asserted in tests/unit/platforms/react-native/entry.test.ts
+ * instead: importing it needs that suite's RN module harness, which a plain node test
+ * environment does not provide.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { validateStakekitActionAddress, validateStakekitActionInput } from '@/index'
+import {
+  validateStakekitActionAddress as addressFromStakekit,
+  validateStakekitActionInput as inputFromStakekit,
+} from '@/tools/defi/stakekit'
+import {
+  validateStakekitActionAddress as addressFromTools,
+  validateStakekitActionInput as inputFromTools,
+} from '@/tools/index'
+
+describe('StakeKit action validators are exported from the public surfaces (sdk#1902)', () => {
+  it('root @/index re-exports the canonical implementations', () => {
+    expect(validateStakekitActionAddress).toBe(addressFromStakekit)
+    expect(validateStakekitActionInput).toBe(inputFromStakekit)
+  })
+
+  it('the tools barrel re-exports the same identities', () => {
+    expect(addressFromTools).toBe(addressFromStakekit)
+    expect(inputFromTools).toBe(inputFromStakekit)
+  })
+
+  // A consumer's reason for wanting these: the preflight rules must agree with what the
+  // builders enforce. Spot-check the contract through the PUBLIC surface so an export
+  // that accidentally pointed at a different function would be caught by behaviour too.
+  it('the exported validators behave as the preflight contract documents', () => {
+    expect(validateStakekitActionAddress(`0x${'ab'.repeat(20)}`)).toBeNull() // EVM, 40 hex
+    expect(validateStakekitActionAddress(`0x${'ab'.repeat(32)}`)).toBeNull() // Sui, 64 hex
+    // A 0x-prefixed value of any other length is refused locally rather than forwarded
+    // to yield.xyz as an opaque 4xx.
+    expect(validateStakekitActionAddress('0xdeadbeef')).toMatch(/Invalid 0x-prefixed address/)
+    // Non-0x families pass through — yield.xyz validates them server-side.
+    expect(validateStakekitActionAddress('cosmos1abcdef')).toBeNull()
+
+    expect(validateStakekitActionInput(`0x${'ab'.repeat(20)}`, '1.5')).toBeNull()
+    expect(validateStakekitActionInput('0xdeadbeef', '1.5')).toMatch(/Invalid 0x-prefixed address/)
+  })
+})


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#1902

> **Stacked on #1900** (`fix/r134-rn-stakekit-exports`) — base that first. Its diff is
> included below until it merges. See "why stacked" at the bottom.

## what

`validateStakekitActionAddress` and `validateStakekitActionInput` are pure canonicals in
`tools/defi/stakekit`. They are already used by the builders themselves and already
test-covered — but no public entrypoint exported them, so consumers had to re-declare the
same address/amount preflight rules after the SDK had ported them.

Exported from all three public surfaces: root `@vultisig/sdk`, the `tools` barrel, and the
React Native entry.

## receipts

**The new tests are not vacuous** — reverting only the three export lines fails exactly the
identity assertions, on every surface:

```
$ vitest run tests/unit/public/stakekitValidatorExports.test.ts \
             tests/unit/platforms/react-native/entry.test.ts
⎯⎯⎯ Failed Tests 3 ⎯⎯⎯
      Tests  3 failed | 45 passed (48)
```

With the exports in place, all 48 pass.

Two deliberate choices in how they assert:

- **Identity, not shape.** `expect(root.validateStakekitActionAddress).toBe(canonical)`
  rather than `typeof === 'function'`. The failure mode this issue is about is a consumer
  re-implementing the rules; a `typeof` check would happily pass on a divergent copy
  re-exported under the same name.
- **Plus behaviour through the public surface.** A small contract spot-check (EVM 40-hex and
  Sui 64-hex accepted, other `0x` lengths refused locally, non-`0x` families passed through
  for server-side validation), so an export accidentally wired to a *different* function is
  caught even if identity somehow held.

**Full gate, green:**

```
$ yarn workspace @vultisig/sdk test:unit    Tests 3392 passed (3392)
$ yarn typecheck                            exit 0
$ yarn lint                                 exit 0
$ yarn format:check                         exit 0
```

## notes for the reviewer

- **Why stacked rather than cut from `main`:** #1900 introduces the RN entry's stakekit
  export block that these two lines join. Basing on `main` would have put two PRs in the same
  block and guaranteed a conflict. This branch is cut from #1900's head, so its commits appear
  here until it lands.
- **The RN assertion lives in `tests/unit/platforms/react-native/entry.test.ts`, not in the
  new public test.** Importing the RN entry from a plain node test environment fails on
  `Cannot find package 'react-native'` (via `expo-modules-core`); that suite has the module
  harness for it. I found this by writing it the other way first and watching it fail, and
  noted the reason in the new file's header so the split does not look arbitrary.
- `minor` changeset — additive public surface.
- No emulator screenshot: export-surface change with no user-facing behaviour, and the
  `vultiagent-app` debug build is currently blocked on an expired `TRUSTWALLET_PAT`
  (`com.trustwallet:wallet-core` 401s from GitHub Packages).
