### PR TITLE
fix(utxo): map terminal walletcore plan errors instead of leaking raw error strings

### DIFF
--- a/.changeset/utxo-plan-error-send-max.md
+++ b/.changeset/utxo-plan-error-send-max.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/core-mpc': patch
+'@vultisig/sdk': patch
+---
+
+Inspect WalletCore UTXO `plan.error` and map terminal failures to an actionable SDK error instead of leaking `Error_not_enough_utxos`. Thread optional `sendMaxAmount` (default false) through chain-specific + send payload builders so callers can plan a sweep up front. Empty near-max plans still go to `refineKeysignUtxo`.

--- a/packages/core/mpc/keysign/chainSpecific/resolver.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolver.ts
@@ -14,6 +14,11 @@ export type GetChainSpecificInput<C extends KeysignChainSpecificKey = KeysignCha
   walletCore: WalletCore
   /** XRPL DestinationTag, carried in RippleSpecific for Ripple payments. */
   destinationTag?: number
+  /**
+   * UTXO-only. When true, WalletCore plans a single-output sweep.
+   * Ignored by non-UTXO resolvers. Defaults to false.
+   */
+  sendMaxAmount?: boolean
 } & (C extends 'ethereumSpecific'
   ? {
       feeSettings?: FeeSettings<'evm'>

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/utxo.test.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/utxo.test.ts
@@ -1,0 +1,49 @@
+import { create } from '@bufbuild/protobuf'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { CoinSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/coin_pb'
+import { KeysignPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@vultisig/core-chain/chains/utxo/fee/byteFee', () => ({
+  getUtxoByteFee: vi.fn(async () => 5n),
+}))
+
+import { getUtxoChainSpecific } from './utxo'
+
+const payload = create(KeysignPayloadSchema, {
+  coin: create(CoinSchema, {
+    chain: Chain.Bitcoin,
+    ticker: 'BTC',
+    address: 'bc1qsource',
+    decimals: 8,
+    isNativeToken: true,
+  }),
+  toAddress: 'bc1qdest',
+  toAmount: '100000',
+})
+
+describe('getUtxoChainSpecific sendMaxAmount', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('defaults sendMaxAmount to false', async () => {
+    const specific = await getUtxoChainSpecific({
+      keysignPayload: payload,
+      walletCore: {} as never,
+    })
+
+    expect(specific.sendMaxAmount).toBe(false)
+    expect(specific.byteFee).toBe('5')
+  })
+
+  it('honors an explicit sendMaxAmount: true without changing the default path', async () => {
+    const specific = await getUtxoChainSpecific({
+      keysignPayload: payload,
+      walletCore: {} as never,
+      sendMaxAmount: true,
+    })
+
+    expect(specific.sendMaxAmount).toBe(true)
+  })
+})

--- a/packages/core/mpc/keysign/chainSpecific/resolvers/utxo.ts
+++ b/packages/core/mpc/keysign/chainSpecific/resolvers/utxo.ts
@@ -12,6 +12,7 @@ import { GetChainSpecificResolver } from '../resolver'
 export const getUtxoChainSpecific: GetChainSpecificResolver<'utxoSpecific'> = async ({
   keysignPayload,
   feeSettings,
+  sendMaxAmount = false,
 }) => {
   const coin = getKeysignCoin<UtxoChain>(keysignPayload)
 
@@ -27,7 +28,7 @@ export const getUtxoChainSpecific: GetChainSpecificResolver<'utxoSpecific'> = as
   }
 
   return create(UTXOSpecificSchema, {
-    sendMaxAmount: false,
+    sendMaxAmount,
     byteFee: (await getByteFee()).toString(),
   })
 }

--- a/packages/core/mpc/keysign/send/build.ts
+++ b/packages/core/mpc/keysign/send/build.ts
@@ -36,6 +36,12 @@ export type BuildSendKeysignPayloadInput = {
   libType: KeysignLibType
   walletCore: WalletCore
   feeSettings?: FeeSettings
+  /**
+   * When true, WalletCore plans a single-output sweep. Defaults to false so
+   * existing callers keep the previous 2-output plan; refineKeysignUtxo stays
+   * the backstop for near-max amounts that omit this flag.
+   */
+  sendMaxAmount?: boolean
 }
 
 export const buildSendKeysignPayload = async ({
@@ -51,6 +57,7 @@ export const buildSendKeysignPayload = async ({
   walletCore,
   libType,
   feeSettings,
+  sendMaxAmount,
 }: BuildSendKeysignPayloadInput) => {
   const hexPublicKey = hexPublicKeyOverride ?? (publicKey ? Buffer.from(publicKey.data()).toString('hex') : undefined)
   if (!hexPublicKey) {
@@ -117,6 +124,7 @@ export const buildSendKeysignPayload = async ({
         feeSettings,
         walletCore,
         destinationTag: effectiveDestinationTag,
+        sendMaxAmount,
       })
 
   const balance = await getCoinBalance(coin)

--- a/packages/core/mpc/keysign/signingInputs/resolvers/utxo.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/utxo.test.ts
@@ -21,13 +21,16 @@ vi.mock('@vultisig/core-chain/chains/utxo/zcashBranchId', () => ({
 // and live in integration tests. This file targets the address-validation guard only.
 // A minimal 1-in / recipient+change plan whose fee clears the ZIP-317 floor
 // for a no-memo send, so the Zcash conventional-fee guard returns it as-is.
-const encodeStubPlan = () =>
+const encodeStubPlan = (
+  overrides: Partial<TW.Bitcoin.Proto.ITransactionPlan> = {}
+) =>
   TW.Bitcoin.Proto.TransactionPlan.encode(
     TW.Bitcoin.Proto.TransactionPlan.create({
       amount: 600000,
       availableAmount: 1000000,
       fee: 10000,
       change: 390000,
+      error: TW.Common.Proto.SigningError.OK,
       utxos: [
         TW.Bitcoin.Proto.UnspentTransaction.create({
           amount: 1000000,
@@ -39,10 +42,14 @@ const encodeStubPlan = () =>
           script: new Uint8Array(0),
         }),
       ],
+      ...overrides,
     })
   ).finish()
 
-const makeWalletCore = ({ isValidAddress = true }: { isValidAddress?: boolean } = {}) =>
+const makeWalletCore = ({
+  isValidAddress = true,
+  planBytes,
+}: { isValidAddress?: boolean; planBytes?: Uint8Array } = {}) =>
   ({
     AnyAddress: {
       isValid: vi.fn(() => isValidAddress),
@@ -65,7 +72,7 @@ const makeWalletCore = ({ isValidAddress = true }: { isValidAddress?: boolean } 
       decode: vi.fn(() => new Uint8Array(32)),
     },
     AnySigner: {
-      plan: vi.fn(() => encodeStubPlan()),
+      plan: vi.fn(() => planBytes ?? encodeStubPlan()),
     },
     CoinType: {
       bitcoin: { value: 0 },
@@ -231,5 +238,100 @@ describe('Zcash ZIP-317 fee planning', () => {
     const planInput = vi.mocked(plan).mock.calls[0]?.[0]
     expect(planInput).toBeDefined()
     expect(TW.Bitcoin.Proto.SigningInput.decode(planInput).zip_0317).toBe(true)
+  })
+})
+
+describe('assertUtxoPlanAcceptable', () => {
+  async function loadAssert() {
+    const mod = await import('./utxo')
+    return mod.assertUtxoPlanAcceptable
+  }
+
+  it('allows an empty Error_not_enough_utxos plan when sendMaxAmount is still false so refine can retry', async () => {
+    const assertUtxoPlanAcceptable = await loadAssert()
+    const plan = TW.Bitcoin.Proto.TransactionPlan.create({
+      error: TW.Common.Proto.SigningError.Error_not_enough_utxos,
+      utxos: [],
+    })
+
+    expect(() =>
+      assertUtxoPlanAcceptable({ plan, sendMaxAmount: false, amount: '999450' })
+    ).not.toThrow()
+  })
+
+  it('throws a mapped error when the same empty plan is already a max-send', async () => {
+    const assertUtxoPlanAcceptable = await loadAssert()
+    const plan = TW.Bitcoin.Proto.TransactionPlan.create({
+      error: TW.Common.Proto.SigningError.Error_not_enough_utxos,
+      utxos: [],
+    })
+
+    expect(() => assertUtxoPlanAcceptable({ plan, sendMaxAmount: true, amount: '999450' })).toThrow(
+      /UTXO coin selection failed \(Error_not_enough_utxos\)/
+    )
+  })
+
+  it('throws immediately on dust — that is not a refine-retry case', async () => {
+    const assertUtxoPlanAcceptable = await loadAssert()
+    const plan = TW.Bitcoin.Proto.TransactionPlan.create({
+      error: TW.Common.Proto.SigningError.Error_dust_amount_requested,
+      utxos: [],
+    })
+
+    expect(() => assertUtxoPlanAcceptable({ plan, sendMaxAmount: false, amount: '100' })).toThrow(
+      /dust threshold/
+    )
+  })
+
+  it('does not throw on OK', async () => {
+    const assertUtxoPlanAcceptable = await loadAssert()
+    const plan = TW.Bitcoin.Proto.TransactionPlan.create({
+      error: TW.Common.Proto.SigningError.OK,
+      utxos: [
+        TW.Bitcoin.Proto.UnspentTransaction.create({
+          amount: 1000000,
+        }),
+      ],
+    })
+
+    expect(() => assertUtxoPlanAcceptable({ plan, sendMaxAmount: false, amount: '600000' })).not.toThrow()
+  })
+})
+
+describe('getUtxoSigningInputs — plan.error mapping', () => {
+  it('surfaces a mapped error from a terminal dust plan', async () => {
+    const resolver = await getUtxoSigningInputs()
+    const payload = create(KeysignPayloadSchema, {
+      coin: create(CoinSchema, {
+        chain: Chain.Bitcoin,
+        ticker: 'BTC',
+        address: 'bc1qsource',
+        decimals: 8,
+        isNativeToken: true,
+      }),
+      toAddress: 'bc1qdest',
+      toAmount: '100',
+      blockchainSpecific: {
+        case: 'utxoSpecific',
+        value: create(UTXOSpecificSchema, {
+          byteFee: '10',
+          sendMaxAmount: true,
+        }),
+      },
+      utxoInfo: [],
+    })
+
+    await expect(
+      resolver({
+        keysignPayload: payload,
+        walletCore: makeWalletCore({
+          planBytes: encodeStubPlan({
+            error: TW.Common.Proto.SigningError.Error_dust_amount_requested,
+            utxos: [],
+          }),
+        }),
+        publicKey: {} as never,
+      })
+    ).rejects.toThrow(/UTXO coin selection failed \(Error_dust_amount_requested\)/)
   })
 })

--- a/packages/core/mpc/keysign/signingInputs/resolvers/utxo.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/utxo.ts
@@ -118,6 +118,12 @@ export const getUtxoSigningInputs: SigningInputsResolver<'utxo'> = async ({ keys
         })
       : planInput(input)
 
+  assertUtxoPlanAcceptable({
+    plan: shouldBePresent(input.plan, 'UTXO signing input plan'),
+    sendMaxAmount,
+    amount,
+  })
+
   if (chain === UtxoChain.Zcash) {
     input.plan.branchId = Buffer.from(shouldBePresent(zcashBranchIdHex, 'Zcash branch id'), 'hex')
   }
@@ -127,6 +133,60 @@ export const getUtxoSigningInputs: SigningInputsResolver<'utxo'> = async ({ keys
 
 /** Max non-ZIP-317 re-plans before we give up raising the Zcash fee. */
 const maxZcashFeeBumps = 5
+
+const RETRIABLE_EMPTY_PLAN_ERRORS = new Set<TW.Common.Proto.SigningError>([
+  TW.Common.Proto.SigningError.OK,
+  TW.Common.Proto.SigningError.Error_not_enough_utxos,
+  TW.Common.Proto.SigningError.Error_missing_input_utxos,
+  TW.Common.Proto.SigningError.Error_low_balance,
+])
+
+function utxoPlanErrorName(error: TW.Common.Proto.SigningError): string {
+  return TW.Common.Proto.SigningError[error] ?? `error_${error}`
+}
+
+function utxoPlanErrorHint(error: TW.Common.Proto.SigningError): string {
+  switch (error) {
+    case TW.Common.Proto.SigningError.Error_not_enough_utxos:
+    case TW.Common.Proto.SigningError.Error_missing_input_utxos:
+    case TW.Common.Proto.SigningError.Error_low_balance:
+      return 'Insufficient UTXOs for this amount and fee. Try a smaller amount, or send the maximum so change is not required.'
+    case TW.Common.Proto.SigningError.Error_dust_amount_requested:
+      return 'The requested amount is below the dust threshold for this chain.'
+    case TW.Common.Proto.SigningError.Error_invalid_address:
+      return 'The destination address is not valid for this chain.'
+    default:
+      return 'The transaction could not be planned.'
+  }
+}
+
+/**
+ * Inspect WalletCore `plan.error` instead of letting the raw enum leak out of
+ * `TransactionCompiler.preImageHashes`.
+ *
+ * Empty near-max plans with `sendMaxAmount: false` are left for
+ * `refineKeysignUtxo` to retry as a sweep. Throwing here would disable that
+ * backstop. Every other non-OK error is fail-closed.
+ */
+export function assertUtxoPlanAcceptable({
+  plan,
+  sendMaxAmount,
+  amount,
+}: {
+  plan: TW.Bitcoin.Proto.ITransactionPlan
+  sendMaxAmount: boolean
+  amount: string
+}): void {
+  const error = plan.error ?? TW.Common.Proto.SigningError.OK
+  if (error === TW.Common.Proto.SigningError.OK) return
+
+  const empty = !plan.utxos || plan.utxos.length === 0
+  if (!sendMaxAmount && empty && amount && RETRIABLE_EMPTY_PLAN_ERRORS.has(error)) {
+    return
+  }
+
+  throw new Error(`UTXO coin selection failed (${utxoPlanErrorName(error)}). ${utxoPlanErrorHint(error)}`)
+}
 
 type PlanZcashConventionalFeeInput = {
   input: TW.Bitcoin.Proto.SigningInput

--- a/packages/sdk/src/tools/prep/send.ts
+++ b/packages/sdk/src/tools/prep/send.ts
@@ -20,6 +20,8 @@ export type PrepareSendTxFromKeysParams = {
   /** XRPL DestinationTag, independent from the transaction memo. */
   destinationTag?: number
   feeSettings?: FeeSettings
+  /** When true, plan a UTXO sweep. Defaults to false. */
+  sendMaxAmount?: boolean
 }
 
 /**
@@ -110,5 +112,6 @@ export const prepareSendTxFromKeys = async (
     walletCore,
     libType: identity.libType,
     feeSettings: params.feeSettings,
+    sendMaxAmount: params.sendMaxAmount,
   })
 }


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#1695

Inspect WalletCore UTXO `plan.error` in `getUtxoSigningInputs` and map terminal failures to an actionable SDK error instead of leaking `Error_not_enough_utxos` from `preImageHashes`. Empty near-max plans with `sendMaxAmount: false` still reach `refineKeysignUtxo` (throwing there would disable the existing backstop). Thread optional `sendMaxAmount` (default **false**) through `getUtxoChainSpecific` / `buildSendKeysignPayload` / `prepareSendTxFromKeys` so a caller that knows this is a max send can plan a sweep up front. Blast radius: UTXO send planning only; default stays false so no caller starts sweeping more often. Not verified: windows deposit/agent/Verify UI paths (other repo); no funded-vault max send.

## what I ran
```
yarn test:core packages/core/mpc/keysign/signingInputs/resolvers/utxo.test.ts packages/core/mpc/keysign/chainSpecific/resolvers/utxo.test.ts
 Test Files  2 passed (2)
      Tests  12 passed (12)
   Duration  339ms

yarn tsc --project .config/tsconfig.json --noEmit --pretty false
(exit 0)
```

closes vultisig/vultisig-sdk#1695