### PR TITLE
feat(sdk): export fromChainAmount and fromChainAmountDisplay

### DIFF
--- a/.changeset/sdkg1-1348.md
+++ b/.changeset/sdkg1-1348.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Re-export `fromChainAmount` and `fromChainAmountDisplay` from the root and React Native SDK entrypoints. No amount-math behavior change — visibility only.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -71,7 +71,8 @@ export {
 // round-trip, so it's safe for high-decimal assets). Exported at the root so
 // downstream consumers (CLI, app) can share this instead of hand-rolling
 // their own `BigInt(10 ** decimals)` divisor, which drifts past decimals=22.
-export { fromChainAmountExact } from '@vultisig/core-chain/amount/fromChainAmountExact'
+export { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
+export { fromChainAmountDisplay, fromChainAmountExact } from '@vultisig/core-chain/amount/fromChainAmountExact'
 
 // Public-boundary argument validation (AUDIT-R3 TASK-020).
 // Zod schemas + safe-parse helpers for chain and ticker strings.

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -748,7 +748,8 @@ export {
   toHumanUnits,
 } from '../../utils/convertAmount'
 export { FiatToAmountError } from '../../utils/fiatToAmount'
-export { fromChainAmountExact } from '@vultisig/core-chain/amount/fromChainAmountExact'
+export { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
+export { fromChainAmountDisplay, fromChainAmountExact } from '@vultisig/core-chain/amount/fromChainAmountExact'
 export { ChainAmountParseError, toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'
 export type { ChainKind } from '@vultisig/core-chain/ChainKind'
 export { getChainKind, isChainOfKind } from '@vultisig/core-chain/ChainKind'

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -311,6 +311,10 @@ describe('RN entry exposes pure chain helpers and registry', () => {
 
     expect(typeof rn.fromChainAmountExact).toBe('function')
     expect(rn.fromChainAmountExact(123456789012345678901n, 18)).toBe('123.456789012345678901')
+    expect(typeof rn.fromChainAmount).toBe('function')
+    expect(typeof rn.fromChainAmountDisplay).toBe('function')
+    expect(rn.fromChainAmount(1_000_000n, 6)).toBe(1)
+    expect(rn.fromChainAmountDisplay('999999999999999999999999', 18)).toBe('999999.999999999999999999')
 
     expect(typeof rn.getBlockExplorerUrl).toBe('function')
     expect(rn.getBlockExplorerUrl({ chain: rn.Chain.Ethereum, entity: 'address', value: '0xabc' })).toBe(

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -50,6 +50,10 @@ describe('@vultisig/sdk public exports', () => {
   it('exports fromChainAmountExact, getBlockExplorerUrl, and the chain registry', () => {
     expect(typeof sdk.fromChainAmountExact).toBe('function')
     expect(sdk.fromChainAmountExact(123456789012345678901n, 18)).toBe('123.456789012345678901')
+    expect(typeof sdk.fromChainAmount).toBe('function')
+    expect(typeof sdk.fromChainAmountDisplay).toBe('function')
+    expect(sdk.fromChainAmount(1_000_000n, 6)).toBe(1)
+    expect(sdk.fromChainAmountDisplay('999999999999999999999999', 18)).toBe('999999.999999999999999999')
 
     expect(typeof sdk.getBlockExplorerUrl).toBe('function')
     expect(sdk.getBlockExplorerUrl({ chain: sdk.Chain.Ethereum, entity: 'address', value: '0xabc' })).toBe(


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#1348
`toChainAmount` and `fromChainAmountExact` were already on the root and RN SDK surfaces; `fromChainAmount` (float64) and `fromChainAmountDisplay` (exact-for-integers, float64 fallback for non-integer aggregator amounts) were not. Re-exported both from `packages/sdk/src/index.ts` and `packages/sdk/src/platforms/react-native/index.ts` and pinned them with regression assertions. No amount-math behavior changed — visibility only. Not fund-adjacent: these helpers convert already-known base units for display. Could not verify a published tarball import (`import { fromChainAmount } from '@vultisig/sdk'`) against a built dist, only source-entry tests.

## what I ran
```
cd /tmp/claude-1000/wt-sdk-w1 && node scripts/build-shared-packages.mjs
cd packages/sdk && yarn vitest run --config tests/unit/vitest.config.ts tests/unit/utils/publicExports.test.ts tests/unit/platforms/react-native/entry.test.ts
```
```
 Test Files  2 passed (2)
      Tests  101 passed (101)
   Start at  22:30:02
   Duration  5.68s
```

closes vultisig/vultisig-sdk#1348