### PR TITLE
fix(sdk): parse secured-asset THOR swap memos

### DIFF
--- a/.changeset/bright-lions-swap-memo.md
+++ b/.changeset/bright-lions-swap-memo.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+Accept THORChain secured-asset `CHAIN-ASSET` notation in `parseThorSwapMemo`, so first-party consumers can parse swap memos that target secured assets like `ETH-USDC-0x…` and `XRP-XRP` without keeping drifted local parsers.

--- a/packages/sdk/src/utils/thorSwapMemo.ts
+++ b/packages/sdk/src/utils/thorSwapMemo.ts
@@ -1,4 +1,5 @@
 import { Chain } from '@vultisig/core-chain/Chain'
+import { findThorchainMemoAssetSeparatorIndex } from '@vultisig/core-chain/swap/native/thorchainMemoAsset'
 
 import { VaultError, VaultErrorCode } from '../vault/VaultError'
 
@@ -59,6 +60,8 @@ const THOR_MEMO_ASSET_SHORTCUTS: Record<string, string> = {
  * - `destChainCode` is the raw memo chain prefix (`XRP`, `ETH`, ...).
  * - `destAsset` is the asset ticker only — any ERC-20 contract suffix
  *   (`USDC-0X...`) is stripped because SDK swap callers take the ticker.
+ *   Secured-asset notation (`ETH-USDC-0X...`, `XRP-XRP`) uses the FIRST
+ *   separator as the chain boundary, not the last `-` inside the denom.
  * - `destAddress` is the user-supplied destination on the destination chain.
  *   May be empty when the memo omits it (THORChain treats this as "refund to
  *   source"). FUND-SAFETY: callers MUST validate this against the vault's own
@@ -79,7 +82,8 @@ export type ParsedThorSwapMemo = {
  *
  * Accepts the shorthand notation documented at
  * https://docs.thorchain.org/concepts/asset-notation#asset-shorthand
- * (`x` → `XRP.XRP`, `e` → `ETH.ETH`, ...).
+ * (`x` → `XRP.XRP`, `e` → `ETH.ETH`, ...), plus THORChain secured-asset
+ * notation (`CHAIN-ASSET`) that first-party consumers now emit/display.
  *
  * Throws `VaultError(NotImplemented)` for non-swap memos and
  * `VaultError(InvalidConfig)` for malformed swap memos. Unknown destination
@@ -98,19 +102,21 @@ export function parseThorSwapMemo(memo: string): ParsedThorSwapMemo {
   const parts = memoBody.split(':')
 
   let chainAsset = parts[0]
-  if (chainAsset && !chainAsset.includes('.')) {
+  if (chainAsset && !chainAsset.includes('.') && !chainAsset.includes('-')) {
     const expanded = THOR_MEMO_ASSET_SHORTCUTS[chainAsset.toLowerCase()]
     if (expanded) chainAsset = expanded
   }
 
-  if (!chainAsset || !chainAsset.includes('.')) {
+  const separatorIndex = chainAsset ? findThorchainMemoAssetSeparatorIndex(chainAsset) : -1
+  if (!chainAsset || separatorIndex === -1) {
     throw new VaultError(
       VaultErrorCode.InvalidConfig,
       `parseThorSwapMemo: malformed swap memo '${memo}': missing CHAIN.ASSET in first segment.`
     )
   }
 
-  const [destChainCode, destAssetRaw] = chainAsset.split('.')
+  const destChainCode = chainAsset.slice(0, separatorIndex).toUpperCase()
+  const destAssetRaw = chainAsset.slice(separatorIndex + 1)
   const toChain = THOR_MEMO_CHAIN_TO_ENUM[destChainCode]
   if (!toChain) {
     throw new VaultError(

--- a/packages/sdk/tests/unit/utils/parseThorSwapMemo.test.ts
+++ b/packages/sdk/tests/unit/utils/parseThorSwapMemo.test.ts
@@ -30,6 +30,22 @@ describe('parseThorSwapMemo', () => {
       expect(parsed.toChain).toBe(Chain.Ethereum)
     })
 
+    it('parses secured-asset notation (ETH-USDC-0X...) using the first separator as the chain boundary', () => {
+      const parsed = parseThorSwapMemo('=:ETH-USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48:0xabc::v0:50')
+      expect(parsed.destChainCode).toBe('ETH')
+      expect(parsed.destAsset).toBe('USDC')
+      expect(parsed.destAddress).toBe('0xabc')
+      expect(parsed.toChain).toBe(Chain.Ethereum)
+    })
+
+    it('parses secured-asset notation with no contract suffix (XRP-XRP)', () => {
+      const parsed = parseThorSwapMemo('=:XRP-XRP:rf7SyXdM3aZqkz9bmgGgX6V3eC8oJ8wxYY::v0:50')
+      expect(parsed.destChainCode).toBe('XRP')
+      expect(parsed.destAsset).toBe('XRP')
+      expect(parsed.destAddress).toBe('rf7SyXdM3aZqkz9bmgGgX6V3eC8oJ8wxYY')
+      expect(parsed.toChain).toBe(Chain.Ripple)
+    })
+
     it('accepts memo without slippage suffix', () => {
       const parsed = parseThorSwapMemo('=:BTC.BTC:bc1qzmsk98gqtfvxhfrye8p7xkxlj6g9q6a2yj3yj2')
       expect(parsed.destChainCode).toBe('BTC')


### PR DESCRIPTION
## Summary
- teach `parseThorSwapMemo(...)` to accept THORChain secured-asset `CHAIN-ASSET` notation
- pin the behavior with focused unit coverage for `ETH-USDC-0x...` and `XRP-XRP`
- add a changeset because this is public SDK behavior consumed by downstream app/CLI code

## Issue
- closes https://github.com/vultisig/vultisig-sdk/issues/2032

## Receipts
- RED: `corepack yarn workspace @vultisig/sdk vitest run --config tests/unit/vitest.config.ts tests/unit/utils/parseThorSwapMemo.test.ts` failed on the two new secured-asset cases before the code change
- GREEN: same focused test passed after the fix (`20 passed`)
- `corepack yarn lint` ✅
- `corepack yarn build:platform:node` ✅
- `corepack yarn build:types` ✅
- `corepack yarn workspace @vultisig/sdk pack --out /tmp/improve-r153-sdk/vultisig-sdk-thor-memo-fix.tgz` ✅
- temp consumer receipt: installing that tarball and calling `parseThorSwapMemo('=:ETH-USDC-0X...')` / `parseThorSwapMemo('=:XRP-XRP:...')` returned `{ destAsset: 'USDC' }` and `{ destAsset: 'XRP' }`

## Honest blockers
- `corepack yarn build:sdk` is still red on clean `origin/main` because of the pre-existing Cardano typing error in `packages/core/mpc/keysign/signingInputs/resolvers/cardano.ts` (`auxiliaryData` not accepted by `ISigningInput`).
- `corepack yarn workspace @vultisig/sdk test` in this disposable clone still hits the known borrowed-install missing-dist problem (`packages/core/config/dist/index.js` not found), so I am not claiming a full green workspace test receipt from this environment.

## Cross-repo context
- Round 153 report: https://gist.github.com/gomesalexandre/0f49bbfeb0808227516767c9b6ffbee1
- app follow-up issue (consumer still owns a drifted parser): https://github.com/vultisig/vultiagent-app/issues/2583
- app follow-up issue (consumer source-chain map omits Noble): https://github.com/vultisig/vultiagent-app/issues/2584
