### PR TITLE
refactor(cosmos): consolidate four HRP tables into one canonical registry

### DIFF
--- a/.changeset/w5-1787.md
+++ b/.changeset/w5-1787.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/sdk': patch
+---
+
+Consolidates four independently-maintained, overlapping Cosmos-family bech32 HRP tables — `tools/cosmos/gov.ts`'s `CHAIN_HRP`, `tools/prep/ibcTransfer.ts`'s `IBC_CHAIN_HRP`, `tools/swap/skip/skipSwap.ts`'s `COSMOS_CHAIN_HRPS`, and `tools/token/resolveContract.ts`'s `CW20_CHAIN_PREFIX` — into a single canonical registry, `COSMOS_CHAIN_ID_HRP`/`getCosmosChainHrp` (`@vultisig/core-chain/chains/cosmos/cosmosHrp`). All four consumers now derive their HRP checks from the same source instead of hand-maintained local copies that could drift from each other. As a side effect, Skip swap address validation now also HRP-checks four chain-ids (`axelar-dojo-1`, `juno-1`, `stargaze-1`, `akashnet-2`) it previously had no entry for and silently skipped — strictly safer, not a behavior change for any chain that was already validated. Deliberately does not touch `utils/addressFormat.ts`'s separate `cosmosHRPByChain`/`cosmosValoperByChain` tables, which are keyed by a different (lowercase chain-tag) space and ported 1:1 from a Go reference for cross-language parity.

--- a/packages/core/chain/chains/cosmos/cosmosHrp.test.ts
+++ b/packages/core/chain/chains/cosmos/cosmosHrp.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+
+import { CosmosChain } from '../../Chain'
+import { COSMOS_CHAIN_ID_HRP, getCosmosChainHrp } from './cosmosHrp'
+import { getCosmosChainId } from './chainInfo'
+
+// architecture#1787 — this registry consolidates four independently-maintained,
+// overlapping tables (SDK gov.ts's CHAIN_HRP, ibcTransfer.ts's IBC_CHAIN_HRP,
+// skipSwap.ts's COSMOS_CHAIN_HRPS, resolveContract.ts's CW20_CHAIN_PREFIX).
+// These tests pin the exact literal values each of those four ORIGINALLY
+// declared, so a future edit here can't silently drift one of the four
+// modules that now derive from it.
+
+describe('getCosmosChainHrp', () => {
+  // Every CosmosChain must resolve — a registry gap here is a bug in this
+  // file, not a caller error (see the function's own fail-loud contract).
+  it('resolves an HRP for every CosmosChain member', () => {
+    for (const chain of Object.values(CosmosChain)) {
+      expect(() => getCosmosChainHrp(chain)).not.toThrow()
+    }
+  })
+
+  // Pinned from the original tools/cosmos/gov.ts CHAIN_HRP literal.
+  it('matches gov.ts pre-consolidation values', () => {
+    expect(getCosmosChainHrp(CosmosChain.Cosmos)).toBe('cosmos')
+    expect(getCosmosChainHrp(CosmosChain.Osmosis)).toBe('osmo')
+    expect(getCosmosChainHrp(CosmosChain.Dydx)).toBe('dydx')
+    expect(getCosmosChainHrp(CosmosChain.Kujira)).toBe('kujira')
+    expect(getCosmosChainHrp(CosmosChain.Terra)).toBe('terra')
+    expect(getCosmosChainHrp(CosmosChain.TerraClassic)).toBe('terra')
+    expect(getCosmosChainHrp(CosmosChain.Noble)).toBe('noble')
+    expect(getCosmosChainHrp(CosmosChain.Akash)).toBe('akash')
+  })
+
+  // Pinned from the original tools/token/resolveContract.ts CW20_CHAIN_PREFIX
+  // literal (a subset of gov's set, same values).
+  it('matches resolveContract.ts pre-consolidation CW20 values', () => {
+    expect(getCosmosChainHrp(CosmosChain.TerraClassic)).toBe('terra')
+    expect(getCosmosChainHrp(CosmosChain.Terra)).toBe('terra')
+    expect(getCosmosChainHrp(CosmosChain.Osmosis)).toBe('osmo')
+    expect(getCosmosChainHrp(CosmosChain.Kujira)).toBe('kujira')
+  })
+
+  // THORChain/MayaChain are vault-based (not IBC-enabled), so gov.ts/CW20
+  // never covered them — but skipSwap.ts's COSMOS_CHAIN_HRPS did.
+  it('resolves the two vault-based chains too (previously only in skipSwap.ts)', () => {
+    expect(getCosmosChainHrp(CosmosChain.THORChain)).toBe('thor')
+    expect(getCosmosChainHrp(CosmosChain.MayaChain)).toBe('maya')
+  })
+
+})
+
+describe('COSMOS_CHAIN_ID_HRP', () => {
+  // Pinned from the original tools/prep/ibcTransfer.ts IBC_CHAIN_HRP literal
+  // (the superset — includes IBC destination chains with no CosmosChain
+  // member of their own).
+  it('matches ibcTransfer.ts pre-consolidation values, including chain-ids outside CosmosChain', () => {
+    expect(COSMOS_CHAIN_ID_HRP['phoenix-1']).toBe('terra')
+    expect(COSMOS_CHAIN_ID_HRP['columbus-5']).toBe('terra')
+    expect(COSMOS_CHAIN_ID_HRP['cosmoshub-4']).toBe('cosmos')
+    expect(COSMOS_CHAIN_ID_HRP['osmosis-1']).toBe('osmo')
+    expect(COSMOS_CHAIN_ID_HRP['kaiyo-1']).toBe('kujira')
+    expect(COSMOS_CHAIN_ID_HRP['neutron-1']).toBe('neutron')
+    expect(COSMOS_CHAIN_ID_HRP['axelar-dojo-1']).toBe('axelar')
+    expect(COSMOS_CHAIN_ID_HRP['injective-1']).toBe('inj')
+    expect(COSMOS_CHAIN_ID_HRP['juno-1']).toBe('juno')
+    expect(COSMOS_CHAIN_ID_HRP['stargaze-1']).toBe('stars')
+    expect(COSMOS_CHAIN_ID_HRP['noble-1']).toBe('noble')
+    expect(COSMOS_CHAIN_ID_HRP['akashnet-2']).toBe('akash')
+    expect(COSMOS_CHAIN_ID_HRP['dydx-mainnet-1']).toBe('dydx')
+    expect(COSMOS_CHAIN_ID_HRP['stride-1']).toBe('stride')
+    expect(COSMOS_CHAIN_ID_HRP.celestia).toBe('celestia')
+  })
+
+  // Pinned from the original tools/swap/skip/skipSwap.ts COSMOS_CHAIN_HRPS
+  // literal (the entries IBC's table didn't have).
+  it('matches skipSwap.ts pre-consolidation values not covered by ibcTransfer.ts', () => {
+    expect(COSMOS_CHAIN_ID_HRP['thorchain-1']).toBe('thor')
+    expect(COSMOS_CHAIN_ID_HRP['mayachain-mainnet-v1']).toBe('maya')
+    expect(COSMOS_CHAIN_ID_HRP['agoric-3']).toBe('agoric')
+  })
+
+  // Every CosmosChain's chain-id must have an entry — getCosmosChainHrp
+  // depends on this for every first-class chain.
+  it('covers the chain-id for every CosmosChain', () => {
+    for (const chain of Object.values(CosmosChain)) {
+      expect(COSMOS_CHAIN_ID_HRP[getCosmosChainId(chain)]).toBeDefined()
+    }
+  })
+})

--- a/packages/core/chain/chains/cosmos/cosmosHrp.test.ts
+++ b/packages/core/chain/chains/cosmos/cosmosHrp.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
 import { CosmosChain } from '../../Chain'
-import { COSMOS_CHAIN_ID_HRP, getCosmosChainHrp } from './cosmosHrp'
 import { getCosmosChainId } from './chainInfo'
+import { COSMOS_CHAIN_ID_HRP, getCosmosChainHrp } from './cosmosHrp'
 
 // architecture#1787 — this registry consolidates four independently-maintained,
 // overlapping tables (SDK gov.ts's CHAIN_HRP, ibcTransfer.ts's IBC_CHAIN_HRP,

--- a/packages/core/chain/chains/cosmos/cosmosHrp.ts
+++ b/packages/core/chain/chains/cosmos/cosmosHrp.ts
@@ -1,0 +1,67 @@
+import { CosmosChain } from '../../Chain'
+import { getCosmosChainId } from './chainInfo'
+
+/**
+ * Canonical Cosmos-family bech32 HRP (human-readable prefix), keyed by
+ * CHAIN-ID rather than the SDK `Chain` enum, so it covers both:
+ *
+ *   - every first-class Vultisig-supported Cosmos chain (`CosmosChain`,
+ *     resolvable to an HRP via `getCosmosChainHrp` below), and
+ *   - IBC/Skip DESTINATION chains that are valid transfer/swap targets but
+ *     have no wallet/RPC support of their own (e.g. `neutron-1`, `juno-1`,
+ *     `stargaze-1`) — these have no `CosmosChain` member to key by.
+ *
+ * Consolidates what were four independently-maintained, overlapping copies
+ * (architecture#1787): `tools/cosmos/gov.ts`'s `CHAIN_HRP`, `tools/prep/
+ * ibcTransfer.ts`'s `IBC_CHAIN_HRP`, `tools/swap/skip/skipSwap.ts`'s
+ * `COSMOS_CHAIN_HRPS`, and `tools/token/resolveContract.ts`'s
+ * `CW20_CHAIN_PREFIX`. Every entry below was cross-checked against all four
+ * source tables for the chains they had in common — no value differs across
+ * copies, so this union is a lossless merge, not a judgment call on which
+ * source wins.
+ *
+ * Deliberately does NOT absorb `utils/addressFormat.ts`'s `cosmosHRPByChain`
+ * / `cosmosValoperByChain` — those are keyed by a THIRD, different space
+ * (lowercase "canonical chain tag", not chain-id or `Chain` enum), ported
+ * 1:1 from a Go reference (`chain_prefix_extractor.go`) for cross-language
+ * parity, and cover additional chains (sei, kava, persistence, secret,
+ * crescent, qbtc) this registry has no chain-id for. Forcing that table
+ * through this one would risk silently breaking Go parity for no
+ * consolidation benefit — a real, but separately-scoped, follow-up.
+ */
+export const COSMOS_CHAIN_ID_HRP: Record<string, string> = {
+  'phoenix-1': 'terra',
+  'columbus-5': 'terra',
+  'cosmoshub-4': 'cosmos',
+  'osmosis-1': 'osmo',
+  'kaiyo-1': 'kujira',
+  'neutron-1': 'neutron',
+  'axelar-dojo-1': 'axelar',
+  'injective-1': 'inj',
+  'juno-1': 'juno',
+  'stargaze-1': 'stars',
+  'noble-1': 'noble',
+  'akashnet-2': 'akash',
+  'dydx-mainnet-1': 'dydx',
+  'stride-1': 'stride',
+  celestia: 'celestia',
+  'thorchain-1': 'thor',
+  'mayachain-mainnet-v1': 'maya',
+  'agoric-3': 'agoric',
+}
+
+/**
+ * Resolve the bech32 HRP for a first-class Vultisig `CosmosChain`. Throws on
+ * a registry gap (a `CosmosChain` member with no HRP entry above) rather
+ * than returning `undefined` — that's a bug in this file, not a caller
+ * error, and failing loudly here beats a confusing downstream 404/wrong-HRP
+ * address match.
+ */
+export function getCosmosChainHrp(chain: CosmosChain): string {
+  const chainId = getCosmosChainId(chain)
+  const hrp = COSMOS_CHAIN_ID_HRP[chainId]
+  if (!hrp) {
+    throw new Error(`getCosmosChainHrp: no HRP registered for ${chain} (chainId ${chainId})`)
+  }
+  return hrp
+}

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -240,6 +240,11 @@
       "import": "./dist/chains/cosmos/cosmosGasLimitRecord.js",
       "default": "./dist/chains/cosmos/cosmosGasLimitRecord.js"
     },
+    "./chains/cosmos/cosmosHrp": {
+      "types": "./dist/chains/cosmos/cosmosHrp.d.ts",
+      "import": "./dist/chains/cosmos/cosmosHrp.js",
+      "default": "./dist/chains/cosmos/cosmosHrp.js"
+    },
     "./chains/cosmos/cosmosMemoCap": {
       "types": "./dist/chains/cosmos/cosmosMemoCap.d.ts",
       "import": "./dist/chains/cosmos/cosmosMemoCap.js",

--- a/packages/sdk/src/tools/cosmos/gov.ts
+++ b/packages/sdk/src/tools/cosmos/gov.ts
@@ -19,6 +19,7 @@
 import { fromBech32, toBech32 } from '@cosmjs/encoding'
 import { IbcEnabledCosmosChain } from '@vultisig/core-chain/Chain'
 import { getCosmosChainId } from '@vultisig/core-chain/chains/cosmos/chainInfo'
+import { getCosmosChainHrp } from '@vultisig/core-chain/chains/cosmos/cosmosHrp'
 import { cosmosRpcUrl } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
 import { getAuthAccountUrl } from '@vultisig/core-chain/chains/cosmos/staking/lcdQueries'
 
@@ -30,19 +31,12 @@ export type GovChain = IbcEnabledCosmosChain
 /**
  * Expected bech32 HRP (human-readable prefix) per gov chain, used to reject a
  * voter address that belongs to a different chain (e.g. an `osmo1…` address
- * submitted as a Cosmos Hub vote). No centralized HRP map exists in core-chain,
- * so it's declared here for the small, stable set of gov chains.
+ * submitted as a Cosmos Hub vote). Sourced from the canonical
+ * `getCosmosChainHrp` registry (architecture#1787) instead of a local copy.
  */
-const CHAIN_HRP: Record<GovChain, string> = {
-  Cosmos: 'cosmos',
-  Osmosis: 'osmo',
-  Dydx: 'dydx',
-  Kujira: 'kujira',
-  Terra: 'terra',
-  TerraClassic: 'terra',
-  Noble: 'noble',
-  Akash: 'akash',
-}
+const CHAIN_HRP: Record<GovChain, string> = Object.fromEntries(
+  Object.values(IbcEnabledCosmosChain).map(chain => [chain, getCosmosChainHrp(chain)])
+) as Record<GovChain, string>
 
 /**
  * Whether a chain serves the modern `gov/v1` endpoint. TerraClassic

--- a/packages/sdk/src/tools/prep/ibcTransfer.ts
+++ b/packages/sdk/src/tools/prep/ibcTransfer.ts
@@ -1,4 +1,5 @@
 import { bech32 } from '@scure/base'
+import { COSMOS_CHAIN_ID_HRP } from '@vultisig/core-chain/chains/cosmos/cosmosHrp'
 
 /**
  * Pure-crypto ICS-20 IBC transfer builder.
@@ -30,24 +31,9 @@ import { bech32 } from '@scure/base'
 
 type ChannelKey = `${string}/${string}` // `${fromChain}/${channel}`
 
-/** Chain-ID → bech32 HRP, for address validation. */
-export const IBC_CHAIN_HRP: Record<string, string> = {
-  'phoenix-1': 'terra',
-  'columbus-5': 'terra',
-  'cosmoshub-4': 'cosmos',
-  'osmosis-1': 'osmo',
-  'kaiyo-1': 'kujira',
-  'neutron-1': 'neutron',
-  'axelar-dojo-1': 'axelar',
-  'injective-1': 'inj',
-  'juno-1': 'juno',
-  'stargaze-1': 'stars',
-  'noble-1': 'noble',
-  'akashnet-2': 'akash',
-  'dydx-mainnet-1': 'dydx',
-  'stride-1': 'stride',
-  celestia: 'celestia',
-}
+/** Chain-ID → bech32 HRP, for address validation. Sourced from the canonical
+ * `COSMOS_CHAIN_ID_HRP` registry (architecture#1787) instead of a local copy. */
+export const IBC_CHAIN_HRP: Record<string, string> = COSMOS_CHAIN_ID_HRP
 
 /** Chain-ID → IBC revision number (for timeout_height defaulting). */
 export const IBC_CHAIN_REVISION: Record<string, number> = {

--- a/packages/sdk/src/tools/swap/skip/skipSwap.ts
+++ b/packages/sdk/src/tools/swap/skip/skipSwap.ts
@@ -26,6 +26,7 @@
  * Skip's grpc-gateway returns structured `{code, message, details}` errors;
  * `SkipApiError` surfaces `code` (stable) rather than regexing messages.
  */
+import { COSMOS_CHAIN_ID_HRP } from '@vultisig/core-chain/chains/cosmos/cosmosHrp'
 import { getCosmosMemoMaxBytesByChainId } from '@vultisig/core-chain/chains/cosmos/cosmosMemoCap'
 
 import { buildSkipAffiliates, type SkipChainIdsToAffiliates } from './affiliateConfig'
@@ -358,23 +359,10 @@ function isUstcRoute(args: SkipSwapArgs): boolean {
  * Expected bech32 HRP per supported cosmos chain id. Without this the generic
  * `^[a-z]+1...` regex would accept `terra1...` for `cosmoshub-4` (and vice
  * versa) — the user signs with a vault-derived key on the wrong chain.
+ * Sourced from the canonical `COSMOS_CHAIN_ID_HRP` registry
+ * (architecture#1787) instead of a local copy.
  */
-const COSMOS_CHAIN_HRPS: Record<string, string> = {
-  'cosmoshub-4': 'cosmos',
-  'osmosis-1': 'osmo',
-  'phoenix-1': 'terra',
-  'columbus-5': 'terra',
-  'noble-1': 'noble',
-  'neutron-1': 'neutron',
-  'kaiyo-1': 'kujira',
-  'thorchain-1': 'thor',
-  'mayachain-mainnet-v1': 'maya',
-  'dydx-mainnet-1': 'dydx',
-  'stride-1': 'stride',
-  'agoric-3': 'agoric',
-  celestia: 'celestia',
-  'injective-1': 'inj',
-}
+const COSMOS_CHAIN_HRPS: Record<string, string> = COSMOS_CHAIN_ID_HRP
 
 function validateAddressShape(address: string, chainId: string, field: string): void {
   if (isEvmChainId(chainId)) {

--- a/packages/sdk/src/tools/token/resolveContract.ts
+++ b/packages/sdk/src/tools/token/resolveContract.ts
@@ -1,5 +1,6 @@
 import { PublicKey } from '@solana/web3.js'
 import { CosmosChain, EvmChain } from '@vultisig/core-chain/Chain'
+import { getCosmosChainHrp } from '@vultisig/core-chain/chains/cosmos/cosmosHrp'
 import { getCosmosWasmTokenInfoUrl } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
 import { getEvmClient } from '@vultisig/core-chain/chains/evm/client'
 import { getSolanaClient } from '@vultisig/core-chain/chains/solana/client'
@@ -60,13 +61,12 @@ type Cw20Chain = (typeof CW20_CHAINS)[number]
 // BEFORE any RPC fires, instead of querying the Osmosis LCD with a Terra
 // address (which would 404 against a different contract namespace, or worse,
 // silently hit a same-shaped address on the wrong chain). Mirrors mcp-ts's
-// `validateBech32Contract(addr, expectedPrefix)` prefix guard.
-const CW20_CHAIN_PREFIX: Record<Cw20Chain, string> = {
-  [CosmosChain.TerraClassic]: 'terra',
-  [CosmosChain.Terra]: 'terra',
-  [CosmosChain.Osmosis]: 'osmo',
-  [CosmosChain.Kujira]: 'kujira',
-}
+// `validateBech32Contract(addr, expectedPrefix)` prefix guard. Sourced from
+// the canonical `getCosmosChainHrp` registry (architecture#1787) instead of
+// a local copy.
+const CW20_CHAIN_PREFIX: Record<Cw20Chain, string> = Object.fromEntries(
+  CW20_CHAINS.map(chain => [chain, getCosmosChainHrp(chain)])
+) as Record<Cw20Chain, string>
 
 const isEvmChain = (chain: string): chain is EvmChain => Object.values(EvmChain).includes(chain as EvmChain)
 


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#1787

Added `packages/core/chain/chains/cosmos/cosmosHrp.ts` exporting `COSMOS_CHAIN_ID_HRP` (chain-id keyed, 18 entries) and `getCosmosChainHrp(chain: CosmosChain)` (derived via the existing `getCosmosChainId`). Before writing it, I read all four evidence files' local tables and cross-checked every overlapping entry — they agreed byte-for-byte on every chain they had in common, so the union is a lossless merge, not a judgment call on which source to trust.

Migrated 4 of the 5 evidence points to consume it:
- `packages/sdk/src/tools/cosmos/gov.ts`: `CHAIN_HRP` now built via `Object.values(IbcEnabledCosmosChain).map(chain => [chain, getCosmosChainHrp(chain)])`.
- `packages/sdk/src/tools/prep/ibcTransfer.ts`: `IBC_CHAIN_HRP` now `= COSMOS_CHAIN_ID_HRP` directly (already chain-id keyed, same shape).
- `packages/sdk/src/tools/swap/skip/skipSwap.ts`: `COSMOS_CHAIN_HRPS` now `= COSMOS_CHAIN_ID_HRP` directly.
- `packages/sdk/src/tools/token/resolveContract.ts`: `CW20_CHAIN_PREFIX` now built via `CW20_CHAINS.map(chain => [chain, getCosmosChainHrp(chain)])`.

**Did not touch** `packages/sdk/src/utils/addressFormat.ts`'s `cosmosHRPByChain`/`cosmosValoperByChain` (the 5th evidence point) — this is a deliberate scope exclusion, not an oversight. It's keyed by a THIRD, different space (lowercase "canonical chain tag" like `terraclassic`, `qbtc` — not `Chain` enum PascalCase and not chain-id), is explicitly ported 1:1 from a Go reference (`chain_prefix_extractor.go`) for cross-language parity, and covers chains this new registry has no chain-id entry for (sei, kava, persistence, secret, crescent, qbtc). Forcing it through the new registry would risk silently breaking Go parity for zero consolidation benefit — this file genuinely serves a different purpose than the other four.

Noted side effect worth flagging: `skipSwap.ts`'s address validation previously silently skipped the HRP check for four chain-ids (`axelar-dojo-1`, `juno-1`, `stargaze-1`, `akashnet-2`) it had no local entry for — `COSMOS_CHAIN_ID_HRP` (sourced from `ibcTransfer.ts`'s superset) now HRP-validates those too. Confirmed this is strictly safer by reading the call site (`if (expectedHrp !== undefined && bech32Match[1] !== expectedHrp) throw`) — an unregistered chain-id was previously permissive (any bech32 shape passed), now it's validated. Not a behavior change for any chain that was already checked.

Added `packages/core/chain/chains/cosmos/cosmosHrp.test.ts` (7 tests): every `CosmosChain` member resolves without throwing, the exact literal values each of the four original tables declared are pinned (regression-proofing against a future edit silently drifting one consumer), the two vault-based chains (THORChain/MayaChain, previously only in skipSwap's table) resolve correctly, and every `CosmosChain`'s chain-id has a `COSMOS_CHAIN_ID_HRP` entry.

## what I ran

```
cd /tmp/claude-1000/wt-sdk-w5
npx tsc --noEmit -p .config/tsconfig.json
# => exit 0, no errors (full workspace, covers both core-chain and sdk)

npx vitest run --config .config/vitest.core.config.ts packages/core/chain/chains/cosmos/
# => Test Files 35 passed (35); Tests 451 passed (451)  [444 existing + 7 new]

cd packages/sdk
npx vitest run tests/unit/cosmos/ibcTransfer.test.ts tests/unit/tools/token/resolveContract.test.ts \
  tests/unit/tools/swap/skipSwap.test.ts tests/unit/tools/cosmos/gov.test.ts \
  tests/unit/public/toolNamespaceRootExports.test.ts
# => Test Files 5 passed (5); Tests 71 passed (71) — zero regressions across all 4 migrated consumers
```

closes vultisig/vultisig-sdk#1787

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cosmos address validation across governance, IBC transfers, token contracts, and swaps.
  * Added coverage for additional Cosmos and IBC chain IDs, including vault-based chains.
  * Ensured supported Cosmos chains consistently use the correct bech32 address prefixes.

* **Tests**
  * Added comprehensive validation for Cosmos chain and address-prefix mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->