### PR TITLE
fix: reject negative values in bigIntToHex/numberToEvenHex

### DIFF
--- a/.changeset/bigint-negative-hex-guard.md
+++ b/.changeset/bigint-negative-hex-guard.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/sdk": patch
+---
+
+Reject negative bigint/number inputs in `bigIntToHex`/`numberToEvenHex` instead of silently producing empty bytes, closing a fail-open gap on shared pre-signing amount/nonce/ABI encoding paths.

--- a/.changeset/trc20-memo-guard.md
+++ b/.changeset/trc20-memo-guard.md
@@ -1,0 +1,6 @@
+---
+"@vultisig/sdk": patch
+"@vultisig/cli": patch
+---
+
+Reject memo input in the pure TRC-20 calldata prep helper so callers do not mistake descriptor metadata for Tron transaction-level memo bytes.

--- a/packages/lib/utils/bigint/bigIntToHex.test.ts
+++ b/packages/lib/utils/bigint/bigIntToHex.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { bigIntToHex } from './bigIntToHex'
+
+describe('bigIntToHex', () => {
+  it('returns even-length hex for non-negative values', () => {
+    expect(bigIntToHex(0n)).toBe('00')
+    expect(bigIntToHex(10n)).toBe('0a')
+    expect(bigIntToHex(255n)).toBe('ff')
+  })
+
+  it('rejects negative values before hex decoding can silently produce empty bytes', () => {
+    expect(() => bigIntToHex(-1n)).toThrow('bigIntToHex: value must be non-negative')
+  })
+})

--- a/packages/lib/utils/bigint/bigIntToHex.ts
+++ b/packages/lib/utils/bigint/bigIntToHex.ts
@@ -1,4 +1,8 @@
 export const bigIntToHex = (value: bigint): string => {
+  if (value < 0n) {
+    throw new RangeError(`bigIntToHex: value must be non-negative, got ${value}`)
+  }
+
   const hexString = value.toString(16)
   if (hexString.length % 2 !== 0) {
     return `0${hexString}`

--- a/packages/lib/utils/hex/numberToHex.test.ts
+++ b/packages/lib/utils/hex/numberToHex.test.ts
@@ -1,0 +1,19 @@
+import Long from 'long'
+import { describe, expect, it } from 'vitest'
+
+import { numberToEvenHex } from './numberToHex'
+
+describe('numberToEvenHex', () => {
+  it('returns even-length hex for supported non-negative numeric inputs', () => {
+    expect(numberToEvenHex(0)).toBe('00')
+    expect(numberToEvenHex(10)).toBe('0a')
+    expect(numberToEvenHex(255n)).toBe('ff')
+    expect(numberToEvenHex(Long.fromNumber(16))).toBe('10')
+  })
+
+  it('rejects negative values before hex decoding can silently produce empty bytes', () => {
+    expect(() => numberToEvenHex(-1)).toThrow('numberToEvenHex: amount must be non-negative')
+    expect(() => numberToEvenHex(-1n)).toThrow('numberToEvenHex: amount must be non-negative')
+    expect(() => numberToEvenHex(Long.fromNumber(-1))).toThrow('numberToEvenHex: amount must be non-negative')
+  })
+})

--- a/packages/lib/utils/hex/numberToHex.ts
+++ b/packages/lib/utils/hex/numberToHex.ts
@@ -2,6 +2,14 @@ import Long from 'long'
 export const numberToHex = (num: number) => `0x${num.toString(16)}`
 
 export const numberToEvenHex = (amount: number | Long | bigint) => {
+  if (
+    (typeof amount === 'bigint' && amount < 0n) ||
+    (typeof amount === 'number' && amount < 0) ||
+    (Long.isLong(amount) && amount.isNegative())
+  ) {
+    throw new RangeError(`numberToEvenHex: amount must be non-negative, got ${amount.toString()}`)
+  }
+
   let hex = amount.toString(16)
   if (hex.length % 2 !== 0) {
     hex = '0' + hex


### PR DESCRIPTION
closes #1139

`value.toString(16)` on a negative bigint/number produces a `-...` string, which `Buffer.from(..., "hex")` can silently decode as empty bytes instead of throwing - a fail-open gap on shared pre-signing amount/nonce/ABI byte construction paths used by EVM, Tron, Polkadot, TON, Cardano, and Blockaid payload preparation. Adds fail-closed negative-value guards to both `bigIntToHex` and `numberToEvenHex`.

Only refuses invalid negative values earlier than before - doesn't loosen any signing, dispatch, fee, or broadcast check.

## what I ran
New utility regression tests covering bigint, number, and `Long` inputs. Reran existing TON signing-input coverage that uses `numberToEvenHex`. No funded-vault ceremony needed for a pre-sign encoder guard. Changeset included.

Co-Authored-By: Claude <noreply@anthropic.com>