### PR TITLE
fix(swap): fail closed on evm-general aggregator sell-amount/deadline mismatch for known calldata shapes

### DIFF
--- a/.changeset/sdkh1-1196.md
+++ b/.changeset/sdkh1-1196.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Fail-closed amount + deadline checks for known EVM-general swap calldata shapes (Uniswap V2/V3 exact-in, Universal Router execute, 1inch V5 swap, THOR depositWithExpiry). Unknown aggregator selectors stay fail-open.

--- a/packages/sdk/src/tools/prep/decodeEvmGeneralSwapCommitment.ts
+++ b/packages/sdk/src/tools/prep/decodeEvmGeneralSwapCommitment.ts
@@ -1,0 +1,112 @@
+import { decodeUniversalRouterExecute } from '@vultisig/core-chain/chains/evm/contract/universalRouter/decode'
+import { decodeFunctionData, parseAbi, type Hex } from 'viem'
+
+/**
+ * Sell amount + optional deadline extracted from known EVM-general aggregator
+ * calldata. `null` means the selector is not one of the shapes we can read
+ * safely — callers MUST fail open rather than invent an amount.
+ */
+export type EvmGeneralSwapCommitment = {
+  sellAmount: bigint
+  deadlineSeconds?: number
+}
+
+// Exact-in Uniswap V2/V3 + THOR router + 1inch V5 `swap`. Exact-out variants
+// are intentionally omitted: their first uint is amountOut / amountInMax, and
+// treating that as the committed sell would either reject valid quotes or
+// bless a larger spend than the user reviewed.
+const KNOWN_SWAP_ABI = parseAbi([
+  'function swapExactTokensForTokens(uint256 amountIn, uint256 amountOutMin, address[] path, address to, uint256 deadline)',
+  'function swapExactETHForTokens(uint256 amountOutMin, address[] path, address to, uint256 deadline)',
+  'function swapExactTokensForETH(uint256 amountIn, uint256 amountOutMin, address[] path, address to, uint256 deadline)',
+  'function swapExactTokensForTokensSupportingFeeOnTransferTokens(uint256 amountIn, uint256 amountOutMin, address[] path, address to, uint256 deadline)',
+  'function swapExactETHForTokensSupportingFeeOnTransferTokens(uint256 amountOutMin, address[] path, address to, uint256 deadline)',
+  'function exactInputSingle((address tokenIn, address tokenOut, uint24 fee, address recipient, uint256 deadline, uint256 amountIn, uint256 amountOutMinimum, uint160 sqrtPriceLimitX96) params)',
+  'function exactInput((bytes path, address recipient, uint256 deadline, uint256 amountIn, uint256 amountOutMinimum) params)',
+  'function depositWithExpiry(address vault, address asset, uint256 amount, string memo, uint256 expiry)',
+  'function execute(bytes commands, bytes[] inputs, uint256 deadline)',
+  'function swap(address executor, (address srcToken, address dstToken, address srcReceiver, address dstReceiver, uint256 amount, uint256 minReturnAmount, uint256 flags) desc, bytes permit, bytes data)',
+])
+
+function asHex(data: string): Hex | null {
+  if (!data) return null
+  const hex = (data.startsWith('0x') ? data : `0x${data}`) as Hex
+  return hex.length >= 10 ? hex : null
+}
+
+function parseValue(value: string | undefined): bigint | null {
+  if (value === undefined || value === '') return null
+  try {
+    const parsed = BigInt(value)
+    return parsed > 0n ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Decode a committed sell amount (and deadline, when the function carries one)
+ * out of EVM-general swap calldata.
+ *
+ * Fail-open on unknown selectors: 1inch/Kyber/LI.FI wrap inner executors whose
+ * ABI we do not fully enumerate. A wrong decode would either brick valid
+ * swaps or give false confidence. Known exact-in shapes only.
+ */
+export function decodeEvmGeneralSwapCommitment(
+  data: string,
+  value?: string
+): EvmGeneralSwapCommitment | null {
+  const hex = asHex(data)
+  if (!hex) {
+    const native = parseValue(value)
+    return native === null ? null : { sellAmount: native }
+  }
+
+  try {
+    const decoded = decodeFunctionData({ abi: KNOWN_SWAP_ABI, data: hex })
+    switch (decoded.functionName) {
+      case 'swapExactTokensForTokens':
+      case 'swapExactTokensForETH':
+      case 'swapExactTokensForTokensSupportingFeeOnTransferTokens': {
+        const [amountIn, , , , deadline] = decoded.args
+        return { sellAmount: amountIn, deadlineSeconds: Number(deadline) }
+      }
+      case 'swapExactETHForTokens':
+      case 'swapExactETHForTokensSupportingFeeOnTransferTokens': {
+        const [, , , deadline] = decoded.args
+        const native = parseValue(value)
+        if (native === null) return null
+        return { sellAmount: native, deadlineSeconds: Number(deadline) }
+      }
+      case 'exactInputSingle': {
+        const params = decoded.args[0]
+        return { sellAmount: params.amountIn, deadlineSeconds: Number(params.deadline) }
+      }
+      case 'exactInput': {
+        const params = decoded.args[0]
+        return { sellAmount: params.amountIn, deadlineSeconds: Number(params.deadline) }
+      }
+      case 'depositWithExpiry': {
+        const [, , amount, , expiry] = decoded.args
+        return { sellAmount: amount, deadlineSeconds: Number(expiry) }
+      }
+      case 'execute': {
+        const deadline = decoded.args[2]
+        const intent = decodeUniversalRouterExecute(hex)
+        if (!intent) return null
+        return { sellAmount: intent.amountIn, deadlineSeconds: Number(deadline) }
+      }
+      case 'swap': {
+        return { sellAmount: decoded.args[1].amount }
+      }
+      default:
+        return null
+    }
+  } catch {
+    // Two-arg Universal Router `execute(bytes,bytes[])` has no deadline in the
+    // outer ABI; the existing decoder still recovers amountIn.
+    const intent = decodeUniversalRouterExecute(hex)
+    if (intent) return { sellAmount: intent.amountIn }
+    return null
+  }
+}

--- a/packages/sdk/src/tools/prep/swap.ts
+++ b/packages/sdk/src/tools/prep/swap.ts
@@ -12,6 +12,7 @@ import type { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v
 import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
 
 import { getWalletCore } from '../../context/wasmRuntime'
+import { decodeEvmGeneralSwapCommitment } from './decodeEvmGeneralSwapCommitment'
 import type { VaultIdentity } from './types'
 
 export type PrepareSwapTxFromKeysParams = {
@@ -94,17 +95,19 @@ const assertCowQuoteNotExpired = (validTo: number): void => {
   }
 }
 
-// Defense-in-depth for CoW: the quote-level requested amount must also match the gross value
-// committed to the EIP-712 order. Native/evm/solana do not expose a separate committed-sell
-// field here, so they intentionally fail open after the quote-level amount binding above;
-// `transfer.amount` may legitimately differ (for example, 100_000n -> 99_999n) because providers
-// subtract deposit-channel fees.
+// Defense-in-depth: the quote-level requested amount must also match a value
+// committed inside the signable payload when we can read one. CoW exposes
+// sellAmount+feeAmount on the order. EVM-general quotes bury the sell in
+// aggregator calldata — decode known exact-in shapes and compare; unknown
+// selectors stay fail-open (a wrong decode would brick valid swaps).
+// `transfer.amount` may legitimately differ (for example, 100_000n -> 99_999n)
+// because providers subtract deposit-channel fees.
 const assertAmountMatchesCommittedSellAmount = (params: PrepareSwapTxFromKeysParams): void => {
   const { quote } = params.swapQuote
   if (!('general' in quote)) return
 
   const committed = matchRecordUnion(quote.general.tx, {
-    evm: () => undefined,
+    evm: tx => decodeEvmGeneralSwapCommitment(tx.data, tx.value)?.sellAmount,
     solana: () => undefined,
     transfer: () => undefined,
     cowswap_order: order => BigInt(order.sellAmount) + BigInt(order.feeAmount),
@@ -113,8 +116,26 @@ const assertAmountMatchesCommittedSellAmount = (params: PrepareSwapTxFromKeysPar
 
   const requested = toChainAmount(params.amount, params.fromCoin.decimals)
   if (requested !== committed) {
+    const label =
+      'cowswap_order' in quote.general.tx
+        ? "CoW order's committed gross sell amount"
+        : 'committed sell amount encoded in the EVM swap calldata'
     throw new Error(
-      `prepareSwapTxFromKeys: requested amount (${requested} base units) does not match the CoW order's committed gross sell amount (${committed} base units) — the quote may be stale or for a different request`
+      `prepareSwapTxFromKeys: requested amount (${requested} base units) does not match the ${label} (${committed} base units) — the quote may be stale or for a different request`
+    )
+  }
+}
+
+const assertEvmGeneralDeadlineNotExpired = (params: PrepareSwapTxFromKeysParams): void => {
+  const { quote } = params.swapQuote
+  if (!('general' in quote) || !('evm' in quote.general.tx)) return
+
+  const decoded = decodeEvmGeneralSwapCommitment(quote.general.tx.evm.data, quote.general.tx.evm.value)
+  if (decoded?.deadlineSeconds === undefined) return
+  if (!Number.isFinite(decoded.deadlineSeconds)) return
+  if (decoded.deadlineSeconds <= Math.floor(Date.now() / 1000)) {
+    throw new SwapQuoteExpiredError(
+      'prepareSwapTxFromKeys: EVM swap calldata deadline has expired; refresh the quote before signing'
     )
   }
 }
@@ -158,6 +179,7 @@ export const prepareSwapTxFromKeys = async (
   if ('general' in quote && 'cowswap_order' in quote.general.tx) {
     assertCowQuoteNotExpired(quote.general.tx.cowswap_order.validTo)
   }
+  assertEvmGeneralDeadlineNotExpired(safeParams)
   assertAmountMatchesCommittedSellAmount(safeParams)
 
   const walletCore = walletCoreOverride ?? (await getWalletCore())

--- a/packages/sdk/tests/unit/tools/prep/decodeEvmGeneralSwapCommitment.test.ts
+++ b/packages/sdk/tests/unit/tools/prep/decodeEvmGeneralSwapCommitment.test.ts
@@ -1,0 +1,144 @@
+import { encodeFunctionData, parseAbi, zeroAddress } from 'viem'
+import { describe, expect, it } from 'vitest'
+
+import { decodeEvmGeneralSwapCommitment } from '@/tools/prep/decodeEvmGeneralSwapCommitment'
+
+const USDC = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'
+const ROUTER = '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D'
+const RECIPIENT = '0x1111111111111111111111111111111111111111'
+const FUTURE = BigInt(Math.floor(Date.now() / 1000) + 600)
+const PAST = BigInt(1_700_000_000)
+
+const v2Abi = parseAbi([
+  'function swapExactTokensForTokens(uint256 amountIn, uint256 amountOutMin, address[] path, address to, uint256 deadline)',
+  'function swapExactETHForTokens(uint256 amountOutMin, address[] path, address to, uint256 deadline)',
+  'function swapTokensForExactTokens(uint256 amountOut, uint256 amountInMax, address[] path, address to, uint256 deadline)',
+])
+
+const v3Abi = parseAbi([
+  'function exactInputSingle((address tokenIn, address tokenOut, uint24 fee, address recipient, uint256 deadline, uint256 amountIn, uint256 amountOutMinimum, uint160 sqrtPriceLimitX96) params)',
+])
+
+const oneInchAbi = parseAbi([
+  'function swap(address executor, (address srcToken, address dstToken, address srcReceiver, address dstReceiver, uint256 amount, uint256 minReturnAmount, uint256 flags) desc, bytes permit, bytes data)',
+])
+
+const thorAbi = parseAbi([
+  'function depositWithExpiry(address vault, address asset, uint256 amount, string memo, uint256 expiry)',
+])
+
+describe('decodeEvmGeneralSwapCommitment', () => {
+  it('returns null for opaque aggregator calldata', () => {
+    expect(decodeEvmGeneralSwapCommitment('0xdeadbeef', '0')).toBeNull()
+    expect(decodeEvmGeneralSwapCommitment('0x', '0')).toBeNull()
+    expect(decodeEvmGeneralSwapCommitment('', '0')).toBeNull()
+  })
+
+  it('treats a native-only value (no calldata) as the sell amount', () => {
+    expect(decodeEvmGeneralSwapCommitment('0x', '1000000000000000000')).toEqual({
+      sellAmount: 10n ** 18n,
+    })
+  })
+
+  it('decodes Uniswap V2 swapExactTokensForTokens amountIn + deadline', () => {
+    const data = encodeFunctionData({
+      abi: v2Abi,
+      functionName: 'swapExactTokensForTokens',
+      args: [1_000_000n, 990_000n, [USDC, WETH], RECIPIENT, FUTURE],
+    })
+    expect(decodeEvmGeneralSwapCommitment(data, '0')).toEqual({
+      sellAmount: 1_000_000n,
+      deadlineSeconds: Number(FUTURE),
+    })
+  })
+
+  it('decodes Uniswap V2 swapExactETHForTokens from tx.value + deadline', () => {
+    const data = encodeFunctionData({
+      abi: v2Abi,
+      functionName: 'swapExactETHForTokens',
+      args: [1n, [WETH, USDC], RECIPIENT, FUTURE],
+    })
+    expect(decodeEvmGeneralSwapCommitment(data, '500000000000000000')).toEqual({
+      sellAmount: 5n * 10n ** 17n,
+      deadlineSeconds: Number(FUTURE),
+    })
+  })
+
+  it('returns null for swapExactETHForTokens when value is zero (no sell to bind)', () => {
+    const data = encodeFunctionData({
+      abi: v2Abi,
+      functionName: 'swapExactETHForTokens',
+      args: [1n, [WETH, USDC], RECIPIENT, FUTURE],
+    })
+    expect(decodeEvmGeneralSwapCommitment(data, '0')).toBeNull()
+  })
+
+  it('does not treat exact-out amountInMax as a committed sell', () => {
+    const data = encodeFunctionData({
+      abi: v2Abi,
+      functionName: 'swapTokensForExactTokens',
+      args: [1_000_000n, 2_000_000n, [USDC, WETH], RECIPIENT, FUTURE],
+    })
+    expect(decodeEvmGeneralSwapCommitment(data, '0')).toBeNull()
+  })
+
+  it('decodes Uniswap V3 exactInputSingle amountIn + deadline', () => {
+    const data = encodeFunctionData({
+      abi: v3Abi,
+      functionName: 'exactInputSingle',
+      args: [
+        {
+          tokenIn: USDC,
+          tokenOut: WETH,
+          fee: 3000,
+          recipient: RECIPIENT,
+          deadline: FUTURE,
+          amountIn: 42_000_000n,
+          amountOutMinimum: 1n,
+          sqrtPriceLimitX96: 0n,
+        },
+      ],
+    })
+    expect(decodeEvmGeneralSwapCommitment(data, '0')).toEqual({
+      sellAmount: 42_000_000n,
+      deadlineSeconds: Number(FUTURE),
+    })
+  })
+
+  it('decodes 1inch V5 swap description.amount', () => {
+    const data = encodeFunctionData({
+      abi: oneInchAbi,
+      functionName: 'swap',
+      args: [
+        ROUTER,
+        {
+          srcToken: USDC,
+          dstToken: WETH,
+          srcReceiver: ROUTER,
+          dstReceiver: RECIPIENT,
+          amount: 8_000_000n,
+          minReturnAmount: 1n,
+          flags: 0n,
+        },
+        '0x',
+        '0x',
+      ],
+    })
+    expect(decodeEvmGeneralSwapCommitment(data, '0')).toEqual({
+      sellAmount: 8_000_000n,
+    })
+  })
+
+  it('decodes THOR depositWithExpiry amount + expiry', () => {
+    const data = encodeFunctionData({
+      abi: thorAbi,
+      functionName: 'depositWithExpiry',
+      args: [ROUTER, zeroAddress, 3n * 10n ** 18n, '=:ETH.ETH', PAST],
+    })
+    expect(decodeEvmGeneralSwapCommitment(data, '0')).toEqual({
+      sellAmount: 3n * 10n ** 18n,
+      deadlineSeconds: Number(PAST),
+    })
+  })
+})

--- a/packages/sdk/tests/unit/tools/prep/swap.test.ts
+++ b/packages/sdk/tests/unit/tools/prep/swap.test.ts
@@ -1,5 +1,6 @@
 import { Chain } from '@vultisig/core-chain/Chain'
 import { getSwapQuoteSafetyFingerprint } from '@vultisig/core-chain/swap/quote/getSwapQuoteSafetyFingerprint'
+import { encodeFunctionData, parseAbi } from 'viem'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { mockBuildSwapKeysignPayload, mockGetPublicKey, mockGetWalletCore } = vi.hoisted(() => ({
@@ -563,6 +564,100 @@ describe('prepareSwapTxFromKeys — amount consistency (ABTS/plan 005)', () => {
         swapQuote: quote,
       })
     ).resolves.toBeDefined()
+  })
+
+  it('throws when decoded EVM-general calldata sell amount does not match the requested amount', async () => {
+    const deadline = BigInt(Math.floor(Date.now() / 1000) + 600)
+    const data = encodeFunctionData({
+      abi: parseAbi([
+        'function swapExactTokensForTokens(uint256 amountIn, uint256 amountOutMin, address[] path, address to, uint256 deadline)',
+      ]),
+      functionName: 'swapExactTokensForTokens',
+      args: [
+        500_000_000_000_000_000n,
+        1n,
+        ['0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'],
+        '0x1111111111111111111111111111111111111111',
+        deadline,
+      ],
+    })
+    const quote = bindSwapQuote(
+      { general: { tx: { evm: { to: '0xrouter', data, value: '0' } } } },
+      1_000_000_000_000_000_000n
+    )
+
+    await expect(
+      prepareSwapTxFromKeys(baseIdentity, {
+        fromCoin: ethCoin,
+        toCoin: btcCoin,
+        amount: '1',
+        swapQuote: quote,
+      })
+    ).rejects.toThrow(/committed sell amount encoded in the EVM swap calldata/)
+
+    expect(mockBuildSwapKeysignPayload).not.toHaveBeenCalled()
+  })
+
+  it('builds when decoded EVM-general calldata sell amount matches the requested amount', async () => {
+    mockBuildSwapKeysignPayload.mockResolvedValue({ __mock: 'payload' })
+    const deadline = BigInt(Math.floor(Date.now() / 1000) + 600)
+    const data = encodeFunctionData({
+      abi: parseAbi([
+        'function swapExactTokensForTokens(uint256 amountIn, uint256 amountOutMin, address[] path, address to, uint256 deadline)',
+      ]),
+      functionName: 'swapExactTokensForTokens',
+      args: [
+        1_000_000_000_000_000_000n,
+        1n,
+        ['0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'],
+        '0x1111111111111111111111111111111111111111',
+        deadline,
+      ],
+    })
+    const quote = bindSwapQuote(
+      { general: { tx: { evm: { to: '0xrouter', data, value: '0' } } } },
+      1_000_000_000_000_000_000n
+    )
+
+    await expect(
+      prepareSwapTxFromKeys(baseIdentity, {
+        fromCoin: ethCoin,
+        toCoin: btcCoin,
+        amount: '1',
+        swapQuote: quote,
+      })
+    ).resolves.toBeDefined()
+  })
+
+  it('throws when decoded EVM-general calldata deadline is in the past', async () => {
+    const data = encodeFunctionData({
+      abi: parseAbi([
+        'function swapExactTokensForTokens(uint256 amountIn, uint256 amountOutMin, address[] path, address to, uint256 deadline)',
+      ]),
+      functionName: 'swapExactTokensForTokens',
+      args: [
+        1_000_000_000_000_000_000n,
+        1n,
+        ['0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'],
+        '0x1111111111111111111111111111111111111111',
+        1_700_000_000n,
+      ],
+    })
+    const quote = bindSwapQuote(
+      { general: { tx: { evm: { to: '0xrouter', data, value: '0' } } } },
+      1_000_000_000_000_000_000n
+    )
+
+    await expect(
+      prepareSwapTxFromKeys(baseIdentity, {
+        fromCoin: ethCoin,
+        toCoin: btcCoin,
+        amount: '1',
+        swapQuote: quote,
+      })
+    ).rejects.toThrow(SwapQuoteExpiredError)
+
+    expect(mockBuildSwapKeysignPayload).not.toHaveBeenCalled()
   })
 
   it('accepts a scientific-notation amount on a transfer-route quote (transfer excluded from amount check)', async () => {


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#1196

`prepareSwapTxFromKeys` already bound the quote-level requested amount, but evm-general aggregator calldata still had no sell-amount or expiry check. Added `decodeEvmGeneralSwapCommitment` for known exact-in shapes (Uniswap V2/V3, Universal Router `execute`, 1inch V5 `swap`, THOR `depositWithExpiry`) and fail-closed when the decoded sell amount mismatches or the embedded deadline is in the past. Unknown selectors stay fail-open so a wrong decode cannot brick a valid route.

Blast radius: vault-free and vault-wrapped swap prep that goes through `prepareSwapTxFromKeys`. Only refuses more often, and only when calldata decodes as a known exact-in shape. Exact-out, Kyber/LI.FI inner-executor wrappers, and opaque 1inch variants are still unbound (same residual as before for those shapes). Not verified against a live aggregator quote or a funded-vault sign/broadcast.

## what I ran
```
cd /tmp/claude-1000/wt-sdk-w1 && yarn workspace @vultisig/sdk test:unit tests/unit/tools/prep/decodeEvmGeneralSwapCommitment.test.ts tests/unit/tools/prep/swap.test.ts
```
(workspace script still runs the full unit config; 221 files / 3430 tests passed, including the new decoder + amount/deadline cases)

```
cd /tmp/claude-1000/wt-sdk-w1/packages/sdk && yarn typecheck
```
exit 0

closes vultisig/vultisig-sdk#1196