### PR TITLE
feat(security): publish token-transfer / erc-20-calldata destination guards

### DIFF
--- a/.changeset/w5-1774.md
+++ b/.changeset/w5-1774.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/sdk': patch
+---
+
+Publishes token-transfer / ERC-20-calldata destination safety helpers alongside the existing burn-address guard (`assertSafeDestination`): `assertSafeTokenTransferDestination` (rejects a transfer whose recipient is itself a known token contract — not just its own, any registered token's), `isErc20TransferCalldata`, `decodeErc20Recipient`, `decodeErc20Approve`, and `decodeErc20RecipientFromSig`, all re-exported from `@vultisig/sdk`. Previously only `agent-backend-ts` had this guard family as a private fork; `packages/sdk/src/tools/prep/send.ts`'s inline own-token-contract check is now additionally backed by the registry-based guard (catching sends to a *different* known token's contract, on top of the existing unconditional self-contract check).

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -1543,6 +1543,11 @@
       "import": "./dist/security/dangerousAddresses.js",
       "default": "./dist/security/dangerousAddresses.js"
     },
+    "./security/tokenTransferGuards": {
+      "types": "./dist/security/tokenTransferGuards.d.ts",
+      "import": "./dist/security/tokenTransferGuards.js",
+      "default": "./dist/security/tokenTransferGuards.js"
+    },
     "./signing/SignatureAlgorithm": {
       "types": "./dist/signing/SignatureAlgorithm.d.ts",
       "import": "./dist/signing/SignatureAlgorithm.js",

--- a/packages/core/chain/security/tokenTransferGuards.test.ts
+++ b/packages/core/chain/security/tokenTransferGuards.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest'
+
+import { assertSafeDestination } from './dangerousAddresses'
+import {
+  assertSafeTokenTransferDestination,
+  decodeErc20Approve,
+  decodeErc20Recipient,
+  decodeErc20RecipientFromSig,
+  isErc20TransferCalldata,
+} from './tokenTransferGuards'
+
+// architecture#1774 — ported from agent-backend-ts's local fork
+// (src/mastra/tools/mcp/lib/dangerous-addresses.test.ts), the SDK's only
+// prior copy of these tests.
+
+const SELECTOR_TRANSFER = 'a9059cbb'
+const SELECTOR_TRANSFER_FROM = '23b872dd'
+const pad32 = (addr20: string) => '000000000000000000000000' + addr20.replace(/^0x/, '').toLowerCase()
+const AMOUNT_1 = '0'.repeat(63) + '1'
+const transferCalldata = (addr20: string) => `0x${SELECTOR_TRANSFER}${pad32(addr20)}${AMOUNT_1}`
+const transferFromCalldata = (from20: string, to20: string) =>
+  `0x${SELECTOR_TRANSFER_FROM}${pad32(from20)}${pad32(to20)}${AMOUNT_1}`
+
+const ZERO = '0x0000000000000000000000000000000000000000'
+const DEAD = '0x000000000000000000000000000000000000dead'
+const SAFE = '0x742d35cc6634c0532925a3b844bc454e4438f44e'
+
+describe('calldata-recipient guard chain (decode -> assertSafeDestination)', () => {
+  it('decodeErc20Recipient extracts the transfer recipient from raw calldata', () => {
+    expect(decodeErc20Recipient(transferCalldata(SAFE))?.toLowerCase()).toBe(SAFE)
+    expect(decodeErc20Recipient(transferCalldata(ZERO))?.toLowerCase()).toBe(ZERO)
+  })
+
+  it('decodeErc20Recipient extracts the recipient from transferFrom (second address slot)', () => {
+    const from = '0x1111111111111111111111111111111111111111'
+    expect(decodeErc20Recipient(transferFromCalldata(from, SAFE))?.toLowerCase()).toBe(SAFE)
+  })
+
+  it('REJECTS a burn recipient hidden in the calldata (decode -> assertSafeDestination throws)', () => {
+    for (const burn of [ZERO, DEAD]) {
+      const decoded = decodeErc20Recipient(transferCalldata(burn))
+      expect(decoded, burn).toBeTruthy()
+      expect(() => assertSafeDestination('Ethereum', decoded as string), burn).toThrow(/Refusing to build/)
+    }
+  })
+
+  it('ALLOWS a safe recipient hidden in the calldata (decode -> assertSafeDestination passes)', () => {
+    const decoded = decodeErc20Recipient(transferCalldata(SAFE))
+    expect(() => assertSafeDestination('Ethereum', decoded as string)).not.toThrow()
+  })
+
+  it('returns null for an un-decoded selector (e.g. approve) — the RECIPIENT decoder is a no-op on approve', () => {
+    expect(decodeErc20Recipient(`0x095ea7b3${pad32(SAFE)}${AMOUNT_1}`)).toBeNull()
+  })
+
+  it('returns null for malformed/truncated calldata', () => {
+    expect(decodeErc20Recipient('0x')).toBeNull()
+    expect(decodeErc20Recipient(`0x${SELECTOR_TRANSFER}`)).toBeNull()
+    expect(decodeErc20Recipient(123 as unknown as string)).toBeNull()
+  })
+})
+
+describe('isErc20TransferCalldata', () => {
+  it('true for transfer and transferFrom selectors', () => {
+    expect(isErc20TransferCalldata(transferCalldata(SAFE))).toBe(true)
+    expect(isErc20TransferCalldata(transferFromCalldata(SAFE, SAFE))).toBe(true)
+  })
+
+  it('false for approve and ERC-721 safeTransferFrom (deliberately out of scope)', () => {
+    expect(isErc20TransferCalldata(`0x095ea7b3${pad32(SAFE)}${AMOUNT_1}`)).toBe(false)
+    expect(isErc20TransferCalldata(`0x42842e0e${pad32(SAFE)}${pad32(SAFE)}${AMOUNT_1}`)).toBe(false)
+  })
+
+  it('false for non-string input', () => {
+    expect(isErc20TransferCalldata(undefined as unknown as string)).toBe(false)
+  })
+})
+
+// #1454-equivalent: a raw approve(spender,uint256) was OPAQUE — no spender
+// decode, no WYSIWYS surface. decodeErc20Approve pulls the spender + allowance
+// out so the SAME registry/dead-address guards can run on it.
+const MAX_UINT256_HEX = 'f'.repeat(64)
+const approveCalldata = (spender20: string, amountHex = AMOUNT_1) => `0x095ea7b3${pad32(spender20)}${amountHex}`
+
+describe('decodeErc20Approve', () => {
+  it('extracts the spender + amount from raw approve calldata', () => {
+    expect(decodeErc20Approve(approveCalldata(SAFE))).toEqual({ spender: SAFE, amount: 1n })
+    const unlimited = decodeErc20Approve(approveCalldata(SAFE, MAX_UINT256_HEX))
+    expect(unlimited?.spender).toBe(SAFE)
+    expect(unlimited?.amount).toBe((1n << 256n) - 1n)
+  })
+
+  it('REJECTS a burn/dangerous spender hidden in the calldata (decode -> assertSafeDestination throws)', () => {
+    for (const burn of [ZERO, DEAD]) {
+      const decoded = decodeErc20Approve(approveCalldata(burn))
+      expect(decoded?.spender, burn).toBe(burn)
+      expect(() => assertSafeDestination('Ethereum', decoded!.spender), burn).toThrow(/Refusing to build/)
+    }
+  })
+
+  it('ALLOWS a safe spender hidden in the calldata (decode -> assertSafeDestination passes)', () => {
+    const decoded = decodeErc20Approve(approveCalldata(SAFE))
+    expect(() => assertSafeDestination('Ethereum', decoded!.spender)).not.toThrow()
+  })
+
+  it('returns null for a non-approve selector (transfer) and for malformed/truncated calldata', () => {
+    expect(decodeErc20Approve(transferCalldata(SAFE))).toBeNull()
+    expect(decodeErc20Approve('0x095ea7b3')).toBeNull() // selector only, no args
+    expect(decodeErc20Approve(`0x095ea7b3${pad32(SAFE)}`)).toBeNull() // missing amount slot
+    expect(decodeErc20Approve('0x')).toBeNull()
+  })
+})
+
+describe('decodeErc20RecipientFromSig', () => {
+  it('extracts the recipient from a transfer(address,uint256) signature + args', () => {
+    expect(decodeErc20RecipientFromSig('transfer(address,uint256)', [SAFE, '1000000'])).toBe(SAFE)
+    expect(decodeErc20RecipientFromSig('function transfer(address to, uint256 amount)', [SAFE, '1'])).toBe(SAFE)
+  })
+
+  it('extracts the SECOND address for transferFrom/safeTransferFrom (never the "from")', () => {
+    const from = '0x1111111111111111111111111111111111111111'
+    expect(decodeErc20RecipientFromSig('transferFrom(address,address,uint256)', [from, SAFE, '1'])).toBe(SAFE)
+    expect(decodeErc20RecipientFromSig('safeTransferFrom(address,address,uint256)', [from, SAFE, '1'])).toBe(SAFE)
+  })
+
+  it('returns null for a non-transfer signature (e.g. approve)', () => {
+    expect(decodeErc20RecipientFromSig('approve(address,uint256)', [SAFE, '1'])).toBeNull()
+  })
+
+  it('returns null for malformed input (wrong arg types, missing args, non-array args)', () => {
+    expect(decodeErc20RecipientFromSig('transfer(uint256,uint256)', ['1', '1'])).toBeNull()
+    expect(decodeErc20RecipientFromSig('transfer(address,uint256)', [SAFE])).not.toBeNull() // args[0] present is enough
+    expect(decodeErc20RecipientFromSig('transfer(address,uint256)', 'not-an-array')).toBeNull()
+    expect(decodeErc20RecipientFromSig(123, [SAFE, '1'])).toBeNull()
+  })
+})
+
+// A token sent to a known token CONTRACT (most often its own contract)
+// permanently strands the funds. These lock the fix: a registry match
+// (knownTokensIndex), never an eth_getCode probe.
+describe('assertSafeTokenTransferDestination', () => {
+  // Real mainnet USDC contract — present in the SDK's knownTokensIndex.
+  const USDC_ETHEREUM = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+  // Real mainnet USDT contract — a DIFFERENT known token contract on the same chain.
+  const USDT_ETHEREUM = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
+  const WALLET = '0x742d35Cc6634C0532925a3b844Bc454e4438f44'
+
+  it('BLOCKS sending USDC to the USDC contract itself (the exact prod repro)', () => {
+    expect(() => assertSafeTokenTransferDestination('Ethereum', USDC_ETHEREUM, USDC_ETHEREUM)).toThrow(
+      /USDC.*USDC token contract|permanently burn/i
+    )
+  })
+
+  it('BLOCKS case-mutated same-token-contract recipient (checksum vs lowercase)', () => {
+    expect(() => assertSafeTokenTransferDestination('Ethereum', USDC_ETHEREUM.toLowerCase(), USDC_ETHEREUM)).toThrow(
+      /permanently burn/i
+    )
+  })
+
+  it('BLOCKS sending a token to a DIFFERENT known token contract on the same chain', () => {
+    expect(() => assertSafeTokenTransferDestination('Ethereum', USDT_ETHEREUM, USDC_ETHEREUM)).toThrow(
+      /USDT token contract/i
+    )
+  })
+
+  it('ALLOWS sending a token to a normal wallet address', () => {
+    expect(() => assertSafeTokenTransferDestination('Ethereum', WALLET, USDC_ETHEREUM)).not.toThrow()
+  })
+
+  it('is a NO-OP for a native-coin send (no sendingTokenContract)', () => {
+    expect(() => assertSafeTokenTransferDestination('Ethereum', USDC_ETHEREUM, undefined)).not.toThrow()
+  })
+
+  it('is a NO-OP when the recipient is not in the known-token registry (no eth_getCode probe)', () => {
+    const RANDOM_CONTRACT = '0x1234567890123456789012345678901234567890'
+    expect(() => assertSafeTokenTransferDestination('Ethereum', RANDOM_CONTRACT, USDC_ETHEREUM)).not.toThrow()
+  })
+})

--- a/packages/core/chain/security/tokenTransferGuards.ts
+++ b/packages/core/chain/security/tokenTransferGuards.ts
@@ -1,0 +1,209 @@
+/**
+ * Token-transfer / ERC-20-calldata destination safety helpers
+ * (architecture#1774).
+ *
+ * Ported from `agent-backend-ts`'s local fork
+ * (`src/mastra/tools/mcp/lib/dangerous-addresses.ts`), which the SDK didn't
+ * publish a canonical for — the SDK only exposed `assertSafeDestination`
+ * (burn/dead addresses) and had a narrower, inline own-token-contract check
+ * duplicated in `tools/prep/send.ts`. This is a sibling guard: rejecting a
+ * transfer whose RECIPIENT is itself a known token contract (not just a
+ * generic burn address), plus the calldata decoders needed to find that
+ * recipient when it's hidden inside an ERC-20 `transfer`/`transferFrom`
+ * call rather than a plain send.
+ *
+ * Lives in `core-chain` (not the SDK) so it can be imported by both SDK
+ * build-tx primitives and any lower-level core-chain guard — mirrors
+ * `dangerousAddresses.ts`'s own placement rationale.
+ */
+import { Chain } from '@vultisig/core-chain/Chain'
+import { knownTokensIndex } from '@vultisig/core-chain/coin/knownTokens'
+
+const EVM_ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/
+
+/**
+ * Throws when a plain token-transfer `recipient` is itself a known token
+ * contract address on `chain` — most commonly the SAME token being sent to
+ * its own contract, but also catches a transfer aimed at a different known
+ * token's contract.
+ *
+ * Call this ONLY on plain-transfer recipients (a native/ERC-20 send, or a
+ * decoded ERC-20 `transfer` hidden inside an arbitrary contract-call's
+ * calldata — see `decodeErc20Recipient` below). `sendingTokenContract` is
+ * the contract address of the token actually being sent (`undefined` for a
+ * native-coin send, which this guard is a no-op for — there is no "the ETH
+ * contract" to accidentally send ETH to).
+ */
+export function assertSafeTokenTransferDestination(
+  chain: string,
+  recipient: string,
+  sendingTokenContract: string | undefined
+): void {
+  if (!sendingTokenContract) return
+  const hit = knownTokensIndex[chain as Chain]?.[recipient.toLowerCase()]
+  if (!hit) return
+  const isSameToken = recipient.toLowerCase() === sendingTokenContract.toLowerCase()
+  if (isSameToken) {
+    throw new Error(
+      `Refusing to build transaction: sending ${hit.ticker} to the ${hit.ticker} token contract ` +
+        `(${recipient}) would permanently burn it — the contract cannot credit a balance to itself. ` +
+        'Did you mean to send to a wallet address instead?'
+    )
+  }
+  throw new Error(
+    `Refusing to build transaction: destination ${recipient} is the ${hit.ticker} token contract on ${chain}, ` +
+      'not a wallet — tokens sent to a token contract are permanently unrecoverable. ' +
+      'Did you mean to send to a wallet address instead?'
+  )
+}
+
+// ── ERC-20 calldata recipient decoding ───────────────────────────────────────
+
+const ERC20_TRANSFER_SELECTOR = '0xa9059cbb'
+const ERC20_TRANSFER_FROM_SELECTOR = '0x23b872dd'
+// ERC-721 safeTransferFrom — same recipient offset as ERC-20 transferFrom
+// (second 32-byte slot). Two overloads; both hit the same decode path:
+//   safeTransferFrom(address,address,uint256)       → 0x42842e0e (3-arg)
+//   safeTransferFrom(address,address,uint256,bytes) → 0xb88d4fde (4-arg, common in wallet SDKs)
+const ERC721_SAFE_TRANSFER_FROM_SELECTOR = '0x42842e0e'
+const ERC721_SAFE_TRANSFER_FROM_BYTES_SELECTOR = '0xb88d4fde'
+
+/**
+ * True when `data`'s selector is a plain ERC-20 `transfer`/`transferFrom` —
+ * the two calldata shapes where the call target IS the token being moved, so
+ * a recipient that is itself a known token contract strands the funds and
+ * `assertSafeTokenTransferDestination` applies. ERC-721 `safeTransferFrom`
+ * deliberately returns false: the 721 standard's on-chain `onERC721Received`
+ * check already reverts a transfer to a non-receiver contract, so extending
+ * the registry guard there would add false-positive surface without closing
+ * a loss path. Every other selector is an arbitrary contract call and stays
+ * out of scope.
+ */
+export function isErc20TransferCalldata(data: string): boolean {
+  if (typeof data !== 'string') return false
+  const hex = data.startsWith('0x') ? data : `0x${data}`
+  const selector = hex.slice(0, 10).toLowerCase()
+  return selector === ERC20_TRANSFER_SELECTOR || selector === ERC20_TRANSFER_FROM_SELECTOR
+}
+
+/**
+ * If `data` looks like an ERC-20 `transfer`/`transferFrom` (or the
+ * same-shaped ERC-721 `safeTransferFrom`) call, return the decoded recipient
+ * address (lower-cased, `0x`-prefixed). Otherwise returns `null`.
+ *
+ * A contract-call builder that sets `to = <token contract>` + `data =
+ * <encoded transfer>` must run this to check the ACTUAL recipient —
+ * otherwise a destination guard that only vets the token contract address
+ * lets the real recipient slip through unchecked.
+ *
+ * Calldata layout for `transfer(address,uint256)`:
+ *   0x00–0x04  selector (4 bytes)
+ *   0x04–0x24  recipient (32-byte padded; address in last 20 bytes)
+ *   0x24–0x44  amount
+ *
+ * For `transferFrom(address,address,uint256)` (ERC-20) and
+ * `safeTransferFrom(address,address,uint256[,bytes])` (ERC-721 — same head layout):
+ *   0x00–0x04  selector
+ *   0x04–0x24  sender
+ *   0x24–0x44  recipient
+ *   0x44–0x64  amount / tokenId
+ */
+export function decodeErc20Recipient(data: string): string | null {
+  if (typeof data !== 'string') return null
+  const hex = data.startsWith('0x') ? data : `0x${data}`
+  if (hex.length < 10) return null
+  const selector = hex.slice(0, 10).toLowerCase()
+
+  let recipientSliceStart: number
+  if (selector === ERC20_TRANSFER_SELECTOR) {
+    // recipient is at bytes 4..36 → hex chars 10..74, last 40 chars = addr
+    recipientSliceStart = 10
+  } else if (
+    selector === ERC20_TRANSFER_FROM_SELECTOR ||
+    selector === ERC721_SAFE_TRANSFER_FROM_SELECTOR ||
+    selector === ERC721_SAFE_TRANSFER_FROM_BYTES_SELECTOR
+  ) {
+    // recipient is at bytes 36..68 → hex chars 74..138, last 40 chars = addr
+    recipientSliceStart = 74
+  } else {
+    return null
+  }
+
+  const slotEnd = recipientSliceStart + 64
+  if (hex.length < slotEnd) return null
+  const slot = hex.slice(recipientSliceStart, slotEnd)
+  // Recipient occupies the last 40 hex chars (rightmost 20 bytes) of the slot.
+  const addr = `0x${slot.slice(24).toLowerCase()}`
+  if (!EVM_ADDRESS_RE.test(addr)) return null
+  return addr
+}
+
+// ERC-20 approve(address spender, uint256 amount) — 0x095ea7b3. The SPENDER
+// receives spend authority over the owner's tokens; a raw approve built via
+// an arbitrary contract-call path is OPAQUE (no spender decode, no
+// WYSIWYS surface) unless decoded explicitly.
+export const ERC20_APPROVE_SELECTOR = '0x095ea7b3'
+
+/**
+ * If `data` is an ERC-20 `approve(address spender, uint256 amount)` call,
+ * decode the SPENDER (lower-cased, `0x`-prefixed) + the raw allowance
+ * amount. Otherwise null. Mirrors `decodeErc20Recipient`'s slot math:
+ * spender = first 32-byte slot (bytes 4..36), amount = second slot (bytes
+ * 36..68).
+ */
+export function decodeErc20Approve(data: string): { spender: string; amount: bigint } | null {
+  if (typeof data !== 'string') return null
+  const hex = data.startsWith('0x') ? data : `0x${data}`
+  if (hex.slice(0, 10).toLowerCase() !== ERC20_APPROVE_SELECTOR) return null
+  // 4-byte selector + 32-byte spender + 32-byte amount = 138 hex chars incl the `0x`.
+  if (hex.length < 138) return null
+  const spender = `0x${hex.slice(10, 74).slice(24).toLowerCase()}`
+  if (!EVM_ADDRESS_RE.test(spender)) return null
+  let amount: bigint
+  try {
+    amount = BigInt(`0x${hex.slice(74, 138)}`)
+  } catch {
+    return null
+  }
+  return { spender, amount }
+}
+
+/**
+ * Extract the ERC-20/721 transfer RECIPIENT from a `function_sig` + `args`
+ * shape — the alternative to raw ABI-encoded `data` some builders accept
+ * (function signature + positional args, ABI-encoded server/caller-side
+ * AFTER any pre-dispatch destination guard already ran). Without this, a
+ * transfer expressed as `function_sig: "transfer(address,uint256)"` +
+ * `args: [<recipient>, <amount>]` has no `data` for `decodeErc20Recipient`
+ * to see and a destination guard silently no-ops.
+ *
+ * Mirrors `decodeErc20Recipient`'s selector→slot mapping on the parsed
+ * signature: `transfer(address,uint256)` → `args[0]`;
+ * `transferFrom`/`safeTransferFrom(address from,address to,…)` → `args[1]`
+ * (the recipient is the SECOND address, never `from`). A non-transfer
+ * signature (or one that doesn't match either shape) → `null`.
+ */
+export function decodeErc20RecipientFromSig(functionSig: unknown, args: unknown): string | null {
+  if (typeof functionSig !== 'string' || !Array.isArray(args)) return null
+  // Accept "function transfer(address,uint256)" or "transfer(address,uint256)".
+  const m = functionSig
+    .replace(/^\s*function\s+/i, '')
+    .trim()
+    .match(/^(\w+)\s*\(([^)]*)\)/)
+  if (!m) return null
+  const name = m[1]
+  // Strip any inline arg names ("address to" → "address") so we compare pure types.
+  const argTypes = m[2].split(',').map(t => t.trim().split(/\s+/)[0])
+  let idx: number
+  if (name === 'transfer' && argTypes[0] === 'address') {
+    idx = 0 // transfer(address to, uint256 amount) — recipient is the FIRST arg
+  } else if ((name === 'transferFrom' || name === 'safeTransferFrom') && argTypes[0] === 'address' && argTypes[1] === 'address') {
+    idx = 1 // transferFrom/safeTransferFrom(address from, address to, …) — recipient is the SECOND arg
+  } else {
+    return null
+  }
+  const raw = args[idx]
+  if (typeof raw !== 'string') return null
+  const addr = raw.trim().toLowerCase()
+  return EVM_ADDRESS_RE.test(addr) ? addr : null
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -409,6 +409,21 @@ export {
   XRP_DANGEROUS_ADDRESSES,
 } from './utils/dangerousAddresses'
 
+// Token-transfer / ERC-20-calldata destination guards (architecture#1774).
+// A sibling to the burn-address guard above: rejects a transfer whose
+// RECIPIENT is itself a known token contract, plus the calldata decoders
+// needed to find that recipient when it's hidden inside an ERC-20
+// transfer/transferFrom call rather than a plain send. Exported so
+// first-party consumers stop hand-maintaining a private fork.
+export {
+  assertSafeTokenTransferDestination,
+  decodeErc20Approve,
+  decodeErc20Recipient,
+  decodeErc20RecipientFromSig,
+  ERC20_APPROVE_SELECTOR,
+  isErc20TransferCalldata,
+} from './utils/dangerousAddresses'
+
 // EVM chainId ↔ chain mapping plus the canonical priority-fee sanity clamp.
 // Single source of truth for the per-chain EVM chainId table and fee-ceiling
 // policy so consumers (app, agent-backend-ts) import it instead of

--- a/packages/sdk/src/tools/prep/send.ts
+++ b/packages/sdk/src/tools/prep/send.ts
@@ -3,6 +3,7 @@ import { Chain } from '@vultisig/core-chain/Chain'
 import type { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
 import { getPublicKey } from '@vultisig/core-chain/publicKey/getPublicKey'
 import { assertSafeDestination } from '@vultisig/core-chain/security/dangerousAddresses'
+import { assertSafeTokenTransferDestination } from '@vultisig/core-chain/security/tokenTransferGuards'
 import { isValidAddress } from '@vultisig/core-chain/utils/isValidAddress'
 import type { FeeSettings } from '@vultisig/core-mpc/keysign/chainSpecific/FeeSettings'
 import { buildSendKeysignPayload } from '@vultisig/core-mpc/keysign/send/build'
@@ -71,12 +72,21 @@ export const prepareSendTxFromKeys = async (
   // contract address. Tokens sent to their own contract are unrecoverable for
   // almost all users (the contract has no sweep path for arbitrary senders).
   // This applies to ERC-20 and any token where `coin.id` encodes the contract
-  // address — native sends (no `coin.id`) are unaffected.
+  // address — native sends (no `coin.id`) are unaffected. Kept as an
+  // UNCONDITIONAL check (not registry-gated) so a brand-new/unlisted token's
+  // own contract is caught even before it's indexed anywhere.
   if (params.coin.id !== undefined && params.coin.id.trim().toLowerCase() === params.receiver.trim().toLowerCase()) {
     throw new Error(
       `Refusing to build transaction: recipient ${params.receiver} is the token contract address for ${params.coin.ticker}. Sending tokens to their own contract is almost certainly a mistake and funds would be unrecoverable.`
     )
   }
+
+  // Fund-safety (architecture#1774): reject sends where the recipient is a
+  // DIFFERENT known token's contract (not the one being sent — that case is
+  // already caught above). Registry-based (only fires for a contract in
+  // `knownTokensIndex`), so it's additive coverage on top of the unconditional
+  // self-check, not a replacement for it.
+  assertSafeTokenTransferDestination(params.coin.chain, params.receiver, params.coin.id)
 
   const isQbtc = params.coin.chain === Chain.QBTC
 

--- a/packages/sdk/src/utils/dangerousAddresses.ts
+++ b/packages/sdk/src/utils/dangerousAddresses.ts
@@ -6,3 +6,11 @@
  * existing sdk import path + public re-exports stay stable.
  */
 export * from '@vultisig/core-chain/security/dangerousAddresses'
+
+/**
+ * Re-export of the canonical token-transfer / ERC-20-calldata destination
+ * guards (architecture#1774) — same shim rationale as above: lives in
+ * `core-chain` so both the SDK and lower-level core-chain guards can import
+ * it, re-exported here so `@vultisig/sdk` consumers don't need to know that.
+ */
+export * from '@vultisig/core-chain/security/tokenTransferGuards'

--- a/packages/sdk/tests/unit/services/TransactionBuilder.contractCall.test.ts
+++ b/packages/sdk/tests/unit/services/TransactionBuilder.contractCall.test.ts
@@ -60,6 +60,8 @@ vi.mock('@vultisig/core-chain/coin/chainFeeCoin', () => ({
     Mantle: { ticker: 'MNT', decimals: 18, logo: 'mnt' },
     Hyperliquid: { ticker: 'HYPE', decimals: 18, logo: 'hype' },
     Sei: { ticker: 'SEI', decimals: 18, logo: 'sei' },
+    // Required by kujiraCoinsOnThorChain module init — reads THORChain decimals at import time
+    THORChain: { ticker: 'RUNE', decimals: 8, logo: 'rune' },
   },
 }))
 

--- a/packages/sdk/tests/unit/tools/prep/send.test.ts
+++ b/packages/sdk/tests/unit/tools/prep/send.test.ts
@@ -301,4 +301,24 @@ describe('prepareSendTxFromKeys', () => {
 
     expect(mockBuildSendKeysignPayload).toHaveBeenCalledTimes(1)
   })
+
+  it('rejects a USDC send whose recipient is a DIFFERENT known token contract (architecture#1774)', async () => {
+    const usdcContract = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+    const usdtContract = '0xdac17f958d2ee523a2206206994597c13d831ec7'
+    await expect(
+      prepareSendTxFromKeys(baseIdentity, {
+        coin: {
+          chain: Chain.Ethereum,
+          address: '0xfrom',
+          decimals: 6,
+          ticker: 'USDC',
+          id: usdcContract,
+        } as any,
+        receiver: usdtContract,
+        amount: 1_000_000n,
+      })
+    ).rejects.toThrow(/destination.*is the USDT token contract/)
+
+    expect(mockBuildSendKeysignPayload).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#1774

Added `packages/core/chain/security/tokenTransferGuards.ts`, ported from `agent-backend-ts/src/mastra/tools/mcp/lib/dangerous-addresses.ts`'s local fork (read-only reference at `/home/gomes/Sites/agent-backend-ts`, present on this machine): `assertSafeTokenTransferDestination`, `isErc20TransferCalldata`, `decodeErc20Recipient`, `decodeErc20Approve`, `ERC20_APPROVE_SELECTOR`, `decodeErc20RecipientFromSig`. Placed alongside the existing `dangerousAddresses.ts` (burn-address guard) in `core-chain/security/` rather than inside it — same placement rationale (importable by both the SDK and lower-level core-chain guards), but a distinct file since it's a genuinely different concern (recipient-is-a-token-contract, not recipient-is-a-burn-address). `assertSafeTokenTransferDestination` reuses the SDK's existing `knownTokensIndex` (`@vultisig/core-chain/coin/knownTokens`) rather than a separate registry.

Did NOT port `chainFromThorAsset` (also in the backend file) — unrelated concern (THOR asset-string chain parsing, not a calldata destination guard), out of scope for this issue's "token-calldata destination guards" ask.

Re-exported from `@vultisig/sdk` via the existing `utils/dangerousAddresses.ts` shim (`export * from '@vultisig/core-chain/security/tokenTransferGuards'`) and flattened at the top-level `packages/sdk/src/index.ts`, matching how the sibling burn-address guard is already exposed.

**Migrated `tools/prep/send.ts` carefully, not as a pure swap.** The SDK's existing inline check (`coin.id === receiver`) is *unconditional* — it fires regardless of whether the token contract is registered anywhere. The ported `assertSafeTokenTransferDestination` is *registry-gated* (`knownTokensIndex` lookup) — it additionally catches sending to a *different* known token's contract, but would silently NOT catch a self-send to an *unregistered/brand-new* token's own contract. Replacing the old check outright would have been a real regression for any token not yet in the registry. Instead: the original unconditional self-check stays first (same wording, same behavior — confirmed via 2 unchanged pre-existing tests), and `assertSafeTokenTransferDestination` runs after it as *additive* coverage for the different-token case.

Added `packages/core/chain/security/tokenTransferGuards.test.ts` (23 tests), ported from `agent-backend-ts`'s own `dangerous-addresses.test.ts` for `assertSafeTokenTransferDestination`/`decodeErc20Recipient`/`decodeErc20Approve` (real mainnet USDC/USDT contract fixtures — same-contract burn, cross-token-contract burn, native-coin no-op, unregistered-contract no-op), plus new direct unit tests I wrote for `isErc20TransferCalldata` and `decodeErc20RecipientFromSig` (no direct unit coverage existed for these two in the backend, only integration-style usages). Added one new test to `packages/sdk/tests/unit/tools/prep/send.test.ts` proving the new additive guard fires for a USDC→USDT-contract send.

## what I ran

```
cd /tmp/claude-1000/wt-sdk-w5
npx tsc --noEmit -p .config/tsconfig.json
# => exit 0, no errors (full workspace)

npx vitest run --config .config/vitest.core.config.ts packages/core/chain/security/
# => Test Files 3 passed (3); Tests 42 passed (42)  [incl. 23 new in tokenTransferGuards.test.ts]

cd packages/sdk
npx vitest run tests/unit/tools/prep/send.test.ts
# => Test Files 1 passed (1); Tests 15 passed (15)  [14 existing unchanged + 1 new]
```

closes vultisig/vultisig-sdk#1774