### PR TITLE
fix(solana): preserve raw transaction signature metadata

### DIFF
--- a/.changeset/fix-solana-raw-tx-hash.md
+++ b/.changeset/fix-solana-raw-tx-hash.md
@@ -1,5 +1,6 @@
 ---
 '@vultisig/core-mpc': patch
+'@vultisig/sdk': patch
 ---
 
 Populate Solana `SigningOutput.signatures` when compiling dApp-supplied raw transactions so downstream transaction-hash resolution returns the spliced fee-payer signature instead of crashing after keysign.

--- a/.changeset/fix-solana-raw-tx-hash.md
+++ b/.changeset/fix-solana-raw-tx-hash.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/core-mpc': patch
+---
+
+Populate Solana `SigningOutput.signatures` when compiling dApp-supplied raw transactions so downstream transaction-hash resolution returns the spliced fee-payer signature instead of crashing after keysign.

--- a/packages/core/mpc/keysign/signingInputs/resolvers/solana/rawTx.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/solana/rawTx.test.ts
@@ -11,6 +11,8 @@ import {
 import { create } from '@bufbuild/protobuf'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { getCoinType } from '@vultisig/core-chain/coin/coinType'
+import { getTxHash } from '@vultisig/core-chain/tx/hash'
+import { decodeSigningOutput } from '@vultisig/core-chain/tw/signingOutput'
 import { initWasm, TW, type WalletCore } from '@trustwallet/wallet-core'
 import type { PublicKey } from '@trustwallet/wallet-core/dist/src/wallet-core'
 import base58 from 'bs58'
@@ -273,7 +275,7 @@ describe('signSolana pipeline e2e (encode → hash → sign → compile)', () =>
           keysignPayload,
         })
 
-        const output = TW.Solana.Proto.SigningOutput.decode(compiled)
+        const output = decodeSigningOutput(Chain.Solana, compiled)
         const signedTx = base58.decode(output.encoded)
 
         // The signed tx is the ORIGINAL bytes with our signature in slot 0.
@@ -288,6 +290,17 @@ describe('signSolana pipeline e2e (encode → hash → sign → compile)', () =>
 
         // The spliced signature verifies over the ORIGINAL message bytes.
         expect(publicKey.verify(new Uint8Array(spliced), Buffer.from(message))).toBe(true)
+
+        // The splice path must preserve WalletCore's SigningOutput contract:
+        // downstream hash resolution reads the Solana txid from this metadata.
+        const encodedSignature = base58.encode(spliced)
+        expect(output.signatures).toEqual([
+          {
+            pubkey: feePayer.toBase58(),
+            signature: encodedSignature,
+          },
+        ])
+        expect(getTxHash({ chain: Chain.Solana, tx: output })).toBe(encodedSignature)
 
         return new Uint8Array(signedTx)
       })

--- a/packages/core/mpc/tx/compile/compileTx.ts
+++ b/packages/core/mpc/tx/compile/compileTx.ts
@@ -105,12 +105,21 @@ export const compileTx = ({
     })
 
     const signedTx = spliceSolanaSignature(txInputData, new Uint8Array(signature))
+    const encodedSignature = base58.encode(signature)
 
     return TW.Solana.Proto.SigningOutput.encode(
       TW.Solana.Proto.SigningOutput.create({
         // WalletCore's Solana SigningOutput.encoded is base58 — the broadcast
         // resolver (`broadcastSolanaTx`) and Blockaid inputs decode it as such.
         encoded: base58.encode(signedTx),
+        // getSolanaTxHash reads the fee-payer signature from this metadata.
+        // Keep it identical to the signature spliced into signer slot 0.
+        signatures: [
+          {
+            pubkey: base58.encode(publicKey.data()),
+            signature: encodedSignature,
+          },
+        ],
       })
     ).finish()
   }


### PR DESCRIPTION
Closes #2145
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Solana raw transactions now correctly include fee-payer and generated signature metadata in signing results.
  * Transaction hashes are correctly derived after signatures are added.
* **Tests**
  * Added coverage to verify preserved signature metadata and encoded transaction hashes.
* **Release**
  * Prepared a patch release for the Solana signing fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->