### PR TITLE
Add canonical IBC ACK-poller route helpers

### DIFF
--- a/.changeset/ibc-ack-poller-routes.md
+++ b/.changeset/ibc-ack-poller-routes.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+Expose the canonical direct-IBC ACK-poller route helpers on the SDK root and React Native entrypoint.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -771,6 +771,8 @@ export {
   getCosmosBalance,
   getCosmosSwapGasLimit,
   getEvmBalances,
+  getIbcCounterpartyChannel,
+  getIbcDestinationChainId,
   getMaxSendAmountFromKeys,
   getNativeSwapDecimals,
   getNativeSwapMinAmountIn,

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -242,6 +242,20 @@ export {
 export type { BuildCosmosWasmExecuteMsgParams, CosmWasmExecuteFund } from '../../tools/prep/cosmosWasmExecute'
 export { buildCosmosWasmExecuteMsg } from '../../tools/prep/cosmosWasmExecute'
 export { buildCw20TransferMsg } from '../../tools/prep/cw20Transfer'
+// Canonical direct-IBC route helpers/tables (pure bech32 + const lookups).
+// Keep this RN allow-list in parity with the root entry so app-side ACK polling
+// can import the reviewed route metadata instead of re-declaring it locally.
+export {
+  getIbcCounterpartyChannel,
+  getIbcDestinationChainId,
+  IBC_CHAIN_HRP,
+  IBC_CHAIN_REVISION,
+  IBC_CHANNEL_DEST,
+  IBC_MSG_TRANSFER_TYPE_URL,
+  normaliseIbcChainId,
+  prepareIbcTransfer,
+  supportedIbcDestinationsFrom,
+} from '../../tools/prep/ibcTransfer'
 // `preparePolkadotAssetSend` is pure-crypto (@polkadot/util + @polkadot/util-crypto,
 // both RN-safe) with no MPC/wasm dependency, so it ships as a static re-export
 // rather than a lazy `await import(...)` wrapper. `POLKADOT_ASSET_HUB_KNOWN_ASSETS`

--- a/packages/sdk/src/tools/index.ts
+++ b/packages/sdk/src/tools/index.ts
@@ -348,6 +348,8 @@ export {
   type CosmosStakingMsgEnvelope,
   type CosmWasmExecuteFund,
   type DelegateParams,
+  getIbcCounterpartyChannel,
+  getIbcDestinationChainId,
   getMaxSendAmountFromKeys,
   type GetMaxSendAmountFromKeysParams,
   IBC_CHAIN_HRP,

--- a/packages/sdk/src/tools/prep/ibcTransfer.ts
+++ b/packages/sdk/src/tools/prep/ibcTransfer.ts
@@ -98,6 +98,7 @@ export const IBC_CHANNEL_DEST: Record<ChannelKey, string> = {
   'osmosis-1/channel-6994': 'celestia',
   // cosmoshub-4 outbound
   'cosmoshub-4/channel-141': 'osmosis-1',
+  'cosmoshub-4/channel-536': 'noble-1',
 }
 
 /**
@@ -130,6 +131,44 @@ export function supportedIbcDestinationsFrom(fromChain: string): string[] {
     .filter(routeKey => routeKey.startsWith(`${fromChain}→`))
     .map(routeKey => routeKey.split('→')[1]!)
     .sort()
+}
+
+const IBC_COUNTERPARTY_CHANNEL_BY_ROUTE: Record<ChannelKey, string> = {
+  'osmosis-1/channel-0': 'channel-141',
+  'osmosis-1/channel-42': 'channel-0',
+  'osmosis-1/channel-750': 'channel-1',
+  'osmosis-1/channel-341': 'channel-26',
+  'osmosis-1/channel-1': 'channel-9',
+  'osmosis-1/channel-6787': 'channel-3',
+  'osmosis-1/channel-208': 'channel-3',
+  'osmosis-1/channel-259': 'channel-3',
+  'osmosis-1/channel-874': 'channel-10',
+  'osmosis-1/channel-122': 'channel-8',
+  'osmosis-1/channel-326': 'channel-5',
+  'osmosis-1/channel-6994': 'channel-2',
+  'cosmoshub-4/channel-141': 'channel-0',
+  'cosmoshub-4/channel-536': 'channel-4',
+  'phoenix-1/channel-1': 'channel-251',
+  'columbus-5/channel-1': 'channel-72',
+}
+
+for (const routeKey of Object.keys(IBC_COUNTERPARTY_CHANNEL_BY_ROUTE) as ChannelKey[]) {
+  if (!(routeKey in IBC_CHANNEL_DEST)) {
+    throw new Error(
+      `IBC_COUNTERPARTY_CHANNEL_BY_ROUTE["${routeKey}"] has no matching destination route in IBC_CHANNEL_DEST; ` +
+        `add the destination mapping before shipping.`,
+    )
+  }
+}
+
+/** ACK-poller counterparty channel for a verified outbound IBC route, or null. */
+export function getIbcCounterpartyChannel(fromChainId: string, sourceChannel: string): string | null {
+  return IBC_COUNTERPARTY_CHANNEL_BY_ROUTE[`${fromChainId}/${sourceChannel}` as ChannelKey] ?? null
+}
+
+/** ACK-poller destination chain-id for a verified outbound IBC route, or null. */
+export function getIbcDestinationChainId(fromChainId: string, sourceChannel: string): string | null {
+  return IBC_CHANNEL_DEST[`${fromChainId}/${sourceChannel}` as ChannelKey] ?? null
 }
 
 // ── chain name aliases ──────────────────────────────────────────────────────

--- a/packages/sdk/src/tools/prep/index.ts
+++ b/packages/sdk/src/tools/prep/index.ts
@@ -19,6 +19,8 @@ export {
 } from './cosmosWasmExecute'
 export { buildCw20TransferMsg, type BuildCw20TransferMsgParams, type BuildCw20TransferMsgResult } from './cw20Transfer'
 export {
+  getIbcCounterpartyChannel,
+  getIbcDestinationChainId,
   IBC_CHAIN_HRP,
   IBC_CHAIN_REVISION,
   IBC_CHANNEL_DEST,

--- a/packages/sdk/tests/unit/cosmos/ibcTransfer.test.ts
+++ b/packages/sdk/tests/unit/cosmos/ibcTransfer.test.ts
@@ -10,6 +10,8 @@ import { bech32 } from '@scure/base'
 import { describe, expect, it } from 'vitest'
 
 import {
+  getIbcCounterpartyChannel,
+  getIbcDestinationChainId,
   IBC_MSG_TRANSFER_TYPE_URL,
   normaliseIbcChainId,
   prepareIbcTransfer,
@@ -27,6 +29,29 @@ const COSMOS = addr('cosmos')
 const TERRA = addr('terra')
 // 2026-07-01T00:00:00Z, comfortably in the future for timeout checks.
 const FIXED_NOW = 1782604800000
+
+describe('IBC ACK-poller route helpers', () => {
+  it('returns the verified destination chain-id for supported source channels', () => {
+    expect(getIbcDestinationChainId('osmosis-1', 'channel-750')).toBe('noble-1')
+    expect(getIbcDestinationChainId('cosmoshub-4', 'channel-536')).toBe('noble-1')
+    expect(getIbcDestinationChainId('phoenix-1', 'channel-1')).toBe('osmosis-1')
+    expect(getIbcDestinationChainId('columbus-5', 'channel-1')).toBe('osmosis-1')
+  })
+
+  it('returns the verified counterparty channel for supported source channels', () => {
+    expect(getIbcCounterpartyChannel('osmosis-1', 'channel-750')).toBe('channel-1')
+    expect(getIbcCounterpartyChannel('cosmoshub-4', 'channel-536')).toBe('channel-4')
+    expect(getIbcCounterpartyChannel('phoenix-1', 'channel-1')).toBe('channel-251')
+    expect(getIbcCounterpartyChannel('columbus-5', 'channel-1')).toBe('channel-72')
+  })
+
+  it('fails closed for unknown source-chain/channel pairs', () => {
+    expect(getIbcDestinationChainId('osmosis-1', 'channel-999999')).toBeNull()
+    expect(getIbcCounterpartyChannel('osmosis-1', 'channel-999999')).toBeNull()
+    expect(getIbcDestinationChainId('unknown-chain', 'channel-1')).toBeNull()
+    expect(getIbcCounterpartyChannel('unknown-chain', 'channel-1')).toBeNull()
+  })
+})
 
 describe('prepareIbcTransfer', () => {
   it('builds an OSMO→cosmoshub-4 MsgTransfer with channel reverse-resolved from toChainId', () => {

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -119,6 +119,20 @@ describe('RN entry wires configureCrypto and configureDefaultStorage', () => {
       rn.Chain.Dash,
     ])
   })
+
+  it('exports the canonical IBC route helper family from the RN entry', async () => {
+    const rn = await import('../../../../src/platforms/react-native/index')
+
+    expect(rn.IBC_CHAIN_HRP['osmosis-1']).toBe('osmo')
+    expect(rn.IBC_CHAIN_REVISION['cosmoshub-4']).toBe(4)
+    expect(rn.IBC_CHANNEL_DEST['cosmoshub-4/channel-536']).toBe('noble-1')
+    expect(rn.IBC_MSG_TRANSFER_TYPE_URL).toBe('/ibc.applications.transfer.v1.MsgTransfer')
+    expect(rn.normaliseIbcChainId('Osmosis')).toBe('osmosis-1')
+    expect(rn.supportedIbcDestinationsFrom('cosmoshub-4')).toEqual(['noble-1', 'osmosis-1'])
+    expect(rn.getIbcDestinationChainId('cosmoshub-4', 'channel-536')).toBe('noble-1')
+    expect(rn.getIbcCounterpartyChannel('cosmoshub-4', 'channel-536')).toBe('channel-4')
+    expect(typeof rn.prepareIbcTransfer).toBe('function')
+  })
 })
 
 // RN-entry parity guard: the root barrel (packages/sdk/src/index.ts, resolved


### PR DESCRIPTION
## Summary
- add canonical direct-IBC ACK-poller helpers to `@vultisig/sdk`
- expose the IBC helper family on the React Native entrypoint
- add focused unit coverage for the new route helpers and RN exports

## What changed
- added `getIbcCounterpartyChannel(fromChainId, sourceChannel)`
- added `getIbcDestinationChainId(fromChainId, sourceChannel)`
- synced the verified direct-route table with the app-side validator by adding `cosmoshub-4/channel-536 -> noble-1`
- re-exported the new helpers from `tools/prep`, `tools`, the root SDK surface, and the RN entrypoint
- added a changeset for the public API addition

## Receipts
### Focused tests
```bash
yarn workspace @vultisig/sdk vitest run --config tests/unit/vitest.config.ts tests/unit/cosmos/ibcTransfer.test.ts tests/unit/platforms/react-native/entry.test.ts
```
- pass: `Test Files  2 passed (2)`
- pass: `Tests  30 passed (30)`

### Typecheck
```bash
yarn workspace @vultisig/sdk typecheck
```
- pass

### RN bundle build
```bash
yarn workspace @vultisig/sdk build:platform:react-native
```
- pass: created `./dist/index.react-native.js`

### Root runtime import smoke
```bash
node --input-type=module -e "import('./packages/sdk/dist/index.node.esm.js').then((m) => { console.log(JSON.stringify({ rootCounterparty: m.getIbcCounterpartyChannel('cosmoshub-4','channel-536'), rootDestination: m.getIbcDestinationChainId('cosmoshub-4','channel-536') })) })"
```
- output: `{"rootCounterparty":"channel-4","rootDestination":"noble-1"}`

### RN runtime smoke blocker
I also tried a direct Node import smoke for `dist/index.react-native.js`, but that runtime requires RN/expo deps that are not present in plain Node:

```text
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'expo-crypto' imported from .../packages/sdk/dist/index.react-native.js
```

The RN entry export coverage is therefore verified by the dedicated unit test instead.

## Tracking
- closes #2123
- report mirror: https://gist.github.com/gomesalexandre/b45457199ce01ab811d277a07c4d296b
- I did **not** touch `mcp-ts`.
- This is additive / low-risk: pure lookup helpers plus re-exports/tests only.
