### PR TITLE
fix(sdk): publish @vultisig/sdk/tools subpath

### DIFF
--- a/.changeset/publish-tools-umbrella-barrel-r151.md
+++ b/.changeset/publish-tools-umbrella-barrel-r151.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Publish `@vultisig/sdk/tools` as a real package subpath with dedicated runtime and type bundles.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -76,6 +76,19 @@
       "require": "./dist/vite/index.cjs",
       "default": "./dist/vite/index.js"
     },
+    "./tools": {
+      "types": "./dist/tools/index.d.ts",
+      "browser": "./dist/tools/index.js",
+      "worker": "./dist/tools/index.js",
+      "react-native": "./dist/tools/index.js",
+      "node": {
+        "import": "./dist/tools/index.js",
+        "require": "./dist/tools/index.cjs"
+      },
+      "import": "./dist/tools/index.js",
+      "require": "./dist/tools/index.cjs",
+      "default": "./dist/tools/index.cjs"
+    },
     "./tools/parse": {
       "types": "./dist/tools/parse/index.d.ts",
       "browser": "./dist/tools/parse/index.js",

--- a/packages/sdk/rollup.platforms.config.js
+++ b/packages/sdk/rollup.platforms.config.js
@@ -324,6 +324,10 @@ const configs = {
       }),
     },
     ...createSubpathConfigs({
+      input: './src/tools/index.ts',
+      distBase: 'tools',
+    }),
+    ...createSubpathConfigs({
       input: './src/tools/parse/index.ts',
       distBase: 'tools/parse',
     }),

--- a/packages/sdk/rollup.types.config.js
+++ b/packages/sdk/rollup.types.config.js
@@ -121,6 +121,7 @@ export default defineConfig([
   // Dedicated public subpath types — keep these as first-class bundles so
   // package-name imports resolve to narrow declarations instead of the root
   // index type graph.
+  createSubpathTypesConfig('src/tools/index.ts', 'dist/tools/index.d.ts'),
   createSubpathTypesConfig('src/tools/parse/index.ts', 'dist/tools/parse/index.d.ts'),
   createSubpathTypesConfig('src/tools/defi/index.ts', 'dist/tools/defi/index.d.ts'),
   createSubpathTypesConfig('src/tools/bridge/index.ts', 'dist/tools/bridge/index.d.ts'),

--- a/packages/sdk/tests/unit/public-api/toolsSubpathExports.test.ts
+++ b/packages/sdk/tests/unit/public-api/toolsSubpathExports.test.ts
@@ -107,9 +107,7 @@ describe('public API subpath exports', () => {
     expect(platformRollupConfig).toContain("input: './src/tx/index.ts'")
     expect(platformRollupConfig).toContain("distBase: 'tx'")
 
-    expect(typesRollupConfig).toContain(
-      "createSubpathTypesConfig('src/tools/index.ts', 'dist/tools/index.d.ts')"
-    )
+    expect(typesRollupConfig).toContain("createSubpathTypesConfig('src/tools/index.ts', 'dist/tools/index.d.ts')")
     expect(typesRollupConfig).toContain(
       "createSubpathTypesConfig('src/tools/parse/index.ts', 'dist/tools/parse/index.d.ts')"
     )

--- a/packages/sdk/tests/unit/public-api/toolsSubpathExports.test.ts
+++ b/packages/sdk/tests/unit/public-api/toolsSubpathExports.test.ts
@@ -11,6 +11,7 @@ const typesRollupConfig = readFileSync(path.join(sdkRoot, 'rollup.types.config.j
 
 describe('public API subpath exports', () => {
   it('publishes dedicated export-map entries for every narrow public surface', () => {
+    const toolsExport = sdkPackageJson.exports['./tools']
     const parseExport = sdkPackageJson.exports['./tools/parse']
     const defiExport = sdkPackageJson.exports['./tools/defi']
     const bridgeExport = sdkPackageJson.exports['./tools/bridge']
@@ -20,6 +21,12 @@ describe('public API subpath exports', () => {
     const decodeExport = sdkPackageJson.exports['./tools/decode']
     const txExport = sdkPackageJson.exports['./tx']
 
+    expect(toolsExport).toMatchObject({
+      types: './dist/tools/index.d.ts',
+      import: './dist/tools/index.js',
+      require: './dist/tools/index.cjs',
+      default: './dist/tools/index.cjs',
+    })
     expect(parseExport).toMatchObject({
       types: './dist/tools/parse/index.d.ts',
       import: './dist/tools/parse/index.js',
@@ -69,6 +76,7 @@ describe('public API subpath exports', () => {
       default: './dist/tx/index.cjs',
     })
 
+    expect(JSON.stringify(toolsExport)).not.toContain('dist/index.node')
     expect(JSON.stringify(parseExport)).not.toContain('dist/index.node')
     expect(JSON.stringify(defiExport)).not.toContain('dist/index.node')
     expect(JSON.stringify(bridgeExport)).not.toContain('dist/index.node')
@@ -80,6 +88,8 @@ describe('public API subpath exports', () => {
   })
 
   it('keeps dedicated JS and d.ts bundle generation wired for every narrow public surface', () => {
+    expect(platformRollupConfig).toContain("input: './src/tools/index.ts'")
+    expect(platformRollupConfig).toContain("distBase: 'tools'")
     expect(platformRollupConfig).toContain("input: './src/tools/parse/index.ts'")
     expect(platformRollupConfig).toContain("distBase: 'tools/parse'")
     expect(platformRollupConfig).toContain("input: './src/tools/defi/index.ts'")
@@ -97,6 +107,9 @@ describe('public API subpath exports', () => {
     expect(platformRollupConfig).toContain("input: './src/tx/index.ts'")
     expect(platformRollupConfig).toContain("distBase: 'tx'")
 
+    expect(typesRollupConfig).toContain(
+      "createSubpathTypesConfig('src/tools/index.ts', 'dist/tools/index.d.ts')"
+    )
     expect(typesRollupConfig).toContain(
       "createSubpathTypesConfig('src/tools/parse/index.ts', 'dist/tools/parse/index.d.ts')"
     )


### PR DESCRIPTION
## Summary
- publish `@vultisig/sdk/tools` as a real package subpath
- add dedicated runtime + d.ts bundle wiring for `src/tools/index.ts`
- lock the new public surface in the existing subpath export regression test

Closes #2030.

## Testing
- `corepack yarn workspace @vultisig/sdk vitest run --config tests/unit/vitest.config.ts tests/unit/public-api/toolsSubpathExports.test.ts`
- `corepack yarn build:platform:node` (from `packages/sdk/`)
- `corepack yarn build:types` (from `packages/sdk/`)
- `corepack yarn workspace @vultisig/sdk pack --out /tmp/sdk-r151-tools-barrel/vultisig-sdk-tools-barrel.tgz`
- fresh temp consumer import smoke for `@vultisig/sdk/tools`

## Receipts
### Targeted public-surface test
```text
✓ tests/unit/public-api/toolsSubpathExports.test.ts
  ✓ publishes dedicated export-map entries for every narrow public surface
  ✓ keeps dedicated JS and d.ts bundle generation wired for every narrow public surface
```

### Fresh temp consumer import smoke
```json
{"findSwapQuote":"function","decodeFromToolResult":"function","gas":"object"}
```

## Honest blockers observed
- `corepack yarn build:sdk` on the fresh clone is still blocked by the pre-existing Cardano typing error in `packages/core/mpc/keysign/signingInputs/resolvers/cardano.ts` (`auxiliaryData` not accepted by `ISigningInput`).
- `corepack yarn cli:build` is still blocked by pre-existing missing Ripple dist exports from sibling workspaces (`@vultisig/core-chain/chains/ripple/address`, `@vultisig/core-mpc/.../rippleDestinationTag`).
- Neither blocker is introduced by this subpath-export patch.

## Audit report
- Round 151 gist mirror: https://gist.github.com/gomesalexandre/ef014aae3a903a1720f27f9b2a5f894e
- Campaign index artifact (unchanged; Artifact tool unavailable in this runtime): https://claude.ai/code/artifact/be2deadf-6195-4dfa-a910-b269b9af7a84
