### PR TITLE
fix(sdk): wire the missing @vultisig/sdk/server package export map entry

### DIFF
--- a/.changeset/sdkg1-1322.md
+++ b/.changeset/sdkg1-1322.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Add the missing `./server` export map entry (JS/CJS/DTS) so `@vultisig/sdk/server` is actually importable — the module existed but had no package.json subpath wiring. Packaging-only, no signing/broadcast behavior change.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -202,6 +202,19 @@
       "import": "./dist/tools/gas/index.js",
       "require": "./dist/tools/gas/index.cjs",
       "default": "./dist/tools/gas/index.cjs"
+    },
+    "./server": {
+      "types": "./dist/server/index.d.ts",
+      "browser": "./dist/server/index.js",
+      "worker": "./dist/server/index.js",
+      "react-native": "./dist/server/index.js",
+      "node": {
+        "import": "./dist/server/index.js",
+        "require": "./dist/server/index.cjs"
+      },
+      "import": "./dist/server/index.js",
+      "require": "./dist/server/index.cjs",
+      "default": "./dist/server/index.cjs"
     }
   },
   "scripts": {

--- a/packages/sdk/rollup.platforms.config.js
+++ b/packages/sdk/rollup.platforms.config.js
@@ -363,6 +363,10 @@ const configs = {
       input: './src/tx/index.ts',
       distBase: 'tx',
     }),
+    ...createSubpathConfigs({
+      input: './src/server/index.ts',
+      distBase: 'server',
+    }),
   ],
   browser: {
     input: './src/platforms/browser/index.ts',

--- a/packages/sdk/rollup.types.config.js
+++ b/packages/sdk/rollup.types.config.js
@@ -133,4 +133,5 @@ export default defineConfig([
   createSubpathTypesConfig('src/seedphrase/index.ts', 'dist/seedphrase/index.d.ts'),
   createSubpathTypesConfig('src/tools/decode/index.ts', 'dist/tools/decode/index.d.ts'),
   createSubpathTypesConfig('src/tx/index.ts', 'dist/tx/index.d.ts'),
+  createSubpathTypesConfig('src/server/index.ts', 'dist/server/index.d.ts'),
 ])

--- a/packages/sdk/tests/unit/public-api/serverSubpath.test.ts
+++ b/packages/sdk/tests/unit/public-api/serverSubpath.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import * as server from '../../../src/server'
+
+describe('@vultisig/sdk/server source surface', () => {
+  it('exports the documented fast-vault and relay helpers', () => {
+    expect(typeof server.setupVaultWithServer).toBe('function')
+    expect(typeof server.createVaultWithServer).toBe('function')
+    expect(typeof server.signWithServer).toBe('function')
+    expect(typeof server.verifyVaultEmailCode).toBe('function')
+    expect(typeof server.getVaultFromServer).toBe('function')
+    expect(typeof server.reshareWithServer).toBe('function')
+    expect(typeof server.batchReshareWithServer).toBe('function')
+    expect(typeof server.keyImportWithServer).toBe('function')
+    expect(typeof server.sequentialKeyImportWithServer).toBe('function')
+    expect(typeof server.sendMpcRelayMessage).toBe('function')
+    expect(typeof server.getMpcRelayMessages).toBe('function')
+    expect(typeof server.deleteMpcRelayMessage).toBe('function')
+    expect(typeof server.waitForSetupMessage).toBe('function')
+    expect(typeof server.uploadMpcSetupMessage).toBe('function')
+    expect(typeof server.joinMpcSession).toBe('function')
+    expect(typeof server.fromMpcServerMessage).toBe('function')
+    expect(typeof server.toMpcServerMessage).toBe('function')
+  })
+
+  it('does not leak the internal ServerManager on the public server surface', () => {
+    expect('ServerManager' in server).toBe(false)
+  })
+})

--- a/packages/sdk/tests/unit/public-api/toolsSubpathExports.test.ts
+++ b/packages/sdk/tests/unit/public-api/toolsSubpathExports.test.ts
@@ -20,6 +20,7 @@ describe('public API subpath exports', () => {
     const utxoExport = sdkPackageJson.exports['./chains/utxo']
     const decodeExport = sdkPackageJson.exports['./tools/decode']
     const txExport = sdkPackageJson.exports['./tx']
+    const serverExport = sdkPackageJson.exports['./server']
 
     expect(parseExport).toMatchObject({
       types: './dist/tools/parse/index.d.ts',
@@ -75,6 +76,12 @@ describe('public API subpath exports', () => {
       require: './dist/tx/index.cjs',
       default: './dist/tx/index.cjs',
     })
+    expect(serverExport).toMatchObject({
+      types: './dist/server/index.d.ts',
+      import: './dist/server/index.js',
+      require: './dist/server/index.cjs',
+      default: './dist/server/index.cjs',
+    })
 
     expect(JSON.stringify(parseExport)).not.toContain('dist/index.node')
     expect(JSON.stringify(defiExport)).not.toContain('dist/index.node')
@@ -85,6 +92,7 @@ describe('public API subpath exports', () => {
     expect(JSON.stringify(utxoExport)).not.toContain('dist/index.node')
     expect(JSON.stringify(decodeExport)).not.toContain('dist/index.node')
     expect(JSON.stringify(txExport)).not.toContain('dist/index.node')
+    expect(JSON.stringify(serverExport)).not.toContain('dist/index.node')
   })
 
   it('keeps dedicated JS and d.ts bundle generation wired for every narrow public surface', () => {
@@ -106,6 +114,8 @@ describe('public API subpath exports', () => {
     expect(platformRollupConfig).toContain("distBase: 'tools/decode'")
     expect(platformRollupConfig).toContain("input: './src/tx/index.ts'")
     expect(platformRollupConfig).toContain("distBase: 'tx'")
+    expect(platformRollupConfig).toContain("input: './src/server/index.ts'")
+    expect(platformRollupConfig).toContain("distBase: 'server'")
 
     expect(typesRollupConfig).toContain(
       "createSubpathTypesConfig('src/tools/parse/index.ts', 'dist/tools/parse/index.d.ts')"
@@ -132,5 +142,6 @@ describe('public API subpath exports', () => {
       "createSubpathTypesConfig('src/tools/decode/index.ts', 'dist/tools/decode/index.d.ts')"
     )
     expect(typesRollupConfig).toContain("createSubpathTypesConfig('src/tx/index.ts', 'dist/tx/index.d.ts')")
+    expect(typesRollupConfig).toContain("createSubpathTypesConfig('src/server/index.ts', 'dist/server/index.d.ts')")
   })
 })


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#1322
`packages/sdk/src/server/index.ts` already advertised a public fast-vault + relay helper surface, but `package.json` had no `./server` export map entry, so `@vultisig/sdk/server` was unimportable. Added the same JS/CJS/DTS subpath wiring used by `./tools/gas`, plus regression tests that lock the export map, rollup inputs, and the documented helper names. `ServerManager` stays off this surface. Blast radius is packaging-only: no signing/broadcast behavior change. Did not run `yarn build:sdk` (full build out of scope); verified via source import + export-map contract tests.

## what I ran
```
cd /tmp/claude-1000/wt-sdk-w1/packages/sdk && yarn vitest run --config tests/unit/vitest.config.ts tests/unit/public-api/toolsSubpathExports.test.ts tests/unit/public-api/serverSubpath.test.ts
```
```
 Test Files  2 passed (2)
      Tests  4 passed (4)
   Start at  22:31:10
   Duration  244ms
```

closes vultisig/vultisig-sdk#1322