### PR TITLE
fix(cli): fail closed on non-native tx_ready sends instead of forwarding a wrong symbol

### DIFF
--- a/.changeset/sdkg2-1403.md
+++ b/.changeset/sdkg2-1403.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/cli': patch
+---
+
+Fail closed in the CLI non-EVM `tx_ready` parser when `token_resolved` is not the chain's native ticker. Those envelopes were converted with native decimals and then still forwarded as a token symbol, which would mis-scale a future SPL/TRC-20 send.

--- a/clients/cli/src/agent/__tests__/parseNonEvmEnvelope.test.ts
+++ b/clients/cli/src/agent/__tests__/parseNonEvmEnvelope.test.ts
@@ -182,6 +182,46 @@ describe('parseNonEvmEnvelope', () => {
       ).toThrow(/failed to convert amount/)
     })
 
+    it('throws on a non-native token_resolved label instead of forwarding the symbol', () => {
+      const splUsdc = {
+        chain: 'Solana',
+        resolved: {
+          labels: {
+            resolved_amount: '1 USDC',
+            token_resolved: 'USDC',
+          },
+        },
+        txArgs: {
+          chain: 'Solana',
+          to: 'iwMx27vvAiaQteMhdpSBVDRztiSt1Cxwcfkm6SQBpxA',
+          amount: '1000000',
+        },
+      }
+
+      expect(() => parseNonEvmEnvelope(splUsdc, Chain.Solana)).toThrow(/non-native token 'USDC'/)
+      try {
+        parseNonEvmEnvelope(splUsdc, Chain.Solana)
+        expect.fail('expected throw')
+      } catch (err) {
+        expect(err).toBeInstanceOf(VaultError)
+        expect((err as VaultError).code).toBe(VaultErrorCode.NotImplemented)
+      }
+    })
+
+    it('still omits symbol for a native token_resolved label', () => {
+      const nativeSol = {
+        chain: 'Solana',
+        resolved: { labels: { token_resolved: 'SOL' } },
+        txArgs: {
+          chain: 'Solana',
+          to: 'iwMx27vvAiaQteMhdpSBVDRztiSt1Cxwcfkm6SQBpxA',
+          amount: '1000000',
+        },
+      }
+
+      expect(parseNonEvmEnvelope(nativeSol, Chain.Solana).symbol).toBeUndefined()
+    })
+
     it('throws VaultError instances (not plain Error) for downstream normalizeAgentError', () => {
       try {
         parseNonEvmEnvelope({} as any, Chain.Bitcoin)

--- a/clients/cli/src/agent/executor.ts
+++ b/clients/cli/src/agent/executor.ts
@@ -2230,18 +2230,21 @@ export function parseNonEvmEnvelope(serverTxData: any, chain: Chain): NonEvmSend
   // Token symbol — for native sends, leave undefined (vault.send defaults
   // to native). resolved.labels.token_resolved is the agent-resolved
   // symbol; for native it equals the chain's native ticker (BTC/SOL/RUNE).
-  // Phase D PR 0 only wires native sends; non-native (e.g. SPL, TRC-20)
-  // is PR 1+ scope.
-  let symbol: string | undefined
+  // Amount conversion above used the chain's *native* decimals, so a
+  // non-native token symbol would sign at the wrong magnitude (SPL/TRC-20
+  // etc.). Fail closed until envelopes carry token-aware decimals/ids.
   const tokenResolved = serverTxData?.resolved?.labels?.token_resolved
   const nativeTicker = chainFeeCoin[chain]?.ticker
   if (typeof tokenResolved === 'string' && tokenResolved !== nativeTicker) {
-    symbol = tokenResolved
+    throw new VaultError(
+      VaultErrorCode.NotImplemented,
+      `parseNonEvmEnvelope: non-native token '${tokenResolved}' on ${chain} is not supported until envelopes carry token decimals/ids. Refusing to sign.`
+    )
   }
 
   const memo: string | undefined = typeof txArgs.memo === 'string' && txArgs.memo.length > 0 ? txArgs.memo : undefined
 
-  return { chain, to, amount: amountDecimal, symbol, memo }
+  return { chain, to, amount: amountDecimal, symbol: undefined, memo }
 }
 
 /**


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#1403

`parseNonEvmEnvelope` converted `tx_ready` amounts with the chain's native decimals and still forwarded `resolved.labels.token_resolved` as `vault.send`'s `symbol` whenever it differed from the native ticker. A future SPL/TRC-20/XRPL token envelope would therefore sign at the wrong magnitude. Replaced that silent assignment with a `VaultError(NotImplemented)` throw. Native sends are unchanged (`symbol` stays undefined). Blast radius: CLI non-EVM `tx_ready` dispatch only - fail-closed, can only refuse more often, never sign a previously-accepted native send. Could not verify a live non-native token ceremony (none are wired yet; that is the point of the guard).

## what I ran
```
cd /tmp/claude-1000/wt-sdk-w2 && yarn workspace @vultisig/cli exec vitest run src/agent/__tests__/parseNonEvmEnvelope.test.ts --reporter=dot
# Test Files  1 passed (1)
#      Tests  17 passed (17)

cd /tmp/claude-1000/wt-sdk-w2 && yarn workspace @vultisig/cli exec vitest run src/agent/__tests__/executor.summary.test.ts src/agent/__tests__/sessionConfirmGate.test.ts --reporter=dot
# Test Files  2 passed (2)
#      Tests  30 passed (30)

cd /tmp/claude-1000/wt-sdk-w2 && yarn workspace @vultisig/cli exec tsc --noEmit --pretty false
# exit 0
```

closes vultisig/vultisig-sdk#1403