### PR TITLE
fix(sdk): export cosmos staking validator canonicals

### DIFF
--- a/.changeset/export-cosmos-staking-validator-surface.md
+++ b/.changeset/export-cosmos-staking-validator-surface.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+Export the Cosmos staking validator helpers from the root and React Native SDK entrypoints.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -651,6 +651,12 @@ export {
 export type {
   ContinuousVestingAccount,
   Coin as CosmosStakingCoin,
+  // Aliased: `Validator` is already public as StakeKit's yield-validator shape
+  // (name/apr/commission/stakedBalance), and this is the cosmos staking LCD
+  // shape (operatorAddress/jailed/status/tokens). Different domains, same word.
+  // The StakeKit one keeps the bare name because it was public first; renaming
+  // it would break consumers.
+  Validator as CosmosStakingValidator,
   DelayedVestingAccount,
   Delegation,
   DelegatorReward,
@@ -659,7 +665,6 @@ export type {
   StakingChain,
   UnbondingDelegation,
   UnbondingEntry,
-  Validator,
   ValidatorCommission,
   ValidatorDescription,
   ValidatorStatus,
@@ -676,8 +681,8 @@ export {
   getDelegationsUrl,
   getDelegatorRewardsUrl,
   getUnbondingDelegationsUrl,
-  getValidatorUrl,
   getValidatorsUrl,
+  getValidatorUrl,
 } from '@vultisig/core-chain/chains/cosmos/staking/lcdQueries'
 
 // Cosmos governance (read proposals + build unsigned MsgVote envelope —

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -656,8 +656,13 @@ export type {
   DelegatorReward,
   DelegatorRewardsResponse,
   PeriodicVestingAccount,
+  StakingChain,
   UnbondingDelegation,
   UnbondingEntry,
+  Validator,
+  ValidatorCommission,
+  ValidatorDescription,
+  ValidatorStatus,
   VestingAccount,
 } from '@vultisig/core-chain/chains/cosmos/staking/lcdQueries'
 export {
@@ -665,10 +670,14 @@ export {
   getCosmosDelegations,
   getCosmosDelegatorRewards,
   getCosmosUnbondingDelegations,
+  getCosmosValidator,
+  getCosmosValidators,
   getCosmosVestingAccount,
   getDelegationsUrl,
   getDelegatorRewardsUrl,
   getUnbondingDelegationsUrl,
+  getValidatorUrl,
+  getValidatorsUrl,
 } from '@vultisig/core-chain/chains/cosmos/staking/lcdQueries'
 
 // Cosmos governance (read proposals + build unsigned MsgVote envelope —

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -505,8 +505,13 @@ export type {
   DelegatorReward,
   DelegatorRewardsResponse,
   PeriodicVestingAccount,
+  StakingChain,
   UnbondingDelegation,
   UnbondingEntry,
+  Validator,
+  ValidatorCommission,
+  ValidatorDescription,
+  ValidatorStatus,
   VestingAccount,
 } from '@vultisig/core-chain/chains/cosmos/staking/lcdQueries'
 export {
@@ -514,10 +519,14 @@ export {
   getCosmosDelegations,
   getCosmosDelegatorRewards,
   getCosmosUnbondingDelegations,
+  getCosmosValidator,
+  getCosmosValidators,
   getCosmosVestingAccount,
   getDelegationsUrl,
   getDelegatorRewardsUrl,
   getUnbondingDelegationsUrl,
+  getValidatorUrl,
+  getValidatorsUrl,
 } from '@vultisig/core-chain/chains/cosmos/staking/lcdQueries'
 
 // Cosmos governance — read proposals + build unsigned MsgVote envelope.

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -525,8 +525,8 @@ export {
   getDelegationsUrl,
   getDelegatorRewardsUrl,
   getUnbondingDelegationsUrl,
-  getValidatorUrl,
   getValidatorsUrl,
+  getValidatorUrl,
 } from '@vultisig/core-chain/chains/cosmos/staking/lcdQueries'
 
 // Cosmos governance — read proposals + build unsigned MsgVote envelope.

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -208,7 +208,9 @@ describe('RN entry wires configureCrypto and configureDefaultStorage', () => {
     expect(rn.getValidatorsUrl(rn.Chain.Cosmos, { status: 'BOND_STATUS_BONDED', limit: 25 })).toContain(
       'status=BOND_STATUS_BONDED'
     )
-    expect(rn.getValidatorUrl(rn.Chain.Cosmos, 'cosmosvaloper1validator')).toContain('/validators/cosmosvaloper1validator')
+    expect(rn.getValidatorUrl(rn.Chain.Cosmos, 'cosmosvaloper1validator')).toContain(
+      '/validators/cosmosvaloper1validator'
+    )
   })
 
   it('exports the generic CosmWasm execute message builder from the RN root surface', async () => {

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -198,6 +198,19 @@ describe('RN entry wires configureCrypto and configureDefaultStorage', () => {
     expect(rn.isCosmosMemoWithinCap(rn.Chain.Osmosis, 'a'.repeat(257))).toBe(false)
   })
 
+  it('exports the Cosmos staking validator helpers from the RN entry', async () => {
+    const rn = await import('../../../../src/platforms/react-native/index')
+
+    expect(typeof rn.getCosmosValidators).toBe('function')
+    expect(typeof rn.getCosmosValidator).toBe('function')
+    expect(typeof rn.getValidatorsUrl).toBe('function')
+    expect(typeof rn.getValidatorUrl).toBe('function')
+    expect(rn.getValidatorsUrl(rn.Chain.Cosmos, { status: 'BOND_STATUS_BONDED', limit: 25 })).toContain(
+      'status=BOND_STATUS_BONDED'
+    )
+    expect(rn.getValidatorUrl(rn.Chain.Cosmos, 'cosmosvaloper1validator')).toContain('/validators/cosmosvaloper1validator')
+  })
+
   it('exports the generic CosmWasm execute message builder from the RN root surface', async () => {
     const sdk = await import('../../../../src/platforms/react-native/index')
 

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -252,6 +252,17 @@ describe('@vultisig/sdk public exports', () => {
     expect(sdk.thorchainSecuredAssetFallback.length).toBeGreaterThan(10)
   })
 
+  it('exports the Cosmos staking validator helpers from the root sdk surface', () => {
+    expect(typeof sdk.getCosmosValidators).toBe('function')
+    expect(typeof sdk.getCosmosValidator).toBe('function')
+    expect(typeof sdk.getValidatorsUrl).toBe('function')
+    expect(typeof sdk.getValidatorUrl).toBe('function')
+    expect(sdk.getValidatorsUrl(sdk.Chain.Cosmos, { status: 'BOND_STATUS_BONDED', limit: 25 })).toContain(
+      'status=BOND_STATUS_BONDED'
+    )
+    expect(sdk.getValidatorUrl(sdk.Chain.Cosmos, 'cosmosvaloper1validator')).toContain('/validators/cosmosvaloper1validator')
+  })
+
   it('exports canonical EVM chain-id, RPC, and priority-fee-clamp helpers from the root sdk surface', () => {
     expect(typeof sdk.getEvmChainId).toBe('function')
     expect(typeof sdk.getEvmChainByChainId).toBe('function')

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -260,7 +260,9 @@ describe('@vultisig/sdk public exports', () => {
     expect(sdk.getValidatorsUrl(sdk.Chain.Cosmos, { status: 'BOND_STATUS_BONDED', limit: 25 })).toContain(
       'status=BOND_STATUS_BONDED'
     )
-    expect(sdk.getValidatorUrl(sdk.Chain.Cosmos, 'cosmosvaloper1validator')).toContain('/validators/cosmosvaloper1validator')
+    expect(sdk.getValidatorUrl(sdk.Chain.Cosmos, 'cosmosvaloper1validator')).toContain(
+      '/validators/cosmosvaloper1validator'
+    )
   })
 
   it('exports canonical EVM chain-id, RPC, and priority-fee-clamp helpers from the root sdk surface', () => {


### PR DESCRIPTION
## Summary
- export the Cosmos staking validator helper family from the root SDK entry
- export the same validator helper family from the React Native SDK entry
- extend root/RN public-surface regression coverage

## Testing
- `VULTISIG_STRICT_SINGLETON=0 ../../node_modules/.bin/vitest run --config packages/sdk/tests/unit/vitest.config.ts packages/sdk/tests/unit/utils/publicExports.test.ts packages/sdk/tests/unit/platforms/react-native/entry.test.ts --testTimeout=15000`
  - ✅ 103 tests passed
- `corepack yarn build:sdk`
  - ❌ pre-existing clean-main blocker: `packages/core/mpc/keysign/signingInputs/resolvers/cardano.ts(72,5): error TS2353: 'auxiliaryData' does not exist in type 'ISigningInput'`
- `corepack yarn workspace @vultisig/sdk pack --out /tmp/sdk-r153-staking-export-surface.tgz`
  - ✅ tarball generated
- throwaway consumer import of the packed tarball
  - ❌ blocked because `build:sdk` is already red on clean main, so the package lacks `dist/index.node.esm.js`

## Receipts
- focused root + RN public export tests prove the new surface is available from source
- broader SDK bundle / tarball-consumer receipts remain blocked by the pre-existing Cardano build failure above

Closes #2035
