### PR TITLE
fix(sdk): export the LI.FI fee-chain resolver

### DIFF
--- a/.changeset/sdk-lifi-fee-chain-export.md
+++ b/.changeset/sdk-lifi-fee-chain-export.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+Export the canonical LI.FI swap-fee chain resolver from the root and React Native SDK entrypoints so consumers stop deep-importing or reimplementing the fee-chain mapping logic.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -522,6 +522,8 @@ export {
 export type { JupiterAffiliateConfig } from '@vultisig/core-chain/swap/general/jupiter/config'
 export type { LifiAffiliateConfig, LifiBootstrapConfig } from '@vultisig/core-chain/swap/general/lifi/config'
 export { setupLifi } from '@vultisig/core-chain/swap/general/lifi/config'
+export type { LifiSwapEnabledChain } from '@vultisig/core-chain/swap/general/lifi/LifiSwapEnabledChains'
+export { resolveSwapFeeChain } from '@vultisig/core-chain/swap/general/lifi/api/lifiSwapFeeChain'
 export type { SwapKitConfig } from '@vultisig/core-chain/swap/general/swapkit/config'
 export { configureSwapKit, getSwapKitConfig } from '@vultisig/core-chain/swap/general/swapkit/config'
 export type {

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -80,8 +80,11 @@ export {
   MAYA_SEND_FEE_BASE_UNITS,
   TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS,
 } from '@vultisig/core-chain/chains/cosmos/gas'
+export type { LifiSwapEnabledChain } from '@vultisig/core-chain/swap/general/lifi/LifiSwapEnabledChains'
+export { resolveSwapFeeChain } from '@vultisig/core-chain/swap/general/lifi/api/lifiSwapFeeChain'
 
 // Cosmos x/auth.MaxMemoCharacters cap, per chain — single source of truth for
+
 // "will this memo fit before broadcast rejects it with sdk code 12 (memo too
 // long) after the user has already signed?" Kept in parity with the root SDK
 // entrypoint (sdk#1538) so RN consumers don't hand-roll their own memo-cap table.

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -3,6 +3,8 @@ import * as customRpcSupportedChains from '@vultisig/core-chain/chains/customRpc
 import { AuthInfo, SignDoc, TxBody } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
 import { describe, expect, it, vi } from 'vitest'
 
+import { resolveSwapFeeChain as canonicalResolveSwapFeeChain } from '@vultisig/core-chain/swap/general/lifi/api/lifiSwapFeeChain'
+
 import { cosmosTxFeeGasParityCases } from '../../../fixtures/cosmosTxFeeGasParity'
 
 process.env.VULTISIG_STRICT_SINGLETON = '0'
@@ -88,6 +90,13 @@ describe('RN entry wires configureCrypto and configureDefaultStorage', () => {
     expect(rn.IbcEnabledCosmosChain.TerraClassic).toBe('TerraClassic')
     expect(rn.VaultBasedCosmosChain.THORChain).toBe('THORChain')
     expect(Object.values(rn.IbcEnabledCosmosChain)).not.toContain(rn.Chain.THORChain)
+  })
+
+  it('exports the canonical LI.FI fee-chain resolver from the RN entry', async () => {
+    const rn = await import('../../../../src/platforms/react-native/index')
+
+    expect(rn.resolveSwapFeeChain).toBe(canonicalResolveSwapFeeChain)
+    expect(rn.resolveSwapFeeChain(999_999, rn.Chain.Solana)).toBe(rn.Chain.Solana)
   })
 
   it.each(cosmosTxFeeGasParityCases)(

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -2,6 +2,8 @@ import * as customRpcOverrides from '@vultisig/core-chain/chains/customRpc/custo
 import * as customRpcSupportedChains from '@vultisig/core-chain/chains/customRpc/customRpcSupportedChains'
 import { describe, expect, it } from 'vitest'
 
+import { resolveSwapFeeChain as canonicalResolveSwapFeeChain } from '@vultisig/core-chain/swap/general/lifi/api/lifiSwapFeeChain'
+
 import * as sdk from '../../../src/index'
 import * as dangerousAddresses from '../../../src/utils/dangerousAddresses'
 import { cosmosTxFeeGasParityCases } from '../../fixtures/cosmosTxFeeGasParity'
@@ -80,6 +82,11 @@ describe('@vultisig/sdk public exports', () => {
     expect(typeof sdk.findSwapQuote).toBe('function')
     expect(typeof sdk.abiEncode).toBe('function')
     expect(typeof sdk.evmCheckAllowance).toBe('function')
+  })
+
+  it('exports the canonical LI.FI fee-chain resolver from the root sdk surface', () => {
+    expect(sdk.resolveSwapFeeChain).toBe(canonicalResolveSwapFeeChain)
+    expect(sdk.resolveSwapFeeChain(999_999, sdk.Chain.Solana)).toBe(sdk.Chain.Solana)
   })
 
   it('exports encodeErc20Approve, encodeErc20Revoke, MAX_UINT256 (ERC-20 approve/revoke calldata)', () => {


### PR DESCRIPTION
## Summary
- export the canonical LI.FI fee-chain resolver from the root SDK entrypoint
- mirror the export on the React Native SDK entrypoint
- pin both public surfaces with regression coverage and a changeset

Closes https://github.com/vultisig/vultisig-sdk/issues/2098

## Verification
- `corepack yarn build:shared` ✅
- `VULTISIG_STRICT_SINGLETON=0 corepack yarn workspace @vultisig/sdk vitest run --config tests/unit/vitest.config.ts tests/unit/utils/publicExports.test.ts -t "LI.FI fee-chain resolver"` ✅
- `VULTISIG_STRICT_SINGLETON=0 corepack yarn workspace @vultisig/sdk vitest run --config tests/unit/vitest.config.ts tests/unit/platforms/react-native/entry.test.ts -t "LI.FI fee-chain resolver"` ✅
- `corepack yarn build:sdk` ✅
- `corepack yarn workspace @vultisig/sdk pack --out /tmp/sdk-r155-pack/vultisig-sdk-lifi-fee-chain.tgz` ✅
- throwaway consumer import smoke from the packed tarball (`root_has function`, `root_fallback Solana`) ✅
- built RN bundle contains `resolveSwapFeeChain` export (`rn_bundle_mentions True`) ✅

## Notes
- Running the entire `tests/unit/platforms/react-native/entry.test.ts` file on clean main still hits the pre-existing unrelated failure around `TERRA_CLASSIC_STAKING_ULUNA_FEE_BASE_UNITS`; the new LI.FI-focused test passes in isolation and `build:sdk` is green.
