### PR TITLE
fix(sdk): export Cardano extended UTXOs on RN surface

### DIFF
--- a/.changeset/r159-cardano-extended-utxos-export.md
+++ b/.changeset/r159-cardano-extended-utxos-export.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+Export `chains.cardano.getCardanoExtendedUtxos` and the `CardanoExtendedUtxo` type on the curated React Native SDK entry so downstream consumers can reuse the canonical asset-aware Cardano UTXO fetcher instead of maintaining app-local Koios overlays.

--- a/packages/sdk/src/platforms/react-native/chains/cardano/index.ts
+++ b/packages/sdk/src/platforms/react-native/chains/cardano/index.ts
@@ -4,6 +4,8 @@ export { buildCardanoWitnessSet } from '@vultisig/core-chain/chains/cardano/cip3
 export { cardanoTxBodyHash } from '@vultisig/core-chain/chains/cardano/cip30/cardanoTxBodyHash'
 export { getCardanoCurrentSlot } from '@vultisig/core-chain/chains/cardano/client/currentSlot'
 export { submitCardanoCbor } from '@vultisig/core-chain/chains/cardano/submit/submitCardanoCbor'
+export type { CardanoExtendedUtxo } from '@vultisig/core-chain/chains/cardano/utxo/getCardanoExtendedUtxos'
+export { getCardanoExtendedUtxos } from '@vultisig/core-chain/chains/cardano/utxo/getCardanoExtendedUtxos'
 export { getCardanoUtxos } from '@vultisig/core-chain/chains/cardano/utxo/getCardanoUtxos'
 export { deriveCardanoAddress } from '@vultisig/core-chain/publicKey/address/cardano'
 export { getCardanoPublicKeyData } from '@vultisig/core-chain/publicKey/cardano'

--- a/packages/sdk/tests/unit/public/cardanoRnExports.test.ts
+++ b/packages/sdk/tests/unit/public/cardanoRnExports.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+describe('cardano RN public exports', () => {
+  it('re-exports the canonical extended UTXO helper and type from the curated RN entry', () => {
+    const sdkRoot = resolve(__dirname, '../../..')
+    const cardanoEntry = readFileSync(resolve(sdkRoot, 'src/platforms/react-native/chains/cardano/index.ts'), 'utf8')
+
+    expect(cardanoEntry).toContain("export type { CardanoExtendedUtxo } from '@vultisig/core-chain/chains/cardano/utxo/getCardanoExtendedUtxos'")
+    expect(cardanoEntry).toContain("export { getCardanoExtendedUtxos } from '@vultisig/core-chain/chains/cardano/utxo/getCardanoExtendedUtxos'")
+  })
+})


### PR DESCRIPTION
## Summary
- export  and  on the curated React Native SDK entry
- add a focused public-surface regression test for the RN Cardano export line
- document the /improve finding in a changeset so the SDK + CLI patch together

Closes https://github.com/vultisig/vultisig-sdk/issues/2143

## Why
The SDK already owned the canonical Cardano  UTXO fetcher in core, but the RN entry omitted it, so vultiagent-app kept an app-local Koios overlay for token-aware UTXO selection.

## Verification
- 
[1m[30m[46m RUN [49m[39m[22m [36mv4.1.8 [39m[90m/private/tmp/vultisig-sdk-r159-vy7tjW[39m

 [32m✓[39m packages/sdk/tests/unit/public/cardanoRnExports.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 1[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m   Start at [22m 15:08:41
[2m   Duration [22m 63ms[2m (transform 7ms, setup 0ms, import 11ms, tests 1ms, environment 0ms)[22m
  - PASS
- packages/core/mpc/keysign/signingInputs/resolvers/cardano.ts(72,5): error TS2353: Object literal may only specify known properties, and 'auxiliaryData' does not exist in type 'ISigningInput'.
  - FAILS on current main with a pre-existing blocker in 
  - Error: 

## Cross-repo note
The downstream app migration is intentionally separate: this PR exposes the canonical RN helper so the app can delete its local Koios overlay in a follow-up.

## Report
https://gist.github.com/gomesalexandre/b79de3ad5ce61901c3f3b566d13b052c
