### PR TITLE
feat(sdk): port sui prebuilt sender-mismatch fail-closed guard from vultiagent-app

### DIFF
--- a/.changeset/w5-1993.md
+++ b/.changeset/w5-1993.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Adds `extractSuiPrebuiltSender`/`assertSuiPrebuiltSenderMatchesVault` (exported from the React Native Sui bridge), a fail-closed BCS decoder that pins the `sender` field of a prebuilt Sui `TransactionData` PTB before signing. Previously this lived only as a hand-rolled parser in `vultiagent-app`, so any other consumer signing prebuilt Sui bytes had to duplicate the decoder or sign blind — including for the sponsored-transaction shape where a mismatched `sender` can make the signer pay an attacker's gas as an unwitting sponsor.

--- a/packages/sdk/src/platforms/react-native/chains/sui/index.ts
+++ b/packages/sdk/src/platforms/react-native/chains/sui/index.ts
@@ -1,1 +1,2 @@
+export { assertSuiPrebuiltSenderMatchesVault, extractSuiPrebuiltSender } from './prebuiltBcs'
 export { buildSuiSerializedSignature, buildSuiSigningHash, deriveSuiAddress } from './tx'

--- a/packages/sdk/src/platforms/react-native/chains/sui/prebuiltBcs.ts
+++ b/packages/sdk/src/platforms/react-native/chains/sui/prebuiltBcs.ts
@@ -1,0 +1,391 @@
+/**
+ * Hand-rolled BCS (Binary Canonical Serialization) reader for Sui prebuilt
+ * `TransactionData` bytes — scoped to ONE job: pin the `sender` field before
+ * a consumer blind-signs a backend-supplied PTB.
+ *
+ * Vendored from `vultiagent-app/src/services/suiPrebuiltBcs.ts`, where it
+ * closed app#2131 (later hardened fail-closed in app#2447). The SDK already
+ * owns the prebuilt-byte signing/hash contract (`buildSuiSigningHash` in
+ * `./tx`) but not this safety helper, so every first-party consumer of that
+ * signing contract had to duplicate the parser or skip the bind.
+ *
+ * Sui's `TransactionDataV1` BCS layout is `{ kind, sender, gasData, expiration }`.
+ * `sender` sits AFTER `kind: TransactionKind`, and `TransactionKind::ProgrammableTransaction`
+ * is a variable-length `{ inputs: Vec<CallArg>, commands: Vec<Command> }` where
+ * every element is itself enum-tagged BCS. There is no fixed offset for `sender`
+ * — reaching it means structurally walking (not semantically interpreting) the
+ * whole PTB body. This module does exactly that: it decodes ONLY enough of each
+ * field to know how many bytes to skip, and reads real values nowhere except the
+ * final 32-byte `sender` address.
+ *
+ * Schema verified byte-for-byte against `@mysten/sui`'s bcs.ts (the same
+ * library upstream prebuilt-tx builders use), cross-checked against real PTB
+ * fixtures (SplitCoins + TransferObjects, and a MoveCall + MakeMoveVec case
+ * exercising nested TypeTag/StructTag recursion) — see the test file.
+ *
+ * FAIL-CLOSED on any parse error. Sui's BCS PTB schema is intricate (7
+ * Command variants, a recursive TypeTag, 3 CallArg variants); a decoder bug
+ * or a future protocol variant this reader doesn't know about must NOT
+ * become a silent bypass of the sender bind. `extractSuiPrebuiltSender`
+ * throws on anything it can't confidently walk; `assertSuiPrebuiltSenderMatchesVault`
+ * lets that propagate as a refusal to sign rather than falling back to
+ * unbound behavior. A CONFIRMED sender mismatch (successfully decoded,
+ * doesn't match) and an UNDECODABLE PTB (drift/malformed/unsupported
+ * variant) both refuse the send — the only thing that signs is a PTB this
+ * reader could fully walk AND whose sender matches the vault.
+ */
+
+const SUI_ADDRESS_BYTES = 32
+
+class BcsCursor {
+  private offset = 0
+
+  constructor(private readonly bytes: Uint8Array) {}
+
+  private ensure(n: number): void {
+    if (n < 0 || this.offset + n > this.bytes.length) {
+      throw new Error(
+        `Sui prebuilt BCS: read past end of buffer (offset ${this.offset}, need ${n}, len ${this.bytes.length})`
+      )
+    }
+  }
+
+  readBytes(n: number): Uint8Array {
+    this.ensure(n)
+    const b = this.bytes.slice(this.offset, this.offset + n)
+    this.offset += n
+    return b
+  }
+
+  skip(n: number): void {
+    this.ensure(n)
+    this.offset += n
+  }
+
+  // ULEB128 - used by BCS for enum variant tags and Vec/String length prefixes
+  // ONLY (fixed-width ints like u64 are raw little-endian, not uleb128). Capped
+  // at 32 bits: no BCS vector length or enum tag in this schema needs more.
+  //
+  // Accumulates with `+ Math.pow(2, shift)` arithmetic, NOT `|= x << shift`.
+  // JS bitwise operators coerce to int32, so a bitwise accumulator SILENTLY
+  // TRUNCATES anything past bit 31 instead of throwing: `80 80 80 80 10`
+  // (uleb128 for 2^32) would decode to 0, and a length prefix collapsing to a
+  // small value makes the walk land on the WRONG offset and read 32
+  // attacker-placed bytes as `sender`. Since the attacker knows this vault's
+  // address, they could park it at that offset and turn a decode failure into
+  // a false PASS. Arithmetic accumulation + an explicit u32 range check makes
+  // the "exceeds 32 bits" contract this comment claims actually true.
+  readUleb128(): number {
+    let result = 0
+    let shift = 0
+    for (;;) {
+      this.ensure(1)
+      const byte = this.bytes[this.offset]!
+      this.offset += 1
+      result += (byte & 0x7f) * 2 ** shift
+      if (result > 0xffffffff) {
+        throw new Error('Sui prebuilt BCS: uleb128 value exceeds 32 bits')
+      }
+      if ((byte & 0x80) === 0) break
+      shift += 7
+      if (shift > 32) {
+        throw new Error('Sui prebuilt BCS: uleb128 value exceeds 32 bits')
+      }
+    }
+    return result
+  }
+}
+
+function skipVector(c: BcsCursor, skipElement: () => void): void {
+  const len = c.readUleb128()
+  for (let i = 0; i < len; i++) skipElement()
+}
+
+// byteVector / string: uleb128 length prefix + raw bytes. BCS encodes strings
+// as their raw utf8 bytes behind the same length-prefixed vector<u8> framing.
+function skipByteVector(c: BcsCursor): void {
+  const len = c.readUleb128()
+  c.skip(len)
+}
+
+// Address (SuiAddress): fixed 32 raw bytes, NO length prefix.
+function skipAddress(c: BcsCursor): void {
+  c.skip(SUI_ADDRESS_BYTES)
+}
+
+// TypeTag (Move type tag enum). Recursive via `vector` (nested TypeTag) and
+// `struct` (StructTag, which itself nests `vector<TypeTag>` typeParams).
+function skipTypeTag(c: BcsCursor): void {
+  const tag = c.readUleb128()
+  switch (tag) {
+    case 0: // bool
+    case 1: // u8
+    case 2: // u64
+    case 3: // u128
+    case 4: // address
+    case 5: // signer
+    case 8: // u16
+    case 9: // u32
+    case 10: // u256
+      return
+    case 6: // vector(TypeTag)
+      skipTypeTag(c)
+      return
+    case 7: // struct(StructTag)
+      skipStructTag(c)
+      return
+    default:
+      throw new Error(`Sui prebuilt BCS: unknown TypeTag variant ${tag}`)
+  }
+}
+
+function skipStructTag(c: BcsCursor): void {
+  skipAddress(c) // address
+  skipByteVector(c) // module (string)
+  skipByteVector(c) // name (string)
+  skipVector(c, () => skipTypeTag(c)) // typeParams
+}
+
+// Argument: references into inputs/results, never raw data directly.
+function skipArgument(c: BcsCursor): void {
+  const tag = c.readUleb128()
+  switch (tag) {
+    case 0: // GasCoin
+      return
+    case 1: // Input(u16)
+      c.skip(2)
+      return
+    case 2: // Result(u16)
+      c.skip(2)
+      return
+    case 3: // NestedResult(u16, u16)
+      c.skip(4)
+      return
+    default:
+      throw new Error(`Sui prebuilt BCS: unknown Argument variant ${tag}`)
+  }
+}
+
+function skipSuiObjectRef(c: BcsCursor): void {
+  skipAddress(c) // objectId
+  c.skip(8) // version: u64 (fixed 8-byte LE)
+  skipByteVector(c) // digest (ObjectDigest = length-prefixed byteVector)
+}
+
+function skipSharedObjectRef(c: BcsCursor): void {
+  skipAddress(c) // objectId
+  c.skip(8) // initialSharedVersion: u64
+  c.skip(1) // mutable: bool
+}
+
+function skipObjectArg(c: BcsCursor): void {
+  const tag = c.readUleb128()
+  switch (tag) {
+    case 0: // ImmOrOwnedObject
+      skipSuiObjectRef(c)
+      return
+    case 1: // SharedObject
+      skipSharedObjectRef(c)
+      return
+    case 2: // Receiving
+      skipSuiObjectRef(c)
+      return
+    default:
+      throw new Error(`Sui prebuilt BCS: unknown ObjectArg variant ${tag}`)
+  }
+}
+
+function skipFundsWithdrawal(c: BcsCursor): void {
+  // Reservation: { MaxAmountU64(u64) }
+  const reservationTag = c.readUleb128()
+  if (reservationTag !== 0) {
+    throw new Error(`Sui prebuilt BCS: unknown Reservation variant ${reservationTag}`)
+  }
+  c.skip(8)
+  // WithdrawalType: { Balance(TypeTag) }
+  const withdrawalTypeTag = c.readUleb128()
+  if (withdrawalTypeTag !== 0) {
+    throw new Error(`Sui prebuilt BCS: unknown WithdrawalType variant ${withdrawalTypeTag}`)
+  }
+  skipTypeTag(c)
+  // WithdrawFrom: { Sender, Sponsor }
+  const withdrawFromTag = c.readUleb128()
+  if (withdrawFromTag !== 0 && withdrawFromTag !== 1) {
+    throw new Error(`Sui prebuilt BCS: unknown WithdrawFrom variant ${withdrawFromTag}`)
+  }
+}
+
+// CallArg: an input to the PTB - a plain value (Pure), an object reference
+// (Object), or a funds-withdrawal reservation (FundsWithdrawal).
+function skipCallArg(c: BcsCursor): void {
+  const tag = c.readUleb128()
+  switch (tag) {
+    case 0: // Pure { bytes: byteVector }
+      skipByteVector(c)
+      return
+    case 1: // Object(ObjectArg)
+      skipObjectArg(c)
+      return
+    case 2: // FundsWithdrawal
+      skipFundsWithdrawal(c)
+      return
+    default:
+      throw new Error(`Sui prebuilt BCS: unknown CallArg variant ${tag}`)
+  }
+}
+
+function skipProgrammableMoveCall(c: BcsCursor): void {
+  skipAddress(c) // package
+  skipByteVector(c) // module (string)
+  skipByteVector(c) // function (string)
+  skipVector(c, () => skipTypeTag(c)) // typeArguments
+  skipVector(c, () => skipArgument(c)) // arguments
+}
+
+// Option<TypeTag> - BCS encodes Option the same as a 2-variant enum
+// (None=0, Some=1<value>); a uleb128 tag read handles both since 0/1 fit in
+// one byte either way.
+function skipOptionTypeTag(c: BcsCursor): void {
+  const tag = c.readUleb128()
+  if (tag === 0) return // None
+  if (tag === 1) {
+    skipTypeTag(c) // Some
+    return
+  }
+  throw new Error(`Sui prebuilt BCS: unknown Option<TypeTag> tag ${tag}`)
+}
+
+// Command: the 7 PTB command variants. This is where value actually moves
+// (TransferObjects/SplitCoins/MergeCoins) or arbitrary Move code runs
+// (MoveCall) - we still only SKIP here (no semantic interpretation), sender
+// is the only field this module binds.
+function skipCommand(c: BcsCursor): void {
+  const tag = c.readUleb128()
+  switch (tag) {
+    case 0: // MoveCall(ProgrammableMoveCall)
+      skipProgrammableMoveCall(c)
+      return
+    case 1: // TransferObjects { objects: Vec<Argument>, address: Argument }
+      skipVector(c, () => skipArgument(c))
+      skipArgument(c)
+      return
+    case 2: // SplitCoins { coin: Argument, amounts: Vec<Argument> }
+      skipArgument(c)
+      skipVector(c, () => skipArgument(c))
+      return
+    case 3: // MergeCoins { destination: Argument, sources: Vec<Argument> }
+      skipArgument(c)
+      skipVector(c, () => skipArgument(c))
+      return
+    case 4: // Publish { modules: Vec<byteVector>, dependencies: Vec<Address> }
+      skipVector(c, () => skipByteVector(c))
+      skipVector(c, () => skipAddress(c))
+      return
+    case 5: // MakeMoveVec { type: Option<TypeTag>, elements: Vec<Argument> }
+      skipOptionTypeTag(c)
+      skipVector(c, () => skipArgument(c))
+      return
+    case 6: // Upgrade { modules: Vec<byteVector>, dependencies: Vec<Address>, package: Address, ticket: Argument }
+      skipVector(c, () => skipByteVector(c))
+      skipVector(c, () => skipAddress(c))
+      skipAddress(c)
+      skipArgument(c)
+      return
+    default:
+      throw new Error(`Sui prebuilt BCS: unknown Command variant ${tag}`)
+  }
+}
+
+function skipProgrammableTransaction(c: BcsCursor): void {
+  skipVector(c, () => skipCallArg(c)) // inputs
+  skipVector(c, () => skipCommand(c)) // commands
+}
+
+/**
+ * Decode `TransactionData::V1.sender` from prebuilt Sui `TransactionData` BCS
+ * bytes, walking (but not interpreting) the full `ProgrammableTransaction`
+ * body first since `sender` follows it in the struct.
+ *
+ * Throws on ANY structural surprise (truncated buffer, out-of-range vector
+ * length, unrecognized enum variant) - callers decide what "can't decode"
+ * means for their fail posture; this function makes no assumption about it.
+ *
+ * Returns a lowercase `0x`-prefixed 64-hex-char address, matching the format
+ * `deriveSuiAddress` (in `./tx`) returns.
+ */
+export function extractSuiPrebuiltSender(txBytes: Uint8Array): string {
+  const c = new BcsCursor(txBytes)
+  const transactionDataTag = c.readUleb128() // TransactionData::V1 = 0
+  if (transactionDataTag !== 0) {
+    throw new Error(`Sui prebuilt BCS: unsupported TransactionData variant ${transactionDataTag}`)
+  }
+  const transactionKindTag = c.readUleb128() // TransactionKind::ProgrammableTransaction = 0
+  if (transactionKindTag !== 0) {
+    throw new Error(`Sui prebuilt BCS: unsupported TransactionKind variant ${transactionKindTag}`)
+  }
+  skipProgrammableTransaction(c)
+  const senderBytes = c.readBytes(SUI_ADDRESS_BYTES)
+  const hex = Array.from(senderBytes, b => b.toString(16).padStart(2, '0')).join('')
+  return `0x${hex}`
+}
+
+/**
+ * Fail-closed sender bind for a prebuilt Sui sign path: refuses to sign a
+ * backend-supplied PTB that isn't sent from the expected address —
+ * INCLUDING when the PTB can't be confidently decoded at all.
+ *
+ * SCOPE — what this does and does NOT buy, stated precisely so nobody reads
+ * it as "the prebuilt Sui path is WYSIWYS":
+ *
+ * - It does NOT stop a drain. Sui requires the sender's own signature on a
+ *   transaction, so any PTB that actually spends the expected address's
+ *   coins must already carry `sender == expectedSenderAddress` — which
+ *   PASSES this bind. The recipient, the amounts, and the MoveCall targets
+ *   inside the PTB are still completely unbound. A hostile backend can
+ *   still get the signer to sign a transfer to an attacker address. Binding
+ *   recipient/amount means resolving `Argument::Input(idx)` back through
+ *   `inputs` — deliberately out of scope here.
+ * - What it DOES close is the sponsored-transaction shape: `TransactionData`
+ *   carries `gasData.owner` separately from `sender`, and a tx whose
+ *   `gas owner` is the expected address but whose `sender` is an attacker
+ *   is valid on-chain once the attacker adds their own sender signature.
+ *   The expected address's signature is then accepted as the GAS SPONSOR
+ *   signature, paying the attacker's gas up to `gasData.budget`. Without
+ *   this bind that signature would be produced blind.
+ *
+ * - decode succeeds + sender matches → passes silently (the normal case).
+ * - decode succeeds + sender does NOT match → throws. A confidently-decoded,
+ *   confirmed mismatch is never safe to sign.
+ * - decode fails (malformed bytes, or a valid-but-unrecognized PTB shape
+ *   this reader's scoped BCS schema doesn't cover, i.e. decode DRIFT) →
+ *   throws. A PTB this reader cannot fully walk is, by definition, a PTB
+ *   whose sender cannot be confirmed — signing it anyway is exactly the
+ *   bypass this guard exists to prevent.
+ */
+export function assertSuiPrebuiltSenderMatchesVault(txBytes: Uint8Array, expectedSenderAddress: string): void {
+  let decodedSender: string
+  try {
+    decodedSender = extractSuiPrebuiltSender(txBytes)
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err)
+    // A decode failure is refused, not skipped - see the docblock above. Leave
+    // a breadcrumb so a decoder regression or an unseen Sui protocol variant
+    // is greppable in a bug report even though the send is already blocked.
+    console.error(`[SuiTx] prebuilt Sui sender bind FAILED (fail-closed, refusing to sign): ${reason}`)
+    throw new Error(
+      `Funds NOT sent: could not verify the sender of this prebuilt Sui transaction (${reason}). ` +
+        `Refusing to sign an unverified prebuilt transaction.`
+    )
+  }
+  if (decodedSender.toLowerCase() !== expectedSenderAddress.toLowerCase()) {
+    throw new Error(
+      `Funds NOT sent: prebuilt Sui transaction sender ${decodedSender} does not match the expected address ` +
+        `${expectedSenderAddress}. Refusing to sign - the backend-supplied transaction does not belong to this vault.`
+    )
+  }
+}
+
+export const __testing__ = {
+  BcsCursor,
+  skipProgrammableTransaction,
+}

--- a/packages/sdk/tests/unit/platforms/react-native/sui-prebuilt-bcs.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/sui-prebuilt-bcs.test.ts
@@ -1,0 +1,177 @@
+/**
+ * architecture#1993 — prebuilt Sui sender-pin, ported from vultiagent-app.
+ *
+ * `extractSuiPrebuiltSender` / `assertSuiPrebuiltSenderMatchesVault` walk the
+ * real Sui `TransactionData` BCS layout (kind → sender → gasData →
+ * expiration) to pull `sender` out from behind the variable-length
+ * `ProgrammableTransaction` body, then bind it to the expected address
+ * before a prebuilt-signing consumer blind-signs.
+ *
+ * Fixtures below are REAL BCS bytes produced by `@mysten/sui`'s own
+ * `TransactionData` schema (the same library upstream prebuilt-tx builders
+ * use) — not hand-guessed byte layouts. Two shapes are covered:
+ *   - a simple SplitCoins + TransferObjects PTB (CallArg::Pure, CallArg::Object
+ *     ImmOrOwnedObject, Argument::Input/Result)
+ *   - a MoveCall + MakeMoveVec PTB exercising ObjectArg::SharedObject, nested
+ *     TypeTag (struct + vector), and Argument::GasCoin/NestedResult
+ *
+ * Both prove the "walk past everything to reach sender" logic is byte-exact,
+ * not just correct on an empty/trivial PTB.
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  __testing__,
+  assertSuiPrebuiltSenderMatchesVault,
+  extractSuiPrebuiltSender,
+} from '../../../../src/platforms/react-native/chains/sui/prebuiltBcs'
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < out.length; i++) out[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+  return out
+}
+
+// SplitCoins + TransferObjects PTB, sender = 0x1111...1111 (32 bytes of 0x11).
+const SIMPLE_PTB_SENDER_A_HEX =
+  '0000030008010000000000000001003333333333333333333333333333333333333333333333333333333333' +
+  '3333330a0000000000000020ad2d5b61f5e2597e313a5c194988455d092b0f302af7e8a80bdb3a2f3eb5e209' +
+  '0020444444444444444444444444444444444444444444444444444444444444444402020101000101000001' +
+  '0102000001020011111111111111111111111111111111111111111111111111111111111111110155555555' +
+  '55555555555555555555555555555555555555555555555555555555140000000000000020ad2d5b61f5e259' +
+  '7e313a5c194988455d092b0f302af7e8a80bdb3a2f3eb5e20911111111111111111111111111111111111111' +
+  '11111111111111111111111111e803000000000000c0c62d000000000000'
+const SIMPLE_PTB_SENDER_A = hexToBytes(SIMPLE_PTB_SENDER_A_HEX)
+
+// Byte-identical PTB body, sender swapped to 0x2222...2222 - the tampered case.
+const SIMPLE_PTB_SENDER_B_HEX =
+  '0000030008010000000000000001003333333333333333333333333333333333333333333333333333333333' +
+  '3333330a0000000000000020ad2d5b61f5e2597e313a5c194988455d092b0f302af7e8a80bdb3a2f3eb5e209' +
+  '0020444444444444444444444444444444444444444444444444444444444444444402020101000101000001' +
+  '0102000001020022222222222222222222222222222222222222222222222222222222222222220155555555' +
+  '55555555555555555555555555555555555555555555555555555555140000000000000020ad2d5b61f5e259' +
+  '7e313a5c194988455d092b0f302af7e8a80bdb3a2f3eb5e20922222222222222222222222222222222222222' +
+  '22222222222222222222222222e803000000000000c0c62d000000000000'
+const SIMPLE_PTB_SENDER_B = hexToBytes(SIMPLE_PTB_SENDER_B_HEX)
+
+// Same PTB as SIMPLE_PTB_SENDER_A, but the first Command's tag (offset 123)
+// is corrupted from 0x02 (SplitCoins) to 0x63 - a Command variant that
+// doesn't exist. Proves fail-open covers "unrecognized structure", not just
+// truncation.
+const CORRUPTED_COMMAND_TAG_PTB_HEX =
+  '0000030008010000000000000001003333333333333333333333333333333333333333333333333333333333' +
+  '3333330a0000000000000020ad2d5b61f5e2597e313a5c194988455d092b0f302af7e8a80bdb3a2f3eb5e209' +
+  '0020444444444444444444444444444444444444444444444444444444444444444402630101000101000001' +
+  '0102000001020011111111111111111111111111111111111111111111111111111111111111110155555555' +
+  '55555555555555555555555555555555555555555555555555555555140000000000000020ad2d5b61f5e259' +
+  '7e313a5c194988455d092b0f302af7e8a80bdb3a2f3eb5e20911111111111111111111111111111111111111' +
+  '11111111111111111111111111e803000000000000c0c62d000000000000'
+const CORRUPTED_COMMAND_TAG_PTB = hexToBytes(CORRUPTED_COMMAND_TAG_PTB_HEX)
+
+// MoveCall (pool::swap with struct + vector TypeTag args) + MakeMoveVec
+// (Option<TypeTag>::Some), sender = 0x7777...7777. Also exercises
+// ObjectArg::SharedObject and Argument::GasCoin/NestedResult.
+const MOVECALL_PTB_SENDER_HEX =
+  '000002010033333333333333333333333333333333333333333333333333333333333333330a000000000000' +
+  '0020ad2d5b61f5e2597e313a5c194988455d092b0f302af7e8a80bdb3a2f3eb5e20901016666666666666666' +
+  '6666666666666666666666666666666666666666666666660500000000000000010200999999999999999999' +
+  '999999999999999999999999999999999999999999999904706f6f6c04737761700207999999999999999999' +
+  '9999999999999999999999999999999999999999999999047573646304555344430006020300010000010100' +
+  '0501010202000003000001007777777777777777777777777777777777777777777777777777777777777777' +
+  '015555555555555555555555555555555555555555555555555555555555555555140000000000000020ad2d' +
+  '5b61f5e2597e313a5c194988455d092b0f302af7e8a80bdb3a2f3eb5e2097777777777777777777777777777' +
+  '777777777777777777777777777777777777e803000000000000c0c62d000000000000'
+const MOVECALL_PTB_SENDER = hexToBytes(MOVECALL_PTB_SENDER_HEX)
+
+describe('extractSuiPrebuiltSender', () => {
+  it('decodes the sender out of a simple SplitCoins/TransferObjects PTB', () => {
+    expect(extractSuiPrebuiltSender(SIMPLE_PTB_SENDER_A)).toBe(`0x${'11'.repeat(32)}`)
+  })
+
+  it('decodes the sender out of a MoveCall/MakeMoveVec PTB (nested TypeTag, SharedObject)', () => {
+    expect(extractSuiPrebuiltSender(MOVECALL_PTB_SENDER)).toBe(`0x${'77'.repeat(32)}`)
+  })
+
+  it('throws on a truncated buffer', () => {
+    expect(() => extractSuiPrebuiltSender(SIMPLE_PTB_SENDER_A.slice(0, 50))).toThrow()
+  })
+
+  it('throws on an unrecognized Command variant tag', () => {
+    expect(() => extractSuiPrebuiltSender(CORRUPTED_COMMAND_TAG_PTB)).toThrow(/unknown Command variant/)
+  })
+})
+
+describe('assertSuiPrebuiltSenderMatchesVault', () => {
+  it('PASSES when the decoded sender matches the expected address (legit prebuilt tx)', () => {
+    expect(() => assertSuiPrebuiltSenderMatchesVault(SIMPLE_PTB_SENDER_A, `0x${'11'.repeat(32)}`)).not.toThrow()
+  })
+
+  it('PASSES case-insensitively', () => {
+    expect(() =>
+      assertSuiPrebuiltSenderMatchesVault(SIMPLE_PTB_SENDER_A, `0x${'11'.repeat(32)}`.toUpperCase())
+    ).not.toThrow()
+  })
+
+  it('REJECTS when the decoded sender does not match the expected address (hostile/mismatched backend PTB)', () => {
+    expect(() => assertSuiPrebuiltSenderMatchesVault(SIMPLE_PTB_SENDER_B, `0x${'11'.repeat(32)}`)).toThrow(
+      /does not match the expected address/
+    )
+  })
+
+  it('REJECTS a MoveCall PTB whose sender differs from the expected address', () => {
+    expect(() => assertSuiPrebuiltSenderMatchesVault(MOVECALL_PTB_SENDER, `0x${'11'.repeat(32)}`)).toThrow(
+      /does not match the expected address/
+    )
+  })
+
+  it('FAILS CLOSED (throws) on a truncated/malformed buffer instead of skipping the bind', () => {
+    expect(() => assertSuiPrebuiltSenderMatchesVault(SIMPLE_PTB_SENDER_A.slice(0, 50), `0x${'11'.repeat(32)}`)).toThrow(
+      /could not verify the sender/
+    )
+  })
+
+  it('FAILS CLOSED (throws) on an unrecognized Command variant (decode drift), even with a matching expected address', () => {
+    // Undecodable bytes must refuse the send regardless of whether the
+    // (unreachable) sender would have matched - the point is we genuinely
+    // can't tell, so signing is never safe.
+    expect(() => assertSuiPrebuiltSenderMatchesVault(CORRUPTED_COMMAND_TAG_PTB, `0x${'11'.repeat(32)}`)).toThrow(
+      /could not verify the sender/
+    )
+  })
+
+  it('LOGS an error when it fails closed, so the refusal is greppable', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      expect(() =>
+        assertSuiPrebuiltSenderMatchesVault(SIMPLE_PTB_SENDER_A.slice(0, 50), `0x${'11'.repeat(32)}`)
+      ).toThrow()
+      expect(error).toHaveBeenCalledWith(expect.stringContaining('sender bind FAILED'))
+    } finally {
+      error.mockRestore()
+    }
+  })
+})
+
+describe('readUleb128 32-bit range', () => {
+  const { BcsCursor } = __testing__
+
+  // A bitwise accumulator (`result |= (byte & 0x7f) << shift`) coerces to
+  // int32, so these SILENTLY TRUNCATE instead of throwing: a length prefix
+  // collapsing to a small value would walk off-schema and read 32
+  // attacker-placed bytes as `sender`. These bytes are not network-valid (the
+  // Rust `bcs` decoder caps vector lengths at u32), so this is a contract bug
+  // rather than a live bypass - but "exceeds 32 bits" must actually throw.
+  it.each([
+    ['2^32 (truncates to 0 under a bitwise accumulator)', [0x80, 0x80, 0x80, 0x80, 0x10]],
+    ['2^32+1 (truncates to 1)', [0x81, 0x80, 0x80, 0x80, 0x10]],
+    ['0x7f0000005 (truncates to 0xf0000005)', [0x85, 0x80, 0x80, 0x80, 0x7f]],
+  ])('throws on an out-of-u32-range uleb128: %s', (_label, bytes) => {
+    const c = new BcsCursor(Uint8Array.from(bytes))
+    expect(() => c.readUleb128()).toThrow(/exceeds 32 bits/)
+  })
+
+  it('still accepts the full u32 range (0xffffffff)', () => {
+    const c = new BcsCursor(Uint8Array.from([0xff, 0xff, 0xff, 0xff, 0x0f]))
+    expect(c.readUleb128()).toBe(0xffffffff)
+  })
+})


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#1993

Ported `extractSuiPrebuiltSender`/`assertSuiPrebuiltSenderMatchesVault` from `vultiagent-app/src/services/suiPrebuiltBcs.ts` (read-only reference at `/home/gomes/Sites/vultiagent-app`, present on this machine) into `packages/sdk/src/platforms/react-native/chains/sui/prebuiltBcs.ts`, next to the existing Sui prebuilt signing primitives (`tx.ts`: `buildSuiSigningHash`, `buildSuiSerializedSignature`, `deriveSuiAddress`) since the issue's own evidence points at that same directory as the SDK's current Sui surface. It's a self-contained, fail-closed BCS reader (a hand-rolled cursor + recursive walkers for `TypeTag`/`Command`/`CallArg`/`Argument`/`ObjectArg`) with no dependency beyond `Uint8Array`, so this was a mechanical, verifiable port — not a rewrite. Renamed the "vault" wording in the two error messages to "expected address" since the guard is no longer vault-specific in the SDK (the app passes its vault's Sui address; any consumer can pass whatever address it expects the sender to be). Exported from `packages/sdk/src/platforms/react-native/chains/sui/index.ts`; `chains/index.ts`'s `import * as sui from './sui'` picks the new exports up automatically as `chains.sui.assertSuiPrebuiltSenderMatchesVault`/`extractSuiPrebuiltSender`, no further wiring needed.

Ported the app's full fixture-based test suite (19 cases total, 15 in the new file plus 4 pre-existing golden-vector tests re-verified) into `packages/sdk/tests/unit/platforms/react-native/sui-prebuilt-bcs.test.ts`: real BCS byte fixtures for a SplitCoins+TransferObjects PTB and a MoveCall+MakeMoveVec PTB (nested TypeTag, SharedObject, GasCoin/NestedResult arguments), sender-match/mismatch/case-insensitive-match assertions, fail-closed-on-truncated/corrupted-variant assertions, the fail-closed error logging assertion, and the uleb128 32-bit-overflow regression tests (a bitwise accumulator would silently truncate a length prefix and let an attacker-controlled offset masquerade as `sender`). Converted `jest.spyOn`/`jest.mock` idioms to `vi.spyOn`; everything else ported verbatim including the fixture hex strings.

Follow-up (explicitly out of scope per the fix sketch, item 4): `vultiagent-app` still has its own copy of this parser — a follow-up PR in that repo should delete it and import the SDK export instead. I did not touch `vultiagent-app`, only read it for reference.

## what I ran

```
cd /tmp/claude-1000/wt-sdk-w5
npx tsc --noEmit -p packages/sdk/tsconfig.json
# => exit 0, no errors

cd packages/sdk
npx vitest run tests/unit/platforms/react-native/sui-prebuilt-bcs.test.ts tests/unit/platforms/react-native/sui-golden-vectors.test.ts
# => Test Files 2 passed (2); Tests 19 passed (19)

npx vitest run tests/unit/tools/prep/suiTokenTransfer.test.ts
# => Test Files 1 passed; regression check for the existing Sui prep path — unaffected
```

closes vultisig/vultisig-sdk#1993