### PR TITLE
feat(sdk): export getSwapKitTrackerUrl and swapKitTrackerChainIds

### DIFF
--- a/.changeset/sdkg1-1393.md
+++ b/.changeset/sdkg1-1393.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Re-export `getSwapKitTrackerUrl` and `swapKitTrackerChainIds` from the root and React Native SDK entrypoints, so a `{chain, txHash}` caller doesn't need a full `KeysignSwapPayload`. Explorer/tracker URLs only, not fund-adjacent.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -368,6 +368,7 @@ export * from './signable-transaction'
 // chain-only explorer URLs when rendering swap tx history.
 export type { GetSwapExplorerUrlInput, SwapExplorerProvider } from '@vultisig/core-chain/swap/utils/getSwapExplorerUrl'
 export { getSwapExplorerUrl, swapExplorerProviders } from '@vultisig/core-chain/swap/utils/getSwapExplorerUrl'
+export { getSwapKitTrackerUrl, swapKitTrackerChainIds } from '@vultisig/core-chain/swap/general/swapkit/getSwapKitTrackerUrl'
 
 // Chain-native block explorer URL builder (address/tx) for the non-swap case.
 export { getBlockExplorerUrl } from '@vultisig/core-chain/utils/getBlockExplorerUrl'

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -765,6 +765,7 @@ export { getThorchainInboundAddress } from '@vultisig/core-chain/chains/cosmos/t
 export * from '@vultisig/core-chain/chains/cosmos/thor/lp'
 export type { GetSwapExplorerUrlInput, SwapExplorerProvider } from '@vultisig/core-chain/swap/utils/getSwapExplorerUrl'
 export { getSwapExplorerUrl, swapExplorerProviders } from '@vultisig/core-chain/swap/utils/getSwapExplorerUrl'
+export { getSwapKitTrackerUrl, swapKitTrackerChainIds } from '@vultisig/core-chain/swap/general/swapkit/getSwapKitTrackerUrl'
 export { getBlockExplorerUrl } from '@vultisig/core-chain/utils/getBlockExplorerUrl'
 export async function fiatToAmount(...args: unknown[]) {
   const mod = await import('../../utils/fiatToAmount')

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -349,6 +349,10 @@ describe('RN entry exposes pure chain helpers and registry', () => {
 
     expect(rn.getSwapExplorerUrl).toBe(swap.getSwapExplorerUrl)
     expect(rn.swapExplorerProviders).toBe(swap.swapExplorerProviders)
+    expect(typeof rn.getSwapKitTrackerUrl).toBe('function')
+    expect(rn.getSwapKitTrackerUrl({ chain: rn.Chain.Ethereum, txHash: '0xabc' })).toBe(
+      'https://track.swapkit.dev/?hash=0xabc&chainId=1'
+    )
     expect(
       rn.getSwapExplorerUrl({
         provider: 'li.fi',

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -185,6 +185,17 @@ describe('@vultisig/sdk public exports', () => {
         fromChain: sdk.Chain.Base,
       })
     ).toBe('https://scan.li.fi/tx/0xabc')
+    expect(typeof sdk.getSwapKitTrackerUrl).toBe('function')
+    expect(sdk.getSwapKitTrackerUrl({ chain: sdk.Chain.Ethereum, txHash: '0xabc' })).toBe(
+      'https://track.swapkit.dev/?hash=0xabc&chainId=1'
+    )
+    expect(
+      sdk.getSwapExplorerUrl({
+        provider: 'swapkit',
+        txHash: '0xabc',
+        fromChain: sdk.Chain.Ethereum,
+      })
+    ).toBe('https://track.swapkit.dev/?hash=0xabc&chainId=1')
   })
 
   it('exports Noon USDC yield helpers for Windows and Station consumers', () => {


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#1393
The original Station bug is already fixed on main: `getSwapExplorerUrl` has a real `swapkit` branch, uses the mobile `?hash=&chainId=` URL shape, and `swapKitTrackerChainIds` covers the previously missing chains (Blast, ZkSync, Cardano, Cosmos, Dash, Sui, Kujira, Maya, THOR). The remaining public-surface gap was that `getSwapKitTrackerUrl` / the chainId map were still not re-exported from `@vultisig/sdk` or the RN entry. Re-exported both so a `{chain, txHash}` caller does not need a `KeysignSwapPayload`. Not fund-adjacent (explorer/tracker URLs only). Did not verify iOS/Android URL parity against a live tracker page.

## what I ran
```
cd /tmp/claude-1000/wt-sdk-w1/packages/sdk && yarn vitest run --config tests/unit/vitest.config.ts tests/unit/utils/publicExports.test.ts tests/unit/platforms/react-native/entry.test.ts
```
```
 Test Files  2 passed (2)
      Tests  101 passed (101)
   Start at  22:33:11
   Duration  4.54s
```

closes vultisig/vultisig-sdk#1393