### PR TITLE
fix(sdk): resolve address-shaped token refs by address before symbol

### DIFF
--- a/.changeset/fix-tokenref-address-spoofing.md
+++ b/.changeset/fix-tokenref-address-spoofing.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Fix a token-spoofing gap in `resolveTokenRef`: an EVM-address-shaped ref (e.g. `send({ symbol: '0xA0b8…' })`) now matches the vault's own tokens by contract address BEFORE symbol. Previously symbol was tried first even for address-shaped refs, so a poisoned/airdropped vault token whose attacker-controlled `symbol` field was set to a real token's address string (e.g. USDC's contract address) could hijack a ref the caller typed as a genuine address, resolving the send to the scam contract with the scam token's decimals instead.

--- a/packages/sdk/src/vault/tokenRef.ts
+++ b/packages/sdk/src/vault/tokenRef.ts
@@ -12,6 +12,16 @@
  * contract address, and the user's own tokens before the well-known registry.
  * Every ref that resolved before this module existed resolves to exactly the
  * same token — the only change is that refs which used to throw now resolve.
+ *
+ * Exception, for fund safety: when `ref` is itself shaped like an EVM contract
+ * address (`0x` + 40 hex), the user's own tokens are matched by address BEFORE
+ * symbol. A vault token's `symbol` is an attacker-controlled string persisted
+ * from on-chain discovery — a poisoned/airdropped token can set its symbol to
+ * the literal address string of a real token (e.g. USDC's contract address).
+ * Trying symbol first there would let that poisoned token hijack a ref the
+ * caller typed as a genuine address. Address-shaped refs cannot ambiguously
+ * mean "look up my ticker `0xA0b8…`" the way a real symbol can, so there is no
+ * legitimate resolution this reordering could break.
  */
 import { Chain } from '@vultisig/core-chain/Chain'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
@@ -49,9 +59,16 @@ export function resolveTokenRef(chain: Chain, ref: string | undefined, userToken
   // 1. The user's configured tokens — by symbol first, then by contract address
   //    or stored id (the CLI's `--add` writes id as `<Chain>-<address>`, token
   //    discovery writes the bare address, so both are checked).
-  const token =
-    userTokens.find(t => t.symbol?.toUpperCase() === upper) ??
+  //
+  //    Address-shaped refs flip that order (address before symbol): a stored
+  //    token's `symbol` is attacker-controlled (see the module doc comment),
+  //    so a symbol match must not be able to shadow a ref the caller typed as
+  //    a real contract address.
+  const isEvmAddressShaped = /^0x[0-9a-fA-F]{40}$/.test(ref)
+  const bySymbol = () => userTokens.find(t => t.symbol?.toUpperCase() === upper)
+  const byAddress = () =>
     userTokens.find(t => t.contractAddress?.toLowerCase() === lower || t.id?.toLowerCase() === lower)
+  const token = isEvmAddressShaped ? (byAddress() ?? bySymbol()) : (bySymbol() ?? byAddress())
   if (token) {
     return {
       ticker: token.symbol ?? token.contractAddress ?? token.id,

--- a/packages/sdk/tests/unit/vault/tokenRef.test.ts
+++ b/packages/sdk/tests/unit/vault/tokenRef.test.ts
@@ -95,22 +95,38 @@ describe('resolveTokenRef', () => {
     })
   })
 
-  it('prefers a symbol match over an address match, and user tokens over the registry', () => {
-    const decoy: Token = {
+  it('prefers a symbol match over an address match for a symbol-shaped ref, and user tokens over the registry', () => {
+    const custom: Token = { ...storedUsdc, contractAddress: '0x00000000000000000000000000000000000000bb', decimals: 8 }
+    expect(resolveTokenRef(Chain.Ethereum, 'USDC', [custom])).toMatchObject({
+      decimals: 8,
+      contractAddress: '0x00000000000000000000000000000000000000bb',
+    })
+  })
+
+  // sdk#1634: a vault token's `symbol` is attacker-controlled (persisted from
+  // on-chain discovery). A poisoned/airdropped token can set its symbol to the
+  // literal address string of a real token — here, USDC's contract address —
+  // to hijack a ref the caller typed as a genuine address. An address-shaped
+  // ref must resolve by address first, never by a symbol that merely happens
+  // to spell the same address.
+  it('resolves an address-shaped ref by address, not by a same-string symbol on a poisoned token (spoofing guard)', () => {
+    const poisoned: Token = {
       id: '0x00000000000000000000000000000000000000aa',
       symbol: USDC_LOWER,
-      name: 'decoy',
+      name: 'scam airdrop',
       decimals: 18,
       contractAddress: '0x00000000000000000000000000000000000000aa',
       chainId: Chain.Ethereum,
       isNative: false,
     }
-    expect(resolveTokenRef(Chain.Ethereum, USDC_LOWER, [decoy, storedUsdc])).toMatchObject({ ticker: USDC_LOWER })
 
-    const custom: Token = { ...storedUsdc, contractAddress: '0x00000000000000000000000000000000000000bb', decimals: 8 }
-    expect(resolveTokenRef(Chain.Ethereum, 'USDC', [custom])).toMatchObject({
-      decimals: 8,
-      contractAddress: '0x00000000000000000000000000000000000000bb',
+    expect(resolveTokenRef(Chain.Ethereum, USDC_LOWER, [poisoned, storedUsdc])).toEqual({
+      ticker: 'USDC',
+      decimals: 6,
+      contractAddress: USDC_LOWER,
+    })
+    expect(resolveTokenRef(Chain.Ethereum, USDC_CHECKSUM, [poisoned, storedUsdc])).toMatchObject({
+      contractAddress: USDC_LOWER,
     })
   })
 


### PR DESCRIPTION
Closes #1634

## what was wrong

`resolveTokenRef` (`packages/sdk/src/vault/tokenRef.ts:52-54`) matches a vault's own tokens by symbol first, then by contract address/id — unconditionally, even when the ref itself is shaped like an EVM contract address.

A vault token's `symbol` field is attacker-controlled, persisted verbatim from on-chain discovery (`tokens --discover`). A scam/airdrop token can set its `symbol` to the literal string of a real token's contract address (e.g. USDC's address). If a victim has that poisoned token in their vault and later runs `send --token <the-real-USDC-address>` — typing the genuine address correctly — the resolver matched the ref against the scam token's `symbol` field first, resolving the send to the scam contract with the scam token's decimals instead of the real USDC contract.

This is a fix split out of the sdk#1606 review (unified token reference resolution) — address-shaped refs simply threw before that PR, so this spoofing surface didn't exist prior to it.

## fix

When `ref` matches `/^0x[0-9a-fA-F]{40}$/` (EVM-address-shaped), try the address/id match before the symbol match. Every other ref shape (symbols, tickers, non-EVM ids) keeps the existing symbol-first order — this only flips the order for refs that cannot legitimately mean "look up my ticker `0xA0b8…`" the way a real symbol can, so no existing resolution changes.

## mutation-test proof

Replaced the pre-existing test that had pinned the vulnerable ordering as intended behavior (`'prefers a symbol match over an address match, and user tokens over the registry'` used to assert a decoy token whose `symbol` spelled USDC's address would win over the real stored USDC token) with a dedicated spoofing-guard test.

Reverted the fix locally (restored symbol-first matching unconditionally) to confirm the new test is not vacuous:

```
 FAIL  resolveTokenRef > resolves an address-shaped ref by address, not by a same-string symbol on a poisoned token (spoofing guard)
AssertionError: expected { …(3) } to deeply equal { ticker: 'USDC', decimals: 6, …(1) }
- Expected
+ Received
  {
-   "contractAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-   "decimals": 6,
-   "ticker": "USDC",
+   "contractAddress": "0x00000000000000000000000000000000000000aa",
+   "decimals": 18,
+   "ticker": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
  }
```

That's the exact bug: a genuine USDC-address ref resolving to the poisoned token's contract and decimals. Restored the fix, confirmed green again (26/26 in the file).

## verification

```
$ yarn vitest run --config packages/sdk/tests/unit/vitest.config.ts packages/sdk/tests/unit/vault/tokenRef.test.ts --reporter=verbose
 Test Files  1 passed (1)
      Tests  26 passed (26)

$ yarn workspace @vultisig/sdk test:unit
 Test Files  220 passed (220)
      Tests  3396 passed (3396)
```

`yarn typecheck` — no new errors introduced (pre-existing unrelated `cliDescription`/CLI + ripple-module errors present identically on `main`, confirmed via `git stash` A/B on the same tree).

`yarn lint:fix` / `yarn format` — no changes needed on the touched files.

Changeset added (`@vultisig/sdk` patch).

## risk

Low, fund-safety-positive. Purely reorders which stored token wins a lookup when the ref is shaped like an address; every non-address-shaped ref (the overwhelming majority of calls — symbols, tickers) is byte-for-byte unaffected, and the send/balance-path parity tests in the same file stay green.
