### PR TITLE
feat(swap): export general swap quote policy helper

### DIFF
--- a/.changeset/tl-sdk-1291.md
+++ b/.changeset/tl-sdk-1291.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/sdk': patch
+---
+
+Add an SDK-owned general swap quote policy helper for backend/chat consumers. The new policy exports the default quote slippage tolerance, the same-chain EVM ERC-20 provider exclusions for route-dependent approval-spender providers, and metadata explaining the provider risk classification.

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -1998,6 +1998,11 @@
       "import": "./dist/swap/quote/findSwapQuote.js",
       "default": "./dist/swap/quote/findSwapQuote.js"
     },
+    "./swap/quote/generalSwapQuotePolicy": {
+      "types": "./dist/swap/quote/generalSwapQuotePolicy.d.ts",
+      "import": "./dist/swap/quote/generalSwapQuotePolicy.js",
+      "default": "./dist/swap/quote/generalSwapQuotePolicy.js"
+    },
     "./swap/quote/getSwapQuoteProviderName": {
       "types": "./dist/swap/quote/getSwapQuoteProviderName.d.ts",
       "import": "./dist/swap/quote/getSwapQuoteProviderName.js",

--- a/packages/core/chain/swap/quote/generalSwapQuotePolicy.test.ts
+++ b/packages/core/chain/swap/quote/generalSwapQuotePolicy.test.ts
@@ -1,0 +1,104 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_GENERAL_SWAP_QUOTE_SLIPPAGE_TOLERANCE_PERCENT,
+  generalSwapProviderRiskMetadata,
+  isSameChainEvmErc20SellForQuotePolicy,
+  resolveGeneralSwapQuotePolicy,
+  SAME_CHAIN_EVM_ERC20_SELL_EXCLUDED_PROVIDERS,
+} from './generalSwapQuotePolicy'
+
+describe('general swap quote policy', () => {
+  it('applies the SDK-owned default slippage tolerance', () => {
+    expect(
+      resolveGeneralSwapQuotePolicy({
+        fromChain: Chain.Ethereum,
+        toChain: Chain.Base,
+      })
+    ).toEqual({ slippageTolerance: DEFAULT_GENERAL_SWAP_QUOTE_SLIPPAGE_TOLERANCE_PERCENT })
+  })
+
+  it('preserves explicit slippage tolerance', () => {
+    expect(
+      resolveGeneralSwapQuotePolicy({
+        fromChain: Chain.Ethereum,
+        toChain: Chain.Base,
+        slippageTolerance: 2.5,
+      })
+    ).toEqual({ slippageTolerance: 2.5 })
+  })
+
+  it('excludes route-dependent spender providers for same-chain EVM ERC-20 sells', () => {
+    expect(
+      resolveGeneralSwapQuotePolicy({
+        fromChain: Chain.Ethereum,
+        toChain: Chain.Ethereum,
+        fromTokenId: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      })
+    ).toEqual({
+      slippageTolerance: DEFAULT_GENERAL_SWAP_QUOTE_SLIPPAGE_TOLERANCE_PERCENT,
+      excludeProviders: [...SAME_CHAIN_EVM_ERC20_SELL_EXCLUDED_PROVIDERS],
+    })
+  })
+
+  it('keeps SwapKit and LiFi eligible for cross-chain EVM swaps', () => {
+    expect(
+      resolveGeneralSwapQuotePolicy({
+        fromChain: Chain.Ethereum,
+        toChain: Chain.Base,
+        fromTokenId: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      })
+    ).toEqual({ slippageTolerance: DEFAULT_GENERAL_SWAP_QUOTE_SLIPPAGE_TOLERANCE_PERCENT })
+  })
+
+  it('keeps SwapKit and LiFi eligible for same-chain native EVM sells', () => {
+    expect(
+      resolveGeneralSwapQuotePolicy({
+        fromChain: Chain.Ethereum,
+        toChain: Chain.Ethereum,
+      })
+    ).toEqual({ slippageTolerance: DEFAULT_GENERAL_SWAP_QUOTE_SLIPPAGE_TOLERANCE_PERCENT })
+  })
+
+  it('keeps SwapKit and LiFi eligible for non-EVM same-chain swaps', () => {
+    expect(
+      resolveGeneralSwapQuotePolicy({
+        fromChain: Chain.Solana,
+        toChain: Chain.Solana,
+        fromTokenId: 'So11111111111111111111111111111111111111112',
+      })
+    ).toEqual({ slippageTolerance: DEFAULT_GENERAL_SWAP_QUOTE_SLIPPAGE_TOLERANCE_PERCENT })
+  })
+
+  it('preserves caller exclusions and appends policy exclusions once', () => {
+    expect(
+      resolveGeneralSwapQuotePolicy({
+        fromChain: Chain.Ethereum,
+        toChain: Chain.Ethereum,
+        fromTokenId: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+        excludeProviders: ['CowSwap', 'LiFi'],
+      })
+    ).toEqual({
+      slippageTolerance: DEFAULT_GENERAL_SWAP_QUOTE_SLIPPAGE_TOLERANCE_PERCENT,
+      excludeProviders: ['CowSwap', 'LiFi', 'SwapKit'],
+    })
+  })
+
+  it('exports the swap-shape predicate for callers that need branch-specific rendering', () => {
+    expect(
+      isSameChainEvmErc20SellForQuotePolicy({
+        fromChain: Chain.Arbitrum,
+        toChain: Chain.Arbitrum,
+        fromTokenId: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+      })
+    ).toBe(true)
+  })
+
+  it('documents provider risk metadata for the policy-owned exclusions', () => {
+    expect(generalSwapProviderRiskMetadata.SwapKit.sameChainEvmErc20Sell).toBe('excluded')
+    expect(generalSwapProviderRiskMetadata.LiFi.sameChainEvmErc20Sell).toBe('excluded')
+    expect(generalSwapProviderRiskMetadata.KyberSwap.sameChainEvmErc20Sell).toBe('eligible')
+    expect(generalSwapProviderRiskMetadata['1inch'].sameChainEvmErc20Sell).toBe('eligible')
+  })
+})

--- a/packages/core/chain/swap/quote/generalSwapQuotePolicy.ts
+++ b/packages/core/chain/swap/quote/generalSwapQuotePolicy.ts
@@ -1,0 +1,97 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { isChainOfKind } from '@vultisig/core-chain/ChainKind'
+
+import type { SwapQuoteProviderExcludeName, SwapQuoteProviderName } from './findSwapQuote'
+
+export const DEFAULT_GENERAL_SWAP_QUOTE_SLIPPAGE_TOLERANCE_PERCENT = 1
+
+export const SAME_CHAIN_EVM_ERC20_SELL_EXCLUDED_PROVIDERS = ['SwapKit', 'LiFi'] as const
+
+export type GeneralSwapProviderRiskMetadata = {
+  approvalSpender: 'router' | 'provider-reported' | 'route-dependent'
+  sameChainEvmErc20Sell: 'eligible' | 'excluded'
+  reason: string
+}
+
+export const generalSwapProviderRiskMetadata = {
+  '1inch': {
+    approvalSpender: 'router',
+    sameChainEvmErc20Sell: 'eligible',
+    reason: 'Same-chain EVM ERC-20 routes use a stable router spender.',
+  },
+  KyberSwap: {
+    approvalSpender: 'router',
+    sameChainEvmErc20Sell: 'eligible',
+    reason: 'Same-chain EVM ERC-20 routes use a stable router spender.',
+  },
+  LiFi: {
+    approvalSpender: 'provider-reported',
+    sameChainEvmErc20Sell: 'excluded',
+    reason: 'Same-chain EVM ERC-20 routes can require a route-dependent spender outside the router fast path.',
+  },
+  SwapKit: {
+    approvalSpender: 'route-dependent',
+    sameChainEvmErc20Sell: 'excluded',
+    reason: 'Same-chain EVM ERC-20 routes can bury the effective spender inside provider calldata.',
+  },
+} as const satisfies Partial<Record<SwapQuoteProviderName, GeneralSwapProviderRiskMetadata>>
+
+export type ResolveGeneralSwapQuotePolicyInput = {
+  fromChain: Chain
+  toChain: Chain
+  /**
+   * Source token contract/id. Undefined/null/empty means the source is the
+   * chain fee coin, which does not need an ERC-20 approval spender.
+   */
+  fromTokenId?: string | null
+  /**
+   * Optional caller-supplied tolerance in percent. When omitted, chat/backend
+   * consumers use the SDK-owned default instead of each provider's unrelated
+   * fallback.
+   */
+  slippageTolerance?: number
+  /**
+   * Existing caller exclusions are preserved and the policy exclusions are
+   * appended when the swap shape requires them.
+   */
+  excludeProviders?: readonly SwapQuoteProviderExcludeName[]
+}
+
+export type GeneralSwapQuotePolicy = {
+  slippageTolerance: number
+  excludeProviders?: SwapQuoteProviderExcludeName[]
+}
+
+const hasSourceTokenId = (fromTokenId: string | null | undefined): boolean =>
+  typeof fromTokenId === 'string' && fromTokenId.trim().length > 0
+
+export const isSameChainEvmErc20SellForQuotePolicy = ({
+  fromChain,
+  toChain,
+  fromTokenId,
+}: Pick<ResolveGeneralSwapQuotePolicyInput, 'fromChain' | 'toChain' | 'fromTokenId'>): boolean =>
+  fromChain === toChain && isChainOfKind(fromChain, 'evm') && hasSourceTokenId(fromTokenId)
+
+const appendUniqueExclusions = (
+  base: readonly SwapQuoteProviderExcludeName[] | undefined,
+  additions: readonly SwapQuoteProviderExcludeName[]
+): SwapQuoteProviderExcludeName[] => {
+  const result = [...(base ?? [])]
+  for (const provider of additions) {
+    if (!result.includes(provider)) {
+      result.push(provider)
+    }
+  }
+  return result
+}
+
+export const resolveGeneralSwapQuotePolicy = (input: ResolveGeneralSwapQuotePolicyInput): GeneralSwapQuotePolicy => {
+  const excludeProviders = isSameChainEvmErc20SellForQuotePolicy(input)
+    ? appendUniqueExclusions(input.excludeProviders, SAME_CHAIN_EVM_ERC20_SELL_EXCLUDED_PROVIDERS)
+    : [...(input.excludeProviders ?? [])]
+
+  return {
+    slippageTolerance: input.slippageTolerance ?? DEFAULT_GENERAL_SWAP_QUOTE_SLIPPAGE_TOLERANCE_PERCENT,
+    ...(excludeProviders.length > 0 ? { excludeProviders } : {}),
+  }
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -530,6 +530,18 @@ export type {
   SwapQuoteProviderExcludeName,
   SwapQuoteProviderName,
 } from '@vultisig/core-chain/swap/quote/findSwapQuote'
+export type {
+  GeneralSwapProviderRiskMetadata,
+  GeneralSwapQuotePolicy,
+  ResolveGeneralSwapQuotePolicyInput,
+} from '@vultisig/core-chain/swap/quote/generalSwapQuotePolicy'
+export {
+  DEFAULT_GENERAL_SWAP_QUOTE_SLIPPAGE_TOLERANCE_PERCENT,
+  generalSwapProviderRiskMetadata,
+  isSameChainEvmErc20SellForQuotePolicy,
+  resolveGeneralSwapQuotePolicy,
+  SAME_CHAIN_EVM_ERC20_SELL_EXCLUDED_PROVIDERS,
+} from '@vultisig/core-chain/swap/quote/generalSwapQuotePolicy'
 
 // THORChain limit orders (`=<` advanced swap queue). The memo IS the order, so
 // `parseLimitSwapMemo` / `getKeysignLimitSwapOrder` are how any device — the

--- a/packages/sdk/src/tools/swap/findSwapQuote.ts
+++ b/packages/sdk/src/tools/swap/findSwapQuote.ts
@@ -13,6 +13,18 @@ import {
 import type { BoundSwapQuote, SwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
 
 export type { FindSwapQuotesResult, SwapAffiliateConfig, SwapQuoteCandidate, SwapQuoteProviderExcludeName }
+export type {
+  GeneralSwapProviderRiskMetadata,
+  GeneralSwapQuotePolicy,
+  ResolveGeneralSwapQuotePolicyInput,
+} from '@vultisig/core-chain/swap/quote/generalSwapQuotePolicy'
+export {
+  DEFAULT_GENERAL_SWAP_QUOTE_SLIPPAGE_TOLERANCE_PERCENT,
+  generalSwapProviderRiskMetadata,
+  isSameChainEvmErc20SellForQuotePolicy,
+  resolveGeneralSwapQuotePolicy,
+  SAME_CHAIN_EVM_ERC20_SELL_EXCLUDED_PROVIDERS,
+} from '@vultisig/core-chain/swap/quote/generalSwapQuotePolicy'
 
 export type FindSwapQuoteParams = {
   fromChain: Chain

--- a/packages/sdk/src/tools/swap/index.ts
+++ b/packages/sdk/src/tools/swap/index.ts
@@ -4,10 +4,21 @@ export type {
   BoundSwapQuote,
   FindSwapQuoteParams,
   FindSwapQuotesResult,
+  GeneralSwapProviderRiskMetadata,
+  GeneralSwapQuotePolicy,
+  ResolveGeneralSwapQuotePolicyInput,
   SwapQuote,
   SwapQuoteCandidate,
 } from './findSwapQuote'
-export { findSwapQuote, findSwapQuotes } from './findSwapQuote'
+export {
+  DEFAULT_GENERAL_SWAP_QUOTE_SLIPPAGE_TOLERANCE_PERCENT,
+  findSwapQuote,
+  findSwapQuotes,
+  generalSwapProviderRiskMetadata,
+  isSameChainEvmErc20SellForQuotePolicy,
+  resolveGeneralSwapQuotePolicy,
+  SAME_CHAIN_EVM_ERC20_SELL_EXCLUDED_PROVIDERS,
+} from './findSwapQuote'
 export type { JupiterQuoteResponse, JupiterSwapParams, JupiterSwapResult } from './jupiter'
 export {
   buildJupiterSwapTx,


### PR DESCRIPTION
closes vultisig/agent-backend-ts#1291

`execute_swap` in agent-backend-ts carries backend-only provider-selection policy for general EVM swaps (default slippage tolerance + burying-provider exclusions for same-chain EVM ERC-20 sells) instead of consuming an SDK-owned quote-policy contract. If app/backend/CLI/SDK consumers each hand-roll this, they drift in route selection and user-visible behavior.

Adds `packages/core/chain/swap/quote/generalSwapQuotePolicy.ts` — a pure, SDK-owned policy contract (`resolveGeneralSwapQuotePolicy`, `isSameChainEvmErc20SellForQuotePolicy`, `generalSwapProviderRiskMetadata`, `DEFAULT_GENERAL_SWAP_QUOTE_SLIPPAGE_TOLERANCE_PERCENT`, `SAME_CHAIN_EVM_ERC20_SELL_EXCLUDED_PROVIDERS`). Preserves caller-supplied slippage/exclusions, adds the default slippage only when omitted, and appends provider exclusions only for same-chain EVM ERC-20 source sells — cross-chain, native-source, and non-EVM swaps are unaffected. Exported through core-chain, `@vultisig/sdk`, and `@vultisig/sdk/tools/swap`.

Pure additive API — no changes to `findSwapQuote` default behavior, quote fetching, transaction construction, signing, allowance checks, or broadcast paths. Fund-adjacent behavior is fail-closed only for consumers that explicitly opt in by calling `resolveGeneralSwapQuotePolicy`.

**Scope note**: this is the SDK-side half only. Migrating `agent-backend-ts`'s `execute_swap.ts` to consume this instead of its local policy assembly is a legitimate follow-up in that repo (cross-repo, not implementable from this worktree) — filed as the honest remaining gap, not silently dropped.

## what I ran
```
yarn vitest run .../generalSwapQuotePolicy.test.ts .../findSwapQuote.slippage.test.ts .../findSwapQuote.selection.test.ts
Test Files  3 passed (3)
Tests  79 passed (79)
```
Full `yarn build:sdk`, typecheck, lint, `check:shared-exports` all green. Verified the built dist actually exports and runs correctly via direct `node --input-type=module` imports of both the ESM and CJS builds, confirming real runtime output (not just type-level correctness). Changeset included.

Co-Authored-By: Claude <noreply@anthropic.com>