### PR TITLE
feat(ripple): read delivered_amount instead of never confirming actual delivered value

### DIFF
--- a/.changeset/sdkh1-982.md
+++ b/.changeset/sdkh1-982.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/core-chain': patch
+---
+
+Surface XRPL Payment `delivered_amount` on tx status and never fall back to the send-side `Amount` field (partial-payment over-credit class).

--- a/packages/core/chain/chains/ripple/deliveredAmount.test.ts
+++ b/packages/core/chain/chains/ripple/deliveredAmount.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+
+import { readRippleDeliveredAmount } from './deliveredAmount'
+
+describe('readRippleDeliveredAmount', () => {
+  it('reads native XRP drops from delivered_amount', () => {
+    expect(readRippleDeliveredAmount({ delivered_amount: '1000000', TransactionResult: 'tesSUCCESS' })).toEqual({
+      type: 'xrp',
+      drops: 1_000_000n,
+    })
+  })
+
+  it('reads the legacy DeliveredAmount alias when delivered_amount is absent', () => {
+    expect(readRippleDeliveredAmount({ DeliveredAmount: '42' })).toEqual({
+      type: 'xrp',
+      drops: 42n,
+    })
+  })
+
+  it('prefers delivered_amount over the legacy alias', () => {
+    expect(
+      readRippleDeliveredAmount({
+        delivered_amount: '1',
+        DeliveredAmount: '999',
+      })
+    ).toEqual({ type: 'xrp', drops: 1n })
+  })
+
+  it('reads an issued-currency delivered_amount object', () => {
+    expect(
+      readRippleDeliveredAmount({
+        delivered_amount: {
+          currency: 'USD',
+          issuer: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B',
+          value: '8.5',
+        },
+      })
+    ).toEqual({
+      type: 'issued',
+      currency: 'USD',
+      issuer: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B',
+      value: '8.5',
+    })
+  })
+
+  it('never falls back to Amount when delivered_amount is missing', () => {
+    expect(readRippleDeliveredAmount({ Amount: '999999999', TransactionResult: 'tesSUCCESS' })).toBeNull()
+    expect(readRippleDeliveredAmount({ amount: '999999999' })).toBeNull()
+  })
+
+  it('never falls back to Amount when delivered_amount is present but malformed', () => {
+    expect(
+      readRippleDeliveredAmount({
+        delivered_amount: 'not-a-drop-amount',
+        Amount: '1000000',
+      })
+    ).toBeNull()
+  })
+
+  it('returns null for missing or non-object metadata', () => {
+    expect(readRippleDeliveredAmount(undefined)).toBeNull()
+    expect(readRippleDeliveredAmount(null)).toBeNull()
+    expect(readRippleDeliveredAmount('tesSUCCESS')).toBeNull()
+    expect(readRippleDeliveredAmount({})).toBeNull()
+  })
+})

--- a/packages/core/chain/chains/ripple/deliveredAmount.ts
+++ b/packages/core/chain/chains/ripple/deliveredAmount.ts
@@ -1,0 +1,57 @@
+/**
+ * XRPL Payment confirmation amount.
+ *
+ * Under `tfPartialPayment`, the transaction `Amount` field is a *ceiling*, not
+ * a delivery. Credit / history / confirmation MUST read metadata
+ * `delivered_amount` (legacy alias `DeliveredAmount`). Falling back to `Amount`
+ * is the classic over-credit exploit.
+ *
+ * @see https://xrpl.org/docs/concepts/payment-types/partial-payments
+ */
+export type RippleDeliveredAmount =
+  | { type: 'xrp'; drops: bigint }
+  | { type: 'issued'; currency: string; issuer: string; value: string }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function parseDeliveredAmountField(raw: unknown): RippleDeliveredAmount | null {
+  if (typeof raw === 'string') {
+    if (!/^\d+$/.test(raw)) return null
+    return { type: 'xrp', drops: BigInt(raw) }
+  }
+
+  if (
+    isRecord(raw) &&
+    typeof raw.currency === 'string' &&
+    raw.currency.length > 0 &&
+    typeof raw.issuer === 'string' &&
+    raw.issuer.length > 0 &&
+    typeof raw.value === 'string' &&
+    raw.value.length > 0
+  ) {
+    return { type: 'issued', currency: raw.currency, issuer: raw.issuer, value: raw.value }
+  }
+
+  return null
+}
+
+/**
+ * Extract the delivered value from XRPL `tx` metadata.
+ *
+ * Returns `null` when the field is absent or malformed. Never consults
+ * `Amount` / `amount` — callers that need a confirmed value must fail closed
+ * on `null` rather than substitute the send-side ceiling.
+ */
+export function readRippleDeliveredAmount(meta: unknown): RippleDeliveredAmount | null {
+  if (!isRecord(meta)) return null
+
+  if ('delivered_amount' in meta) {
+    return parseDeliveredAmountField(meta.delivered_amount)
+  }
+  if ('DeliveredAmount' in meta) {
+    return parseDeliveredAmountField(meta.DeliveredAmount)
+  }
+  return null
+}

--- a/packages/core/chain/tx/status/resolver.ts
+++ b/packages/core/chain/tx/status/resolver.ts
@@ -1,6 +1,7 @@
 import { Resolver } from '@vultisig/lib-utils/types/Resolver'
 
 import { Chain } from '../../Chain'
+import type { RippleDeliveredAmount } from '../../chains/ripple/deliveredAmount'
 
 // `not_found` is terminal-ish: the node affirmatively has no record of the hash
 // (never seen it), as opposed to `pending` which means "known/plausibly in-flight,
@@ -19,6 +20,12 @@ export type TxStatusResult = {
   status: TxStatus
   isKnown?: boolean
   receipt?: TxReceiptInfo
+  /**
+   * XRPL Payment only. Always sourced from metadata `delivered_amount`
+   * (legacy `DeliveredAmount`). Never from the send-side `Amount` field —
+   * that is a ceiling under tfPartialPayment.
+   */
+  rippleDelivered?: RippleDeliveredAmount
 }
 
 export type TxStatusInput<T extends Chain = Chain> = {

--- a/packages/core/chain/tx/status/resolvers/ripple.test.ts
+++ b/packages/core/chain/tx/status/resolvers/ripple.test.ts
@@ -116,4 +116,36 @@ describe('getRippleTxStatus', () => {
     expect(result.status).toBe('success')
     expect(result.receipt).toBeUndefined()
   })
+
+  it('surfaces delivered_amount on success and ignores the send-side Amount ceiling', async () => {
+    mocks.request.mockResolvedValue({
+      result: {
+        validated: true,
+        meta: {
+          TransactionResult: 'tesSUCCESS',
+          delivered_amount: '500000',
+          Amount: '1000000',
+        },
+        tx_json: { Fee: '20', Amount: '1000000' },
+      },
+    })
+
+    const result = await getRippleTxStatus({ chain: OtherChain.Ripple, hash })
+    expect(result.status).toBe('success')
+    expect(result.rippleDelivered).toEqual({ type: 'xrp', drops: 500_000n })
+  })
+
+  it('does not invent a delivered amount from Amount when metadata omits delivered_amount', async () => {
+    mocks.request.mockResolvedValue({
+      result: {
+        validated: true,
+        meta: { TransactionResult: 'tesSUCCESS', Amount: '1000000' },
+        tx_json: { Fee: '20', Amount: '1000000' },
+      },
+    })
+
+    const result = await getRippleTxStatus({ chain: OtherChain.Ripple, hash })
+    expect(result.status).toBe('success')
+    expect(result.rippleDelivered).toBeUndefined()
+  })
 })

--- a/packages/core/chain/tx/status/resolvers/ripple.ts
+++ b/packages/core/chain/tx/status/resolvers/ripple.ts
@@ -1,5 +1,6 @@
 import { Chain, OtherChain } from '@vultisig/core-chain/Chain'
 import { getRippleClient } from '@vultisig/core-chain/chains/ripple/client'
+import { readRippleDeliveredAmount } from '../../../chains/ripple/deliveredAmount'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { attempt } from '@vultisig/lib-utils/attempt'
 
@@ -50,7 +51,8 @@ export const getRippleTxStatus: TxStatusResolver<OtherChain.Ripple> = async ({ h
           }
         : undefined
 
-    return { status, receipt }
+    const rippleDelivered = readRippleDeliveredAmount(meta)
+    return { status, receipt, ...(rippleDelivered ? { rippleDelivered } : {}) }
   }
 
   // Genuinely in the ledger but not yet validated — XRPL knows about it.


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#982

The spike asked whether XRPL received/history reads `delivered_amount` or `Amount`. The SDK status resolver previously read neither (only tesSUCCESS + fee), so it was not over-crediting — but it also could not confirm delivered value. Added `readRippleDeliveredAmount` that prefers `delivered_amount` / legacy `DeliveredAmount` and never falls back to `Amount`, and attached the result as optional `rippleDelivered` on tx status.

Blast radius: additive optional field on `TxStatusResult`. No existing status consumer is required to honor it. Confirmation callers that need a delivered value must fail closed on absence rather than substitute `Amount`. iOS/Android history surfaces are not in this tree and were not verified. No live XRPL `tx` RPC was queried.

## what I ran
```
cd /tmp/claude-1000/wt-sdk-w1 && yarn test:core packages/core/chain/chains/ripple/deliveredAmount.test.ts packages/core/chain/tx/status/resolvers/ripple.test.ts
```
```
 Test Files  2 passed (2)
      Tests  17 passed (17)
   Duration  178ms
```

closes vultisig/vultisig-sdk#982