### PR TITLE
docs(notification): fix vaultId examples to use computeNotificationVaultId

### DIFF
--- a/docs/SDK-USERS-GUIDE.md
+++ b/docs/SDK-USERS-GUIDE.md
@@ -2041,11 +2041,14 @@ Coordinate multi-party signing sessions by sending push notifications to vault m
 ### Register a Device
 
 ```typescript
+import { computeNotificationVaultId } from '@vultisig/sdk'
+
 // Obtain a push token from your platform (APNs, FCM, Web Push)
 const token = await getMyPlatformPushToken()
+const notificationVaultId = await computeNotificationVaultId(vault.publicKeys.ecdsa, vault.hexChainCode)
 
 await sdk.notifications.registerDevice({
-  vaultId: vault.publicKeys.ecdsa,
+  vaultId: notificationVaultId,
   partyName: vault.localPartyId,
   token,
   deviceType: 'ios', // 'ios' | 'android' | 'web'
@@ -2057,8 +2060,10 @@ await sdk.notifications.registerDevice({
 When initiating a signing session, notify other members so they can join:
 
 ```typescript
+const notificationVaultId = await computeNotificationVaultId(vault.publicKeys.ecdsa, vault.hexChainCode)
+
 await sdk.notifications.notifyVaultMembers({
-  vaultId: vault.publicKeys.ecdsa,
+  vaultId: notificationVaultId,
   vaultName: vault.name,
   localPartyId: vault.localPartyId,
   qrCodeData: keysignQrPayload, // session data for joining
@@ -2100,9 +2105,11 @@ unsubscribe()
 For environments where platform push isn't available (browser extensions, Electron, Node.js), the SDK provides a built-in WebSocket transport. Messages are delivered through the same `onSigningRequest()` callbacks — no platform push handler wiring needed.
 
 ```typescript
+const notificationVaultId = await computeNotificationVaultId(vault.publicKeys.ecdsa, vault.hexChainCode)
+
 // Step 1: Register device (same as platform push)
 await sdk.notifications.registerDevice({
-  vaultId: vault.publicKeys.ecdsa,
+  vaultId: notificationVaultId,
   partyName: vault.localPartyId,
   token: myDeviceToken, // Any stable unique identifier
   deviceType: 'web',
@@ -2110,7 +2117,7 @@ await sdk.notifications.registerDevice({
 
 // Step 2: Connect WebSocket
 sdk.notifications.connect({
-  vaultId: vault.publicKeys.ecdsa,
+  vaultId: notificationVaultId,
   partyName: vault.localPartyId,
   token: myDeviceToken, // Same token used for registerDevice()
 })
@@ -2151,7 +2158,7 @@ const subscription = await registration.pushManager.subscribe({
 })
 
 await sdk.notifications.registerDevice({
-  vaultId: vault.publicKeys.ecdsa,
+  vaultId: await computeNotificationVaultId(vault.publicKeys.ecdsa, vault.hexChainCode),
   partyName: vault.localPartyId,
   token: JSON.stringify(subscription.toJSON()),
   deviceType: 'web',
@@ -2163,14 +2170,16 @@ await sdk.notifications.registerDevice({
 ### Utility Methods
 
 ```typescript
+const notificationVaultId = await computeNotificationVaultId(vault.publicKeys.ecdsa, vault.hexChainCode)
+
 // Check if a vault has local registration
-const registered = await sdk.notifications.isVaultRegistered(vaultId)
+const registered = await sdk.notifications.isVaultRegistered(notificationVaultId)
 
 // Check if any devices are registered on the server
-const hasRemote = await sdk.notifications.hasRemoteRegistrations(vaultId)
+const hasRemote = await sdk.notifications.hasRemoteRegistrations(notificationVaultId)
 
 // Remove local registration
-await sdk.notifications.unregisterVault(vaultId)
+await sdk.notifications.unregisterVault(notificationVaultId)
 
 // Parse notification payload manually (without invoking callbacks)
 const parsed = sdk.notifications.parseNotificationPayload(rawData)

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -310,10 +310,14 @@ if (buyUrl) window.open(buyUrl)
 Coordinate multi-party signing by notifying vault members when a signing session is initiated.
 
 ```typescript
+import { computeNotificationVaultId } from '@vultisig/sdk'
+
+const notificationVaultId = await computeNotificationVaultId(vault.publicKeys.ecdsa, vault.hexChainCode)
+
 // Step 1: Register device for vault notifications
 // Token comes from your platform's push service (APNs, FCM, or Web Push)
 await sdk.notifications.registerDevice({
-  vaultId: vault.publicKeys.ecdsa,
+  vaultId: notificationVaultId,
   partyName: vault.localPartyId,
   token: myPlatformPushToken,
   deviceType: 'ios', // 'ios' | 'android' | 'web'
@@ -321,7 +325,7 @@ await sdk.notifications.registerDevice({
 
 // Step 2: Notify other vault members when initiating a signing session
 await sdk.notifications.notifyVaultMembers({
-  vaultId: vault.publicKeys.ecdsa,
+  vaultId: notificationVaultId,
   vaultName: vault.name,
   localPartyId: vault.localPartyId,
   qrCodeData: keysignQrPayload, // session data for joining
@@ -368,9 +372,11 @@ sdk.notifications.handleIncomingPush(remoteMessage.data)
 **Browser / Extension** — Use WebSocket for real-time delivery (no service worker needed):
 
 ```typescript
+const notificationVaultId = await computeNotificationVaultId(vault.publicKeys.ecdsa, vault.hexChainCode)
+
 // Register device
 await sdk.notifications.registerDevice({
-  vaultId: vault.publicKeys.ecdsa,
+  vaultId: notificationVaultId,
   partyName: vault.localPartyId,
   token: myDeviceToken,
   deviceType: 'web',
@@ -378,7 +384,7 @@ await sdk.notifications.registerDevice({
 
 // Connect WebSocket — notifications delivered via onSigningRequest()
 sdk.notifications.connect({
-  vaultId: vault.publicKeys.ecdsa,
+  vaultId: notificationVaultId,
   partyName: vault.localPartyId,
   token: myDeviceToken,
 })
@@ -396,7 +402,7 @@ const subscription = await registration.pushManager.subscribe({
   applicationServerKey: vapidKey,
 })
 await sdk.notifications.registerDevice({
-  vaultId: vault.publicKeys.ecdsa,
+  vaultId: await computeNotificationVaultId(vault.publicKeys.ecdsa, vault.hexChainCode),
   partyName: vault.localPartyId,
   token: JSON.stringify(subscription.toJSON()),
   deviceType: 'web',
@@ -972,7 +978,7 @@ Register a device to receive push notifications for a vault.
 
 **Parameters:**
 
-- `options.vaultId: string` - Vault ID (`publicKeys.ecdsa`)
+- `options.vaultId: string` - Notification vault ID from `computeNotificationVaultId(vault.publicKeys.ecdsa, vault.hexChainCode)`
 - `options.partyName: string` - Local party ID of the device
 - `options.token: string` - Push token from APNs, FCM, or Web Push
 - `options.deviceType: 'ios' | 'android' | 'web'` - Platform type
@@ -987,7 +993,7 @@ Send a push notification to all other registered devices for a vault.
 
 **Parameters:**
 
-- `options.vaultId: string` - Vault ID
+- `options.vaultId: string` - Notification vault ID from `computeNotificationVaultId(vault.publicKeys.ecdsa, vault.hexChainCode)`
 - `options.vaultName: string` - Vault display name
 - `options.localPartyId: string` - Sender's party ID (excluded from recipients)
 - `options.qrCodeData: string` - Keysign session data for joining
@@ -1022,7 +1028,7 @@ Open a WebSocket connection for real-time notification delivery. Messages are di
 
 **Parameters:**
 
-- `options.vaultId: string` - Vault ID (`publicKeys.ecdsa`)
+- `options.vaultId: string` - Notification vault ID from `computeNotificationVaultId(vault.publicKeys.ecdsa, vault.hexChainCode)`
 - `options.partyName: string` - Local party ID of the device
 - `options.token: string` - Same token used for `registerDevice()`
 


### PR DESCRIPTION
closes #1341

First-party SDK docs told consumers to use the raw ECDSA pubkey as the notification `vaultId`, but the runtime actually uses `computeNotificationVaultId(pubKeyECDSA, hexChainCode)` - a consumer following the docs as written would register/connect/notify under the wrong vault bucket and silently miss signing notifications. Updates the SDK README and SDK users guide notification examples to derive `vaultId` via `computeNotificationVaultId(vault.publicKeys.ecdsa, vault.hexChainCode)`, and calls out the notification-specific ID contract in the API option descriptions.

Documentation-only - no signing, dispatch, fee, transaction-building, or runtime notification code changed. No changeset - docs-only, no package behavior change.

## what I ran
Grepped for remaining raw-pubkey `vaultId` references in README/docs after the edit - none found. Did not run typecheck (Markdown-only change).

Co-Authored-By: Claude <noreply@anthropic.com>