### PR TITLE
fix(oneinch): fail closed on a min-return bind mismatch for known selectors

### DIFF
--- a/.changeset/oneinch-min-out-bind.md
+++ b/.changeset/oneinch-min-out-bind.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/core-chain': patch
+---
+
+Refuse 1inch quotes whose known-selector calldata encodes a `minReturn` below `dstAmount * (1 - slippage)`. Unknown selectors stay signable so a router upgrade does not brick honest swaps.

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -1733,6 +1733,11 @@
       "import": "./dist/swap/general/oneInch/api/OneInchSwapQuoteResponse.js",
       "default": "./dist/swap/general/oneInch/api/OneInchSwapQuoteResponse.js"
     },
+    "./swap/general/oneInch/decodeMinReturn": {
+      "types": "./dist/swap/general/oneInch/decodeMinReturn.d.ts",
+      "import": "./dist/swap/general/oneInch/decodeMinReturn.js",
+      "default": "./dist/swap/general/oneInch/decodeMinReturn.js"
+    },
     "./swap/general/oneInch/oneInchAffiliateConfig": {
       "types": "./dist/swap/general/oneInch/oneInchAffiliateConfig.d.ts",
       "import": "./dist/swap/general/oneInch/oneInchAffiliateConfig.js",

--- a/packages/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.test.ts
+++ b/packages/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.test.ts
@@ -1,5 +1,6 @@
 import { Chain } from '@vultisig/core-chain/Chain'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+import { encodeFunctionData, parseAbi } from 'viem'
 import { describe, expect, it, vi } from 'vitest'
 
 import { getOneInchSwapQuote } from './getOneInchSwapQuote'
@@ -262,5 +263,61 @@ describe('getOneInchSwapQuote — token-source tx.value guard (P3 hardening)', (
 
     const quote = await getOneInchSwapQuote({ account, fromCoinId: '0xsrc', toCoinId: '0xdst', amount: 1_000_000n })
     expect('evm' in quote.tx ? quote.tx.evm.value : undefined).toBe('0')
+  })
+})
+
+describe('getOneInchSwapQuote — known-selector min-out bind', () => {
+  const REAL_ROUTER = '0x111111125421ca6dc452d289314280a0f8842a65'
+  const V6_SWAP = parseAbi([
+    'function swap(address executor, (address srcToken, address dstToken, address srcReceiver, address dstReceiver, uint256 amount, uint256 minReturnAmount, uint256 flags) desc, bytes data)',
+  ])
+  const ZERO = '0x0000000000000000000000000000000000000001' as const
+
+  function encodeV6Swap(minReturnAmount: bigint): `0x${string}` {
+    return encodeFunctionData({
+      abi: V6_SWAP,
+      functionName: 'swap',
+      args: [
+        ZERO,
+        {
+          srcToken: ZERO,
+          dstToken: ZERO,
+          srcReceiver: ZERO,
+          dstReceiver: ZERO,
+          amount: 1_000_000n,
+          minReturnAmount,
+          flags: 0n,
+        },
+        '0x',
+      ],
+    })
+  }
+
+  it('REJECTS a quote whose decoded minReturn is 1 wei against a large dstAmount', async () => {
+    vi.mocked(queryUrl).mockResolvedValueOnce({
+      dstAmount: '1000000000',
+      tx: {
+        from: '0xsender',
+        to: REAL_ROUTER,
+        data: encodeV6Swap(1n),
+        value: '0',
+        gasPrice: '1',
+        gas: 210000,
+      },
+    })
+
+    await expect(
+      getOneInchSwapQuote({ account, fromCoinId: '0xsrc', toCoinId: '0xdst', amount: 1_000_000n })
+    ).rejects.toThrow(/minReturn \(1\) is below dstAmount\*\(1-slippage\) floor/)
+  })
+
+  it('still accepts undecodable calldata (unknown selectors stay signable)', async () => {
+    vi.mocked(queryUrl).mockResolvedValueOnce({
+      dstAmount: '1000000000',
+      tx: { from: '0xsender', to: REAL_ROUTER, data: '0xdeadbeef', value: '0', gasPrice: '1', gas: 210000 },
+    })
+
+    const quote = await getOneInchSwapQuote({ account, fromCoinId: '0xsrc', toCoinId: '0xdst', amount: 1_000_000n })
+    expect(quote.dstAmount).toBe('1000000000')
   })
 })

--- a/packages/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.test.ts
+++ b/packages/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.test.ts
@@ -218,14 +218,14 @@ describe('getOneInchSwapQuote — affiliateFee display (AGG-05)', () => {
 })
 
 describe('getOneInchSwapQuote — token-source tx.value guard (P3 hardening)', () => {
-  const REAL_ROUTER = '0x111111125421ca6dc452d289314280a0f8842a65'
+  const realRouter = '0x111111125421ca6dc452d289314280a0f8842a65'
 
   it('REJECTS a non-zero tx.value for a token-source swap (native-value injection)', async () => {
     vi.mocked(queryUrl).mockResolvedValueOnce({
       dstAmount: '1000000',
       tx: {
         from: '0xsender',
-        to: REAL_ROUTER,
+        to: realRouter,
         data: '0xswap',
         value: '1000000000000000000',
         gasPrice: '1',
@@ -243,7 +243,7 @@ describe('getOneInchSwapQuote — token-source tx.value guard (P3 hardening)', (
       dstAmount: '1000000',
       tx: {
         from: '0xsender',
-        to: REAL_ROUTER,
+        to: realRouter,
         data: '0xswap',
         value: '1000000000000000000',
         gasPrice: '1',
@@ -267,23 +267,23 @@ describe('getOneInchSwapQuote — token-source tx.value guard (P3 hardening)', (
 })
 
 describe('getOneInchSwapQuote — known-selector min-out bind', () => {
-  const REAL_ROUTER = '0x111111125421ca6dc452d289314280a0f8842a65'
-  const V6_SWAP = parseAbi([
+  const realRouter = '0x111111125421ca6dc452d289314280a0f8842a65'
+  const v6Swap = parseAbi([
     'function swap(address executor, (address srcToken, address dstToken, address srcReceiver, address dstReceiver, uint256 amount, uint256 minReturnAmount, uint256 flags) desc, bytes data)',
   ])
-  const ZERO = '0x0000000000000000000000000000000000000001' as const
+  const zero = '0x0000000000000000000000000000000000000001' as const
 
   function encodeV6Swap(minReturnAmount: bigint): `0x${string}` {
     return encodeFunctionData({
-      abi: V6_SWAP,
+      abi: v6Swap,
       functionName: 'swap',
       args: [
-        ZERO,
+        zero,
         {
-          srcToken: ZERO,
-          dstToken: ZERO,
-          srcReceiver: ZERO,
-          dstReceiver: ZERO,
+          srcToken: zero,
+          dstToken: zero,
+          srcReceiver: zero,
+          dstReceiver: zero,
           amount: 1_000_000n,
           minReturnAmount,
           flags: 0n,
@@ -298,7 +298,7 @@ describe('getOneInchSwapQuote — known-selector min-out bind', () => {
       dstAmount: '1000000000',
       tx: {
         from: '0xsender',
-        to: REAL_ROUTER,
+        to: realRouter,
         data: encodeV6Swap(1n),
         value: '0',
         gasPrice: '1',
@@ -314,7 +314,7 @@ describe('getOneInchSwapQuote — known-selector min-out bind', () => {
   it('still accepts undecodable calldata (unknown selectors stay signable)', async () => {
     vi.mocked(queryUrl).mockResolvedValueOnce({
       dstAmount: '1000000000',
-      tx: { from: '0xsender', to: REAL_ROUTER, data: '0xdeadbeef', value: '0', gasPrice: '1', gas: 210000 },
+      tx: { from: '0xsender', to: realRouter, data: '0xdeadbeef', value: '0', gasPrice: '1', gas: 210000 },
     })
 
     const quote = await getOneInchSwapQuote({ account, fromCoinId: '0xsrc', toCoinId: '0xdst', amount: 1_000_000n })

--- a/packages/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.test.ts
+++ b/packages/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.test.ts
@@ -258,7 +258,7 @@ describe('getOneInchSwapQuote — token-source tx.value guard (P3 hardening)', (
   it('accepts a zero tx.value for a token-source swap', async () => {
     vi.mocked(queryUrl).mockResolvedValueOnce({
       dstAmount: '1000000',
-      tx: { from: '0xsender', to: REAL_ROUTER, data: '0xswap', value: '0', gasPrice: '1', gas: 210000 },
+      tx: { from: '0xsender', to: realRouter, data: '0xswap', value: '0', gasPrice: '1', gas: 210000 },
     })
 
     const quote = await getOneInchSwapQuote({ account, fromCoinId: '0xsrc', toCoinId: '0xdst', amount: 1_000_000n })

--- a/packages/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.ts
+++ b/packages/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.ts
@@ -14,6 +14,7 @@ import { addQueryParams } from '@vultisig/lib-utils/query/addQueryParams'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
 import { evmNativeCoinAddress } from '../../../../chains/evm/config'
+import { assertOneInchCalldataMinOut } from '../decodeMinReturn'
 
 export type OneInchAffiliateConfig = typeof oneInchAffiliateConfig
 
@@ -119,6 +120,11 @@ export const getOneInchSwapQuote = async ({
       `1inch quote returned a non-zero tx.value (${tx.value}) for a token-source swap on ${chain} — a token swap pulls the sell token via allowance and must not move native value; refusing to sign.`
     )
   }
+
+  // Known-selector min-out bind. Unknown 1inch selectors stay signable so a
+  // router upgrade does not brick honest swaps; a decoded floor below the
+  // requested slippage is refused.
+  assertOneInchCalldataMinOut(tx.data, dstAmount, slippage)
 
   return {
     dstAmount,

--- a/packages/core/chain/swap/general/oneInch/decodeMinReturn.test.ts
+++ b/packages/core/chain/swap/general/oneInch/decodeMinReturn.test.ts
@@ -1,0 +1,71 @@
+import { encodeFunctionData, parseAbi } from 'viem'
+import { describe, expect, it } from 'vitest'
+
+import { assertOneInchCalldataMinOut, decodeOneInchMinReturn, minAcceptableOneInchOut } from './decodeMinReturn'
+
+const V6_SWAP = parseAbi([
+  'function swap(address executor, (address srcToken, address dstToken, address srcReceiver, address dstReceiver, uint256 amount, uint256 minReturnAmount, uint256 flags) desc, bytes data)',
+])
+
+const UNOSWAP = parseAbi(['function unoswap(uint256 token, uint256 amount, uint256 minReturn, uint256 dex)'])
+
+const ZERO = '0x0000000000000000000000000000000000000001'
+
+function encodeV6Swap(minReturnAmount: bigint): `0x${string}` {
+  return encodeFunctionData({
+    abi: V6_SWAP,
+    functionName: 'swap',
+    args: [
+      ZERO,
+      {
+        srcToken: ZERO,
+        dstToken: ZERO,
+        srcReceiver: ZERO,
+        dstReceiver: ZERO,
+        amount: 1_000_000n,
+        minReturnAmount,
+        flags: 0n,
+      },
+      '0x',
+    ],
+  })
+}
+
+describe('decodeOneInchMinReturn', () => {
+  it('reads minReturnAmount from AggregationRouterV6 swap', () => {
+    expect(decodeOneInchMinReturn(encodeV6Swap(995_000n))).toBe(995_000n)
+  })
+
+  it('reads minReturn from unoswap', () => {
+    const data = encodeFunctionData({
+      abi: UNOSWAP,
+      functionName: 'unoswap',
+      args: [1n, 1_000_000n, 990_000n, 0n],
+    })
+    expect(decodeOneInchMinReturn(data)).toBe(990_000n)
+  })
+
+  it('returns undefined for unknown selectors (do not brick production)', () => {
+    expect(decodeOneInchMinReturn('0xdeadbeef')).toBeUndefined()
+    expect(decodeOneInchMinReturn('0xswap')).toBeUndefined()
+    expect(decodeOneInchMinReturn('0x')).toBeUndefined()
+  })
+})
+
+describe('assertOneInchCalldataMinOut', () => {
+  it('refuses a known-selector swap whose minReturn is 1 wei against a 1000 USDC quote', () => {
+    expect(() => assertOneInchCalldataMinOut(encodeV6Swap(1n), '1000000000', 0.5)).toThrow(
+      /minReturn \(1\) is below dstAmount\*\(1-slippage\) floor/
+    )
+  })
+
+  it('accepts a known-selector swap whose minReturn meets the slippage floor', () => {
+    const dstAmount = '1000000000'
+    const floor = minAcceptableOneInchOut(dstAmount, 0.5)
+    expect(() => assertOneInchCalldataMinOut(encodeV6Swap(floor), dstAmount, 0.5)).not.toThrow()
+  })
+
+  it('does not refuse undecodable calldata', () => {
+    expect(() => assertOneInchCalldataMinOut('0xdeadbeef', '1000000000', 0.5)).not.toThrow()
+  })
+})

--- a/packages/core/chain/swap/general/oneInch/decodeMinReturn.test.ts
+++ b/packages/core/chain/swap/general/oneInch/decodeMinReturn.test.ts
@@ -8,8 +8,10 @@ const v6Swap = parseAbi([
 ])
 
 const unoswap = parseAbi(['function unoswap(uint256 token, uint256 amount, uint256 minReturn, uint256 dex)'])
-const unoswapTo = parseAbi(['function unoswapTo(address to, uint256 token, uint256 amount, uint256 minReturn, uint256 dex)'])
-const ethUnoswapTo = parseAbi(['function ethUnoswapTo(address to, uint256 minReturn, uint256 dex)'])
+const unoswapTo = parseAbi([
+  'function unoswapTo(uint256 to, uint256 token, uint256 amount, uint256 minReturn, uint256 dex)',
+])
+const ethUnoswapTo = parseAbi(['function ethUnoswapTo(uint256 to, uint256 minReturn, uint256 dex)'])
 
 const zero = '0x0000000000000000000000000000000000000001'
 
@@ -47,23 +49,23 @@ describe('decodeOneInchMinReturn', () => {
     expect(decodeOneInchMinReturn(data)).toBe(990_000n)
   })
 
-it('reads minReturn from unoswapTo', () => {
-  const data = encodeFunctionData({
-    abi: unoswapTo,
-    functionName: 'unoswapTo',
-    args: [zero, 1n, 1_000_000n, 989_000n, 0n],
+  it('reads minReturn from unoswapTo', () => {
+    const data = encodeFunctionData({
+      abi: unoswapTo,
+      functionName: 'unoswapTo',
+      args: [1n, 1n, 1_000_000n, 989_000n, 0n],
+    })
+    expect(decodeOneInchMinReturn(data)).toBe(989_000n)
   })
-  expect(decodeOneInchMinReturn(data)).toBe(989_000n)
-})
 
-it('reads minReturn from ethUnoswapTo', () => {
-  const data = encodeFunctionData({
-    abi: ethUnoswapTo,
-    functionName: 'ethUnoswapTo',
-    args: [zero, 988_000n, 0n],
+  it('reads minReturn from ethUnoswapTo', () => {
+    const data = encodeFunctionData({
+      abi: ethUnoswapTo,
+      functionName: 'ethUnoswapTo',
+      args: [1n, 988_000n, 0n],
+    })
+    expect(decodeOneInchMinReturn(data)).toBe(988_000n)
   })
-  expect(decodeOneInchMinReturn(data)).toBe(988_000n)
-})
 
   it('returns undefined for unknown selectors (do not brick production)', () => {
     expect(decodeOneInchMinReturn('0xdeadbeef')).toBeUndefined()
@@ -85,27 +87,27 @@ describe('assertOneInchCalldataMinOut', () => {
     expect(() => assertOneInchCalldataMinOut(encodeV6Swap(floor), dstAmount, 0.5)).not.toThrow()
   })
 
-it('refuses a known-selector unoswapTo whose minReturn is below the slippage floor', () => {
-  const data = encodeFunctionData({
-    abi: unoswapTo,
-    functionName: 'unoswapTo',
-    args: [zero, 1n, 1_000_000n, 1n, 0n],
+  it('refuses a known-selector unoswapTo whose minReturn is below the slippage floor', () => {
+    const data = encodeFunctionData({
+      abi: unoswapTo,
+      functionName: 'unoswapTo',
+      args: [1n, 1n, 1_000_000n, 1n, 0n],
+    })
+    expect(() => assertOneInchCalldataMinOut(data, '1000000000', 0.5)).toThrow(
+      /minReturn \(1\) is below dstAmount\*\(1-slippage\) floor/
+    )
   })
-  expect(() => assertOneInchCalldataMinOut(data, '1000000000', 0.5)).toThrow(
-    /minReturn \(1\) is below dstAmount\*\(1-slippage\) floor/
-  )
-})
 
-it('refuses a known-selector ethUnoswapTo whose minReturn is below the slippage floor', () => {
-  const data = encodeFunctionData({
-    abi: ethUnoswapTo,
-    functionName: 'ethUnoswapTo',
-    args: [zero, 1n, 0n],
+  it('refuses a known-selector ethUnoswapTo whose minReturn is below the slippage floor', () => {
+    const data = encodeFunctionData({
+      abi: ethUnoswapTo,
+      functionName: 'ethUnoswapTo',
+      args: [1n, 1n, 0n],
+    })
+    expect(() => assertOneInchCalldataMinOut(data, '1000000000', 0.5)).toThrow(
+      /minReturn \(1\) is below dstAmount\*\(1-slippage\) floor/
+    )
   })
-  expect(() => assertOneInchCalldataMinOut(data, '1000000000', 0.5)).toThrow(
-    /minReturn \(1\) is below dstAmount\*\(1-slippage\) floor/
-  )
-})
 
   it('does not refuse undecodable calldata', () => {
     expect(() => assertOneInchCalldataMinOut('0xdeadbeef', '1000000000', 0.5)).not.toThrow()

--- a/packages/core/chain/swap/general/oneInch/decodeMinReturn.test.ts
+++ b/packages/core/chain/swap/general/oneInch/decodeMinReturn.test.ts
@@ -3,25 +3,27 @@ import { describe, expect, it } from 'vitest'
 
 import { assertOneInchCalldataMinOut, decodeOneInchMinReturn, minAcceptableOneInchOut } from './decodeMinReturn'
 
-const V6_SWAP = parseAbi([
+const v6Swap = parseAbi([
   'function swap(address executor, (address srcToken, address dstToken, address srcReceiver, address dstReceiver, uint256 amount, uint256 minReturnAmount, uint256 flags) desc, bytes data)',
 ])
 
-const UNOSWAP = parseAbi(['function unoswap(uint256 token, uint256 amount, uint256 minReturn, uint256 dex)'])
+const unoswap = parseAbi(['function unoswap(uint256 token, uint256 amount, uint256 minReturn, uint256 dex)'])
+const unoswapTo = parseAbi(['function unoswapTo(address to, uint256 token, uint256 amount, uint256 minReturn, uint256 dex)'])
+const ethUnoswapTo = parseAbi(['function ethUnoswapTo(address to, uint256 minReturn, uint256 dex)'])
 
-const ZERO = '0x0000000000000000000000000000000000000001'
+const zero = '0x0000000000000000000000000000000000000001'
 
 function encodeV6Swap(minReturnAmount: bigint): `0x${string}` {
   return encodeFunctionData({
-    abi: V6_SWAP,
+    abi: v6Swap,
     functionName: 'swap',
     args: [
-      ZERO,
+      zero,
       {
-        srcToken: ZERO,
-        dstToken: ZERO,
-        srcReceiver: ZERO,
-        dstReceiver: ZERO,
+        srcToken: zero,
+        dstToken: zero,
+        srcReceiver: zero,
+        dstReceiver: zero,
         amount: 1_000_000n,
         minReturnAmount,
         flags: 0n,
@@ -38,12 +40,30 @@ describe('decodeOneInchMinReturn', () => {
 
   it('reads minReturn from unoswap', () => {
     const data = encodeFunctionData({
-      abi: UNOSWAP,
+      abi: unoswap,
       functionName: 'unoswap',
       args: [1n, 1_000_000n, 990_000n, 0n],
     })
     expect(decodeOneInchMinReturn(data)).toBe(990_000n)
   })
+
+it('reads minReturn from unoswapTo', () => {
+  const data = encodeFunctionData({
+    abi: unoswapTo,
+    functionName: 'unoswapTo',
+    args: [zero, 1n, 1_000_000n, 989_000n, 0n],
+  })
+  expect(decodeOneInchMinReturn(data)).toBe(989_000n)
+})
+
+it('reads minReturn from ethUnoswapTo', () => {
+  const data = encodeFunctionData({
+    abi: ethUnoswapTo,
+    functionName: 'ethUnoswapTo',
+    args: [zero, 988_000n, 0n],
+  })
+  expect(decodeOneInchMinReturn(data)).toBe(988_000n)
+})
 
   it('returns undefined for unknown selectors (do not brick production)', () => {
     expect(decodeOneInchMinReturn('0xdeadbeef')).toBeUndefined()
@@ -64,6 +84,28 @@ describe('assertOneInchCalldataMinOut', () => {
     const floor = minAcceptableOneInchOut(dstAmount, 0.5)
     expect(() => assertOneInchCalldataMinOut(encodeV6Swap(floor), dstAmount, 0.5)).not.toThrow()
   })
+
+it('refuses a known-selector unoswapTo whose minReturn is below the slippage floor', () => {
+  const data = encodeFunctionData({
+    abi: unoswapTo,
+    functionName: 'unoswapTo',
+    args: [zero, 1n, 1_000_000n, 1n, 0n],
+  })
+  expect(() => assertOneInchCalldataMinOut(data, '1000000000', 0.5)).toThrow(
+    /minReturn \(1\) is below dstAmount\*\(1-slippage\) floor/
+  )
+})
+
+it('refuses a known-selector ethUnoswapTo whose minReturn is below the slippage floor', () => {
+  const data = encodeFunctionData({
+    abi: ethUnoswapTo,
+    functionName: 'ethUnoswapTo',
+    args: [zero, 1n, 0n],
+  })
+  expect(() => assertOneInchCalldataMinOut(data, '1000000000', 0.5)).toThrow(
+    /minReturn \(1\) is below dstAmount\*\(1-slippage\) floor/
+  )
+})
 
   it('does not refuse undecodable calldata', () => {
     expect(() => assertOneInchCalldataMinOut('0xdeadbeef', '1000000000', 0.5)).not.toThrow()

--- a/packages/core/chain/swap/general/oneInch/decodeMinReturn.ts
+++ b/packages/core/chain/swap/general/oneInch/decodeMinReturn.ts
@@ -46,22 +46,24 @@ const oneInchMinReturnDecoders: readonly MinReturnDecoder[] = [
     ]) as Abi,
     pick: args => (typeof args[2] === 'bigint' ? args[2] : undefined),
   },
-{
-  abi: parseAbi(['function unoswapTo(address to, uint256 token, uint256 amount, uint256 minReturn, uint256 dex)']) as Abi,
-  pick: args => (typeof args[3] === 'bigint' ? args[3] : undefined),
-},
-{
-  abi: parseAbi([
-    'function unoswapTo2(address to, uint256 token, uint256 amount, uint256 minReturn, uint256 dex, uint256 dex2)',
-  ]) as Abi,
-  pick: args => (typeof args[3] === 'bigint' ? args[3] : undefined),
-},
-{
-  abi: parseAbi([
-    'function unoswapTo3(address to, uint256 token, uint256 amount, uint256 minReturn, uint256 dex, uint256 dex2, uint256 dex3)',
-  ]) as Abi,
-  pick: args => (typeof args[3] === 'bigint' ? args[3] : undefined),
-},
+  {
+    abi: parseAbi([
+      'function unoswapTo(uint256 to, uint256 token, uint256 amount, uint256 minReturn, uint256 dex)',
+    ]) as Abi,
+    pick: args => (typeof args[3] === 'bigint' ? args[3] : undefined),
+  },
+  {
+    abi: parseAbi([
+      'function unoswapTo2(uint256 to, uint256 token, uint256 amount, uint256 minReturn, uint256 dex, uint256 dex2)',
+    ]) as Abi,
+    pick: args => (typeof args[3] === 'bigint' ? args[3] : undefined),
+  },
+  {
+    abi: parseAbi([
+      'function unoswapTo3(uint256 to, uint256 token, uint256 amount, uint256 minReturn, uint256 dex, uint256 dex2, uint256 dex3)',
+    ]) as Abi,
+    pick: args => (typeof args[3] === 'bigint' ? args[3] : undefined),
+  },
   {
     abi: parseAbi(['function ethUnoswap(uint256 minReturn, uint256 dex)']) as Abi,
     pick: args => (typeof args[0] === 'bigint' ? args[0] : undefined),
@@ -75,15 +77,17 @@ const oneInchMinReturnDecoders: readonly MinReturnDecoder[] = [
     pick: args => (typeof args[0] === 'bigint' ? args[0] : undefined),
   },
   {
-    abi: parseAbi(['function ethUnoswapTo(address to, uint256 minReturn, uint256 dex)']) as Abi,
+    abi: parseAbi(['function ethUnoswapTo(uint256 to, uint256 minReturn, uint256 dex)']) as Abi,
     pick: args => (typeof args[1] === 'bigint' ? args[1] : undefined),
   },
   {
-    abi: parseAbi(['function ethUnoswapTo2(address to, uint256 minReturn, uint256 dex, uint256 dex2)']) as Abi,
+    abi: parseAbi(['function ethUnoswapTo2(uint256 to, uint256 minReturn, uint256 dex, uint256 dex2)']) as Abi,
     pick: args => (typeof args[1] === 'bigint' ? args[1] : undefined),
   },
   {
-    abi: parseAbi(['function ethUnoswapTo3(address to, uint256 minReturn, uint256 dex, uint256 dex2, uint256 dex3)']) as Abi,
+    abi: parseAbi([
+      'function ethUnoswapTo3(uint256 to, uint256 minReturn, uint256 dex, uint256 dex2, uint256 dex3)',
+    ]) as Abi,
     pick: args => (typeof args[1] === 'bigint' ? args[1] : undefined),
   },
 ]

--- a/packages/core/chain/swap/general/oneInch/decodeMinReturn.ts
+++ b/packages/core/chain/swap/general/oneInch/decodeMinReturn.ts
@@ -1,0 +1,109 @@
+import { type Abi, decodeFunctionData, parseAbi } from 'viem'
+
+type MinReturnDecoder = {
+  abi: Abi
+  pick: (args: readonly unknown[]) => bigint | undefined
+}
+
+function pickSwapDescriptionMinReturn(args: readonly unknown[]): bigint | undefined {
+  const desc = args[1]
+  if (Array.isArray(desc) && typeof desc[5] === 'bigint') return desc[5]
+  if (desc && typeof desc === 'object' && 'minReturnAmount' in desc) {
+    const value = (desc as { minReturnAmount: unknown }).minReturnAmount
+    if (typeof value === 'bigint') return value
+  }
+  return undefined
+}
+
+const ONE_INCH_MIN_RETURN_DECODERS: readonly MinReturnDecoder[] = [
+  {
+    // AggregationRouterV6 classic swap
+    abi: parseAbi([
+      'function swap(address executor, (address srcToken, address dstToken, address srcReceiver, address dstReceiver, uint256 amount, uint256 minReturnAmount, uint256 flags) desc, bytes data)',
+    ]) as Abi,
+    pick: pickSwapDescriptionMinReturn,
+  },
+  {
+    // AggregationRouterV5 classic swap (extra permit arg)
+    abi: parseAbi([
+      'function swap(address executor, (address srcToken, address dstToken, address srcReceiver, address dstReceiver, uint256 amount, uint256 minReturnAmount, uint256 flags) desc, bytes permit, bytes data)',
+    ]) as Abi,
+    pick: pickSwapDescriptionMinReturn,
+  },
+  {
+    abi: parseAbi(['function unoswap(uint256 token, uint256 amount, uint256 minReturn, uint256 dex)']) as Abi,
+    pick: args => (typeof args[2] === 'bigint' ? args[2] : undefined),
+  },
+  {
+    abi: parseAbi([
+      'function unoswap2(uint256 token, uint256 amount, uint256 minReturn, uint256 dex, uint256 dex2)',
+    ]) as Abi,
+    pick: args => (typeof args[2] === 'bigint' ? args[2] : undefined),
+  },
+  {
+    abi: parseAbi([
+      'function unoswap3(uint256 token, uint256 amount, uint256 minReturn, uint256 dex, uint256 dex2, uint256 dex3)',
+    ]) as Abi,
+    pick: args => (typeof args[2] === 'bigint' ? args[2] : undefined),
+  },
+  {
+    abi: parseAbi(['function ethUnoswap(uint256 minReturn, uint256 dex)']) as Abi,
+    pick: args => (typeof args[0] === 'bigint' ? args[0] : undefined),
+  },
+  {
+    abi: parseAbi(['function ethUnoswap2(uint256 minReturn, uint256 dex, uint256 dex2)']) as Abi,
+    pick: args => (typeof args[0] === 'bigint' ? args[0] : undefined),
+  },
+  {
+    abi: parseAbi(['function ethUnoswap3(uint256 minReturn, uint256 dex, uint256 dex2, uint256 dex3)']) as Abi,
+    pick: args => (typeof args[0] === 'bigint' ? args[0] : undefined),
+  },
+]
+
+/** Slippage is quoted as a percent (0.5 = 0.5% = 50 bps). */
+export function minAcceptableOneInchOut(dstAmount: string, slippagePercent: number): bigint {
+  const dst = BigInt(dstAmount)
+  if (!Number.isFinite(slippagePercent) || slippagePercent < 0) {
+    throw new Error(`1inch min-out check: invalid slippage percent ${slippagePercent}`)
+  }
+  const bps = BigInt(Math.round(slippagePercent * 100))
+  if (bps >= 10_000n) return 0n
+  return (dst * (10_000n - bps)) / 10_000n
+}
+
+/**
+ * Decode `minReturn` / `minReturnAmount` from known 1inch V5/V6 selectors.
+ * Unknown or undecodable calldata returns `undefined` — callers must not treat
+ * that as a failure (new 1inch selectors would otherwise brick honest swaps).
+ */
+export function decodeOneInchMinReturn(data: string): bigint | undefined {
+  if (typeof data !== 'string' || !data.startsWith('0x') || data.length < 10) return undefined
+
+  for (const decoder of ONE_INCH_MIN_RETURN_DECODERS) {
+    try {
+      const decoded = decodeFunctionData({ abi: decoder.abi, data: data as `0x${string}` })
+      const minReturn = decoder.pick(decoded.args ?? [])
+      if (typeof minReturn === 'bigint') return minReturn
+    } catch {
+      // try the next known selector
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Fail-closed for *known* 1inch selectors: refuse if calldata min-out is below
+ * `dstAmount * (1 - slippage)`. Unknown selectors are left signable.
+ */
+export function assertOneInchCalldataMinOut(data: string, dstAmount: string, slippagePercent: number): void {
+  const decoded = decodeOneInchMinReturn(data)
+  if (decoded === undefined) return
+
+  const floor = minAcceptableOneInchOut(dstAmount, slippagePercent)
+  if (decoded < floor) {
+    throw new Error(
+      `1inch calldata minReturn (${decoded.toString()}) is below dstAmount*(1-slippage) floor (${floor.toString()}); refusing to sign.`
+    )
+  }
+}

--- a/packages/core/chain/swap/general/oneInch/decodeMinReturn.ts
+++ b/packages/core/chain/swap/general/oneInch/decodeMinReturn.ts
@@ -15,7 +15,7 @@ function pickSwapDescriptionMinReturn(args: readonly unknown[]): bigint | undefi
   return undefined
 }
 
-const ONE_INCH_MIN_RETURN_DECODERS: readonly MinReturnDecoder[] = [
+const oneInchMinReturnDecoders: readonly MinReturnDecoder[] = [
   {
     // AggregationRouterV6 classic swap
     abi: parseAbi([
@@ -46,6 +46,22 @@ const ONE_INCH_MIN_RETURN_DECODERS: readonly MinReturnDecoder[] = [
     ]) as Abi,
     pick: args => (typeof args[2] === 'bigint' ? args[2] : undefined),
   },
+{
+  abi: parseAbi(['function unoswapTo(address to, uint256 token, uint256 amount, uint256 minReturn, uint256 dex)']) as Abi,
+  pick: args => (typeof args[3] === 'bigint' ? args[3] : undefined),
+},
+{
+  abi: parseAbi([
+    'function unoswapTo2(address to, uint256 token, uint256 amount, uint256 minReturn, uint256 dex, uint256 dex2)',
+  ]) as Abi,
+  pick: args => (typeof args[3] === 'bigint' ? args[3] : undefined),
+},
+{
+  abi: parseAbi([
+    'function unoswapTo3(address to, uint256 token, uint256 amount, uint256 minReturn, uint256 dex, uint256 dex2, uint256 dex3)',
+  ]) as Abi,
+  pick: args => (typeof args[3] === 'bigint' ? args[3] : undefined),
+},
   {
     abi: parseAbi(['function ethUnoswap(uint256 minReturn, uint256 dex)']) as Abi,
     pick: args => (typeof args[0] === 'bigint' ? args[0] : undefined),
@@ -57,6 +73,18 @@ const ONE_INCH_MIN_RETURN_DECODERS: readonly MinReturnDecoder[] = [
   {
     abi: parseAbi(['function ethUnoswap3(uint256 minReturn, uint256 dex, uint256 dex2, uint256 dex3)']) as Abi,
     pick: args => (typeof args[0] === 'bigint' ? args[0] : undefined),
+  },
+  {
+    abi: parseAbi(['function ethUnoswapTo(address to, uint256 minReturn, uint256 dex)']) as Abi,
+    pick: args => (typeof args[1] === 'bigint' ? args[1] : undefined),
+  },
+  {
+    abi: parseAbi(['function ethUnoswapTo2(address to, uint256 minReturn, uint256 dex, uint256 dex2)']) as Abi,
+    pick: args => (typeof args[1] === 'bigint' ? args[1] : undefined),
+  },
+  {
+    abi: parseAbi(['function ethUnoswapTo3(address to, uint256 minReturn, uint256 dex, uint256 dex2, uint256 dex3)']) as Abi,
+    pick: args => (typeof args[1] === 'bigint' ? args[1] : undefined),
   },
 ]
 
@@ -79,7 +107,7 @@ export function minAcceptableOneInchOut(dstAmount: string, slippagePercent: numb
 export function decodeOneInchMinReturn(data: string): bigint | undefined {
   if (typeof data !== 'string' || !data.startsWith('0x') || data.length < 10) return undefined
 
-  for (const decoder of ONE_INCH_MIN_RETURN_DECODERS) {
+  for (const decoder of oneInchMinReturnDecoders) {
     try {
       const decoded = decodeFunctionData({ abi: decoder.abi, data: data as `0x${string}` })
       const minReturn = decoder.pick(decoded.args ?? [])


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#1438

Added a fail-closed 1inch known-selector min-out bind: decode V5/V6 `swap` / `unoswap*` / `ethUnoswap*` calldata and refuse when `minReturn < dstAmount * (1 - slippage)`. Unknown selectors stay signable so a router upgrade does not brick honest swaps. Wired at `getOneInchSwapQuote` after the existing router + tx.value guards. Blast radius: 1inch quote construction only; Kyber/LiFi calldata is still opaque (per-router ABI decode is a follow-up). Not verified: a live 1inch quote + signed swap.

## what I ran
```
yarn test:core packages/core/chain/swap/general/oneInch/decodeMinReturn.test.ts packages/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.test.ts
 Test Files  2 passed (2)
      Tests  20 passed (20)
   Duration  517ms

yarn tsc --project .config/tsconfig.json --noEmit --pretty false
(exit 0)
```

closes vultisig/vultisig-sdk#1438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added validation for 1inch swap quotes to ensure minimum received amounts meet the requested slippage tolerance.
  - Supports recognized 1inch swap transaction formats while allowing unknown or undecodable calldata to proceed.

- **Bug Fixes**
  - Prevents signing known 1inch swaps when their minimum output falls below the acceptable slippage-adjusted amount.

- **Tests**
  - Added coverage for supported transaction formats, invalid data, boundary values, and rejected minimum outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->