### PR TITLE
fix(sdk): export ChainDiscoveryAggregate publicly

### DIFF
--- a/.changeset/r151-seedphrase-aggregate-export.md
+++ b/.changeset/r151-seedphrase-aggregate-export.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+Export the `ChainDiscoveryAggregate` type from the public SDK seedphrase and root entrypoints so consumers can import the aggregate result returned by seedphrase discovery without restating the contract locally.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -463,6 +463,7 @@ export {
 
 // Seedphrase validation and vault creation from seedphrase types
 export type {
+  ChainDiscoveryAggregate,
   ChainDiscoveryPhase,
   ChainDiscoveryProgress,
   ChainDiscoveryResult,

--- a/packages/sdk/src/seedphrase/index.ts
+++ b/packages/sdk/src/seedphrase/index.ts
@@ -11,6 +11,7 @@
 // Types
 export type {
   Bip39Language,
+  ChainDiscoveryAggregate,
   ChainDiscoveryPhase,
   ChainDiscoveryProgress,
   ChainDiscoveryResult,

--- a/packages/sdk/tests/unit/public-api/seedphraseSubpathExports.test.ts
+++ b/packages/sdk/tests/unit/public-api/seedphraseSubpathExports.test.ts
@@ -2,9 +2,11 @@ import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 
 import * as seedphrase from '../../../src/seedphrase'
+import type { ChainDiscoveryAggregate as RootChainDiscoveryAggregate } from '../../../src/index'
+import type { ChainDiscoveryAggregate as SeedphraseChainDiscoveryAggregate, ChainDiscoveryResult } from '../../../src/seedphrase'
 
 const sdkRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..')
 const sdkPackageJson = JSON.parse(readFileSync(path.join(sdkRoot, 'package.json'), 'utf8'))
@@ -69,5 +71,14 @@ describe('@vultisig/sdk/seedphrase public surface', () => {
         'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
       )
     ).toBe('english')
+  })
+
+  it('exports the chain-discovery aggregate type from both the seedphrase subpath and root sdk surface', () => {
+    expectTypeOf<SeedphraseChainDiscoveryAggregate>().toEqualTypeOf<{
+      results: ChainDiscoveryResult[]
+      usePhantomSolanaPath: boolean
+      useCosmosPathTerra: boolean
+    }>()
+    expectTypeOf<RootChainDiscoveryAggregate>().toEqualTypeOf<SeedphraseChainDiscoveryAggregate>()
   })
 })

--- a/packages/sdk/tests/unit/public-api/seedphraseSubpathExports.test.ts
+++ b/packages/sdk/tests/unit/public-api/seedphraseSubpathExports.test.ts
@@ -4,9 +4,12 @@ import { fileURLToPath } from 'node:url'
 
 import { describe, expect, expectTypeOf, it } from 'vitest'
 
-import * as seedphrase from '../../../src/seedphrase'
 import type { ChainDiscoveryAggregate as RootChainDiscoveryAggregate } from '../../../src/index'
-import type { ChainDiscoveryAggregate as SeedphraseChainDiscoveryAggregate, ChainDiscoveryResult } from '../../../src/seedphrase'
+import type {
+  ChainDiscoveryAggregate as SeedphraseChainDiscoveryAggregate,
+  ChainDiscoveryResult,
+} from '../../../src/seedphrase'
+import * as seedphrase from '../../../src/seedphrase'
 
 const sdkRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..')
 const sdkPackageJson = JSON.parse(readFileSync(path.join(sdkRoot, 'package.json'), 'utf8'))


### PR DESCRIPTION
## Summary
- export `ChainDiscoveryAggregate` from `@vultisig/sdk/seedphrase` and the root `@vultisig/sdk` barrel
- add a compile-time public-surface regression test covering both entrypoints
- add a changeset for the public SDK surface fix

Closes #1995

## Why
`ChainDiscoveryService.discoverChains()` and `Vultisig.discoverChainsFromSeedphrase()` already return `Promise<ChainDiscoveryAggregate>`, but consumers could not import that type from either public SDK entrypoint. That forced local re-statements of the aggregate contract even though the SDK already owned it.

## Verification
- `corepack yarn workspace @vultisig/sdk vitest run tests/unit/public-api/seedphraseSubpathExports.test.ts --testTimeout=15000` ✅
- `corepack yarn build:shared` ❌ pre-existing unrelated clean-main blocker:
  - `packages/core/mpc/keysign/signingInputs/resolvers/cardano.ts(72,5): error TS2353: Object literal may only specify known properties, and 'auxiliaryData' does not exist in type 'ISigningInput'.`

## Report
- Round 151 report: https://gist.github.com/gomesalexandre/b46a6001a8b3e9d530abaa08429a2da2
- Campaign index artifact: https://claude.ai/code/artifact/be2deadf-6195-4dfa-a910-b269b9af7a84
