### PR TITLE
fix(sdk-rn): re-export symbols that landed on root but were missed on the RN entry

### DIFF
--- a/.changeset/rn-half-landed-exports.md
+++ b/.changeset/rn-half-landed-exports.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Export the half-landed root symbols from `@vultisig/sdk/react-native` (IBC helpers, native-swap min, StakeKit named helpers, Jupiter constants + lazy builders, lazy Sui token transfer). Root-only vs RN-missing is the worst surface state; this does not decide the remaining draft-PR batch.

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -315,6 +315,21 @@ export { buildCw20TransferMsg } from '../../tools/prep/cw20Transfer'
 // Asset Hub send builder (same hand-curated-allow-list gap as prior prep builders).
 export { POLKADOT_ASSET_HUB_KNOWN_ASSETS, preparePolkadotAssetSend } from '../../tools/prep/polkadotAssetSend'
 export { SUI_NATIVE_COIN_TYPE } from '../../tools/prep/suiTokenTransfer'
+export type { PrepareIbcTransferParams, PrepareIbcTransferResult } from '../../tools/prep/ibcTransfer'
+export {
+  IBC_CHAIN_HRP,
+  IBC_CHAIN_REVISION,
+  IBC_CHANNEL_DEST,
+  IBC_MSG_TRANSFER_TYPE_URL,
+  normaliseIbcChainId,
+  prepareIbcTransfer,
+  supportedIbcDestinationsFrom,
+} from '../../tools/prep/ibcTransfer'
+export type { PrepareSuiTokenTransferFromKeysParams } from '../../tools/prep/suiTokenTransfer'
+export async function prepareSuiTokenTransferFromKeys(...args: unknown[]) {
+  const mod = await import('../../tools/prep/suiTokenTransfer')
+  return mod.prepareSuiTokenTransferFromKeys(...(args as Parameters<typeof mod.prepareSuiTokenTransferFromKeys>))
+}
 export { TRC20_TRANSFER_SELECTOR } from '../../tools/prep/trc20'
 export { CONSOLIDATE_CHAINS } from '../../tools/prep/utxoConsolidate'
 
@@ -477,6 +492,17 @@ export type {
   GlifUnsignedTx,
 } from '../../tools/defi'
 export { buildBalancerV3SwapCalldata, defi } from '../../tools/defi'
+export {
+  buildYieldActionScanRequest,
+  parseActionDisplay,
+  stakekitBalances,
+  stakekitBuildEnter,
+  stakekitBuildExit,
+  stakekitBuildManage,
+  stakekitDetails,
+  stakekitSearch,
+  validateStakekitActionInput,
+} from '../../tools/defi'
 export {
   buildGlifRedeemSticnt,
   buildGlifStakeIcnt,
@@ -765,6 +791,26 @@ export { getThorchainInboundAddress } from '@vultisig/core-chain/chains/cosmos/t
 export * from '@vultisig/core-chain/chains/cosmos/thor/lp'
 export type { GetSwapExplorerUrlInput, SwapExplorerProvider } from '@vultisig/core-chain/swap/utils/getSwapExplorerUrl'
 export { getSwapExplorerUrl, swapExplorerProviders } from '@vultisig/core-chain/swap/utils/getSwapExplorerUrl'
+export {
+  getNativeSwapMinAmountIn,
+  NATIVE_SWAP_MIN_OUTBOUND_FEE_MULTIPLIER,
+} from '@vultisig/core-chain/swap/native/minimum/getNativeSwapMinAmountIn'
+export {
+  JUPITER_AFFILIATE_FEE_ATAS,
+  JUPITER_AFFILIATE_FEE_OWNER,
+  JUPITER_API_BASE_URL,
+  JUPITER_DEFAULT_SLIPPAGE_BPS,
+  JUPITER_PLATFORM_FEE_BPS,
+  SOL_NATIVE_MINT,
+} from '../../tools/swap/jupiterConstants'
+export async function buildJupiterSwapTx(...args: unknown[]) {
+  const mod = await import('../../tools/swap/jupiter')
+  return mod.buildJupiterSwapTx(...(args as Parameters<typeof mod.buildJupiterSwapTx>))
+}
+export async function resolveJupiterFeeAccount(...args: unknown[]) {
+  const mod = await import('../../tools/swap/jupiter')
+  return mod.resolveJupiterFeeAccount(...(args as Parameters<typeof mod.resolveJupiterFeeAccount>))
+}
 export { getBlockExplorerUrl } from '@vultisig/core-chain/utils/getBlockExplorerUrl'
 export async function fiatToAmount(...args: unknown[]) {
   const mod = await import('../../utils/fiatToAmount')

--- a/packages/sdk/src/tools/swap/jupiter.ts
+++ b/packages/sdk/src/tools/swap/jupiter.ts
@@ -34,60 +34,29 @@ import {
   type JupiterFeeAccount,
   prependJupiterFeeAta,
 } from '@vultisig/core-chain/swap/general/jupiter/api/jupiterFeeAta'
-import { jupiterFeeOwnerAddress } from '@vultisig/core-chain/swap/general/jupiter/config'
 import {
   assertJupiterPriceImpactWithinCeiling,
   PriceImpactTooHighError,
 } from '@vultisig/core-chain/swap/general/priceImpactGuard'
+import {
+  JUPITER_AFFILIATE_FEE_OWNER,
+  JUPITER_API_BASE_URL,
+  JUPITER_DEFAULT_SLIPPAGE_BPS,
+  JUPITER_PLATFORM_FEE_BPS,
+  SOL_NATIVE_MINT,
+} from './jupiterConstants'
 
 export { PriceImpactTooHighError }
-
-/** SOL native mint address (used when no SPL token contract is specified). */
-export const SOL_NATIVE_MINT = 'So11111111111111111111111111111111111111112'
-
-/**
- * Treasury OWNER pubkey on Solana. This is NOT the `feeAccount` itself.
- * Jupiter's `feeAccount` field expects an SPL Token ATA derived per output
- * mint and owned by this pubkey.
- *
- * SOL-03 (audit fix): this used to hardcode a DIFFERENT address
- * ('5QXePTia...'), an ad-hoc unblock from a single GitHub comment
- * (vultisig/agent-backend#631, 2026-06-01) that predates and was never
- * reconciled with the later formal cross-platform shared-spec decision
- * (vultisig-ios#4669, vultisig-android#5053, vultisig-sdk#894) which settled
- * on '8iqhrtBz...' and already shipped on iOS/Android main. Re-export the
- * SDK's own general-swap config value so both Jupiter integrations agree.
- */
-export const JUPITER_AFFILIATE_FEE_OWNER = jupiterFeeOwnerAddress
-
-/**
- * Affiliate fee in basis points (50 bps = 0.5%). Mirrors `baseAffiliateBps`
- * and the bps used for THORChain / 1inch / KyberSwap / Skip.
- */
-export const JUPITER_PLATFORM_FEE_BPS = 50
-
-/**
- * Default base URL for Jupiter's V6 swap API. Routed through the Vultisig
- * proxy so rate-limits and observability stay on our side. Overridable per
- * call via the `apiBaseUrl` param.
- */
-export const JUPITER_API_BASE_URL = 'https://api.vultisig.com/jup'
-
-/**
- * Default slippage in basis points (0.5%).
- *
- * SOL-04 (audit fix): this used to be 100 bps, mirroring `recipes/sdk/swap/
- * jupiter.go`'s fallback constant — which itself predates and was never
- * reconciled with the shared cross-platform spec (vultisig-ios#4669) that
- * explicitly settled on 50 bps, matching iOS/Android/the SDK's own
- * general-swap Jupiter path (getJupiterSwapQuote.ts) and 1inch.
- */
-export const JUPITER_DEFAULT_SLIPPAGE_BPS = 50
+export {
+  JUPITER_AFFILIATE_FEE_ATAS,
+  JUPITER_AFFILIATE_FEE_OWNER,
+  JUPITER_API_BASE_URL,
+  JUPITER_DEFAULT_SLIPPAGE_BPS,
+  JUPITER_PLATFORM_FEE_BPS,
+  SOL_NATIVE_MINT,
+} from './jupiterConstants'
 
 const JUPITER_TIMEOUT_MS = 15_000
-
-/** @deprecated Jupiter fee accounts are derived and prepended per swap. */
-export const JUPITER_AFFILIATE_FEE_ATAS: Readonly<Record<string, string>> = {}
 
 /**
  * Resolve the affiliate fee account for a given output mint.

--- a/packages/sdk/src/tools/swap/jupiterConstants.ts
+++ b/packages/sdk/src/tools/swap/jupiterConstants.ts
@@ -1,0 +1,23 @@
+import { jupiterFeeOwnerAddress } from '@vultisig/core-chain/swap/general/jupiter/config'
+
+/** SOL native mint address (used when no SPL token contract is specified). */
+export const SOL_NATIVE_MINT = 'So11111111111111111111111111111111111111112'
+
+/**
+ * Treasury OWNER pubkey on Solana. This is NOT the `feeAccount` itself.
+ * Jupiter's `feeAccount` field expects an SPL Token ATA derived per output
+ * mint and owned by this pubkey.
+ */
+export const JUPITER_AFFILIATE_FEE_OWNER = jupiterFeeOwnerAddress
+
+/** Affiliate fee in basis points (50 bps = 0.5%). */
+export const JUPITER_PLATFORM_FEE_BPS = 50
+
+/** Default base URL for Jupiter's V6 swap API. */
+export const JUPITER_API_BASE_URL = 'https://api.vultisig.com/jup'
+
+/** Default slippage in basis points (0.5%). */
+export const JUPITER_DEFAULT_SLIPPAGE_BPS = 50
+
+/** @deprecated Jupiter fee accounts are derived and prepended per swap. */
+export const JUPITER_AFFILIATE_FEE_ATAS: Readonly<Record<string, string>> = {}

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -367,6 +367,33 @@ describe('RN entry exposes pure chain helpers and registry', () => {
     expect(rn.readNoonVaultState).toBe(noon.readNoonVaultState)
     expect(rn.fetchNoonUsdcVaultMetrics).toBe(noon.fetchNoonUsdcVaultMetrics)
   })
+
+  it('re-exports the half-landed root symbols that were missing from RN', async () => {
+    const rn = await import('../../../../src/platforms/react-native/index')
+    const ibc = await import('../../../../src/tools/prep/ibcTransfer')
+    const nativeMin = await import('@vultisig/core-chain/swap/native/minimum/getNativeSwapMinAmountIn')
+    const jupiterConstants = await import('../../../../src/tools/swap/jupiterConstants')
+    const defi = await import('../../../../src/tools/defi')
+
+    expect(rn.prepareIbcTransfer).toBe(ibc.prepareIbcTransfer)
+    expect(rn.supportedIbcDestinationsFrom).toBe(ibc.supportedIbcDestinationsFrom)
+    expect(rn.IBC_CHAIN_HRP).toBe(ibc.IBC_CHAIN_HRP)
+    expect(rn.normaliseIbcChainId).toBe(ibc.normaliseIbcChainId)
+    expect(typeof rn.prepareSuiTokenTransferFromKeys).toBe('function')
+
+    expect(rn.getNativeSwapMinAmountIn).toBe(nativeMin.getNativeSwapMinAmountIn)
+    expect(rn.NATIVE_SWAP_MIN_OUTBOUND_FEE_MULTIPLIER).toBe(nativeMin.NATIVE_SWAP_MIN_OUTBOUND_FEE_MULTIPLIER)
+
+    expect(rn.JUPITER_AFFILIATE_FEE_OWNER).toBe(jupiterConstants.JUPITER_AFFILIATE_FEE_OWNER)
+    expect(rn.SOL_NATIVE_MINT).toBe(jupiterConstants.SOL_NATIVE_MINT)
+    expect(typeof rn.buildJupiterSwapTx).toBe('function')
+    expect(typeof rn.resolveJupiterFeeAccount).toBe('function')
+
+    expect(rn.stakekitSearch).toBe(defi.stakekitSearch)
+    expect(rn.stakekitDetails).toBe(defi.stakekitDetails)
+    expect(rn.stakekitBuildEnter).toBe(defi.stakekitBuildEnter)
+    expect(rn.validateStakekitActionInput).toBe(defi.validateStakekitActionInput)
+  })
 })
 
 // Same parity guard for the hardened human-amount -> base-units parser: the RN


### PR DESCRIPTION
Closes vultisig/vultisig-sdk#1711

Did not unilaterally close or squash the remaining ~17 draft PRs. Fixed the worst state: symbols already on the root entry but missing from RN (`prepareIbcTransfer` + IBC tables, `getNativeSwapMinAmountIn`, StakeKit named helpers, Jupiter constants, lazy `prepareSuiTokenTransferFromKeys` / `buildJupiterSwapTx`). Jupiter functions stay lazy so `@solana/web3.js` does not land in the eager RN graph. Remaining not-landed-at-all draft PRs still need a human batch-or-close call.

## what I ran
```
yarn workspace @vultisig/sdk exec vitest run --config tests/unit/vitest.config.ts tests/unit/platforms/react-native/entry.test.ts
 Test Files  1 passed (1)
      Tests  47 passed (47)
   Duration  4.63s

yarn tsc --project .config/tsconfig.json --noEmit --pretty false
(exit 0)
```

closes vultisig/vultisig-sdk#1711