### PR TITLE
feat(sdk): export resolveSwapFeeChain and LifiSwapEnabledChain

### DIFF
--- a/.changeset/sdkg2-2098.md
+++ b/.changeset/sdkg2-2098.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Export the canonical LI.FI `resolveSwapFeeChain` helper (and `LifiSwapEnabledChain`) from the root and React Native SDK entrypoints so first-party consumers no longer deep-import the core-chain path.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -522,6 +522,8 @@ export {
 export type { JupiterAffiliateConfig } from '@vultisig/core-chain/swap/general/jupiter/config'
 export type { LifiAffiliateConfig, LifiBootstrapConfig } from '@vultisig/core-chain/swap/general/lifi/config'
 export { setupLifi } from '@vultisig/core-chain/swap/general/lifi/config'
+export type { LifiSwapEnabledChain } from '@vultisig/core-chain/swap/general/lifi/LifiSwapEnabledChains'
+export { resolveSwapFeeChain } from '@vultisig/core-chain/swap/general/lifi/api/lifiSwapFeeChain'
 export type { SwapKitConfig } from '@vultisig/core-chain/swap/general/swapkit/config'
 export { configureSwapKit, getSwapKitConfig } from '@vultisig/core-chain/swap/general/swapkit/config'
 export type {

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -765,6 +765,8 @@ export { getThorchainInboundAddress } from '@vultisig/core-chain/chains/cosmos/t
 export * from '@vultisig/core-chain/chains/cosmos/thor/lp'
 export type { GetSwapExplorerUrlInput, SwapExplorerProvider } from '@vultisig/core-chain/swap/utils/getSwapExplorerUrl'
 export { getSwapExplorerUrl, swapExplorerProviders } from '@vultisig/core-chain/swap/utils/getSwapExplorerUrl'
+export type { LifiSwapEnabledChain } from '@vultisig/core-chain/swap/general/lifi/LifiSwapEnabledChains'
+export { resolveSwapFeeChain } from '@vultisig/core-chain/swap/general/lifi/api/lifiSwapFeeChain'
 export { getBlockExplorerUrl } from '@vultisig/core-chain/utils/getBlockExplorerUrl'
 export async function fiatToAmount(...args: unknown[]) {
   const mod = await import('../../utils/fiatToAmount')

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -358,6 +358,15 @@ describe('RN entry exposes pure chain helpers and registry', () => {
     ).toBe('https://scan.li.fi/tx/0xabc')
   })
 
+  it('re-exports the canonical LI.FI fee-chain resolver from the RN entrypoint', async () => {
+    const rn = await import('../../../../src/platforms/react-native/index')
+    const feeChain = await import('@vultisig/core-chain/swap/general/lifi/api/lifiSwapFeeChain')
+    const { lifiSwapChainId } = await import('@vultisig/core-chain/swap/general/lifi/LifiSwapEnabledChains')
+
+    expect(rn.resolveSwapFeeChain).toBe(feeChain.resolveSwapFeeChain)
+    expect(rn.resolveSwapFeeChain(lifiSwapChainId[rn.Chain.Ethereum], rn.Chain.Solana)).toBe(rn.Chain.Ethereum)
+  })
+
   it('re-exports Noon vault helpers from the RN entrypoint', async () => {
     const rn = await import('../../../../src/platforms/react-native/index')
     const noon = await import('@vultisig/core-chain/chains/evm/noon')

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -244,6 +244,13 @@ describe('@vultisig/sdk public exports', () => {
     expect(typeof sdk.parseThorSwapMemo).toBe('function')
   })
 
+  it('exports the canonical LI.FI fee-chain resolver from the root sdk surface', async () => {
+    const { lifiSwapChainId } = await import('@vultisig/core-chain/swap/general/lifi/LifiSwapEnabledChains')
+
+    expect(typeof sdk.resolveSwapFeeChain).toBe('function')
+    expect(sdk.resolveSwapFeeChain(lifiSwapChainId[sdk.Chain.Ethereum], sdk.Chain.Solana)).toBe(sdk.Chain.Ethereum)
+  })
+
   it('exports the shared THORChain secured-asset catalog helpers', () => {
     expect(typeof sdk.getThorchainSecuredAssetCatalog).toBe('function')
     expect(typeof sdk.createThorchainSecuredAssetCatalog).toBe('function')


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#2098

Re-exported the already-canonical `resolveSwapFeeChain` helper (and `LifiSwapEnabledChain`) from the root `@vultisig/sdk` entry and the curated React Native allow-list. Both LI.FI quote implementations already used this helper internally; the gap was that first-party consumers still had to deep-import `@vultisig/core-chain/swap/general/lifi/api/lifiSwapFeeChain`. No fee-resolution logic changed - this is a public-surface hoist only. Blast radius is additive export surface only; quote math, fee token mapping, and signing are untouched. Could not verify a live LI.FI quote against a funded vault (not needed for an export-only change).

## what I ran
```
cd /tmp/claude-1000/wt-sdk-w2 && yarn workspace @vultisig/sdk exec vitest run tests/unit/utils/publicExports.test.ts tests/unit/platforms/react-native/entry.test.ts --reporter=dot
# Test Files  2 passed (2)
#      Tests  103 passed (103)

cd /tmp/claude-1000/wt-sdk-w2/packages/sdk && yarn exec tsc --noEmit --pretty false -p tsconfig.json
# exit 0
```

closes vultisig/vultisig-sdk#2098