### PR TITLE
fix(security): blockaid native-leg drop is fee-magnitude-bound, decline instead of read positionally

### DIFF
--- a/.changeset/sdkg2-2091.md
+++ b/.changeset/sdkg2-2091.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/core-chain': patch
+---
+
+Stop dropping a Blockaid native SOL/SUI simulation leg just because the response has three diffs. Only fee-sized native outflows are filtered; a principal native inflow no longer reverses the approval headline, and leftover multi-leg shapes decline instead of guessing.

--- a/packages/core/chain/security/blockaid/tx/simulation/api/core.test.ts
+++ b/packages/core/chain/security/blockaid/tx/simulation/api/core.test.ts
@@ -1,7 +1,14 @@
 import { EvmChain } from '@vultisig/core-chain/Chain'
 import { describe, expect, it } from 'vitest'
 
-import { BlockaidEVMSimulation, parseBlockaidEvmSimulation } from './core'
+import {
+  BlockaidEVMSimulation,
+  BlockaidSolanaSimulation,
+  BlockaidSuiSimulation,
+  parseBlockaidEvmSimulation,
+  parseBlockaidSolanaSimulation,
+  parseBlockaidSuiSimulation,
+} from './core'
 
 type AssetDiff = BlockaidEVMSimulation['account_summary']['assets_diffs'][number]
 type Asset = AssetDiff['asset']
@@ -315,5 +322,135 @@ describe('parseBlockaidEvmSimulation', () => {
       amount: 100n,
     })
     expect(result?.changes[0].coin.ticker).toBe('ETH')
+  })
+})
+
+type SolanaDiff = BlockaidSolanaSimulation['account_summary']['account_assets_diff'][number]
+
+const solSide = (rawValue: string) => ({
+  usd_price: 0,
+  summary: '',
+  value: 0,
+  raw_value: rawValue,
+})
+
+const solNative = (parts: Pick<SolanaDiff, 'in' | 'out'>): SolanaDiff => ({
+  asset: { type: 'SOL', symbol: 'SOL', decimals: 9, logo: '' },
+  asset_type: 'SOL',
+  in: null,
+  out: null,
+  ...parts,
+})
+
+const solToken = (address: string, symbol: string, parts: Pick<SolanaDiff, 'in' | 'out'>): SolanaDiff => ({
+  asset: { type: 'TOKEN', symbol, address, decimals: 6, logo: '' },
+  asset_type: 'TOKEN',
+  in: null,
+  out: null,
+  ...parts,
+})
+
+describe('parseBlockaidSolanaSimulation', () => {
+  it('still drops a fee-sized native SOL outflow from a three-diff swap', async () => {
+    const result = await parseBlockaidSolanaSimulation({
+      account_summary: {
+        account_assets_diff: [
+          solNative({ out: solSide('5000') }),
+          solToken('mint-a', 'A', { out: solSide('100') }),
+          solToken('mint-b', 'B', { in: solSide('200') }),
+        ],
+      },
+    })
+
+    expect(result).toEqual({
+      swap: {
+        fromMint: 'mint-a',
+        toMint: 'mint-b',
+        fromAmount: 100n,
+        toAmount: 200n,
+        toAssetDecimal: 6,
+      },
+    })
+  })
+
+  it('does not drop a principal native SOL inflow and refuses a reversed headline', async () => {
+    await expect(
+      parseBlockaidSolanaSimulation({
+        account_summary: {
+          account_assets_diff: [
+            solNative({ in: solSide('1_000_000_000'.replaceAll('_', '')) }),
+            solToken('wsol', 'WSOL', { out: solSide('42') }),
+            solToken('receipt', 'RCPT', { out: solSide('1') }),
+          ],
+        },
+      })
+    ).rejects.toThrow(/Invalid simulation data/)
+  })
+
+  it('does not drop a principal native SOL outflow and refuses a partial headline', async () => {
+    await expect(
+      parseBlockaidSolanaSimulation({
+        account_summary: {
+          account_assets_diff: [
+            solNative({ out: solSide('500000000') }),
+            solToken('mint-a', 'A', { out: solSide('100') }),
+            solToken('mint-b', 'B', { in: solSide('200') }),
+          ],
+        },
+      })
+    ).rejects.toThrow(/Invalid simulation data/)
+  })
+})
+
+describe('parseBlockaidSuiSimulation', () => {
+  const suiNative = (parts: { in?: { raw_value: number } | null; out?: { raw_value: number } | null }) => ({
+    asset: { type: 'NATIVE' as const, symbol: 'SUI', decimals: 9 },
+    in: parts.in ?? null,
+    out: parts.out ?? null,
+  })
+
+  const suiCoin = (
+    id: string,
+    symbol: string,
+    parts: { in?: { raw_value: number } | null; out?: { raw_value: number } | null }
+  ) => ({
+    asset: { type: 'COIN' as const, id, symbol, decimals: 6 },
+    in: parts.in ?? null,
+    out: parts.out ?? null,
+  })
+
+  it('still drops a fee-sized native SUI outflow from a three-diff swap', async () => {
+    const result = await parseBlockaidSuiSimulation({
+      account_summary: {
+        account_assets_diffs: [
+          suiNative({ out: { raw_value: 1_000_000 } }),
+          suiCoin('0x1::a::A', 'A', { out: { raw_value: 100 } }),
+          suiCoin('0x1::b::B', 'B', { in: { raw_value: 200 } }),
+        ],
+      },
+    })
+
+    expect(result).toEqual({
+      swap: {
+        from: expect.objectContaining({ coinType: '0x1::a::A', symbol: 'A' }),
+        to: expect.objectContaining({ coinType: '0x1::b::B', symbol: 'B' }),
+        fromAmount: 100n,
+        toAmount: 200n,
+      },
+    })
+  })
+
+  it('does not drop a principal native SUI inflow and returns null instead of a reversed send', async () => {
+    const result = await parseBlockaidSuiSimulation({
+      account_summary: {
+        account_assets_diffs: [
+          suiNative({ in: { raw_value: 1_000_000_000 } }),
+          suiCoin('0x1::wsol::WSOL', 'WSOL', { out: { raw_value: 42 } }),
+          suiCoin('0x1::rcpt::RCPT', 'RCPT', { out: { raw_value: 1 } }),
+        ],
+      },
+    })
+
+    expect(result).toBeNull()
   })
 })

--- a/packages/core/chain/security/blockaid/tx/simulation/api/core.ts
+++ b/packages/core/chain/security/blockaid/tx/simulation/api/core.ts
@@ -13,6 +13,14 @@ import {
 
 const SUI_NATIVE_COIN_TYPE = '0x2::sui::SUI'
 
+// Native legs are dropped only when they look like gas, never because a
+// three-diff response "probably" includes a fee. These ceilings are well
+// above typical priority fees and well below any principal movement we
+// would want to headline. A larger native outflow (or any native inflow)
+// stays in the set; the parser then declines rather than guessing.
+const SOL_NATIVE_FEE_CEILING_LAMPORTS = 100_000n
+const SUI_NATIVE_FEE_CEILING_MIST = 50_000_000n
+
 // Blockaid's `/sui/transaction/scan` simulation block exposes per-asset diffs
 // under `account_summary.account_assets_diffs` (plural). Asset entries use
 // `type === 'NATIVE'` for SUI and `type === 'COIN'` for fungible Move coins,
@@ -88,6 +96,16 @@ const toBigInt = (raw: number | string): bigint | null => {
   return BigInt(raw)
 }
 
+const isFeeSizedNativeOutflow = (
+  inSide: { raw_value?: number | string } | null | undefined,
+  outRaw: number | string | undefined,
+  ceiling: bigint
+): boolean => {
+  if (inSide || outRaw === undefined) return false
+  const amount = toBigInt(outRaw)
+  return amount !== null && amount > 0n && amount <= ceiling
+}
+
 /**
  * Parse a Blockaid Sui simulation into the user's net balance changes,
  * mirroring how Solana classifies into a `swap` or `transfer` headline.
@@ -108,13 +126,14 @@ export const parseBlockaidSuiSimulation = async (
   const assetDiffs = simulation.account_summary?.account_assets_diffs ?? simulation.account_summary?.account_assets_diff
   if (!assetDiffs || assetDiffs.length === 0) return null
 
-  // When we have 3 items and one is native SUI, filter it out and use the
-  // other two tokens — the native SUI is likely the gas charge, not part of
-  // the swap itself. Same heuristic as Solana.
+  // Drop a native SUI leg only when it is an out-only, fee-sized movement.
+  // A three-diff wrapped-SUI withdrawal (native in + residual + receipt)
+  // must not lose the principal inflow — that reverses the approval headline.
   let relevantDiffs = assetDiffs
   if (assetDiffs.length === 3) {
     const nativeIdx = assetDiffs.findIndex(diff => isNativeSui(diff.asset))
-    if (nativeIdx !== -1) {
+    const native = nativeIdx === -1 ? undefined : assetDiffs[nativeIdx]
+    if (native && isFeeSizedNativeOutflow(native.in, native.out?.raw_value, SUI_NATIVE_FEE_CEILING_MIST)) {
       relevantDiffs = assetDiffs.filter((_, i) => i !== nativeIdx)
     }
   }
@@ -252,12 +271,15 @@ export const parseBlockaidSolanaSimulation = async (
 ): Promise<BlockaidSolanaSimulationInfo> => {
   const assetDiffs = simulation.account_summary.account_assets_diff
 
-  // When we have 3 items and one is native SOL, filter it out and use the other two tokens.
-  // The native SOL is likely the transaction fee, not part of the swap itself.
+  // Drop a native SOL leg only when it is an out-only, fee-sized movement.
+  // Array length alone is not evidence of a fee: a three-diff wrapped-SOL
+  // withdrawal (native in + WSOL residual out + receipt out) would otherwise
+  // delete the principal inflow and headline the residual as a send.
   let relevantDiffs = assetDiffs
   if (assetDiffs.length === 3) {
     const nativeSolIndex = assetDiffs.findIndex(diff => diff.asset.type === 'SOL' || diff.asset_type === 'SOL')
-    if (nativeSolIndex !== -1) {
+    const native = nativeSolIndex === -1 ? undefined : assetDiffs[nativeSolIndex]
+    if (native && isFeeSizedNativeOutflow(native.in, native.out?.raw_value, SOL_NATIVE_FEE_CEILING_LAMPORTS)) {
       relevantDiffs = assetDiffs.filter((_, index) => index !== nativeSolIndex)
     }
   }
@@ -280,7 +302,10 @@ export const parseBlockaidSolanaSimulation = async (
     }
   }
 
-  if (relevantDiffs.length > 1) {
+  // Two relevant diffs is the only multi-leg shape we will headline. More
+  // than that used to be read positionally (first two only), which can hide
+  // a second spend or reverse the direction after a dropped native inflow.
+  if (relevantDiffs.length === 2) {
     const [potentialOutAsset, potentialInAsset] = relevantDiffs
     const { inAsset, inValue } = potentialInAsset.in
       ? {


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#2091

The Solana and Sui Blockaid simulation parsers dropped a native SOL/SUI leg whenever the response had exactly three diffs, on the assumption it was a fee. A wrapped-SOL withdrawal (native inflow + residual out + receipt) then lost the principal inflow and headlined the residual as a send - reversed direction on an approval screen. Native legs are now dropped only when they are out-only and fee-sized (100k lamports / 0.05 SUI); anything else stays, and leftover 3+ diff shapes decline instead of being read positionally. Blast radius: approval-screen headlines only, not signing/broadcast. Fail-closed: can only refuse a headline more often, never invent a new confident amount. Could not confirm against a captured live Blockaid payload of this shape (issue notes that gap); the regression is bound with fixtures of that shape.

## what I ran
```
cd /tmp/claude-1000/wt-sdk-w2 && yarn exec vitest run packages/core/chain/security/blockaid/tx/simulation/api/core.test.ts --reporter=dot
# Test Files  1 passed (1)
#      Tests  19 passed (19)

cd /tmp/claude-1000/wt-sdk-w2 && yarn exec tsc --noEmit --pretty false -p .config/tsconfig.shared-publish.json
# exit 0
```

closes vultisig/vultisig-sdk#2091