### PR TITLE
feat(sdk): export single-source EVM gas-floor table

### DIFF
--- a/.changeset/w6-1351.md
+++ b/.changeset/w6-1351.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Add `EVM_GAS_FLOOR_WEI` and `getEvmMaxFeeFloorWei`, exported from both the root SDK entry and the React Native entry — a single source for the per-chain EVM gas-pricing floor (base + priority fee, wei) previously hand-copied between vultiagent-app's `MIN_PRIORITY_FEE_BY_CHAIN`/`MIN_MAX_FEE_BY_CHAIN` and agent-backend-ts's `GAS_FLOORS_WEI`, synced only by comment. The app's copy had already drifted from abts's (missing an Ethereum entry abts carries), which this consolidation prevents going forward. Values are sourced from abts's table, the more complete of the two. Consumers migrating onto this export retire their own copies in a follow-up PR.

--- a/packages/core/chain/tx/fee/evm/evmGasFloor.test.ts
+++ b/packages/core/chain/tx/fee/evm/evmGasFloor.test.ts
@@ -1,0 +1,45 @@
+import { EvmChain } from '@vultisig/core-chain/Chain'
+import { describe, expect, it } from 'vitest'
+
+import { EVM_GAS_FLOOR_WEI, getEvmMaxFeeFloorWei } from './evmGasFloor'
+
+const gwei = (n: number) => BigInt(Math.round(n * 1e9))
+
+describe('EVM_GAS_FLOOR_WEI', () => {
+  // Pins the values previously hand-copied between vultiagent-app's
+  // MIN_PRIORITY_FEE_BY_CHAIN/MIN_MAX_FEE_BY_CHAIN and agent-backend-ts's
+  // GAS_FLOORS_WEI, sourced from abts's copy (the more complete one — the
+  // app's copy was missing an Ethereum entry, sdk#1351).
+  it.each([
+    [EvmChain.Sei, gwei(1.5), gwei(0.1)],
+    [EvmChain.Hyperliquid, gwei(1), gwei(0.1)],
+    [EvmChain.Arbitrum, gwei(0.1), gwei(0.01)],
+    [EvmChain.Optimism, gwei(0.1), gwei(0.001)],
+    [EvmChain.Base, gwei(0.1), gwei(0.001)],
+    [EvmChain.Mantle, gwei(0.1), gwei(0.001)],
+    [EvmChain.BSC, gwei(1), gwei(3)],
+    [EvmChain.Polygon, gwei(1), gwei(30)],
+    [EvmChain.Ethereum, gwei(1), gwei(1)],
+  ])('pins the %s base/priority floor', (chain, basePerGas, priorityPerGas) => {
+    expect(EVM_GAS_FLOOR_WEI[chain]).toEqual({ basePerGas, priorityPerGas })
+  })
+
+  it.each([EvmChain.Avalanche, EvmChain.CronosChain, EvmChain.Blast, EvmChain.Zksync, EvmChain.Robinhood])(
+    'has no floor for %s (no documented evidence of a sub-floor rejection)',
+    chain => {
+      expect(EVM_GAS_FLOOR_WEI[chain]).toBeUndefined()
+    }
+  )
+})
+
+describe('getEvmMaxFeeFloorWei', () => {
+  it('sums base + priority for a floored chain', () => {
+    expect(getEvmMaxFeeFloorWei(EvmChain.BSC)).toBe(gwei(4)) // 1 + 3 gwei
+    expect(getEvmMaxFeeFloorWei(EvmChain.Polygon)).toBe(gwei(31)) // 1 + 30 gwei
+    expect(getEvmMaxFeeFloorWei(EvmChain.Ethereum)).toBe(gwei(2)) // 1 + 1 gwei
+  })
+
+  it('returns undefined for an unfloored chain', () => {
+    expect(getEvmMaxFeeFloorWei(EvmChain.Avalanche)).toBeUndefined()
+  })
+})

--- a/packages/core/chain/tx/fee/evm/evmGasFloor.ts
+++ b/packages/core/chain/tx/fee/evm/evmGasFloor.ts
@@ -1,0 +1,50 @@
+import { EvmChain } from '@vultisig/core-chain/Chain'
+
+/**
+ * Per-chain minimum EVM gas pricing (wei), keyed by `EvmChain`.
+ *
+ * Chains absent from this table have no known evidence they need one — their
+ * fee markets clear without a protocol-level minimum (no floor is the safe
+ * default; an unfloored fee only under-quotes on those chains if a wallet's
+ * own RPC sampling is broken, which this table doesn't defend against).
+ *
+ * Single source of truth: this table used to be hand-copied between
+ * `vultiagent-app`'s `MIN_PRIORITY_FEE_BY_CHAIN`/`MIN_MAX_FEE_BY_CHAIN`
+ * (src/services/evmTx.ts) and `agent-backend-ts`'s `GAS_FLOORS_WEI`
+ * (src/mastra/tools/mcp/tools/evm/evm-tx-info.ts), synced by comment rather
+ * than import — the app's copy had already drifted (missing an Ethereum
+ * entry abts carries). Values below are sourced from abts's `GAS_FLOORS_WEI`
+ * as of 2026-07, the more complete of the two copies (vultisig-sdk#1351).
+ *
+ * This is a distinct concern from `clampEvmPriorityFee` in this same
+ * directory: that one clamps an RPC-*reported* priority fee against a sanity
+ * ceiling/floor on the SDK's own signing path. This table floors a
+ * client/server-computed fee *before* it reaches an RPC-backed estimate at
+ * all (e.g. a stuck-tx replacement, or a server envelope that omitted gas
+ * pricing) — the two tables aren't required to agree and this change doesn't
+ * touch `clampEvmPriorityFee`.
+ *
+ * Over-floor direction only: every value here can only raise an
+ * under-priced fee, never lower a correctly-priced one.
+ */
+export const EVM_GAS_FLOOR_WEI: Partial<Record<EvmChain, { basePerGas: bigint; priorityPerGas: bigint }>> = {
+  Sei: { basePerGas: 1_500_000_000n, priorityPerGas: 100_000_000n }, // 1.5 gwei / 0.1 gwei
+  Hyperliquid: { basePerGas: 1_000_000_000n, priorityPerGas: 100_000_000n }, // 1 gwei / 0.1 gwei
+  Arbitrum: { basePerGas: 100_000_000n, priorityPerGas: 10_000_000n }, // 0.1 gwei / 0.01 gwei
+  Optimism: { basePerGas: 100_000_000n, priorityPerGas: 1_000_000n }, // 0.1 gwei / 0.001 gwei
+  Base: { basePerGas: 100_000_000n, priorityPerGas: 1_000_000n }, // 0.1 gwei / 0.001 gwei
+  Mantle: { basePerGas: 100_000_000n, priorityPerGas: 1_000_000n }, // 0.1 gwei / 0.001 gwei
+  BSC: { basePerGas: 1_000_000_000n, priorityPerGas: 3_000_000_000n }, // 1 gwei / 3 gwei
+  Polygon: { basePerGas: 1_000_000_000n, priorityPerGas: 30_000_000_000n }, // 1 gwei / 30 gwei
+  Ethereum: { basePerGas: 1_000_000_000n, priorityPerGas: 1_000_000_000n }, // 1 gwei / 1 gwei
+}
+
+/**
+ * `basePerGas + priorityPerGas` floor for a chain, or `undefined` when the
+ * chain has no floor. Matches `MIN_MAX_FEE_BY_CHAIN`'s derivation in the
+ * app's copy — kept as a helper here so consumers don't re-derive it.
+ */
+export const getEvmMaxFeeFloorWei = (chain: EvmChain): bigint | undefined => {
+  const floor = EVM_GAS_FLOOR_WEI[chain]
+  return floor ? floor.basePerGas + floor.priorityPerGas : undefined
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -421,6 +421,16 @@ export {
 export { getEvmChainByChainId, getEvmChainId, getEvmRpcUrl } from '@vultisig/core-chain/chains/evm/chainInfo'
 export { clampEvmPriorityFee } from '@vultisig/core-chain/tx/fee/evm/clampEvmPriorityFee'
 
+// Per-chain EVM gas-floor table — single source of truth for the client/
+// server-computed-fee floor previously hand-copied between vultiagent-app's
+// MIN_PRIORITY_FEE_BY_CHAIN/MIN_MAX_FEE_BY_CHAIN and agent-backend-ts's
+// GAS_FLOORS_WEI, synced by comment rather than import (the exact drift
+// class above — the app's copy had already lost an Ethereum entry abts
+// carries). Distinct from clampEvmPriorityFee: that clamps an RPC-*reported*
+// fee on the SDK's own signing path; this floors a fee before it reaches an
+// RPC estimate at all.
+export { EVM_GAS_FLOOR_WEI, getEvmMaxFeeFloorWei } from '@vultisig/core-chain/tx/fee/evm/evmGasFloor'
+
 // Noon USDC yield vault SDK boundary. Consumers should use these helpers
 // instead of calling Noon/Accountable APIs or hand-encoding ERC-7540 calldata.
 export type {

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -438,6 +438,10 @@ export {
 export { getEvmChainByChainId, getEvmChainId } from '@vultisig/core-chain/chains/evm/chainInfo'
 export { clampEvmPriorityFee } from '@vultisig/core-chain/tx/fee/evm/clampEvmPriorityFee'
 
+// Per-chain EVM gas-floor table — see src/index.ts for the full drift-class
+// rationale (sdk#1351). Pure data + a sum helper, no chain-client deps.
+export { EVM_GAS_FLOOR_WEI, getEvmMaxFeeFloorWei } from '@vultisig/core-chain/tx/fee/evm/evmGasFloor'
+
 // Gas / fee primitives (read-only — uses global `fetch` + type-only imports,
 // no heavy chain client at module init). The RN allow-list omitted these so RN
 // consumers (vultiagent-app) couldn't resolve current UTXO sat/vB rates OR the

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -397,6 +397,19 @@ describe('RN entry exposes toChainAmount + ChainAmountParseError', () => {
     ).toBe(50n * 1_000_000_000n)
   })
 
+  it('exports the shared EVM gas-floor table from the RN entry (sdk#1351)', async () => {
+    const rn = await import('../../../../src/platforms/react-native/index')
+
+    expect(rn.EVM_GAS_FLOOR_WEI[rn.Chain.BSC as keyof typeof rn.EVM_GAS_FLOOR_WEI]).toEqual({
+      basePerGas: 1_000_000_000n,
+      priorityPerGas: 3_000_000_000n,
+    })
+    expect(typeof rn.getEvmMaxFeeFloorWei).toBe('function')
+    expect(rn.getEvmMaxFeeFloorWei(rn.Chain.Polygon as Parameters<typeof rn.getEvmMaxFeeFloorWei>[0])).toBe(
+      31_000_000_000n
+    )
+  })
+
   it('exports the canonical gas comparison helpers from the RN entry', async () => {
     const rn = await import('../../../../src/platforms/react-native/index')
     const gas = await import('../../../../src/tools/gas')

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -266,6 +266,20 @@ describe('@vultisig/sdk public exports', () => {
     ).toBe(50n * 1_000_000_000n)
   })
 
+  it('exports the shared EVM gas-floor table used by app+abts to stop hand-copying it (sdk#1351)', () => {
+    expect(sdk.EVM_GAS_FLOOR_WEI[sdk.Chain.BSC as keyof typeof sdk.EVM_GAS_FLOOR_WEI]).toEqual({
+      basePerGas: 1_000_000_000n,
+      priorityPerGas: 3_000_000_000n,
+    })
+    expect(typeof sdk.getEvmMaxFeeFloorWei).toBe('function')
+    expect(sdk.getEvmMaxFeeFloorWei(sdk.Chain.Polygon as Parameters<typeof sdk.getEvmMaxFeeFloorWei>[0])).toBe(
+      31_000_000_000n
+    )
+    expect(sdk.getEvmMaxFeeFloorWei(sdk.Chain.Avalanche as Parameters<typeof sdk.getEvmMaxFeeFloorWei>[0])).toBe(
+      undefined
+    )
+  })
+
   it('exports gas comparison helpers from the root sdk surface', () => {
     expect(typeof sdk.compareCosts).toBe('function')
     expect(Array.isArray(sdk.DEFAULT_COMPARE_CHAINS)).toBe(true)


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#1351

Added `EVM_GAS_FLOOR_WEI` + `getEvmMaxFeeFloorWei` to
`packages/core/chain/tx/fee/evm/evmGasFloor.ts`, exported from both the SDK root (`packages/sdk/src/index.ts`)
and the React Native entry (`packages/sdk/src/platforms/react-native/index.ts`).

The two hand-copied tables the issue names are real and I confirmed they've already drifted: I have local
read-only checkouts of both consumer repos on this machine (`~/Sites/agent-backend-ts`,
`~/Sites/vultiagent-app`) and diffed them directly (no write access used, no changes made there).
`agent-backend-ts`'s `GAS_FLOORS_WEI` (`src/mastra/tools/mcp/tools/evm/evm-tx-info.ts:44`) has 9 chains
including Ethereum; `vultiagent-app`'s `MIN_PRIORITY_FEE_BY_CHAIN`/`MIN_MAX_FEE_BY_CHAIN`
(`src/services/evmTx.ts:63-99`) only has 8, missing the Ethereum entry abts carries — exactly the "any
chain that gets a gas-floor bump in one repo silently drifts from the other" failure mode the issue
describes. Sourced the new SDK table from abts's copy (the more complete one, and the one the app's own
comments cite as canonical: "Values match agent-backend-ts exactly").

Kept this distinct from the SDK's existing `clampEvmPriorityFee` (same directory): that one clamps an
RPC-*reported* priority fee on the SDK's own signing path (sanity ceiling/floor against a compromised
RPC); this new table floors a fee *before* it reaches an RPC estimate at all — the app/abts use case
(client-side fallback computation, server envelope missing gas pricing). Did not touch
`clampEvmPriorityFee` or merge the two tables — out of scope for this issue.

Did NOT migrate `vultiagent-app` or `agent-backend-ts` onto this export — that's cross-repo work in
those repos' own PRs (the issue frames this as "the foundation for abts#PR-5", i.e. a follow-up).

## what I ran
```
cd /tmp/claude-1000/wt-sdk-w6
npx vitest run --config .config/vitest.core.config.ts packages/core/chain/tx/fee/evm/
# Test Files  2 passed (2)
#      Tests  46 passed (46)   (30 existing clampEvmPriorityFee + 16 new evmGasFloor)

cd packages/sdk
npx vitest run --config tests/unit/vitest.config.ts tests/unit/utils/publicExports.test.ts
# Test Files  1 passed (1)
#      Tests  56 passed (56)   (55 existing + 1 new)

npx vitest run --config tests/unit/vitest.config.ts tests/unit/platforms/react-native/entry.test.ts
# Test Files  1 passed (1)
#      Tests  47 passed (47)   (46 existing + 1 new)

npx tsc --noEmit -p tsconfig.json   # (packages/sdk) — exit 0

cd /tmp/claude-1000/wt-sdk-w6
npx tsc --noEmit -p .config/tsconfig.shared-publish.json --outDir /tmp/claude-1000/tmp/tsc-check-1351
# no errors across the whole shared-packages monorepo build (cleaned up afterward)
```

closes vultisig/vultisig-sdk#1351