### PR TITLE
chore(ci): clarify quality:audit failure mode on a stale branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "knip": "knip --config .config/knip.jsonc",
     "knip:fix": "knip --config .config/knip.jsonc --fix --allow-remove-files",
     "quality:architecture": "depcruise --config .config/dependency-cruiser.cjs --output-type err .",
-    "quality:audit": "yarn npm audit --recursive --all --severity high",
+    "quality:audit": "node scripts/quality-audit.mjs",
     "quality:complexity": "node scripts/run-eslint.mjs --config .config/eslint-health.config.mjs 'packages/sdk/**/*.{js,jsx,ts,tsx}' 'packages/rujira/**/*.{js,jsx,ts,tsx}' 'packages/client-shared/**/*.{js,jsx,ts,tsx}' 'packages/mpc-types/src/**/*.ts' 'packages/core/**/*.ts' 'packages/lib/utils/**/*.{js,jsx,ts,tsx}' 'packages/mpc-native/**/*.{js,jsx,ts,tsx}' 'packages/walletcore-native/**/*.{js,jsx,ts,tsx}' 'clients/**/*.{js,jsx,ts,tsx}' 'examples/**/*.{js,jsx,ts,tsx}'",
     "quality:docs": "yarn quality:docs:markdown && yarn quality:docs:links",
     "quality:docs:links": "git ls-files '*.md' ':!:docs/api/**' ':!:tasks/**' ':!:packages/**/CHANGELOG.md' ':!:clients/**/CHANGELOG.md' | xargs -n 1 markdown-link-check -q -c .config/markdown-link-check.json",

--- a/scripts/quality-audit.mjs
+++ b/scripts/quality-audit.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export const AUDIT_ARGS = ['npm', 'audit', '--recursive', '--all', '--severity', 'high']
+
+export const STALE_LOCKFILE_HINT = [
+  'quality:audit failed on this lockfile (absolute, not vs origin/main).',
+  'If this advisory is already fixed on origin/main, merge main into your branch - that is the whole fix.',
+  'This is not a lint or typecheck failure in your change.',
+].join('\n')
+
+export function runQualityAudit({
+  spawn = spawnSync,
+  write = text => console.error(text),
+  exit = code => process.exit(code),
+} = {}) {
+  const result = spawn('yarn', AUDIT_ARGS, { stdio: 'inherit' })
+  const status = typeof result.status === 'number' ? result.status : 1
+  if (status !== 0) {
+    write(`\n${STALE_LOCKFILE_HINT}\n`)
+  }
+  exit(status)
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  runQualityAudit()
+}

--- a/scripts/quality-audit.test.mjs
+++ b/scripts/quality-audit.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { AUDIT_ARGS, STALE_LOCKFILE_HINT, runQualityAudit } from './quality-audit.mjs'
+
+test('hint tells a stale branch to merge main instead of chasing lint', () => {
+  assert.match(STALE_LOCKFILE_HINT, /merge main into your branch/)
+  assert.match(STALE_LOCKFILE_HINT, /not a lint or typecheck failure/)
+  assert.match(STALE_LOCKFILE_HINT, /absolute, not vs origin\/main/)
+})
+
+test('passing audit exits 0 and does not print the stale-branch hint', () => {
+  const writes = []
+  const exits = []
+
+  runQualityAudit({
+    spawn: (cmd, args) => {
+      assert.equal(cmd, 'yarn')
+      assert.deepEqual(args, AUDIT_ARGS)
+      return { status: 0 }
+    },
+    write: text => writes.push(text),
+    exit: code => exits.push(code),
+  })
+
+  assert.deepEqual(writes, [])
+  assert.deepEqual(exits, [0])
+})
+
+test('failing audit still fails, but names the merge-main remedy', () => {
+  const writes = []
+  const exits = []
+
+  runQualityAudit({
+    spawn: () => ({ status: 1 }),
+    write: text => writes.push(text),
+    exit: code => exits.push(code),
+  })
+
+  assert.equal(exits[0], 1)
+  assert.match(writes.join(''), /merge main into your branch/)
+})


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#1807

`quality:audit` still fails absolutely against the advisory db (correct when main itself is vulnerable). The gap was the failure mode: a branch cut before a lockfile patch stayed red on "Lint and Type Check" with no signal that merging main is the whole fix. Wrapped the existing `yarn npm audit` command in `scripts/quality-audit.mjs` so a non-zero audit still fails, but prints that this is an absolute lockfile check and to merge main if origin/main already cleared the advisory. Blast radius: CI messaging only; the gate still refuses on HIGH advisories. Did not implement a real audit-set diff against origin/main (needs live registry + checking out main's lockfile).

## what I ran
```
cd /tmp/claude-1000/wt-sdk-w2 && node --test scripts/quality-audit.test.mjs
# ✔ hint tells a stale branch to merge main instead of chasing lint
# ✔ passing audit exits 0 and does not print the stale-branch hint
# ✔ failing audit still fails, but names the merge-main remedy
# ℹ tests 3
# ℹ pass 3
```

closes vultisig/vultisig-sdk#1807