### PR TITLE
test(core-chain): cover the 10 untested tx/hash resolvers + cowswap order status

### DIFF
--- a/.changeset/sdkg1-1370.md
+++ b/.changeset/sdkg1-1370.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/core-chain': patch
+---
+
+Add unit test coverage for the 10 previously-untested `tx/hash/resolvers` (evm/utxo/cosmos/solana/ton/tron/ripple/cardano/bittensor/polkadot) and the CoW swap order-status API. Tests-only, no production behavior change.

--- a/packages/core/chain/swap/general/cowswap/api/getCowSwapOrderStatus.test.ts
+++ b/packages/core/chain/swap/general/cowswap/api/getCowSwapOrderStatus.test.ts
@@ -1,0 +1,35 @@
+import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getCowSwapOrderStatus } from './getCowSwapOrderStatus'
+
+vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
+  queryUrl: vi.fn(),
+}))
+
+describe('getCowSwapOrderStatus', () => {
+  beforeEach(() => {
+    vi.mocked(queryUrl).mockReset()
+  })
+
+  it('GETs /api/v1/orders/{uid} and returns status plus optional fill fields', async () => {
+    vi.mocked(queryUrl).mockResolvedValueOnce({
+      status: 'filled',
+      txHash: '0xsettle',
+      executedBuyAmount: '42',
+    })
+
+    await expect(
+      getCowSwapOrderStatus({
+        apiBase: 'https://api.cow.fi/mainnet',
+        uid: '0xuid',
+      })
+    ).resolves.toEqual({
+      status: 'filled',
+      txHash: '0xsettle',
+      executedBuyAmount: '42',
+    })
+
+    expect(queryUrl).toHaveBeenCalledWith('https://api.cow.fi/mainnet/api/v1/orders/0xuid')
+  })
+})

--- a/packages/core/chain/swap/general/cowswap/api/submitCowSwapOrder.test.ts
+++ b/packages/core/chain/swap/general/cowswap/api/submitCowSwapOrder.test.ts
@@ -1,0 +1,54 @@
+import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { CowSwapOrder } from '../sign/buildCowSwapOrder'
+import { submitCowSwapOrder } from './submitCowSwapOrder'
+
+vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
+  queryUrl: vi.fn(),
+}))
+
+const order: CowSwapOrder = {
+  sellToken: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+  buyToken: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+  receiver: '0xreceiver',
+  sellAmount: '1000000000000000000',
+  buyAmount: '990000000',
+  validTo: 1_800_000_000,
+  appData: '{}',
+  appDataHash: '0xapp',
+  feeAmount: '0',
+  kind: 'sell',
+  partiallyFillable: false,
+  sellTokenBalance: 'erc20',
+  buyTokenBalance: 'erc20',
+}
+
+describe('submitCowSwapOrder', () => {
+  beforeEach(() => {
+    vi.mocked(queryUrl).mockReset()
+  })
+
+  it('POSTs the signed EIP-712 order and returns the order uid', async () => {
+    vi.mocked(queryUrl).mockResolvedValueOnce('0xorderuid')
+
+    await expect(
+      submitCowSwapOrder({
+        apiBase: 'https://api.cow.fi/mainnet',
+        order,
+        signature: '0xsig',
+        from: '0xAbCDEF0000000000000000000000000000000001',
+      })
+    ).resolves.toBe('0xorderuid')
+
+    expect(queryUrl).toHaveBeenCalledWith('https://api.cow.fi/mainnet/api/v1/orders', {
+      method: 'POST',
+      body: {
+        ...order,
+        signature: '0xsig',
+        signingScheme: 'eip712',
+        from: '0xabcdef0000000000000000000000000000000001',
+      },
+    })
+  })
+})

--- a/packages/core/chain/tx/hash/resolvers/bittensor.test.ts
+++ b/packages/core/chain/tx/hash/resolvers/bittensor.test.ts
@@ -1,0 +1,11 @@
+import { blake2AsHex } from '@polkadot/util-crypto'
+import { describe, expect, it } from 'vitest'
+
+import { getBittensorTxHash } from './bittensor'
+
+describe('getBittensorTxHash', () => {
+  it('returns blake2b-256 of the length-prefixed extrinsic bytes', async () => {
+    const encoded = Uint8Array.from([0x45, 0x00, 0x01, 0x02, 0x03])
+    await expect(getBittensorTxHash({ encoded } as never)).resolves.toBe(blake2AsHex(encoded, 256))
+  })
+})

--- a/packages/core/chain/tx/hash/resolvers/cardano.test.ts
+++ b/packages/core/chain/tx/hash/resolvers/cardano.test.ts
@@ -1,0 +1,22 @@
+import { blake2b } from '@noble/hashes/blake2b'
+import { describe, expect, it } from 'vitest'
+
+import { cardanoCborEncoder } from '@vultisig/core-chain/chains/cardano/cip30/cborEncoder'
+
+import { getCardanoTxHash } from './cardano'
+
+describe('getCardanoTxHash', () => {
+  it('prefers a precomputed txId over re-encoding', () => {
+    const txId = Uint8Array.from([0xaa, 0xbb, 0xcc])
+    expect(getCardanoTxHash({ txId, encoded: new Uint8Array([0xff]) } as never)).toBe('aabbcc')
+  })
+
+  it('falls back to blake2b-256 of the CBOR body when txId is empty', () => {
+    const body = new Uint8Array([0x01, 0x02, 0x03])
+    const encoded = cardanoCborEncoder.encode([body, new Uint8Array([0x00])])
+    const decoded = cardanoCborEncoder.decode(encoded)
+    const expected = Buffer.from(blake2b(cardanoCborEncoder.encode(decoded[0]), { dkLen: 32 })).toString('hex')
+
+    expect(getCardanoTxHash({ txId: new Uint8Array(), encoded } as never)).toBe(expected)
+  })
+})

--- a/packages/core/chain/tx/hash/resolvers/cosmos.test.ts
+++ b/packages/core/chain/tx/hash/resolvers/cosmos.test.ts
@@ -1,0 +1,23 @@
+import { toBase64 } from '@cosmjs/encoding'
+import { describe, expect, it } from 'vitest'
+import { sha256 } from 'viem'
+
+import { getCosmosTxHash } from './cosmos'
+
+const txBytes = new Uint8Array([0x0a, 0x04, 0x74, 0x65, 0x73, 0x74])
+const txBytesB64 = toBase64(txBytes)
+const expected = sha256(txBytes).slice(2).toUpperCase()
+
+describe('getCosmosTxHash', () => {
+  it('hashes serialized.tx_bytes (base64) with sha256 and uppercases hex', () => {
+    expect(getCosmosTxHash({ serialized: JSON.stringify({ tx_bytes: txBytesB64 }) } as never)).toBe(expected)
+  })
+
+  it('accepts the json field as a fallback when serialized is absent', () => {
+    expect(getCosmosTxHash({ json: JSON.stringify({ tx_bytes: txBytesB64 }) } as never)).toBe(expected)
+  })
+
+  it('throws when neither serialized nor json carries tx_bytes', () => {
+    expect(() => getCosmosTxHash({} as never)).toThrow(/Serialized Cosmos transaction data is missing/)
+  })
+})

--- a/packages/core/chain/tx/hash/resolvers/evm.test.ts
+++ b/packages/core/chain/tx/hash/resolvers/evm.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { keccak256 } from 'viem'
+
+import { getEvmTxHash } from './evm'
+
+describe('getEvmTxHash', () => {
+  it('returns keccak256 of the signed encoded payload', () => {
+    const encoded = new Uint8Array([0x02, 0xf8, 0x6c, 0x01])
+    expect(getEvmTxHash({ encoded } as never)).toBe(keccak256(encoded))
+  })
+
+  it('is deterministic for the same encoded bytes', () => {
+    const encoded = new Uint8Array(64).fill(0xab)
+    expect(getEvmTxHash({ encoded } as never)).toBe(getEvmTxHash({ encoded } as never))
+  })
+})

--- a/packages/core/chain/tx/hash/resolvers/polkadot.test.ts
+++ b/packages/core/chain/tx/hash/resolvers/polkadot.test.ts
@@ -1,0 +1,21 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const createType = vi.fn()
+
+vi.mock('@vultisig/core-chain/chains/polkadot/client', () => ({
+  getPolkadotClient: async () => ({ createType }),
+}))
+
+import { getPolkadotTxHash } from './polkadot'
+
+describe('getPolkadotTxHash', () => {
+  beforeEach(() => createType.mockReset())
+
+  it('hashes the signed v4 extrinsic via the polkadot client', async () => {
+    const encoded = Uint8Array.from([0x45, 0x00])
+    createType.mockReturnValueOnce({ hash: { toHex: () => '0xabc123' } })
+
+    await expect(getPolkadotTxHash({ encoded } as never)).resolves.toBe('0xabc123')
+    expect(createType).toHaveBeenCalledWith('Extrinsic', encoded, { isSigned: true, version: 4 })
+  })
+})

--- a/packages/core/chain/tx/hash/resolvers/ripple.test.ts
+++ b/packages/core/chain/tx/hash/resolvers/ripple.test.ts
@@ -1,0 +1,20 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({ hashSignedTx: vi.fn() }))
+
+vi.mock('xrpl', () => ({
+  hashes: { hashSignedTx: mocks.hashSignedTx },
+}))
+
+import { getRippleTxHash } from './ripple'
+
+describe('getRippleTxHash', () => {
+  beforeEach(() => mocks.hashSignedTx.mockReset())
+
+  it('passes the encoded blob as hex to xrpl.hashSignedTx', () => {
+    mocks.hashSignedTx.mockReturnValueOnce('DEADBEEF')
+    const encoded = Uint8Array.from([0x12, 0xab])
+    expect(getRippleTxHash({ encoded } as never)).toBe('DEADBEEF')
+    expect(mocks.hashSignedTx).toHaveBeenCalledWith('12ab')
+  })
+})

--- a/packages/core/chain/tx/hash/resolvers/solana.test.ts
+++ b/packages/core/chain/tx/hash/resolvers/solana.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { getSolanaTxHash } from './solana'
+
+describe('getSolanaTxHash', () => {
+  it('returns the first signature string', () => {
+    expect(
+      getSolanaTxHash({
+        signatures: [{ signature: '5abcSignatureBase58' }],
+      } as never)
+    ).toBe('5abcSignatureBase58')
+  })
+
+  it('throws when no signature is present', () => {
+    expect(() => getSolanaTxHash({ signatures: [] } as never)).toThrow()
+  })
+})

--- a/packages/core/chain/tx/hash/resolvers/ton.test.ts
+++ b/packages/core/chain/tx/hash/resolvers/ton.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+
+import { getTonTxHash } from './ton'
+
+describe('getTonTxHash', () => {
+  it('hex-encodes the WalletCore hash bytes', () => {
+    const hash = Uint8Array.from([0xde, 0xad, 0xbe, 0xef])
+    expect(getTonTxHash({ hash } as never)).toBe('deadbeef')
+  })
+
+  it('returns an empty string for an empty hash', () => {
+    expect(getTonTxHash({ hash: new Uint8Array() } as never)).toBe('')
+  })
+})

--- a/packages/core/chain/tx/hash/resolvers/tron.test.ts
+++ b/packages/core/chain/tx/hash/resolvers/tron.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+
+import { getTronTxHash } from './tron'
+
+describe('getTronTxHash', () => {
+  it('hex-encodes the tx id without a 0x prefix', () => {
+    const id = Uint8Array.from([0x0a, 0xbc, 0xde])
+    expect(getTronTxHash({ id } as never)).toBe('0abcde')
+  })
+})

--- a/packages/core/chain/tx/hash/resolvers/utxo.test.ts
+++ b/packages/core/chain/tx/hash/resolvers/utxo.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { getUtxoTxHash } from './utxo'
+
+describe('getUtxoTxHash', () => {
+  it('prefers signingResultV2.txid, reversed to display hex', () => {
+    // WalletCore stores txid internal-byte-order; explorers want reversed hex.
+    const txid = Uint8Array.from([0x01, 0x02, 0x03, 0x04])
+    expect(getUtxoTxHash({ transactionId: 'ignored', signingResultV2: { txid } } as never)).toBe('04030201')
+  })
+
+  it('falls back to transactionId when signingResultV2 is absent', () => {
+    expect(getUtxoTxHash({ transactionId: 'aabbccdd' } as never)).toBe('aabbccdd')
+  })
+
+  it('falls back to transactionId when signingResultV2.txid is empty', () => {
+    expect(getUtxoTxHash({ transactionId: 'aabbccdd', signingResultV2: {} } as never)).toBe('aabbccdd')
+  })
+})


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#1370
Added colocated unit tests for the 10 previously untested `tx/hash/resolvers` (evm, utxo, cosmos, solana, ton, tron, ripple, cardano, bittensor, polkadot; sui already had coverage) plus CoW `submitCowSwapOrder` / `getCowSwapOrderStatus`. These hashes drive `verifyBroadcastByHash`; the tests pin the input contracts (keccak/sha256/blake2, reversed UTXO txid, XRPL hex blob, Polkadot signed v4 extrinsic, CoW POST/GET shapes). Tests-only: no production behavior change. Blast radius is coverage, not signing. Did not run against live WalletCore-signed fixtures for every chain (synthetic/mocked inputs).

## what I ran
```
cd /tmp/claude-1000/wt-sdk-w1 && yarn vitest run --config .config/vitest.core.config.ts packages/core/chain/tx/hash/resolvers packages/core/chain/swap/general/cowswap/api/submitCowSwapOrder.test.ts packages/core/chain/swap/general/cowswap/api/getCowSwapOrderStatus.test.ts
```
```
 Test Files  13 passed (13)
      Tests  23 passed (23)
   Start at  22:35:05
   Duration  714ms
```

closes vultisig/vultisig-sdk#1370