### PR TITLE
fix(sdk): align Cosmos governance support

### DIFF
--- a/.changeset/fix-cosmos-governance-parity.md
+++ b/.changeset/fix-cosmos-governance-parity.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Restore Cosmos governance parity with the agent backend by accepting Sei, Injective, Neutron, Celestia, and Stride (including their chain IDs) for proposal reads and unsigned vote preparation. Terra Classic `gov/v1beta1` proposal filters now use the required integer enum values instead of `PROPOSAL_STATUS_*` strings.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -708,6 +708,8 @@ export type {
   GetCosmosGovernanceProposalsParams,
   GetGovernanceProposalsResult,
   GovChain,
+  GovChainId,
+  GovChainInput,
   GovernanceProposal,
   PrepareCosmosVoteParams,
   ProposalStatus,

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -539,6 +539,8 @@ export type {
   GetCosmosGovernanceProposalsParams,
   GetGovernanceProposalsResult,
   GovChain,
+  GovChainId,
+  GovChainInput,
   GovernanceProposal,
   PrepareCosmosVoteParams,
   ProposalStatus,

--- a/packages/sdk/src/tools/cosmos/gov.ts
+++ b/packages/sdk/src/tools/cosmos/gov.ts
@@ -11,60 +11,116 @@
  * module NEVER signs and NEVER broadcasts — the caller routes the envelope
  * through the wallet's signing path.
  *
- * Chains are keyed by the SDK `IbcEnabledCosmosChain` enum and resolve their
- * LCD root from the shared `cosmosRpcUrl` registry, so there's no second
- * chain-id/REST-URL table to drift. Address validation uses `@cosmjs/encoding`
- * (already a core-chain dependency) rather than a hand-rolled bech32 decoder.
+ * First-class wallet chains reuse the SDK's `IbcEnabledCosmosChain`, chain-id,
+ * and LCD registries. Governance-only chains additionally supported by the
+ * agent backend are declared here because they do not have wallet/RPC support
+ * in core-chain. Address validation uses `@cosmjs/encoding` (already a
+ * core-chain dependency) rather than a hand-rolled bech32 decoder.
  */
 import { fromBech32, toBech32 } from '@cosmjs/encoding'
 import { IbcEnabledCosmosChain } from '@vultisig/core-chain/Chain'
 import { getCosmosChainId } from '@vultisig/core-chain/chains/cosmos/chainInfo'
 import { cosmosRpcUrl } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
-import { getAuthAccountUrl } from '@vultisig/core-chain/chains/cosmos/staking/lcdQueries'
 
 // ── chain support ──────────────────────────────────────────────────────────
 
+type GovernanceOnlyChain = 'Celestia' | 'Injective' | 'Neutron' | 'Sei' | 'Stride'
+
 /** Chains this module serves governance reads/votes for. */
-export type GovChain = IbcEnabledCosmosChain
+export type GovChain = IbcEnabledCosmosChain | GovernanceOnlyChain
 
-/**
- * Expected bech32 HRP (human-readable prefix) per gov chain, used to reject a
- * voter address that belongs to a different chain (e.g. an `osmo1…` address
- * submitted as a Cosmos Hub vote). No centralized HRP map exists in core-chain,
- * so it's declared here for the small, stable set of gov chains.
- */
-const CHAIN_HRP: Record<GovChain, string> = {
-  Cosmos: 'cosmos',
-  Osmosis: 'osmo',
-  Dydx: 'dydx',
-  Kujira: 'kujira',
-  Terra: 'terra',
-  TerraClassic: 'terra',
-  Noble: 'noble',
-  Akash: 'akash',
+/** Network chain IDs accepted as aliases for their canonical `GovChain`. */
+export type GovChainId =
+  | 'akashnet-2'
+  | 'celestia'
+  | 'columbus-5'
+  | 'cosmoshub-4'
+  | 'dydx-mainnet-1'
+  | 'injective-1'
+  | 'kaiyo-1'
+  | 'neutron-1'
+  | 'noble-1'
+  | 'osmosis-1'
+  | 'pacific-1'
+  | 'phoenix-1'
+  | 'stride-1'
+
+/** Canonical SDK chain name or its network chain ID. */
+export type GovChainInput = GovChain | GovChainId
+
+type GovChainConfig = {
+  chainId: GovChainId
+  hrp: string
+  lcdRoot: string
+  usesGovV1: boolean
 }
 
+const coreGovChainConfig = (chain: IbcEnabledCosmosChain, hrp: string, usesGovV1 = true): GovChainConfig => ({
+  chainId: getCosmosChainId(chain) as GovChainId,
+  hrp,
+  lcdRoot: cosmosRpcUrl[chain],
+  usesGovV1,
+})
+
 /**
- * Whether a chain serves the modern `gov/v1` endpoint. TerraClassic
- * (columbus-5) runs an older Cosmos SDK and only exposes `gov/v1beta1`; the
- * rest prefer `gov/v1` and fall back to `v1beta1` on 404/501.
+ * Governance transport metadata. First-class wallet chains keep using the
+ * core-chain registries; the five governance-only entries mirror the backend's
+ * wider canonical set. Their REST roots are public endpoints from the Cosmos
+ * chain registry.
  */
-const GOV_V1: Record<GovChain, boolean> = {
-  Cosmos: true,
-  Osmosis: true,
-  Dydx: true,
-  Kujira: true,
-  Terra: true,
-  TerraClassic: false,
-  Noble: true,
-  Akash: true,
+const GOV_CHAIN_CONFIG: Record<GovChain, GovChainConfig> = {
+  Cosmos: coreGovChainConfig('Cosmos', 'cosmos'),
+  Osmosis: coreGovChainConfig('Osmosis', 'osmo'),
+  Dydx: coreGovChainConfig('Dydx', 'dydx'),
+  Kujira: coreGovChainConfig('Kujira', 'kujira'),
+  Terra: coreGovChainConfig('Terra', 'terra'),
+  TerraClassic: coreGovChainConfig('TerraClassic', 'terra', false),
+  Noble: coreGovChainConfig('Noble', 'noble'),
+  Akash: coreGovChainConfig('Akash', 'akash'),
+  Sei: {
+    chainId: 'pacific-1',
+    hrp: 'sei',
+    lcdRoot: 'https://sei-rest.publicnode.com',
+    usesGovV1: false,
+  },
+  Injective: {
+    chainId: 'injective-1',
+    hrp: 'inj',
+    lcdRoot: 'https://injective-rest.publicnode.com',
+    usesGovV1: true,
+  },
+  Neutron: {
+    chainId: 'neutron-1',
+    hrp: 'neutron',
+    lcdRoot: 'https://neutron-rest.publicnode.com',
+    usesGovV1: true,
+  },
+  Celestia: {
+    chainId: 'celestia',
+    hrp: 'celestia',
+    lcdRoot: 'https://celestia-rest.publicnode.com',
+    usesGovV1: true,
+  },
+  Stride: {
+    chainId: 'stride-1',
+    hrp: 'stride',
+    lcdRoot: 'https://stride-api.polkachu.com',
+    usesGovV1: true,
+  },
 }
 
-const isGovChain = (chain: string): chain is GovChain => Object.prototype.hasOwnProperty.call(CHAIN_HRP, chain)
+const isGovChain = (chain: string): chain is GovChain => Object.prototype.hasOwnProperty.call(GOV_CHAIN_CONFIG, chain)
 
-const SUPPORTED_CHAINS = Object.keys(CHAIN_HRP).sort().join(', ')
+const GOV_CHAIN_BY_ID = Object.fromEntries(
+  Object.entries(GOV_CHAIN_CONFIG).map(([chain, config]) => [config.chainId, chain])
+) as Record<GovChainId, GovChain>
 
-const lcdRoot = (chain: GovChain): string => cosmosRpcUrl[chain]
+const resolveGovChain = (input: GovChainInput): GovChain | undefined =>
+  isGovChain(input) ? input : GOV_CHAIN_BY_ID[input as GovChainId]
+
+const SUPPORTED_CHAINS = [...Object.keys(GOV_CHAIN_CONFIG), ...Object.keys(GOV_CHAIN_BY_ID)].sort().join(', ')
+
+const lcdRoot = (chain: GovChain): string => GOV_CHAIN_CONFIG[chain].lcdRoot
 
 // ── proposal status maps ────────────────────────────────────────────────────
 
@@ -79,10 +135,10 @@ const STATUS_V1: Record<ProposalStatus, string> = {
 }
 
 const STATUS_V1BETA1: Record<ProposalStatus, string> = {
-  voting: 'PROPOSAL_STATUS_VOTING_PERIOD',
-  passed: 'PROPOSAL_STATUS_PASSED',
-  rejected: 'PROPOSAL_STATUS_REJECTED',
-  deposit_period: 'PROPOSAL_STATUS_DEPOSIT_PERIOD',
+  voting: '2',
+  passed: '3',
+  rejected: '4',
+  deposit_period: '1',
   all: '0',
 }
 
@@ -304,7 +360,7 @@ function parseAuthAccount(resp: AuthAccountResponse): { accountNumber: string; s
 // ── public: read proposals ───────────────────────────────────────────────────
 
 export type GetCosmosGovernanceProposalsParams = {
-  chain: GovChain
+  chain: GovChainInput
   /** Status filter. Defaults to `voting`. */
   status?: ProposalStatus
   /** Max proposals per page (1-100, default 20). */
@@ -328,15 +384,16 @@ export type GetCosmosGovernanceProposalsParams = {
 export async function getCosmosGovernanceProposals(
   params: GetCosmosGovernanceProposalsParams
 ): Promise<GetGovernanceProposalsResult> {
-  const { chain, status = 'voting', limit: rawLimit, fetchImpl, signal } = params
-  if (!isGovChain(chain)) {
-    throw new Error(`unsupported chain "${chain}" — supported: ${SUPPORTED_CHAINS}`)
+  const { chain: chainInput, status = 'voting', limit: rawLimit, fetchImpl, signal } = params
+  const chain = resolveGovChain(chainInput)
+  if (!chain) {
+    throw new Error(`unsupported chain "${chainInput}" — supported: ${SUPPORTED_CHAINS}`)
   }
   const limit = Math.min(Math.max(rawLimit ?? 20, 1), 100)
   const opts: FetchOpts = { fetchImpl, signal }
 
   let proposals: GovernanceProposal[]
-  if (GOV_V1[chain]) {
+  if (GOV_CHAIN_CONFIG[chain].usesGovV1) {
     try {
       proposals = await fetchProposalsV1(chain, status, limit, opts)
     } catch (e) {
@@ -353,7 +410,7 @@ export async function getCosmosGovernanceProposals(
 
   return {
     chain,
-    chainId: getCosmosChainId(chain),
+    chainId: GOV_CHAIN_CONFIG[chain].chainId,
     status,
     count: proposals.length,
     proposals,
@@ -363,7 +420,7 @@ export async function getCosmosGovernanceProposals(
 // ── public: build unsigned vote envelope ─────────────────────────────────────
 
 export type PrepareCosmosVoteParams = {
-  chain: GovChain
+  chain: GovChainInput
   /** Bech32 voter address (HRP must match the chain). */
   voter: string
   /** Governance proposal ID (positive integer string, e.g. "42"). */
@@ -393,14 +450,15 @@ export type PrepareCosmosVoteParams = {
  * ```
  */
 export async function prepareCosmosVote(params: PrepareCosmosVoteParams): Promise<CosmosVoteEnvelope> {
-  const { chain, voter: rawVoter, proposalId, option, metadata, fetchImpl, signal } = params
+  const { chain: chainInput, voter: rawVoter, proposalId, option, metadata, fetchImpl, signal } = params
 
-  if (!isGovChain(chain)) {
-    throw new Error(`unsupported chain "${chain}" — supported: ${SUPPORTED_CHAINS}`)
+  const chain = resolveGovChain(chainInput)
+  if (!chain) {
+    throw new Error(`unsupported chain "${chainInput}" — supported: ${SUPPORTED_CHAINS}`)
   }
 
   // Validate voter bech32 address + chain HRP, then normalize (re-encode).
-  const expectedHrp = CHAIN_HRP[chain]
+  const expectedHrp = GOV_CHAIN_CONFIG[chain].hrp
   let decoded: ReturnType<typeof fromBech32>
   try {
     decoded = fromBech32(rawVoter.trim())
@@ -437,7 +495,10 @@ export async function prepareCosmosVote(params: PrepareCosmosVoteParams): Promis
   let accountNumber = '0'
   let sequence = '0'
   try {
-    const resp = await lcdGet<AuthAccountResponse>(getAuthAccountUrl(chain, voter), { fetchImpl, signal })
+    const resp = await lcdGet<AuthAccountResponse>(`${lcdRoot(chain)}/cosmos/auth/v1beta1/accounts/${voter}`, {
+      fetchImpl,
+      signal,
+    })
     const parsed = parseAuthAccount(resp)
     if (parsed) {
       accountNumber = parsed.accountNumber
@@ -461,7 +522,7 @@ export async function prepareCosmosVote(params: PrepareCosmosVoteParams): Promis
     action: 'governance_vote',
     signingMode: 'ecdsa_secp256k1',
     chain,
-    chainId: getCosmosChainId(chain),
+    chainId: GOV_CHAIN_CONFIG[chain].chainId,
     voter,
     proposalId,
     option,

--- a/packages/sdk/src/tools/cosmos/gov.ts
+++ b/packages/sdk/src/tools/cosmos/gov.ts
@@ -118,9 +118,7 @@ const GOV_CHAIN_BY_ID = Object.assign(
 
 const resolveGovChain = (input: GovChainInput): GovChain | undefined => {
   if (isGovChain(input)) return input
-  return Object.prototype.hasOwnProperty.call(GOV_CHAIN_BY_ID, input)
-    ? GOV_CHAIN_BY_ID[input as GovChainId]
-    : undefined
+  return Object.prototype.hasOwnProperty.call(GOV_CHAIN_BY_ID, input) ? GOV_CHAIN_BY_ID[input as GovChainId] : undefined
 }
 
 const SUPPORTED_CHAINS = [...Object.keys(GOV_CHAIN_CONFIG), ...Object.keys(GOV_CHAIN_BY_ID)].sort().join(', ')

--- a/packages/sdk/src/tools/cosmos/gov.ts
+++ b/packages/sdk/src/tools/cosmos/gov.ts
@@ -111,12 +111,17 @@ const GOV_CHAIN_CONFIG: Record<GovChain, GovChainConfig> = {
 
 const isGovChain = (chain: string): chain is GovChain => Object.prototype.hasOwnProperty.call(GOV_CHAIN_CONFIG, chain)
 
-const GOV_CHAIN_BY_ID = Object.fromEntries(
-  Object.entries(GOV_CHAIN_CONFIG).map(([chain, config]) => [config.chainId, chain])
-) as Record<GovChainId, GovChain>
+const GOV_CHAIN_BY_ID = Object.assign(
+  Object.create(null) as Record<GovChainId, GovChain>,
+  Object.fromEntries(Object.entries(GOV_CHAIN_CONFIG).map(([chain, config]) => [config.chainId, chain]))
+)
 
-const resolveGovChain = (input: GovChainInput): GovChain | undefined =>
-  isGovChain(input) ? input : GOV_CHAIN_BY_ID[input as GovChainId]
+const resolveGovChain = (input: GovChainInput): GovChain | undefined => {
+  if (isGovChain(input)) return input
+  return Object.prototype.hasOwnProperty.call(GOV_CHAIN_BY_ID, input)
+    ? GOV_CHAIN_BY_ID[input as GovChainId]
+    : undefined
+}
 
 const SUPPORTED_CHAINS = [...Object.keys(GOV_CHAIN_CONFIG), ...Object.keys(GOV_CHAIN_BY_ID)].sort().join(', ')
 

--- a/packages/sdk/src/tools/cosmos/index.ts
+++ b/packages/sdk/src/tools/cosmos/index.ts
@@ -7,6 +7,8 @@ export type {
   GetCosmosGovernanceProposalsParams,
   GetGovernanceProposalsResult,
   GovChain,
+  GovChainId,
+  GovChainInput,
   GovernanceProposal,
   PrepareCosmosVoteParams,
   ProposalStatus,

--- a/packages/sdk/src/tools/index.ts
+++ b/packages/sdk/src/tools/index.ts
@@ -135,6 +135,8 @@ export type {
   GetCosmosGovernanceProposalsParams,
   GetGovernanceProposalsResult,
   GovChain,
+  GovChainId,
+  GovChainInput,
   GovernanceProposal,
   PrepareCosmosVoteParams,
   ProposalStatus,

--- a/packages/sdk/tests/unit/tools/cosmos/gov.test.ts
+++ b/packages/sdk/tests/unit/tools/cosmos/gov.test.ts
@@ -1,3 +1,4 @@
+import { toBech32 } from '@cosmjs/encoding'
 import { describe, expect, it, vi } from 'vitest'
 
 import { getCosmosGovernanceProposals, prepareCosmosVote } from '@/tools/cosmos/gov'
@@ -5,6 +6,44 @@ import { getCosmosGovernanceProposals, prepareCosmosVote } from '@/tools/cosmos/
 // Deterministic valid bech32 test addresses (20-byte payloads).
 const COSMOS_ADDR = 'cosmos1qurswpc8qurswpc8qurswpc8qurswpc8nn86qp'
 const OSMO_ADDR = 'osmo1qurswpc8qurswpc8qurswpc8qurswpc8mg52kn'
+
+const extendedGovernanceChains = [
+  {
+    chain: 'Sei',
+    chainId: 'pacific-1',
+    hrp: 'sei',
+    lcdRoot: 'https://sei-rest.publicnode.com',
+    govVersion: 'v1beta1',
+  },
+  {
+    chain: 'Injective',
+    chainId: 'injective-1',
+    hrp: 'inj',
+    lcdRoot: 'https://injective-rest.publicnode.com',
+    govVersion: 'v1',
+  },
+  {
+    chain: 'Neutron',
+    chainId: 'neutron-1',
+    hrp: 'neutron',
+    lcdRoot: 'https://neutron-rest.publicnode.com',
+    govVersion: 'v1',
+  },
+  {
+    chain: 'Celestia',
+    chainId: 'celestia',
+    hrp: 'celestia',
+    lcdRoot: 'https://celestia-rest.publicnode.com',
+    govVersion: 'v1',
+  },
+  {
+    chain: 'Stride',
+    chainId: 'stride-1',
+    hrp: 'stride',
+    lcdRoot: 'https://stride-api.polkachu.com',
+    govVersion: 'v1',
+  },
+] as const
 
 /** Build a fetch stub that returns `body` (JSON) for any URL matching `match`. */
 function mockFetch(routes: Array<{ match: RegExp; status?: number; body: unknown }>): typeof fetch {
@@ -94,6 +133,47 @@ describe('getCosmosGovernanceProposals', () => {
     expect(res.count).toBe(0)
   })
 
+  it.each([
+    ['deposit_period', '1'],
+    ['voting', '2'],
+    ['passed', '3'],
+    ['rejected', '4'],
+    ['all', '0'],
+  ] as const)('encodes the TerraClassic %s status as gov/v1beta1 integer %s', async (status, expected) => {
+    let requestedUrl = ''
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      requestedUrl = String(input)
+      return { ok: true, status: 200, json: async () => ({ proposals: [] }) } as Response
+    }) as unknown as typeof fetch
+
+    await getCosmosGovernanceProposals({ chain: 'TerraClassic', status, fetchImpl })
+
+    const url = new URL(requestedUrl)
+    expect(url.pathname).toBe('/cosmos/gov/v1beta1/proposals')
+    expect(url.searchParams.get('proposal_status')).toBe(expected)
+  })
+
+  it.each(extendedGovernanceChains)(
+    'supports $chain governance via both the canonical name and $chainId alias',
+    async ({ chain, chainId, lcdRoot, govVersion }) => {
+      const requestedUrls: string[] = []
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+        requestedUrls.push(String(input))
+        return { ok: true, status: 200, json: async () => ({ proposals: [] }) } as Response
+      }) as unknown as typeof fetch
+
+      const byName = await getCosmosGovernanceProposals({ chain, fetchImpl })
+      const byChainId = await getCosmosGovernanceProposals({ chain: chainId, fetchImpl })
+
+      expect(byName).toMatchObject({ chain, chainId, count: 0 })
+      expect(byChainId).toMatchObject({ chain, chainId, count: 0 })
+      expect(requestedUrls).toEqual([
+        expect.stringMatching(new RegExp(`^${lcdRoot}/cosmos/gov/${govVersion}/proposals\\?`)),
+        expect.stringMatching(new RegExp(`^${lcdRoot}/cosmos/gov/${govVersion}/proposals\\?`)),
+      ])
+    }
+  )
+
   it('rejects an unsupported chain', async () => {
     await expect(
       // @ts-expect-error — intentionally passing a non-gov chain
@@ -134,6 +214,33 @@ describe('prepareCosmosVote', () => {
     })
     expect(env.metadata).toBeUndefined()
   })
+
+  it.each(extendedGovernanceChains)(
+    'builds a $chain vote from the $chainId alias with the correct HRP and LCD',
+    async ({ chain, chainId, hrp, lcdRoot }) => {
+      const voter = toBech32(hrp, new Uint8Array(20).fill(7))
+      let requestedUrl = ''
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+        requestedUrl = String(input)
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ account: { account_number: '12', sequence: '3' } }),
+        } as Response
+      }) as unknown as typeof fetch
+
+      const env = await prepareCosmosVote({
+        chain: chainId,
+        voter,
+        proposalId: '9',
+        option: 'yes',
+        fetchImpl,
+      })
+
+      expect(env).toMatchObject({ chain, chainId, voter, accountNumber: '12', sequence: '3' })
+      expect(requestedUrl).toBe(`${lcdRoot}/cosmos/auth/v1beta1/accounts/${voter}`)
+    }
+  )
 
   it('maps every vote option to its VOTE_OPTION_* constant', async () => {
     const fetchImpl = mockFetch([authRoute('1', '0')])

--- a/packages/sdk/tests/unit/tools/cosmos/gov.test.ts
+++ b/packages/sdk/tests/unit/tools/cosmos/gov.test.ts
@@ -174,12 +174,15 @@ describe('getCosmosGovernanceProposals', () => {
     }
   )
 
-  it('rejects an unsupported chain', async () => {
-    await expect(
-      // @ts-expect-error — intentionally passing a non-gov chain
-      getCosmosGovernanceProposals({ chain: 'Bitcoin' })
-    ).rejects.toThrow(/unsupported chain/)
-  })
+  it.each(['Bitcoin', 'toString', 'constructor', '__proto__'] as const)(
+    'rejects unsupported chain input %s for proposal reads',
+    async chain => {
+      await expect(
+        // @ts-expect-error — intentionally passing a non-gov chain-like runtime string
+        getCosmosGovernanceProposals({ chain })
+      ).rejects.toThrow(/unsupported chain/)
+    }
+  )
 })
 
 describe('prepareCosmosVote', () => {
@@ -307,11 +310,21 @@ describe('prepareCosmosVote', () => {
     ).rejects.toThrow(/does not match expected "cosmos"/)
   })
 
-  it('rejects a malformed bech32 address', async () => {
+  it('rejects a malformed bech32 voter address', async () => {
     await expect(
-      prepareCosmosVote({ chain: 'Cosmos', voter: 'not-an-address', proposalId: '1', option: 'yes' })
-    ).rejects.toThrow(/malformed bech32/)
+      prepareCosmosVote({ chain: 'Cosmos', voter: 'not-bech32', proposalId: '1', option: 'yes' })
+    ).rejects.toThrow(/invalid voter address: malformed bech32/)
   })
+
+  it.each(['toString', 'constructor', '__proto__'] as const)(
+    'rejects unsupported chain input %s for vote prep',
+    async chain => {
+      await expect(
+        // @ts-expect-error — intentionally passing a non-gov chain-like runtime string
+        prepareCosmosVote({ chain, voter: COSMOS_ADDR, proposalId: '1', option: 'yes' })
+      ).rejects.toThrow(/unsupported chain/)
+    }
+  )
 
   it('rejects a non-positive proposalId', async () => {
     const fetchImpl = mockFetch([authRoute('1', '0')])


### PR DESCRIPTION
Closes #2139
Closes #2139

Expands the SDK Cosmos governance canonical to Sei, Injective, Neutron, Celestia, and Stride by canonical name or chain ID; exports the public governance input types; and fixes Terra Classic v1beta1 integer proposal-status encoding.

Real QA exercised the built public SDK against live governance endpoints for the five new networks plus Terra Classic and constructed unsigned vote envelopes from live account lookups with the expected chain IDs, HRPs, and VOTE_OPTION_YES. No signing or broadcast was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Cosmos governance support for Sei, Injective, Neutron, Celestia, and Stride.
  * Proposals and votes now accept canonical chain names or chain IDs.
  * Added chain-specific governance endpoints, address formats, and API version handling.
  * Exposed governance chain types and custom-message signing tools through the SDK and React Native SDK.

* **Bug Fixes**
  * Restored Terra Classic proposal filtering compatibility.
  * Improved proposal retrieval and unsigned vote preparation across supported chains.
  * Improved validation for unsupported or malformed chain and voter inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->