### PR TITLE
fix(mpc): bound Long.fromString to reject out-of-range transfer amounts

### DIFF
--- a/.changeset/bounded-long-fromstring.md
+++ b/.changeset/bounded-long-fromstring.md
@@ -1,0 +1,5 @@
+---
+"@vultisig/sdk": patch
+---
+
+Route Sui/Tron/Ripple/Cardano signing-input uint64 fields through a bounded `Long.fromString` helper that rejects negative, fractional, or out-of-64-bit-range values instead of silently two's-complement wrapping them before MPC signing.

--- a/packages/core/mpc/keysign/signingInputs/long.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/long.test.ts
@@ -1,0 +1,24 @@
+import Long from 'long'
+import { describe, expect, it } from 'vitest'
+
+import { unsignedLongFromString } from './long'
+
+const uint64Max = '18446744073709551615'
+const uint64Overflow = '18446744073709551616'
+
+describe('unsignedLongFromString', () => {
+  it('preserves uint64 values above signed int64', () => {
+    expect(unsignedLongFromString('9223372036854775808', 'amount').toString()).toBe('9223372036854775808')
+    expect(unsignedLongFromString(uint64Max, 'amount').toString()).toBe(uint64Max)
+  })
+
+  it('rejects values that long would otherwise wrap', () => {
+    expect(Long.fromString(uint64Overflow, true).toString()).toBe('0')
+    expect(() => unsignedLongFromString(uint64Overflow, 'amount')).toThrow('amount exceeds uint64')
+  })
+
+  it('rejects signed and fractional decimal strings', () => {
+    expect(() => unsignedLongFromString('-1', 'amount')).toThrow('amount must be a non-negative integer')
+    expect(() => unsignedLongFromString('1.5', 'amount')).toThrow('amount must be a non-negative integer')
+  })
+})

--- a/packages/core/mpc/keysign/signingInputs/long.ts
+++ b/packages/core/mpc/keysign/signingInputs/long.ts
@@ -1,0 +1,19 @@
+import Long from 'long'
+
+const uint64Max = (1n << 64n) - 1n
+const unsignedDecimalRegex = /^\d+$/
+
+export const unsignedLongFromString = (value: string | number | bigint, fieldName: string): Long => {
+  const decimal = value.toString()
+
+  if (!unsignedDecimalRegex.test(decimal)) {
+    throw new Error(`${fieldName} must be a non-negative integer`)
+  }
+
+  const parsed = BigInt(decimal)
+  if (parsed > uint64Max) {
+    throw new Error(`${fieldName} exceeds uint64`)
+  }
+
+  return Long.fromString(decimal, true)
+}

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cardano.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cardano.test.ts
@@ -84,6 +84,7 @@ const EXPECTED_TOKEN_AWARE_PRE_IMAGE_HASH = '839ae494ce1af23729a8e918c2d63febb68
 // What the pre-fix (token-blind) SDK derived from the same payload — pinned to
 // document the exact divergence that made iOS↔SDK keysign fail to converge.
 const TOKEN_BLIND_PRE_IMAGE_HASH = 'db6bde29ccda113233a4ac6bc668fd14ad114ca013698948cfe0d7aa818b7903'
+const UINT64_OVERFLOW = 18446744073709551616n
 
 describe('getCardanoSigningInputs — per-UTXO native tokens', () => {
   let walletCore: WalletCore
@@ -181,6 +182,15 @@ describe('getCardanoSigningInputs — per-UTXO native tokens', () => {
 
     // Token-free UTXOs stay without a token_amount entry, matching iOS.
     expect(plainUtxo.tokenAmount ?? []).toHaveLength(0)
+  })
+
+  it('rejects UTXO amounts above uint64 instead of wrapping them', () => {
+    const payload = buildPayload({ withTokens: false })
+    payload.utxoInfo[0].amount = UINT64_OVERFLOW
+
+    expect(() => getCardanoSigningInputs({ keysignPayload: payload, walletCore })).toThrow(
+      'Cardano UTXO amount exceeds uint64'
+    )
   })
 
   it('pins the golden pre-image hash for the token-carrying fixture', async () => {

--- a/packages/core/mpc/keysign/signingInputs/resolvers/cardano.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/cardano.ts
@@ -4,10 +4,10 @@ import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { bigIntSum } from '@vultisig/lib-utils/bigint/bigIntSum'
 import { stripHexPrefix } from '@vultisig/lib-utils/hex/stripHexPrefix'
 import { TW } from '@trustwallet/wallet-core'
-import Long from 'long'
 
 import { getBlockchainSpecificValue } from '../../chainSpecific/KeysignChainSpecific'
 import { buildCip20AuxData } from '../../../tx/compile/cardano/buildCip20AuxData'
+import { unsignedLongFromString } from '../long'
 import { SigningInputsResolver } from '../resolver'
 
 /** Encodes a token amount as big-endian bytes for WalletCore's Cardano proto. */
@@ -63,21 +63,21 @@ export const getCardanoSigningInputs: SigningInputsResolver<'cardano'> = ({ keys
     transferMessage: TW.Cardano.Proto.Transfer.create({
       toAddress: keysignPayload.toAddress,
       changeAddress: coin.address,
-      amount: Long.fromString(sendAmount.toString()),
+      amount: unsignedLongFromString(sendAmount, 'Cardano transfer amount'),
       useMaxAmount: false,
       tokenAmount: tokenBundle,
-      forceFee: Long.fromString(byteFee.toString()),
+      forceFee: unsignedLongFromString(byteFee, 'Cardano force fee'),
     }),
-    ttl: Long.fromString(ttl.toString()),
+    ttl: unsignedLongFromString(ttl, 'Cardano ttl'),
     auxiliaryData,
 
     utxos: keysignPayload.utxoInfo.map(({ hash, amount, index, cardanoTokens }) =>
       TW.Cardano.Proto.TxInput.create({
         outPoint: TW.Cardano.Proto.OutPoint.create({
           txHash: walletCore.HexCoding.decode(stripHexPrefix(hash)),
-          outputIndex: Long.fromString(index.toString()),
+          outputIndex: unsignedLongFromString(index, 'Cardano output index'),
         }),
-        amount: Long.fromString(amount.toString()),
+        amount: unsignedLongFromString(amount, 'Cardano UTXO amount'),
         address: coin.address,
         // Per-UTXO native assets, read verbatim off the keysign wire (the
         // initiator attached them). Without these WalletCore's planner cannot

--- a/packages/core/mpc/keysign/signingInputs/resolvers/ripple.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/ripple.test.ts
@@ -26,6 +26,7 @@ const walletCore = {} as unknown as WalletCore
 
 const ACCOUNT = 'rExampleAccountAddressForTests1234567'
 const RLUSD_ISSUER = 'rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De'
+const UINT64_OVERFLOW = '18446744073709551616'
 // Dummy 33-byte secp256k1 public key (hex) for getKeysignTwPublicKey.
 const HEX_PUBLIC_KEY = `02${'ab'.repeat(32)}`
 
@@ -151,6 +152,15 @@ describe('getRippleSigningInputs -- TrustSet build path (issued currency)', () =
 
     expect(input.opPayment).toBeTruthy()
     expect(input.opTrustSet).toBeFalsy()
+  })
+
+  it('rejects native payment amounts above uint64 instead of wrapping them', () => {
+    const payload = buildPaymentPayload()
+    payload.toAmount = UINT64_OVERFLOW
+
+    expect(() => getRippleSigningInputs({ keysignPayload: payload, walletCore })).toThrow(
+      'Ripple payment amount exceeds uint64'
+    )
   })
 
   it('uses the first-class destination tag when no independent memo is supplied', async () => {

--- a/packages/core/mpc/keysign/signingInputs/resolvers/ripple.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/ripple.ts
@@ -14,6 +14,7 @@ import { getBlockchainSpecificValue } from '../../chainSpecific/KeysignChainSpec
 import { getKeysignTwPublicKey } from '../../tw/getKeysignTwPublicKey'
 import { isRippleTrustSet } from '../../utils/isRippleTrustSet'
 import { getLegacyDestinationTag, resolveDestinationTag } from '../../utils/rippleDestinationTag'
+import { unsignedLongFromString } from '../long'
 import { SigningInputsResolver } from '../resolver'
 
 // tfPartialPayment on an XRPL Payment. It redefines `Amount` from a guaranteed
@@ -279,7 +280,7 @@ export const getRippleSigningInputs: SigningInputsResolver<'ripple'> = ({ keysig
     return {
       opPayment: TW.Ripple.Proto.OperationPayment.create({
         destination: keysignPayload.toAddress,
-        amount: Long.fromString(keysignPayload.toAmount),
+        amount: unsignedLongFromString(keysignPayload.toAmount, 'Ripple payment amount'),
         ...(destinationTag === undefined ? {} : { destinationTag: Long.fromNumber(destinationTag) as any }),
       }),
     }
@@ -287,7 +288,7 @@ export const getRippleSigningInputs: SigningInputsResolver<'ripple'> = ({ keysig
 
   const input = TW.Ripple.Proto.SigningInput.create({
     account,
-    fee: Long.fromString(gas.toString()),
+    fee: unsignedLongFromString(gas, 'Ripple fee'),
     sequence: Number(sequence),
     lastLedgerSequence: Number(lastLedgerSequence),
     publicKey: getKeysignTwPublicKey(keysignPayload),

--- a/packages/core/mpc/keysign/signingInputs/resolvers/sui.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/sui.test.ts
@@ -31,6 +31,7 @@ const UNSIGNED_TX_MSG =
 const hex = (bytes: Uint8Array) => Buffer.from(bytes).toString('hex')
 const SUI_TYPE = '0x2::sui::SUI'
 const TOKEN_TYPE = '0xabc::coin::USDC'
+const UINT64_OVERFLOW = '18446744073709551616'
 
 let walletCore: WalletCore
 let publicKey: PublicKey
@@ -190,6 +191,31 @@ describe('getSuiSigningInputs — native send', () => {
 
     expect(input.paySui).toBeDefined()
     expect(input.paySui?.inputCoins?.map(c => c.objectId)).toEqual(['covering'])
+  })
+
+  it('rejects transfer amounts above uint64 instead of wrapping them', () => {
+    const keysignPayload = create(KeysignPayloadSchema, {
+      coin: create(CoinSchema, {
+        chain: Chain.Sui,
+        ticker: 'SUI',
+        address: signer,
+        decimals: 9,
+        isNativeToken: true,
+        hexPublicKey: hex(publicKey.data()),
+      }),
+      toAddress: signer,
+      toAmount: UINT64_OVERFLOW,
+      blockchainSpecific: {
+        case: 'suicheSpecific',
+        value: create(SuiSpecificSchema, {
+          referenceGasPrice: '1000',
+          gasBudget: '0',
+          coins: [suiCoin('overflow-cover', UINT64_OVERFLOW)],
+        }),
+      },
+    })
+
+    expect(() => getSuiSigningInputs({ keysignPayload, walletCore })).toThrow('Sui transfer amount exceeds uint64')
   })
 
   it('selects token inputs and a smallest-covering native gas object for token sends', async () => {

--- a/packages/core/mpc/keysign/signingInputs/resolvers/sui.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/sui.ts
@@ -1,7 +1,6 @@
 import { suiGasBudget } from '@vultisig/core-chain/chains/sui/config'
 import { SuiCoin } from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
 import { TW } from '@trustwallet/wallet-core'
-import Long from 'long'
 
 import { getBlockchainSpecificValue } from '../../chainSpecific/KeysignChainSpecific'
 import {
@@ -12,6 +11,7 @@ import {
   suiNativeCoinType,
 } from '../../suiCoinSelection'
 import { getKeysignCoin } from '../../utils/getKeysignCoin'
+import { unsignedLongFromString } from '../long'
 import { SigningInputsResolver } from '../resolver'
 
 export const getSuiSigningInputs: SigningInputsResolver<'sui'> = ({ keysignPayload }) => {
@@ -51,15 +51,15 @@ export const getSuiSigningInputs: SigningInputsResolver<'sui'> = ({ keysignPaylo
     TW.Sui.Proto.ObjectRef.create({
       objectDigest: coin.digest,
       objectId: coin.coinObjectId,
-      version: Long.fromString(coin.version),
+      version: unsignedLongFromString(coin.version, 'Sui coin version'),
     })
 
   const gasBudgetAmount = gasBudget ? BigInt(gasBudget) : suiGasBudget
 
   const baseInput = {
-    referenceGasPrice: Long.fromString(referenceGasPrice),
+    referenceGasPrice: unsignedLongFromString(referenceGasPrice, 'Sui reference gas price'),
     signer: coin.address,
-    gasBudget: Long.fromString(gasBudgetAmount.toString()),
+    gasBudget: unsignedLongFromString(gasBudgetAmount, 'Sui gas budget'),
   }
 
   const amount = BigInt(keysignPayload.toAmount || '0')
@@ -79,7 +79,7 @@ export const getSuiSigningInputs: SigningInputsResolver<'sui'> = ({ keysignPaylo
           gas: createObjectRef(gasObject),
           inputCoins: inputCoins,
           recipients: [keysignPayload.toAddress],
-          amounts: [Long.fromString(keysignPayload.toAmount)],
+          amounts: [unsignedLongFromString(keysignPayload.toAmount, 'Sui transfer amount')],
         }),
       }),
     ]
@@ -93,7 +93,7 @@ export const getSuiSigningInputs: SigningInputsResolver<'sui'> = ({ keysignPaylo
       paySui: TW.Sui.Proto.PaySui.create({
         inputCoins: inputCoins,
         recipients: [keysignPayload.toAddress],
-        amounts: [Long.fromString(keysignPayload.toAmount)],
+        amounts: [unsignedLongFromString(keysignPayload.toAmount, 'Sui transfer amount')],
       }),
     }),
   ]

--- a/packages/core/mpc/keysign/signingInputs/resolvers/tron.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/tron.test.ts
@@ -4,6 +4,7 @@ import { Chain } from '@vultisig/core-chain/Chain'
 import { TronSpecificSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
 import { CoinSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/coin_pb'
 import { KeysignPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { TronTransferContractPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/tron_contract_payload_pb'
 import Long from 'long'
 import { describe, expect, it } from 'vitest'
 
@@ -30,6 +31,7 @@ const makeTronSpecific = (gasEstimation = 100_000_000n) =>
   })
 
 const OWNER = 'T9yED5xMV5ARV98BexN97aLZ1UUq7eKSxm'
+const UINT64_OVERFLOW = '18446744073709551616'
 
 const buildPayload = (memo: string, toAmount = '1000000000') =>
   create(KeysignPayloadSchema, {
@@ -95,5 +97,21 @@ describe('getTronSigningInputs -- FREEZE: / UNFREEZE: feeLimit semantics (BUG-7)
     // (a non-zero energy estimate that's semantically meaningless for
     // system contracts and only served to confuse the UI fee display).
     expect(input.transaction?.feeLimit?.equals(Long.ZERO)).toBe(true)
+  })
+
+  it('rejects dApp transfer payload amounts above uint64 instead of wrapping them', () => {
+    const payload = buildPayload('')
+    payload.contractPayload = {
+      case: 'tronTransferContractPayload',
+      value: create(TronTransferContractPayloadSchema, {
+        ownerAddress: OWNER,
+        toAddress: OWNER,
+        amount: UINT64_OVERFLOW,
+      }),
+    }
+
+    expect(() => getTronSigningInputs({ keysignPayload: payload, walletCore })).toThrow(
+      'Tron transfer amount exceeds uint64'
+    )
   })
 })

--- a/packages/core/mpc/keysign/signingInputs/resolvers/tron.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/tron.ts
@@ -9,6 +9,7 @@ import Long from 'long'
 
 import { getBlockchainSpecificValue } from '../../chainSpecific/KeysignChainSpecific'
 import { getKeysignSwapPayload } from '../../swap/getKeysignSwapPayload'
+import { unsignedLongFromString } from '../long'
 import { SigningInputsResolver } from '../resolver'
 
 const createTronBlockHeader = (tronSpecific: {
@@ -20,8 +21,8 @@ const createTronBlockHeader = (tronSpecific: {
   blockHeaderWitnessAddress: string
 }) =>
   TW.Tron.Proto.BlockHeader.create({
-    timestamp: Long.fromString(tronSpecific.blockHeaderTimestamp.toString()),
-    number: Long.fromString(tronSpecific.blockHeaderNumber.toString()),
+    timestamp: unsignedLongFromString(tronSpecific.blockHeaderTimestamp, 'Tron block header timestamp'),
+    number: unsignedLongFromString(tronSpecific.blockHeaderNumber, 'Tron block header number'),
     version: Number(tronSpecific.blockHeaderVersion.toString()),
     txTrieRoot: Buffer.from(tronSpecific.blockHeaderTxTrieRoot, 'hex'),
     parentHash: Buffer.from(tronSpecific.blockHeaderParentHash, 'hex'),
@@ -40,7 +41,7 @@ export const getTronSigningInputs: SigningInputsResolver<'tron'> = ({ keysignPay
       throw new Error(`Invalid TRON resource type: ${resource}`)
     }
 
-    const frozenBalance = Long.fromString(shouldBePresent(keysignPayload?.toAmount))
+    const frozenBalance = unsignedLongFromString(shouldBePresent(keysignPayload?.toAmount), 'Tron frozen balance')
     if (frozenBalance.lessThanOrEqual(Long.ZERO)) {
       throw new Error('Frozen balance must be strictly positive')
     }
@@ -52,8 +53,8 @@ export const getTronSigningInputs: SigningInputsResolver<'tron'> = ({ keysignPay
           frozenBalance,
           resource,
         }),
-        timestamp: Long.fromString(tronSpecific.timestamp.toString()),
-        expiration: Long.fromString(tronSpecific.expiration.toString()),
+        timestamp: unsignedLongFromString(tronSpecific.timestamp, 'Tron timestamp'),
+        expiration: unsignedLongFromString(tronSpecific.expiration, 'Tron expiration'),
         // FreezeBalanceV2 is a system (bandwidth) op, not a smart-contract call.
         // feeLimit caps energy for TriggerSmartContract only; the node ignores it
         // for native staking ops. Set to 0 so the UI does not inherit the energy
@@ -73,7 +74,7 @@ export const getTronSigningInputs: SigningInputsResolver<'tron'> = ({ keysignPay
       throw new Error(`Invalid TRON resource type: ${resource}`)
     }
 
-    const unfreezeBalance = Long.fromString(shouldBePresent(keysignPayload?.toAmount))
+    const unfreezeBalance = unsignedLongFromString(shouldBePresent(keysignPayload?.toAmount), 'Tron unfreeze balance')
     if (unfreezeBalance.lessThanOrEqual(Long.ZERO)) {
       throw new Error('Unfreeze balance must be strictly positive')
     }
@@ -85,8 +86,8 @@ export const getTronSigningInputs: SigningInputsResolver<'tron'> = ({ keysignPay
           unfreezeBalance,
           resource,
         }),
-        timestamp: Long.fromString(tronSpecific.timestamp.toString()),
-        expiration: Long.fromString(tronSpecific.expiration.toString()),
+        timestamp: unsignedLongFromString(tronSpecific.timestamp, 'Tron timestamp'),
+        expiration: unsignedLongFromString(tronSpecific.expiration, 'Tron expiration'),
         // UnfreezeBalanceV2 is a system (bandwidth) op, not a smart-contract call.
         // feeLimit caps energy for TriggerSmartContract only; the node ignores it
         // for native staking ops. Set to 0 so the UI does not inherit the energy
@@ -121,7 +122,7 @@ export const getTronSigningInputs: SigningInputsResolver<'tron'> = ({ keysignPay
             transfer: TW.Tron.Proto.TransferContract.create({
               ownerAddress: value.ownerAddress,
               toAddress: value.toAddress,
-              amount: Long.fromString(value.amount),
+              amount: unsignedLongFromString(value.amount, 'Tron transfer amount'),
             }),
           }
         },
@@ -130,12 +131,14 @@ export const getTronSigningInputs: SigningInputsResolver<'tron'> = ({ keysignPay
             triggerSmartContract: TW.Tron.Proto.TriggerSmartContract.create({
               ownerAddress: value.ownerAddress,
               contractAddress: value.contractAddress,
-              callValue: value.callValue ? Long.fromString(value.callValue?.toString()) : undefined,
+              callValue: value.callValue ? unsignedLongFromString(value.callValue, 'Tron call value') : undefined,
               data: value.data ? Buffer.from(value.data, 'hex') : undefined,
-              callTokenValue: value.callTokenValue ? Long.fromString(value.callTokenValue?.toString()) : undefined,
-              tokenId: value.tokenId ? Long.fromString(value.tokenId?.toString()) : undefined,
+              callTokenValue: value.callTokenValue
+                ? unsignedLongFromString(value.callTokenValue, 'Tron call token value')
+                : undefined,
+              tokenId: value.tokenId ? unsignedLongFromString(value.tokenId, 'Tron token id') : undefined,
             }),
-            feeLimit: Long.fromString(tronSpecific.gasEstimation.toString()),
+            feeLimit: unsignedLongFromString(tronSpecific.gasEstimation, 'Tron fee limit'),
           }
         },
         tronTransferAssetContractPayload: value => {
@@ -143,10 +146,10 @@ export const getTronSigningInputs: SigningInputsResolver<'tron'> = ({ keysignPay
             transferAsset: TW.Tron.Proto.TransferAssetContract.create({
               ownerAddress: value.ownerAddress,
               toAddress: value.toAddress,
-              amount: Long.fromString(value.amount),
+              amount: unsignedLongFromString(value.amount, 'Tron transfer asset amount'),
               assetName: value.assetName,
             }),
-            feeLimit: Long.fromString(tronSpecific.gasEstimation.toString()),
+            feeLimit: unsignedLongFromString(tronSpecific.gasEstimation, 'Tron fee limit'),
           }
         },
         wasmExecuteContractPayload: () => {
@@ -158,16 +161,9 @@ export const getTronSigningInputs: SigningInputsResolver<'tron'> = ({ keysignPay
     const input = TW.Tron.Proto.SigningInput.create({
       transaction: TW.Tron.Proto.Transaction.create({
         ...contract,
-        timestamp: Long.fromString(tronSpecific.timestamp.toString()),
-        blockHeader: TW.Tron.Proto.BlockHeader.create({
-          timestamp: Long.fromString(tronSpecific.blockHeaderTimestamp.toString()),
-          number: Long.fromString(tronSpecific.blockHeaderNumber.toString()),
-          version: Number(tronSpecific.blockHeaderVersion.toString()),
-          txTrieRoot: Buffer.from(tronSpecific.blockHeaderTxTrieRoot, 'hex'),
-          parentHash: Buffer.from(tronSpecific.blockHeaderParentHash, 'hex'),
-          witnessAddress: Buffer.from(tronSpecific.blockHeaderWitnessAddress, 'hex'),
-        }),
-        expiration: Long.fromString(tronSpecific.expiration.toString()),
+        timestamp: unsignedLongFromString(tronSpecific.timestamp, 'Tron timestamp'),
+        blockHeader: createTronBlockHeader(tronSpecific),
+        expiration: unsignedLongFromString(tronSpecific.expiration, 'Tron expiration'),
         memo: keysignPayload.memo,
       }),
     })
@@ -184,22 +180,15 @@ export const getTronSigningInputs: SigningInputsResolver<'tron'> = ({ keysignPay
           const contract = TW.Tron.Proto.TransferContract.create({
             ownerAddress: shouldBePresent(keysignPayload?.coin?.address),
             toAddress: shouldBePresent(vaultAddress),
-            amount: Long.fromString(shouldBePresent(keysignPayload?.toAmount)),
+            amount: unsignedLongFromString(shouldBePresent(keysignPayload?.toAmount), 'Tron transfer amount'),
           })
 
           const input = TW.Tron.Proto.SigningInput.create({
             transaction: TW.Tron.Proto.Transaction.create({
               transfer: contract,
-              timestamp: Long.fromString(tronSpecific.timestamp.toString()),
-              blockHeader: TW.Tron.Proto.BlockHeader.create({
-                timestamp: Long.fromString(tronSpecific.blockHeaderTimestamp.toString()),
-                number: Long.fromString(tronSpecific.blockHeaderNumber.toString()),
-                version: Number(tronSpecific.blockHeaderVersion.toString()),
-                txTrieRoot: Buffer.from(tronSpecific.blockHeaderTxTrieRoot, 'hex'),
-                parentHash: Buffer.from(tronSpecific.blockHeaderParentHash, 'hex'),
-                witnessAddress: Buffer.from(tronSpecific.blockHeaderWitnessAddress, 'hex'),
-              }),
-              expiration: Long.fromString(tronSpecific.expiration.toString()),
+              timestamp: unsignedLongFromString(tronSpecific.timestamp, 'Tron timestamp'),
+              blockHeader: createTronBlockHeader(tronSpecific),
+              expiration: unsignedLongFromString(tronSpecific.expiration, 'Tron expiration'),
               memo: keysignPayload.memo,
             }),
           })
@@ -218,18 +207,11 @@ export const getTronSigningInputs: SigningInputsResolver<'tron'> = ({ keysignPay
 
         const input = TW.Tron.Proto.SigningInput.create({
           transaction: TW.Tron.Proto.Transaction.create({
-            feeLimit: Long.fromString(tronSpecific.gasEstimation.toString()),
+            feeLimit: unsignedLongFromString(tronSpecific.gasEstimation, 'Tron fee limit'),
             transferTrc20Contract: contract,
-            timestamp: Long.fromString(tronSpecific.timestamp.toString()),
-            blockHeader: TW.Tron.Proto.BlockHeader.create({
-              timestamp: Long.fromString(tronSpecific.blockHeaderTimestamp.toString()),
-              number: Long.fromString(tronSpecific.blockHeaderNumber.toString()),
-              version: Number(tronSpecific.blockHeaderVersion.toString()),
-              txTrieRoot: Buffer.from(tronSpecific.blockHeaderTxTrieRoot, 'hex'),
-              parentHash: Buffer.from(tronSpecific.blockHeaderParentHash, 'hex'),
-              witnessAddress: Buffer.from(tronSpecific.blockHeaderWitnessAddress, 'hex'),
-            }),
-            expiration: Long.fromString(tronSpecific.expiration.toString()),
+            timestamp: unsignedLongFromString(tronSpecific.timestamp, 'Tron timestamp'),
+            blockHeader: createTronBlockHeader(tronSpecific),
+            expiration: unsignedLongFromString(tronSpecific.expiration, 'Tron expiration'),
             memo: keysignPayload.memo,
           }),
         })
@@ -247,22 +229,15 @@ export const getTronSigningInputs: SigningInputsResolver<'tron'> = ({ keysignPay
     const contract = TW.Tron.Proto.TransferContract.create({
       ownerAddress: shouldBePresent(keysignPayload?.coin?.address),
       toAddress: shouldBePresent(keysignPayload?.toAddress),
-      amount: Long.fromString(shouldBePresent(keysignPayload?.toAmount)),
+      amount: unsignedLongFromString(shouldBePresent(keysignPayload?.toAmount), 'Tron transfer amount'),
     })
 
     const input = TW.Tron.Proto.SigningInput.create({
       transaction: TW.Tron.Proto.Transaction.create({
         transfer: contract,
-        timestamp: Long.fromString(tronSpecific.timestamp.toString()),
-        blockHeader: TW.Tron.Proto.BlockHeader.create({
-          timestamp: Long.fromString(tronSpecific.blockHeaderTimestamp.toString()),
-          number: Long.fromString(tronSpecific.blockHeaderNumber.toString()),
-          version: Number(tronSpecific.blockHeaderVersion.toString()),
-          txTrieRoot: Buffer.from(tronSpecific.blockHeaderTxTrieRoot, 'hex'),
-          parentHash: Buffer.from(tronSpecific.blockHeaderParentHash, 'hex'),
-          witnessAddress: Buffer.from(tronSpecific.blockHeaderWitnessAddress, 'hex'),
-        }),
-        expiration: Long.fromString(tronSpecific.expiration.toString()),
+        timestamp: unsignedLongFromString(tronSpecific.timestamp, 'Tron timestamp'),
+        blockHeader: createTronBlockHeader(tronSpecific),
+        expiration: unsignedLongFromString(tronSpecific.expiration, 'Tron expiration'),
         memo: keysignPayload.memo,
       }),
     })
@@ -281,18 +256,11 @@ export const getTronSigningInputs: SigningInputsResolver<'tron'> = ({ keysignPay
 
   const input = TW.Tron.Proto.SigningInput.create({
     transaction: TW.Tron.Proto.Transaction.create({
-      feeLimit: Long.fromString(tronSpecific.gasEstimation.toString()),
+      feeLimit: unsignedLongFromString(tronSpecific.gasEstimation, 'Tron fee limit'),
       transferTrc20Contract: contract,
-      timestamp: Long.fromString(tronSpecific.timestamp.toString()),
-      blockHeader: TW.Tron.Proto.BlockHeader.create({
-        timestamp: Long.fromString(tronSpecific.blockHeaderTimestamp.toString()),
-        number: Long.fromString(tronSpecific.blockHeaderNumber.toString()),
-        version: Number(tronSpecific.blockHeaderVersion.toString()),
-        txTrieRoot: Buffer.from(tronSpecific.blockHeaderTxTrieRoot, 'hex'),
-        parentHash: Buffer.from(tronSpecific.blockHeaderParentHash, 'hex'),
-        witnessAddress: Buffer.from(tronSpecific.blockHeaderWitnessAddress, 'hex'),
-      }),
-      expiration: Long.fromString(tronSpecific.expiration.toString()),
+      timestamp: unsignedLongFromString(tronSpecific.timestamp, 'Tron timestamp'),
+      blockHeader: createTronBlockHeader(tronSpecific),
+      expiration: unsignedLongFromString(tronSpecific.expiration, 'Tron expiration'),
       memo: keysignPayload.memo,
     }),
   })


### PR DESCRIPTION
closes #1138

`Long.fromString` has no magnitude bound check - a digit string too large for 64 bits silently two's-complement wraps instead of throwing (confirmed by reading `node_modules/long/umd/index.js`). Unguarded on fund-relevant amount/fee/timing fields for Sui (whose ~1e19 MIST supply exceeds signed-64-bit's ~9.223e18 ceiling), Tron (dApp-supplied `contractPayload`, no upper bound at all), Ripple, and Cardano - the same bug class as the historical osmosis `poolId=2^64→0` incident, here on the actual transfer amount, meaning MPC co-signers could sign over a different value than the UI reported. Severity HIGH per the finding.

Adds a shared `unsignedLongFromString` helper and routes Sui/Tron/Ripple/Cardano signing-input fields through it. TON native untouched - it already uses bounded byte encoding, not `Long.fromString`.

Fund-adjacent (signable transaction construction) but fail-closed only: invalid, signed, fractional, or `> 2^64 - 1` values are rejected before protobuf construction; valid unsigned 64-bit values (including values above signed int64) are preserved.

## what I ran
Targeted signing-input resolver test suites for Sui/Tron/Ripple/Cardano pass. Project-wide `tsc` couldn't complete in this worktree - missing unrelated `koffi` dependency, not touched by this PR; targeted tests and source lint passed. Changeset included.

Co-Authored-By: Claude <noreply@anthropic.com>