### PR TITLE
test(chains): pin guard-shaped map completeness across cosmos/evm chains

### DIFF
--- a/.changeset/sdkh1-1228.md
+++ b/.changeset/sdkh1-1228.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/core-chain': patch
+---
+
+Add completeness assertions for the guard-shaped per-chain maps (memo cap, EVM fee ceiling/floor, cosmos LCD fallbacks) so a new chain cannot silently skip the guard.

--- a/packages/core/chain/chains/cosmos/account/getCosmosAccountInfo.test.ts
+++ b/packages/core/chain/chains/cosmos/account/getCosmosAccountInfo.test.ts
@@ -2,7 +2,7 @@ import { HttpResponseError } from '@vultisig/lib-utils/fetch/HttpResponseError'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { CosmosChain } from '../../../Chain'
-import { getCosmosAccountInfo } from './getCosmosAccountInfo'
+import { cosmosLcdFallbackUrls, getCosmosAccountInfo } from './getCosmosAccountInfo'
 
 vi.mock('@vultisig/core-chain/chains/cosmos/client', () => ({
   getCosmosClient: vi.fn(),
@@ -521,5 +521,16 @@ describe('getCosmosAccountInfo — LCD fallback URL on primary failure', () => {
       })
     ).rejects.toThrow('fallback unavailable')
     expect(queryUrl).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('cosmosLcdFallbackUrls completeness', () => {
+  it('enumerates the intentional no-fallback gap so a new cosmos chain cannot silently skip the second LCD path', () => {
+    // Maya is the only cosmos chain we have not live-verified a distinct
+    // fallback LCD for. Adding a CosmosChain member fails this until the
+    // author either adds a URL or lists it here as an intentional gap.
+    const intentionalGaps: CosmosChain[] = [CosmosChain.MayaChain]
+    const missing = Object.values(CosmosChain).filter(chain => cosmosLcdFallbackUrls[chain] === undefined)
+    expect(missing.sort()).toEqual([...intentionalGaps].sort())
   })
 })

--- a/packages/core/chain/chains/cosmos/account/getCosmosAccountInfo.ts
+++ b/packages/core/chain/chains/cosmos/account/getCosmosAccountInfo.ts
@@ -108,7 +108,8 @@ const parseLcdAccount = (resp: LcdAccountResponse): ParsedAccount => {
 // vultiagent-app#1017 + mcp-ts#266). Keys are the chain id used by
 // cosmos-sdk; chains not in this map have no fallback (degrade fail-closed
 // behaviour preserved).
-const COSMOS_LCD_FALLBACK_URLS: Partial<Record<CosmosChain, string>> = {
+/** Intentional Partial: a missing chain fails closed (no second LCD path). */
+export const cosmosLcdFallbackUrls: Partial<Record<CosmosChain, string>> = {
   [Chain.Cosmos]: 'https://cosmos-api.polkachu.com',
   [Chain.Osmosis]: 'https://osmosis-api.polkachu.com',
   // rest.cosmos.directory/kujira proxies across multiple independent providers
@@ -182,7 +183,7 @@ const fetchAccountViaLcd = async (chain: CosmosChain, address: string): Promise<
   // Network/5xx failure is not evidence that the account is absent. Try the
   // registered fallback, then propagate the failure if exact data is still
   // unavailable instead of silently constructing a sequence-zero payload.
-  const fallback = COSMOS_LCD_FALLBACK_URLS[chain]
+  const fallback = cosmosLcdFallbackUrls[chain]
   if (!fallback) throw primary.error
   const secondary = await tryLcd(fallback, address)
   if (secondary.status === 'found') return secondary.account

--- a/packages/core/chain/chains/cosmos/cosmosMemoCap.test.ts
+++ b/packages/core/chain/chains/cosmos/cosmosMemoCap.test.ts
@@ -15,17 +15,16 @@ describe('getCosmosMemoMaxBytes', () => {
   })
 
   it('returns the sdk default (256) for every other cosmos chain, including TerraClassic', () => {
-    for (const chain of [
-      CosmosChain.TerraClassic,
-      CosmosChain.Osmosis,
-      CosmosChain.Kujira,
-      CosmosChain.Noble,
-      CosmosChain.Dydx,
-      CosmosChain.Akash,
-      CosmosChain.THORChain,
-      CosmosChain.MayaChain,
-    ]) {
+    const raised = new Set<CosmosChain>([CosmosChain.Terra, CosmosChain.Cosmos])
+    for (const chain of Object.values(CosmosChain)) {
+      if (raised.has(chain)) continue
       expect(getCosmosMemoMaxBytes(chain)).toBe(COSMOS_MEMO_DEFAULT_MAX_BYTES)
+    }
+  })
+
+  it('has a memo-cap decision for every CosmosChain (adding a chain fails here until one is chosen)', () => {
+    for (const chain of Object.values(CosmosChain)) {
+      expect(getCosmosMemoMaxBytes(chain)).toBeGreaterThan(0)
     }
   })
 })

--- a/packages/core/chain/chains/cosmos/cosmosRpcUrl.ts
+++ b/packages/core/chain/chains/cosmos/cosmosRpcUrl.ts
@@ -14,7 +14,7 @@ export const cosmosRpcUrl: Record<CosmosChain, string> = {
   Osmosis: 'https://osmosis-rest.publicnode.com',
   Dydx: 'https://dydx-rest.publicnode.com',
   // kujira-rest.publicnode.com returns HTTP 403 "unsupported platform"; use polkachu
-  // (same provider Noble uses below + COSMOS_LCD_FALLBACK_URLS in getCosmosAccountInfo).
+  // (same provider Noble uses below + cosmosLcdFallbackUrls in getCosmosAccountInfo).
   Kujira: 'https://kujira-api.polkachu.com',
   Terra: 'https://terra-lcd.publicnode.com',
   TerraClassic: 'https://terra-classic-lcd.publicnode.com',

--- a/packages/core/chain/tx/fee/evm/clampEvmPriorityFee.test.ts
+++ b/packages/core/chain/tx/fee/evm/clampEvmPriorityFee.test.ts
@@ -72,6 +72,20 @@ describe('clampEvmPriorityFee', () => {
     expect(clampEvmPriorityFee(EvmChain.Ethereum, gwei(1))).toBe(gwei(1))
   })
 
+  it('has a priority-fee ceiling for every EvmChain (adding a chain fails here until one is chosen)', () => {
+    const absurd = 10n ** 24n
+    for (const chain of Object.values(EvmChain)) {
+      const clamped = clampEvmPriorityFee(chain, absurd)
+      expect(clamped).toBeLessThan(absurd)
+      expect(clamped).toBeGreaterThan(0n)
+    }
+  })
+
+  it('floors only the tip-auction chains (Ethereum, Polygon); every other EVM chain is an intentional floor gap', () => {
+    const floored = Object.values(EvmChain).filter(chain => clampEvmPriorityFee(chain, 1n) > 1n)
+    expect(floored.sort()).toEqual([EvmChain.Ethereum, EvmChain.Polygon].sort())
+  })
+
   it.each([
     ['Arbitrum', EvmChain.Arbitrum],
     ['Base', EvmChain.Base],


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#1228

The four named guard-shaped maps are already exhaustive (`Record`) or intentionally Partial. Added completeness assertions that iterate `Object.values(CosmosChain)` / `EvmChain` for memo cap and priority-fee ceiling, pin the fee floor to Ethereum+Polygon only, and enumerate the LCD-fallback gap (MayaChain) so adding a chain is a test failure rather than a silent skip.

Blast radius: test + exporting `cosmosLcdFallbackUrls`. No fee/signing behavior change. Remaining ~35 Partial maps are not guard-shaped (explorer URLs, custom RPC, address maps) and stay Partial by design.

## what I ran
```
cd /tmp/claude-1000/wt-sdk-w1 && yarn test:core packages/core/chain/chains/cosmos/cosmosMemoCap.test.ts packages/core/chain/tx/fee/evm/clampEvmPriorityFee.test.ts packages/core/chain/chains/cosmos/account/getCosmosAccountInfo.test.ts
```
```
 Test Files  3 passed (3)
      Tests  70 passed (70)
```

closes vultisig/vultisig-sdk#1228