### PR TITLE
fix(tx): type camelCase normalization metadata

### DIFF
--- a/.changeset/olive-moose-wave.md
+++ b/.changeset/olive-moose-wave.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+Widen the public tx-normalization types to include camelCase routing metadata and accept camelCase normalization args, matching the metadata `splitMultiTx` already preserves at runtime.

--- a/packages/sdk/src/tx/normalize.ts
+++ b/packages/sdk/src/tx/normalize.ts
@@ -33,19 +33,40 @@ export type NormalizedTx = JsonObject & {
   send_tx?: unknown
   chain?: string
   chain_id?: string
+  chainId?: string
   from_chain?: string
+  fromChain?: string
   to_chain?: string
+  toChain?: string
+  provider?: string
+  from_symbol?: string
+  fromSymbol?: string
+  to_symbol?: string
+  toSymbol?: string
+  from_address?: string
+  fromAddress?: string
+  to_address?: string
+  toAddress?: string
+  from_decimals?: number
+  fromDecimals?: number
+  to_decimals?: number
+  toDecimals?: number
 }
 
 /**
  * Chain-routing args from the originating `build_*` tool call. Mirrors the
- * `{from_chain, to_chain, chain}` probe in Go `enrichBuildResult`. All optional
- * — a flat single-chain `build_evm_tx` only carries `chain`.
+ * `{from_chain, to_chain, chain}` probe in Go `enrichBuildResult`, plus the
+ * camelCase metadata aliases some TS consumers already pass around.
+ * All optional — a flat single-chain `build_evm_tx` only carries `chain`.
  */
 export type NormalizeArgs = {
   from_chain?: string
+  fromChain?: string
   to_chain?: string
+  toChain?: string
   chain?: string
+  chain_id?: string
+  chainId?: string
 }
 
 /** Thrown when a build result can't be parsed into a tx envelope. */
@@ -91,14 +112,21 @@ const LEG_METADATA_KEYS = [
 
 const enrichRoutingMetadata = (txMap: JsonObject, args: NormalizeArgs): JsonObject => {
   const out: JsonObject = { ...txMap }
-  const { from_chain: argFrom, to_chain: argTo, chain: argChain } = args
+  const argFrom = args.from_chain ?? args.fromChain
+  const argTo = args.to_chain ?? args.toChain
+  const argChain = args.chain
+  const argChainId = args.chain_id ?? args.chainId
 
   if (!('from_chain' in out)) {
     if (argFrom) out['from_chain'] = argFrom
     else if (argChain) out['from_chain'] = argChain
   }
+  if (!('fromChain' in out) && argFrom) out['fromChain'] = argFrom
   if (!('chain' in out) && argChain) out['chain'] = argChain
+  if (!('chain_id' in out) && argChainId) out['chain_id'] = argChainId
+  if (!('chainId' in out) && argChainId) out['chainId'] = argChainId
   if (!('to_chain' in out) && argTo) out['to_chain'] = argTo
+  if (!('toChain' in out) && argTo) out['toChain'] = argTo
 
   return out
 }

--- a/packages/sdk/tests/unit/tx/normalize.test.ts
+++ b/packages/sdk/tests/unit/tx/normalize.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { normalizeTx, splitMultiTx, TxNormalizeError } from '../../../src/tx/normalize'
+import { normalizeTx, splitMultiTx, TxNormalizeError, type NormalizeArgs, type NormalizedTx } from '../../../src/tx/normalize'
 
 describe('normalizeTx', () => {
   it('wraps a flat build_* result under "tx" and lifts chain metadata', () => {
@@ -351,5 +351,34 @@ describe('splitMultiTx', () => {
       expect(leg.fromDecimals).toBe(6)
       expect(leg.toDecimals).toBe(6)
     }
+  })
+
+  it('accepts camelCase NormalizeArgs and exposes them on the typed result surface', () => {
+    const args: NormalizeArgs = {
+      chain: 'Base',
+      chainId: '8453',
+      fromChain: 'Base',
+      toChain: 'Arbitrum',
+    }
+
+    const [leg]: NormalizedTx[] = splitMultiTx(
+      {
+        transactions: [{ to: '0xbridge', step: 'bridge' }],
+        provider: 'cctp',
+      },
+      args
+    )
+
+    const typedChainId: string | undefined = leg.chainId
+    const typedFromChain: string | undefined = leg.fromChain
+    const typedToChain: string | undefined = leg.toChain
+    const typedProvider: string | undefined = leg.provider
+    const typedTx = leg.tx as Record<string, unknown>
+
+    expect(typedChainId).toBe('8453')
+    expect(typedFromChain).toBe('Base')
+    expect(typedToChain).toBe('Arbitrum')
+    expect(typedProvider).toBe('cctp')
+    expect(typedTx.step).toBe('bridge')
   })
 })


### PR DESCRIPTION
## summary
- widen the public tx-normalization types to include the camelCase routing metadata the runtime already preserves
- accept camelCase normalization args in the shared routing-enrichment path
- add a regression test and changeset

closes https://github.com/vultisig/vultisig-sdk/issues/2137

## receipts
- `corepack yarn workspace @vultisig/sdk vitest run --config tests/unit/vitest.config.ts tests/unit/tx/normalize.test.ts`
- `corepack yarn workspace @vultisig/sdk build:platform:node`
- `node -e "import('./packages/sdk/dist/tx/index.js').then(m=>{const legs=m.splitMultiTx({transactions:[{to:'0xbridge',step:'bridge'}],provider:'cctp'},{chain:'Base',chainId:'8453',fromChain:'Base',toChain:'Arbitrum'}); console.log(JSON.stringify(legs));})"`

## pre-existing blockers observed
- `corepack yarn workspace @vultisig/sdk typecheck` still fails on the existing Cardano `auxiliaryData` typing errors plus missing `koffi`
- `corepack yarn cli:build` still fails on the existing missing Ripple dist exports from sibling workspaces

## artifact
- round 157 report mirror: https://gist.github.com/gomesalexandre/15092ce5159d9e74ccd8cddcaa19c31f
- companion app issue: https://github.com/vultisig/vultiagent-app/issues/2677
