### PR TITLE
feat(sdk): close five holes in the published surface

### DIFF
--- a/.changeset/feat-close-public-surface-holes.md
+++ b/.changeset/feat-close-public-surface-holes.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': minor
+---
+
+Close five holes in the published surface. `computeMaxSendFromBalance` (and its params type) now ships alongside its already-public sibling `getMaxSendAmountFromKeys`; `ChainDiscoveryAggregate` is exported from the seedphrase barrel even though it is already the return type of a public `Vultisig` method; `prepareSeedphraseImportPrelude` — the step both seedphrase-import services run first — is reachable; the canonical THOR/Maya native-swap metadata (`nativeSwapChains`, `nativeSwapEnabledChainsRecord`, `nativeSwapChainIds`, `getNativeSwapChainId`, `getNativeSwapChainIdFromDenomPrefix`) is exported from the root and React Native entries; and the RN entry gains `getEvmRpcUrl`, which it was missing while exporting its two siblings.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -271,12 +271,23 @@ export {
 // maintained copies in agent-backend-ts (skip-swap.ts's full per-chain table,
 // execute_send.ts's TerraClassic-only hardcoded 256 check that missed every
 // other cosmos chain) and mcp-ts's own copy of the same table.
+// Canonical THOR/Maya native-swap metadata (sdk#1988). The SDK already owns the
+// live-supported chain/ticker contract; without these on a public surface,
+// first-party consumers re-pin their own tables and drift from it.
 export {
   COSMOS_MEMO_DEFAULT_MAX_BYTES,
   getCosmosMemoMaxBytes,
   getCosmosMemoMaxBytesByChainId,
   isCosmosMemoWithinCap,
 } from '@vultisig/core-chain/chains/cosmos/cosmosMemoCap'
+export type { NativeSwapChain, NativeSwapChainId } from '@vultisig/core-chain/swap/native/NativeSwapChain'
+export {
+  getNativeSwapChainId,
+  getNativeSwapChainIdFromDenomPrefix,
+  nativeSwapChainIds,
+  nativeSwapChains,
+  nativeSwapEnabledChainsRecord,
+} from '@vultisig/core-chain/swap/native/NativeSwapChain'
 
 // Fiat currency types
 export type { FiatCurrency } from '@vultisig/core-config/FiatCurrency'
@@ -917,6 +928,7 @@ export {
   coinGeckoIdToSymbol,
   compareCosts,
   computeAstroportMinReceive,
+  computeMaxSendFromBalance,
   CONSOLIDATE_CHAINS,
   cosmos,
   COSMOS_SWAP_FEE_LABEL_CHAINS,

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -85,12 +85,28 @@ export {
 // "will this memo fit before broadcast rejects it with sdk code 12 (memo too
 // long) after the user has already signed?" Kept in parity with the root SDK
 // entrypoint (sdk#1538) so RN consumers don't hand-roll their own memo-cap table.
+// Canonical THOR/Maya native-swap metadata (sdk#1988). The SDK already owns the
+// live-supported chain/ticker contract; without these on a public surface,
+// first-party consumers re-pin their own tables and drift from it.
+export type { NativeSwapChain, NativeSwapChainId } from '@vultisig/core-chain/swap/native/NativeSwapChain'
+export {
+  getNativeSwapChainId,
+  getNativeSwapChainIdFromDenomPrefix,
+  nativeSwapChainIds,
+  nativeSwapChains,
+  nativeSwapEnabledChainsRecord,
+} from '@vultisig/core-chain/swap/native/NativeSwapChain'
+
+// sdk#1957: root exports getEvmRpcUrl alongside getEvmChainByChainId /
+// getEvmChainId; RN had the other two but not this one, so a mobile consumer
+// could identify an EVM chain and then not reach its RPC endpoint.
 export {
   COSMOS_MEMO_DEFAULT_MAX_BYTES,
   getCosmosMemoMaxBytes,
   getCosmosMemoMaxBytesByChainId,
   isCosmosMemoWithinCap,
 } from '@vultisig/core-chain/chains/cosmos/cosmosMemoCap'
+export { getEvmRpcUrl } from '@vultisig/core-chain/chains/evm/chainInfo'
 
 // Dynamic THORChain secured-asset discovery. These fetch-based/pure helpers
 // are RN-safe and intentionally match the root SDK entrypoint so mobile
@@ -321,6 +337,14 @@ export { CONSOLIDATE_CHAINS } from '../../tools/prep/utxoConsolidate'
 export async function getMaxSendAmountFromKeys(...args: unknown[]) {
   const mod = await import('../../tools/prep/maxSend')
   return mod.getMaxSendAmountFromKeys(...(args as Parameters<typeof mod.getMaxSendAmountFromKeys>))
+}
+
+// sdk#1998: the sibling of getMaxSendAmountFromKeys, defined in the same module
+// and used by the vault max-send path, was reachable from no published surface.
+// Lazy-imported the same way so the RN bundle is unaffected.
+export async function computeMaxSendFromBalance(...args: unknown[]) {
+  const mod = await import('../../tools/prep/maxSend')
+  return mod.computeMaxSendFromBalance(...(args as Parameters<typeof mod.computeMaxSendFromBalance>))
 }
 
 export async function prepareContractCallTxFromKeys(...args: unknown[]) {

--- a/packages/sdk/src/seedphrase/index.ts
+++ b/packages/sdk/src/seedphrase/index.ts
@@ -11,6 +11,7 @@
 // Types
 export type {
   Bip39Language,
+  ChainDiscoveryAggregate,
   ChainDiscoveryPhase,
   ChainDiscoveryProgress,
   ChainDiscoveryResult,
@@ -52,3 +53,13 @@ export {
   SEEDPHRASE_IMPORT_SUPPORTED_CHAINS,
   SEEDPHRASE_IMPORT_UNSUPPORTED_CHAINS,
 } from '../constants'
+
+// Shared prelude for both seedphrase-import paths (fast + secure). It is the
+// step a caller has to run before either service, so leaving it internal meant
+// the public API described a flow whose first step could not be reached.
+export {
+  prepareSeedphraseImportPrelude,
+  type SeedphraseImportPreludeInput,
+  type SeedphraseImportPreludeProgressLabels,
+  type SeedphraseImportPreludeResult,
+} from './prepareSeedphraseImportPrelude'

--- a/packages/sdk/src/tools/index.ts
+++ b/packages/sdk/src/tools/index.ts
@@ -350,6 +350,8 @@ export {
   type BuildSplTransferParams,
   buildUndelegateMsg,
   buildWithdrawRewardsMsg,
+  computeMaxSendFromBalance,
+  type ComputeMaxSendFromBalanceParams,
   CONSOLIDATE_CHAINS,
   type ConsolidateChain,
   type ConsolidateUtxo,

--- a/packages/sdk/src/tools/prep/index.ts
+++ b/packages/sdk/src/tools/prep/index.ts
@@ -32,7 +32,12 @@ export {
   supportedIbcDestinationsFrom,
 } from './ibcTransfer'
 export { prepareJettonTransferTxFromKeys, type PrepareJettonTransferTxFromKeysParams } from './jettonTransfer'
-export { getMaxSendAmountFromKeys, type GetMaxSendAmountFromKeysParams } from './maxSend'
+export {
+  computeMaxSendFromBalance,
+  type ComputeMaxSendFromBalanceParams,
+  getMaxSendAmountFromKeys,
+  type GetMaxSendAmountFromKeysParams,
+} from './maxSend'
 export {
   POLKADOT_ASSET_HUB_KNOWN_ASSETS,
   preparePolkadotAssetSend,

--- a/packages/sdk/tests/unit/platforms/react-native/evmRpcUrlExport.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/evmRpcUrlExport.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest'
+
+process.env.VULTISIG_STRICT_SINGLETON = '0'
+
+vi.mock('expo-crypto', () => ({
+  randomUUID: () => '00000000-0000-4000-8000-000000000000',
+  getRandomValues: <T extends ArrayBufferView | null>(a: T) => a,
+}))
+vi.mock('@react-native-async-storage/async-storage', () => ({
+  default: {
+    getItem: async () => null,
+    setItem: async () => {},
+    removeItem: async () => {},
+    getAllKeys: async () => [],
+    multiRemove: async () => {},
+    clear: async () => {},
+  },
+}))
+vi.mock('@vultisig/mpc-native', () => ({
+  NativeMpcEngine: class {
+    initialize = async () => {}
+    dkls = {}
+    schnorr = {}
+  },
+}))
+vi.mock('@vultisig/walletcore-native', () => ({
+  NativeWalletCore: { getInstance: async () => ({}) },
+}))
+
+// sdk#1957 / sdk#1988: the RN entry exported getEvmChainByChainId and
+// getEvmChainId but not getEvmRpcUrl - so a mobile consumer could identify an
+// EVM chain and then not reach its RPC endpoint, which is the one of the three
+// you need to actually make a call. Same for the native-swap metadata.
+describe('RN entry exports the EVM RPC + native-swap canonicals', () => {
+  it.each(['getEvmChainByChainId', 'getEvmChainId', 'getEvmRpcUrl'] as const)(
+    're-exports %s from the canonical evm chainInfo, by identity',
+    async name => {
+      const rn = (await import('../../../../src/platforms/react-native/index')) as Record<string, unknown>
+      const chainInfo = (await import('@vultisig/core-chain/chains/evm/chainInfo')) as Record<string, unknown>
+
+      expect(rn[name]).toBe(chainInfo[name])
+    }
+  )
+
+  it.each([
+    'nativeSwapChains',
+    'nativeSwapEnabledChainsRecord',
+    'nativeSwapChainIds',
+    'getNativeSwapChainId',
+    'getNativeSwapChainIdFromDenomPrefix',
+  ] as const)('re-exports native-swap canonical %s by identity', async name => {
+    const rn = (await import('../../../../src/platforms/react-native/index')) as Record<string, unknown>
+    const canonical = (await import('@vultisig/core-chain/swap/native/NativeSwapChain')) as Record<string, unknown>
+
+    expect(rn[name]).toBe(canonical[name])
+  })
+})

--- a/packages/sdk/tests/unit/public-api/seedphraseSubpathExports.test.ts
+++ b/packages/sdk/tests/unit/public-api/seedphraseSubpathExports.test.ts
@@ -60,6 +60,8 @@ describe('@vultisig/sdk/seedphrase public surface', () => {
         'getWordlist',
         'isSeedphraseImportSupportedChain',
         'normalizeMnemonic',
+        // sdk#1955: the prelude both import services run first.
+        'prepareSeedphraseImportPrelude',
         'validateSeedphrase',
       ].sort()
     )

--- a/packages/sdk/tests/unit/publicSurfaceHoles.test.ts
+++ b/packages/sdk/tests/unit/publicSurfaceHoles.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+
+import type { NativeSwapChain, NativeSwapChainId } from '@/index'
+import type { ChainDiscoveryAggregate, SeedphraseImportPreludeInput, SeedphraseImportPreludeResult } from '@/seedphrase'
+// Compile-time half of the proof. A type has no runtime identity, so the thing
+// that actually fails when a type is missing from a barrel is `yarn typecheck`,
+// not a runtime expect(). These imports are the assertion.
+import type { ComputeMaxSendFromBalanceParams } from '@/tools/prep'
+
+// (used inside the #1995 case below so they are real references, not a dead alias)
+
+/**
+ * Five separate issues, one shape: a symbol that exists, is already treated as
+ * public (a documented return type, a sibling of an exported helper, a
+ * canonical the SDK owns), but is not reachable from any published surface.
+ *
+ * Each case asserts by IDENTITY against the defining module, not just presence,
+ * so a barrel that re-exports a local reimplementation instead of the canonical
+ * still fails.
+ */
+
+describe('sdk#1998 — computeMaxSendFromBalance is reachable from the prep barrel', () => {
+  it('exports it alongside its already-public sibling', async () => {
+    const prep = await import('@/tools/prep')
+    const maxSend = await import('@/tools/prep/maxSend')
+
+    // getMaxSendAmountFromKeys was exported; computeMaxSendFromBalance, defined
+    // in the same file and called by the vault path, was not.
+    expect(prep.getMaxSendAmountFromKeys).toBe(maxSend.getMaxSendAmountFromKeys)
+    expect(prep.computeMaxSendFromBalance).toBe(maxSend.computeMaxSendFromBalance)
+  })
+
+  it('reaches the root entry too', async () => {
+    const root = await import('@/index')
+    const maxSend = await import('@/tools/prep/maxSend')
+    expect((root as Record<string, unknown>).computeMaxSendFromBalance).toBe(maxSend.computeMaxSendFromBalance)
+  })
+})
+
+describe('sdk#1995 — ChainDiscoveryAggregate is exported as a public type', () => {
+  // A type has no runtime identity, so the runtime assertion available is that
+  // its siblings are all present; the real proof is the compile-time import
+  // below, which fails typecheck if the type is not exported.
+  it('sits alongside the other chain-discovery types it is returned with', async () => {
+    // These bindings are the assertion: if any of these types is not exported
+    // from its barrel, this file does not COMPILE, and `yarn typecheck` names
+    // the exact missing member. The runtime expects below are incidental.
+    const aggregate = null as unknown as ChainDiscoveryAggregate
+    const preludeInput = null as unknown as SeedphraseImportPreludeInput
+    const preludeResult = null as unknown as SeedphraseImportPreludeResult
+    const maxSendParams = null as unknown as ComputeMaxSendFromBalanceParams
+    const swapChain = null as unknown as NativeSwapChain
+    const swapChainId = null as unknown as NativeSwapChainId
+    void [aggregate, preludeInput, preludeResult, maxSendParams, swapChain, swapChainId]
+
+    const { ChainDiscoveryService } = await import('@/seedphrase/ChainDiscoveryService')
+    expect(typeof ChainDiscoveryService).toBe('function')
+  })
+})
+
+describe('sdk#1955 — prepareSeedphraseImportPrelude is reachable', () => {
+  it('exports the prelude both seedphrase-import services run first', async () => {
+    const seedphrase = await import('@/seedphrase')
+    const prelude = await import('@/seedphrase/prepareSeedphraseImportPrelude')
+
+    expect(seedphrase.prepareSeedphraseImportPrelude).toBe(prelude.prepareSeedphraseImportPrelude)
+    expect(typeof seedphrase.prepareSeedphraseImportPrelude).toBe('function')
+  })
+})
+
+describe('sdk#1988 — native-swap metadata is on the root surface', () => {
+  it.each([
+    'nativeSwapChains',
+    'nativeSwapEnabledChainsRecord',
+    'nativeSwapChainIds',
+    'getNativeSwapChainId',
+    'getNativeSwapChainIdFromDenomPrefix',
+  ] as const)('re-exports %s by identity', async name => {
+    const root = (await import('@/index')) as Record<string, unknown>
+    const canonical = (await import('@vultisig/core-chain/swap/native/NativeSwapChain')) as Record<string, unknown>
+
+    expect(root[name]).toBe(canonical[name])
+  })
+
+  // The value matters as much as the presence: consumers keep local ticker
+  // tables precisely because they cannot import this one.
+  it('carries the live THOR/Maya contract, not a placeholder', async () => {
+    const root = await import('@/index')
+    expect(root.nativeSwapChains).toEqual(['THORChain', 'MayaChain'])
+    expect(root.getNativeSwapChainId('THORChain')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#1998
Closes vultisig/vultisig-sdk#1995
Closes vultisig/vultisig-sdk#1988
Closes vultisig/vultisig-sdk#1957
Closes vultisig/vultisig-sdk#1955

Five issues, one shape: a symbol that exists, is already treated as public, and is reachable from nowhere.

| # | symbol | why it is already public |
|---|---|---|
| 1998 | `computeMaxSendFromBalance` | same file as `getMaxSendAmountFromKeys`, which IS exported; called by the vault max-send path |
| 1995 | `ChainDiscoveryAggregate` | the declared return type of a public `Vultisig` method, while its siblings `ChainDiscoveryProgress`/`Result` were exported |
| 1955 | `prepareSeedphraseImportPrelude` | the step **both** seedphrase-import services run first |
| 1988 | THOR/Maya native-swap metadata | the SDK owns the live chain/ticker contract; the app keeps a local copy because it cannot import this one |
| 1957 | `getEvmRpcUrl` on RN | RN had `getEvmChainByChainId` and `getEvmChainId` but not this - the one of the three you need to actually make a call |

1995 is the one worth pausing on. `Vultisig` has a method whose signature is `Promise<ChainDiscoveryAggregate>`, and that type was not exported. A consumer could call the method and had no way to name what came back.

## how

Followed each surface's own convention rather than making one uniform edit:

- **root / tools barrels** - added to the existing alphabetised named-export lists.
- **RN** - `computeMaxSendFromBalance` gets a **lazy dynamic-import wrapper**, mirroring exactly how `getMaxSendAmountFromKeys` is already surfaced there. A static re-export would have pulled the heavy prep module into the RN bundle, which is presumably why the sibling was written that way in the first place.

## receipts

**Runtime, before** (barrels reverted, tests unchanged):

```console
$ vitest run tests/unit/publicSurfaceHoles.test.ts tests/unit/platforms/react-native/evmRpcUrlExport.test.ts
 × re-exports getEvmRpcUrl from the canonical evm chainInfo, by identity
 × re-exports native-swap canonical nativeSwapChains by identity
 × re-exports native-swap canonical nativeSwapEnabledChainsRecord by identity
 × re-exports native-swap canonical nativeSwapChainIds by identity
 × re-exports native-swap canonical getNativeSwapChainId by identity
 × re-exports native-swap canonical getNativeSwapChainIdFromDenomPrefix by identity
 × exports it alongside its already-public sibling
 × reaches the root entry too
 × exports the prelude both seedphrase-import services run first
 × re-exports nativeSwapChains by identity                     (root entry)
 ... 14 of 18 failed
```

**after**: `Tests 18 passed (18)`.

**Compile-time, before.** Types have no runtime identity, so `expect()` cannot test them - the thing that actually breaks is `tsc`. The type-only imports at the top of the test file ARE the assertion:

```console
$ yarn typecheck        # barrels reverted
publicSurfaceHoles.test.ts:6  TS2305: Module '"@/tools/prep"' has no exported member 'ComputeMaxSendFromBalanceParams'.
publicSurfaceHoles.test.ts:8  TS2724: '"@/seedphrase"' has no exported member named 'ChainDiscoveryAggregate'. Did you mean 'ChainDiscoveryResult'?
publicSurfaceHoles.test.ts:9  TS2724: '"@/seedphrase"' has no exported member named 'SeedphraseImportPreludeInput'.
publicSurfaceHoles.test.ts:10 TS2724: '"@/seedphrase"' has no exported member named 'SeedphraseImportPreludeResult'.
publicSurfaceHoles.test.ts:12 TS2305: Module '"@/index"' has no exported member 'NativeSwapChain'.
publicSurfaceHoles.test.ts:12 TS2305: Module '"@/index"' has no exported member 'NativeSwapChainId'.
exit=2
```

Every runtime case asserts **identity** against the defining module, not presence - a barrel that re-exports a local reimplementation instead of the canonical satisfies `key in module` while still drifting, and drift is the whole complaint in #1988.

For #1988 there is also a value assertion, because presence alone would not have helped the app:

```ts
expect(root.nativeSwapChains).toEqual(['THORChain', 'MayaChain'])
```

## a test that caught me

`tests/unit/public-api/seedphraseSubpathExports.test.ts` pins the seedphrase barrel's **exact** export list, and my change failed it:

```
AssertionError: expected [ 'BIP39_LANGUAGES', …(19) ] to deeply equal [ 'BIP39_LANGUAGES', …(18) ]
```

That is the test doing its job - a strict allowlist so nothing joins the public surface unnoticed. So it gets the new name added, with a comment, rather than being loosened into a subset check.

## gate

| check | result |
|---|---|
| `yarn workspace @vultisig/sdk test:unit` | 3436 passed |
| new surface tests | 18 passed |
| `yarn typecheck` | exit 0 |
| `yarn lint` | exit 0 |
| `yarn format:check` | exit 0 |

## risk

Additive only. No implementation changed, nothing removed, no existing export altered. The RN addition is lazily imported, so the RN bundle is unaffected until a consumer calls it.
