### PR TITLE
feat(sdk): add branded ChainId/AssetId (CAIP-2) module

### DIFF
--- a/.changeset/sdkg1-1350.md
+++ b/.changeset/sdkg1-1350.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Add a branded `ChainId`/`AssetId` module (CAIP-2 for EVM/Cosmos, frozen unique-id table for the rest), re-exported from the root and React Native entrypoints. Additive only — the existing `Chain` enum stays load-bearing.

--- a/packages/core/chain/chainIdentity.test.ts
+++ b/packages/core/chain/chainIdentity.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { Chain } from './Chain'
+import { chainFromChainId, chainIds, isChainId, toChainId, toNativeAssetId } from './chainIdentity'
+
+describe('chainIdentity', () => {
+  it('covers every Chain with a unique CAIP-2 id', () => {
+    const chains = Object.values(Chain)
+    const ids = chains.map(toChainId)
+
+    expect(ids).toHaveLength(chains.length)
+    expect(new Set(ids).size).toBe(chains.length)
+    expect(Object.keys(chainIds).sort()).toEqual([...chains].sort())
+  })
+
+  it('disambiguates Terra vs TerraClassic without a network probe', () => {
+    expect(toChainId(Chain.Terra)).toBe('cosmos:phoenix-1')
+    expect(toChainId(Chain.TerraClassic)).toBe('cosmos:columbus-5')
+    expect(toChainId(Chain.Terra)).not.toBe(toChainId(Chain.TerraClassic))
+    expect(chainFromChainId('cosmos:phoenix-1')).toBe(Chain.Terra)
+    expect(chainFromChainId('cosmos:columbus-5')).toBe(Chain.TerraClassic)
+  })
+
+  it('gives Terra and TerraClassic distinct native asset ids (same uluna denom, different ChainId)', () => {
+    expect(toNativeAssetId(Chain.Terra)).toBe('cosmos:phoenix-1/native:LUNA')
+    expect(toNativeAssetId(Chain.TerraClassic)).toBe('cosmos:columbus-5/native:LUNC')
+    expect(toNativeAssetId(Chain.Terra)).not.toBe(toNativeAssetId(Chain.TerraClassic))
+  })
+
+  it('derives EVM ids from the existing eip155 chain-id table', () => {
+    expect(toChainId(Chain.Ethereum)).toBe('eip155:1')
+    expect(toChainId(Chain.Polygon)).toBe('eip155:137')
+    expect(toChainId(Chain.Hyperliquid)).toBe('eip155:999')
+    expect(toChainId(Chain.Robinhood)).toBe('eip155:4663')
+  })
+
+  it('round-trips every chain through chainFromChainId', () => {
+    for (const chain of Object.values(Chain)) {
+      expect(chainFromChainId(toChainId(chain))).toBe(chain)
+      expect(isChainId(toChainId(chain))).toBe(true)
+    }
+    expect(chainFromChainId('cosmos:not-a-real-chain')).toBeUndefined()
+    expect(isChainId('nope')).toBe(false)
+  })
+})

--- a/packages/core/chain/chainIdentity.ts
+++ b/packages/core/chain/chainIdentity.ts
@@ -1,0 +1,84 @@
+import { Chain, CosmosChain, EvmChain, OtherChain, UtxoChain } from '@vultisig/core-chain/Chain'
+import { getCosmosChainId } from '@vultisig/core-chain/chains/cosmos/chainInfo'
+import { getEvmChainId } from '@vultisig/core-chain/chains/evm/chainInfo'
+import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
+import { hexToNumber } from '@vultisig/lib-utils/hex/hexToNumber'
+import { isOneOf } from '@vultisig/lib-utils/array/isOneOf'
+
+/**
+ * Branded CAIP-2 chain identifier. Derived from {@link Chain}, not a re-key of
+ * the enum: `Record<Chain, T>` exhaustiveness stays on the existing enum.
+ */
+export type ChainId = string & { readonly __brand: 'ChainId' }
+
+/**
+ * Branded CAIP-19 asset identifier. Native assets are `{chainId}/native:{ticker}`
+ * so same-ticker collisions (LUNA on Terra vs TerraClassic) stay distinct.
+ */
+export type AssetId = string & { readonly __brand: 'AssetId' }
+
+const asChainId = (value: string): ChainId => value as ChainId
+const asAssetId = (value: string): AssetId => value as AssetId
+
+/**
+ * Well-known CAIP-2 references for non-EVM / non-Cosmos families.
+ *
+ * EVM and Cosmos IDs are computed from the existing exhaustive chain-id tables
+ * (`getEvmChainId` / `getCosmosChainId`) so they cannot drift from RPC/LCD
+ * identity. These remaining families do not have an equivalent table today.
+ */
+const otherChainCaip2 = {
+  // bip122 genesis is unique per *original* chain, not per fork: BCH shares
+  // Bitcoin's genesis, so it cannot reuse the BTC CAIP-2 reference.
+  [UtxoChain.Bitcoin]: 'bip122:000000000019d6689c085ae165831e93',
+  [UtxoChain.BitcoinCash]: 'bitcoincash:mainnet',
+  [UtxoChain.Litecoin]: 'bip122:12a765e31ffd4059bada1e25190f6e98',
+  [UtxoChain.Dogecoin]: 'bip122:1a91e3dace36e2be3bf030a65679fe82',
+  [UtxoChain.Dash]: 'bip122:00000ffd590b1485b3caadc19b22e637',
+  [UtxoChain.Zcash]: 'zcash:main',
+  [OtherChain.Solana]: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+  [OtherChain.Sui]: 'sui:mainnet',
+  [OtherChain.Polkadot]: 'polkadot:91b171bb158e2d3848fa23a9f1c25182',
+  [OtherChain.Bittensor]: 'bittensor:finney',
+  [OtherChain.Ton]: 'ton:-239',
+  [OtherChain.Ripple]: 'xrpl:0',
+  [OtherChain.Tron]: 'tron:mainnet',
+  [OtherChain.Cardano]: 'cip34:1-764824073',
+  [OtherChain.QBTC]: 'cosmos:qbtc-1',
+} as const satisfies Record<UtxoChain | OtherChain, string>
+
+const evmChainId = (chain: EvmChain): ChainId => asChainId(`eip155:${hexToNumber(getEvmChainId(chain))}`)
+
+const cosmosChainId = (chain: CosmosChain): ChainId => asChainId(`cosmos:${getCosmosChainId(chain)}`)
+
+/** Frozen CAIP-2 matrix: one unique ChainId per {@link Chain}. */
+export const chainIds = Object.freeze(
+  Object.fromEntries(
+    (Object.values(Chain) as Chain[]).map(chain => {
+      if (isOneOf(chain, Object.values(EvmChain))) {
+        return [chain, evmChainId(chain)]
+      }
+      if (isOneOf(chain, Object.values(CosmosChain))) {
+        return [chain, cosmosChainId(chain)]
+      }
+      return [chain, asChainId(otherChainCaip2[chain as UtxoChain | OtherChain])]
+    })
+  )
+) as Readonly<Record<Chain, ChainId>>
+
+export const toChainId = (chain: Chain): ChainId => chainIds[chain]
+
+export const chainFromChainId = (chainId: string): Chain | undefined => {
+  for (const chain of Object.values(Chain)) {
+    if (chainIds[chain] === chainId) return chain
+  }
+  return undefined
+}
+
+export const isChainId = (value: string): value is ChainId => chainFromChainId(value) !== undefined
+
+export const toNativeAssetId = (chain: Chain): AssetId =>
+  asAssetId(`${toChainId(chain)}/native:${chainFeeCoin[chain].ticker}`)
+
+export const toTokenAssetId = (chain: Chain, tokenReference: string): AssetId =>
+  asAssetId(`${toChainId(chain)}/token:${tokenReference}`)

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -65,6 +65,11 @@
       "import": "./dist/chainRegistry.js",
       "default": "./dist/chainRegistry.js"
     },
+    "./chainIdentity": {
+      "types": "./dist/chainIdentity.d.ts",
+      "import": "./dist/chainIdentity.js",
+      "default": "./dist/chainIdentity.js"
+    },
     "./chains/bittensor/client": {
       "types": "./dist/chains/bittensor/client.d.ts",
       "import": "./dist/chains/bittensor/client.js",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -384,6 +384,15 @@ export type {
   ExtendedChainRegistry,
 } from '@vultisig/core-chain/chainRegistry'
 export { chainRegistry, deriveFromChainRegistry, extendChainRegistry } from '@vultisig/core-chain/chainRegistry'
+export type { AssetId, ChainId } from '@vultisig/core-chain/chainIdentity'
+export {
+  chainFromChainId,
+  chainIds,
+  isChainId,
+  toChainId,
+  toNativeAssetId,
+  toTokenAssetId,
+} from '@vultisig/core-chain/chainIdentity'
 
 // Skip Go routing-eligibility predicates. Single source of truth for "does this
 // from/to chain pair route through Skip Go?" — consolidated here so consumers

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -761,6 +761,15 @@ export type {
   ExtendedChainRegistry,
 } from '@vultisig/core-chain/chainRegistry'
 export { chainRegistry, deriveFromChainRegistry, extendChainRegistry } from '@vultisig/core-chain/chainRegistry'
+export type { AssetId, ChainId } from '@vultisig/core-chain/chainIdentity'
+export {
+  chainFromChainId,
+  chainIds,
+  isChainId,
+  toChainId,
+  toNativeAssetId,
+  toTokenAssetId,
+} from '@vultisig/core-chain/chainIdentity'
 export { getThorchainInboundAddress } from '@vultisig/core-chain/chains/cosmos/thor/getThorchainInboundAddress'
 export * from '@vultisig/core-chain/chains/cosmos/thor/lp'
 export type { GetSwapExplorerUrlInput, SwapExplorerProvider } from '@vultisig/core-chain/swap/utils/getSwapExplorerUrl'

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -59,6 +59,9 @@ describe('@vultisig/sdk public exports', () => {
     expect(Object.keys(sdk.chainRegistry).sort()).toEqual(Object.values(sdk.Chain).sort())
     expect(typeof sdk.deriveFromChainRegistry).toBe('function')
     expect(typeof sdk.extendChainRegistry).toBe('function')
+    expect(typeof sdk.toChainId).toBe('function')
+    expect(sdk.toChainId(sdk.Chain.Terra)).toBe('cosmos:phoenix-1')
+    expect(sdk.toChainId(sdk.Chain.TerraClassic)).toBe('cosmos:columbus-5')
   })
 
   it('exports tx-shape normalization primitives (normalizeTx, splitMultiTx)', () => {


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#1350
Added a branded `ChainId` / `AssetId` module in `packages/core/chain/chainIdentity.ts`, derived from the existing `Chain` enum (the enum stays load-bearing). EVM and Cosmos CAIP-2 ids come from the existing `getEvmChainId` / `getCosmosChainId` tables, so Terra is `cosmos:phoenix-1` and TerraClassic is `cosmos:columbus-5` with no network probe. Remaining families use a frozen unique-id table (BCH cannot reuse Bitcoin's bip122 genesis). Re-exported from the root and RN SDK surfaces. Not itself a signer. Did not migrate app/abts callers onto this module.

## what I ran
```
cd /tmp/claude-1000/wt-sdk-w1 && yarn vitest run --config .config/vitest.core.config.ts packages/core/chain/chainIdentity.test.ts
cd packages/sdk && yarn vitest run --config tests/unit/vitest.config.ts tests/unit/utils/publicExports.test.ts
```
```
 Test Files  1 passed (1)
      Tests  5 passed (5)
 Test Files  1 passed (1)
      Tests  55 passed (55)
```

closes vultisig/vultisig-sdk#1350