### PR TITLE
fix: dust-floor check on buildUtxoSendTx primary output

### DIFF
--- a/.changeset/utxo-primary-dust-floor.md
+++ b/.changeset/utxo-primary-dust-floor.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/sdk": patch
+---
+
+Add a dust-floor check on the primary output amount in `buildUtxoSendTx`, failing closed before address decoding, fee calculation, or an MPC signing ceremony instead of only at broadcast.

--- a/packages/sdk/src/chains/utxo/tx.dustLimit.test.ts
+++ b/packages/sdk/src/chains/utxo/tx.dustLimit.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from 'vitest'
 
-import { getUtxoChainSpec } from './tx'
+import { buildUtxoSendTx, getUtxoChainSpec } from './tx'
+
+const COMPRESSED_PUBKEY = Uint8Array.from(
+  '02'
+    .concat('aa'.repeat(32))
+    .match(/.{2}/g)!
+    .map(b => parseInt(b, 16))
+)
+
+const BTC_ADDRESS = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4'
 
 // UTXO-02 (audit r2): the sdk keeps its OWN per-chain dustLimit map (UTXO_SPECS) separate from core's
 // minUtxo. Both must carry the corrected Litecoin P2WPKH dust — the shared standard 2_940n litoshi (LTC's
@@ -24,5 +33,19 @@ describe('getUtxoChainSpec — Litecoin dust threshold (UTXO-02)', () => {
 
   it('leaves Bitcoin unchanged', () => {
     expect(getUtxoChainSpec('Bitcoin').dustLimit).toBe(546n)
+  })
+
+  it('rejects primary send outputs at or below the chain dust threshold', () => {
+    expect(() =>
+      buildUtxoSendTx({
+        chain: 'Bitcoin',
+        fromAddress: BTC_ADDRESS,
+        toAddress: BTC_ADDRESS,
+        amount: getUtxoChainSpec('Bitcoin').dustLimit,
+        utxos: [{ hash: '11'.repeat(32), index: 0, value: 100_000n }],
+        feeRate: 1,
+        compressedPubKey: COMPRESSED_PUBKEY,
+      })
+    ).toThrow('amount is dust for Bitcoin: amount=546 dustLimit=546')
   })
 })

--- a/packages/sdk/src/chains/utxo/tx.ts
+++ b/packages/sdk/src/chains/utxo/tx.ts
@@ -879,6 +879,11 @@ export function buildUtxoSendTx(opts: BuildUtxoSendOptions): UtxoTxBuilderResult
   const inputs = opts.utxos
   if (inputs.length === 0) throw new Error('no UTXOs provided')
   if (opts.amount <= 0n) throw new Error('amount must be greater than zero')
+  if (opts.amount <= spec.dustLimit) {
+    throw new Error(
+      `amount is dust for ${opts.chain}: amount=${opts.amount} dustLimit=${spec.dustLimit}. Send amount must be greater than dustLimit.`
+    )
+  }
 
   const inputTotal = inputs.reduce((s, u) => s + u.value, 0n)
 


### PR DESCRIPTION
closes #1137

`dustLimit` only gated the change output, never the primary send `opts.amount` - a dust-amount send would burn a full MPC signing ceremony before failing at broadcast as a non-standard output. Adds a primary-output dust check using the same `amount <= dustLimit` threshold semantics already used to suppress dust change outputs.

Fund-adjacent (affects unsigned tx construction before MPC signing) but fail-closed only: dust sends now fail before address decoding, fee calculation, preimage construction, or any signing ceremony; valid non-dust sends are unchanged.

## what I ran
New boundary test at `amount === dustLimit` for Bitcoin, plus the existing UTXO coin-selection/builder agreement suite. Project-wide `tsc` couldn't complete in this worktree - missing unrelated `koffi` dependency required by `packages/sdk/src/platforms/node/fileLock.ts`, not touched by this PR. Changeset included.

Co-Authored-By: Claude <noreply@anthropic.com>