### PR TITLE
fix(spl): vet the destination against the burn list

### DIFF
--- a/.changeset/fix-spl-burn-destination-guard.md
+++ b/.changeset/fix-spl-burn-destination-guard.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Add the burn/program destination guard to `buildSplTransfer`. Its native sibling `prepareSendTxFromKeys` gained `assertSafeDestination` in #1698 and Solana is a covered family in `dangerousAddresses.ts`, but the SPL builder had none - so the two disagreed about destinations this SDK explicitly calls unrecoverable. The gap was not covered by the existing pubkey check: the Solana System Program and the SPL Token Program are both ON the ed25519 curve, so ATA derivation succeeded and a transfer to either built cleanly.

--- a/packages/sdk/src/tools/prep/splTransfer.ts
+++ b/packages/sdk/src/tools/prep/splTransfer.ts
@@ -5,6 +5,7 @@ import {
   TOKEN_PROGRAM_ID,
 } from '@solana/spl-token'
 import { type AccountMeta, PublicKey } from '@solana/web3.js'
+import { assertSafeDestination } from '@vultisig/core-chain/security/dangerousAddresses'
 import { Buffer } from 'buffer'
 
 /**
@@ -113,6 +114,8 @@ const isValidSolanaPubkey = (addr: string): boolean => {
  *
  * Fund-safety guards (ported from mcp-ts `build_spl_transfer_tx`):
  *  - `from`/`to`/`mint` must each be valid 32-byte base58 pubkeys.
+ *  - `to` is vetted against the burn/program destination list (sdk#1723), the
+ *    same `assertSafeDestination` the native `prepareSendTxFromKeys` uses.
  *  - `to !== mint` — sending to the mint account itself credits an ATA owned by
  *    the mint authority (funds lost), so it is rejected explicitly.
  *  - `amount > 0` and `amount <= u64 max` (the on-chain instruction encodes a
@@ -142,6 +145,16 @@ export const buildSplTransfer = (params: BuildSplTransferParams): SplTransferRes
   if (!isValidSolanaPubkey(to)) {
     throw new Error(`buildSplTransfer: invalid Solana \`to\` address: ${to}`)
   }
+  // sdk#1723: burn/program destinations, same guard the native sibling
+  // (prepareSendTxFromKeys) has had since #1698. Without it this builder
+  // disagreed with its own sibling about destinations the SDK explicitly calls
+  // unrecoverable — the Solana System Program and the SPL Token Program are both
+  // ON the ed25519 curve, so ATA derivation succeeds and a transfer to either
+  // built cleanly. (The incinerator happened to be refused, but only by curve
+  // geometry, with an opaque TokenOwnerOffCurveError rather than an honest
+  // reason.) Placed before the mint/amount checks so the destination verdict
+  // does not depend on the rest of the payload being well-formed.
+  assertSafeDestination('Solana', to)
   if (!isValidSolanaPubkey(mint)) {
     throw new Error(`buildSplTransfer: invalid Solana \`mint\` address: ${mint}`)
   }

--- a/packages/sdk/tests/unit/buildSplTransfer.test.ts
+++ b/packages/sdk/tests/unit/buildSplTransfer.test.ts
@@ -132,4 +132,45 @@ describe('buildSplTransfer (pure-crypto unsigned SPL transfer)', () => {
       )
     })
   })
+
+  // --- sdk#1723: burn/program destinations -------------------------------------
+  //
+  // `prepareSendTxFromKeys` gained assertSafeDestination in #1698 and Solana is a
+  // covered family in dangerousAddresses.ts, but this sibling builder had none —
+  // the two disagreed about destinations the SDK explicitly calls unrecoverable.
+  //
+  // These are not caught "for free" by the pubkey check: the System Program and
+  // the SPL Token Program are both ON the ed25519 curve, so ATA derivation
+  // succeeds and the transfer built cleanly before this guard.
+  describe('burn / program destination guard (sdk#1723)', () => {
+    it.each([
+      ['Solana System Program', '11111111111111111111111111111111'],
+      ['SPL Token Program', 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'],
+      ['incinerator', '1nc1nerator11111111111111111111111111111111'],
+    ])('refuses %s with an honest reason', (_label, to) => {
+      expect(() => buildSplTransfer({ mint: USDC_MINT, from: FROM, to, amount: 1_000_000n, decimals: 6 })).toThrow(
+        /Refusing to build transaction/
+      )
+    })
+
+    it('the incinerator refusal is the burn-list reason, not an opaque curve error', () => {
+      // It was previously rejected only by accident — being off-curve made ATA
+      // derivation throw TokenOwnerOffCurveError, which tells the user nothing.
+      expect(() =>
+        buildSplTransfer({
+          mint: USDC_MINT,
+          from: FROM,
+          to: '1nc1nerator11111111111111111111111111111111',
+          amount: 1_000_000n,
+          decimals: 6,
+        })
+      ).not.toThrow(/TokenOwnerOffCurve/)
+    })
+
+    it('a normal wallet destination still builds (guard is not over-broad)', () => {
+      expect(() =>
+        buildSplTransfer({ mint: USDC_MINT, from: FROM, to: TO, amount: 1_000_000n, decimals: 6 })
+      ).not.toThrow()
+    })
+  })
 })


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#1723

## what

`buildSplTransfer` had no burn-destination guard. Its native sibling
`prepareSendTxFromKeys` gained `assertSafeDestination` in #1698, and Solana is a covered
family in `dangerousAddresses.ts` — so the two paths disagreed about destinations this SDK
explicitly calls unrecoverable.

```
$ grep -c assertSafeDestination send.ts         3
$ grep -c assertSafeDestination splTransfer.ts  0
```

## receipts

Real builder, no mocks (QA instrumentation deleted before commit — not in this diff).

**BEFORE (on main):**

```
CONTROL normal address                             BUILT
system program 11111111111111111111111111111111    BUILT
token program  TokenkegQfeZ...                     BUILT
incinerator    1nc1nerator11...                    REFUSED: TokenOwnerOffCurveError
```

**AFTER (this branch):**

```
CONTROL normal address                             BUILT
system program 11111111111111111111111111111111    REFUSED: Refusing to build transaction: destination 11111111111111111111111111111111 is a Solana …
token program  TokenkegQfeZ...                     REFUSED: Refusing to build transaction: destination TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA i…
incinerator    1nc1nerator11...                    REFUSED: Refusing to build transaction: destination 1nc1nerator11111111111111111111111111111111 i…
```

The control building in both runs is what makes the rest meaningful — the builder works; it
simply did not vet the destination.

**Why the existing pubkey check does not already cover this**, which I checked rather than
assumed:

```
control wallet A  onCurve=true
system program    onCurve=true      <- ATA derivation SUCCEEDS
token program     onCurve=true      <- ATA derivation SUCCEEDS
incinerator       onCurve=false
wrapped SOL mint  onCurve=true
```

The System Program and Token Program are **on** the ed25519 curve, so
`getAssociatedTokenAddressSync` derives happily and the transfer builds. Only the incinerator
was rejected, and only by accident of curve geometry — surfacing
`TokenOwnerOffCurveError`, which tells a user nothing about why their transfer was refused.
It now gets the same honest burn-list reason as the others, and there is a test asserting the
message is **not** the curve error.

**Tests — 3 of the 6 new ones fail without the guard:**

```
 × refuses Solana System Program with an honest reason
 × refuses SPL Token Program with an honest reason
 × refuses incinerator with an honest reason
      Tests  3 failed | 10 passed (13)
```

The "normal wallet destination still builds" case passes both ways by design — it is the
guard against this change being over-broad.

**Gate:**

```
$ yarn workspace @vultisig/sdk test:unit    Tests 3399 passed (3399)
$ yarn typecheck                            exit 0
$ yarn lint                                 exit 0
$ yarn format:check                         exit 0
```

## notes for the reviewer

- Guard is placed **before** the mint/amount checks, so the destination verdict does not
  depend on the rest of the payload being well-formed. A caller who gets both the destination
  and the decimals wrong should hear about the destination.
- `assertSafeDestination('Solana', to)` passes the chain literal rather than threading a chain
  param — this builder is Solana-only by construction (it derives SPL ATAs), so there is no
  other value it could take.
- Sibling to mcp-ts#782, which closed the same gap on the MCP-side SPL/Sui builders. This is
  the SDK-side twin; between them the SPL send paths now agree.
- No emulator screenshot: pure builder with no user-facing surface. (The app build is
  unblocked as of today, so app-facing PRs will carry screenshots from here on.)
