### PR TITLE
feat(sdk): export IBC reverse route helper

### DIFF
--- a/.changeset/few-mails-hug.md
+++ b/.changeset/few-mails-hug.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+Export `resolveSourceChannelByDestChain` from the supported SDK root and prep surfaces so first-party IBC consumers can reuse the canonical reverse route lookup instead of rebuilding the route index locally.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1097,6 +1097,7 @@ export {
   stakekitSearch,
   stripChainPrefix,
   SUI_NATIVE_COIN_TYPE,
+  resolveSourceChannelByDestChain,
   supportedIbcDestinationsFrom,
   supportedUtxoBalanceChains,
   SwapQuoteExpiredError,

--- a/packages/sdk/src/tools/index.ts
+++ b/packages/sdk/src/tools/index.ts
@@ -380,6 +380,7 @@ export {
   prepareIbcTransfer,
   type PrepareIbcTransferParams,
   type PrepareIbcTransferResult,
+  resolveSourceChannelByDestChain,
   prepareJettonTransferTxFromKeys,
   type PrepareJettonTransferTxFromKeysParams,
   preparePolkadotAssetSend,

--- a/packages/sdk/src/tools/prep/ibcTransfer.ts
+++ b/packages/sdk/src/tools/prep/ibcTransfer.ts
@@ -124,7 +124,7 @@ const IBC_CHANNEL_BY_ROUTE: Map<string, string> = (() => {
 })()
 
 /** source_channel for a given (from_chain → to_chain_id) route, or null. */
-function resolveSourceChannelByDestChain(fromChain: string, toChainId: string): string | null {
+export function resolveSourceChannelByDestChain(fromChain: string, toChainId: string): string | null {
   return IBC_CHANNEL_BY_ROUTE.get(`${fromChain}→${toChainId}`) ?? null
 }
 

--- a/packages/sdk/src/tools/prep/index.ts
+++ b/packages/sdk/src/tools/prep/index.ts
@@ -29,6 +29,7 @@ export {
   prepareIbcTransfer,
   type PrepareIbcTransferParams,
   type PrepareIbcTransferResult,
+  resolveSourceChannelByDestChain,
   supportedIbcDestinationsFrom,
 } from './ibcTransfer'
 export { prepareJettonTransferTxFromKeys, type PrepareJettonTransferTxFromKeysParams } from './jettonTransfer'

--- a/packages/sdk/tests/unit/cosmos/ibcTransfer.test.ts
+++ b/packages/sdk/tests/unit/cosmos/ibcTransfer.test.ts
@@ -13,6 +13,7 @@ import {
   IBC_MSG_TRANSFER_TYPE_URL,
   normaliseIbcChainId,
   prepareIbcTransfer,
+  resolveSourceChannelByDestChain,
   supportedIbcDestinationsFrom,
 } from '@/tools/prep/ibcTransfer'
 
@@ -113,6 +114,12 @@ describe('prepareIbcTransfer', () => {
     })
     expect(r.destChain).toBe('osmosis-1')
     expect(r.sourceChannel).toBe('channel-1')
+  })
+
+  it('exports the reverse route lookup used by prepareIbcTransfer', () => {
+    expect(resolveSourceChannelByDestChain('osmosis-1', 'cosmoshub-4')).toBe('channel-0')
+    expect(resolveSourceChannelByDestChain('cosmoshub-4', 'noble-1')).toBe('channel-536')
+    expect(resolveSourceChannelByDestChain('cosmoshub-4', 'juno-1')).toBeNull()
   })
 
   it('cross-validates sourceChannel + toChainId and throws on a mismatched pair', () => {

--- a/packages/sdk/tests/unit/public/ibcRouteHelperRootExports.test.ts
+++ b/packages/sdk/tests/unit/public/ibcRouteHelperRootExports.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveSourceChannelByDestChain } from '@/index'
+import { resolveSourceChannelByDestChain as resolveSourceChannelByDestChainFromPrep } from '@/tools/prep'
+
+// sdk#<TBD> - build-ibc-transfer consumers still need the reverse route lookup
+// that prepareIbcTransfer already uses internally. Keeping it private forces
+// first-party consumers to rebuild the SDK's IBC route index locally, which is
+// exactly the duplicated-not-imported drift this campaign keeps finding.
+describe('SDK root exports the IBC reverse route helper', () => {
+  it('re-exports resolveSourceChannelByDestChain as the same reference as the prep barrel', () => {
+    expect(resolveSourceChannelByDestChain).toBe(resolveSourceChannelByDestChainFromPrep)
+    expect(resolveSourceChannelByDestChain('osmosis-1', 'cosmoshub-4')).toBe('channel-0')
+    expect(resolveSourceChannelByDestChain('cosmoshub-4', 'juno-1')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- export `resolveSourceChannelByDestChain(...)` from the supported SDK root and prep surfaces
- add focused regression coverage for the reverse IBC route lookup
- add a changeset for the new public helper

## Why
`prepareIbcTransfer(...)` already relies on the SDK's canonical reverse IBC route lookup internally, but first-party consumers such as `agent-backend-ts` still had to rebuild the same reverse index locally because the helper was private. This is the duplicated-not-imported drift class the recurring `/improve` campaign keeps finding.

## Changes
- `packages/sdk/src/tools/prep/ibcTransfer.ts`
- `packages/sdk/src/tools/prep/index.ts`
- `packages/sdk/src/tools/index.ts`
- `packages/sdk/src/index.ts`
- `packages/sdk/tests/unit/cosmos/ibcTransfer.test.ts`
- `packages/sdk/tests/unit/public/ibcRouteHelperRootExports.test.ts`
- `.changeset/few-mails-hug.md`

## Verification
- `node .yarn/releases/yarn-4.16.0.cjs vitest run --config packages/sdk/tests/unit/vitest.config.ts packages/sdk/tests/unit/cosmos/ibcTransfer.test.ts packages/sdk/tests/unit/public/ibcRouteHelperRootExports.test.ts`
  - `packages/sdk/tests/unit/cosmos/ibcTransfer.test.ts` ✅
  - root-export suite hit a pre-existing local workspace import blocker: `Cannot find module '/packages/core/config/dist/index.js'`
- `node .yarn/releases/yarn-4.16.0.cjs build:platform:node` ✅
- `node .yarn/releases/yarn-4.16.0.cjs build:shared` ⛔ pre-existing blocker already tracked in project memory: `packages/core/mpc/keysign/signingInputs/resolvers/cardano.ts(72,5): auxiliaryData does not exist in type ISigningInput`

## Issues
- fixes 2151
- related backend follow-up: 2961

## Report
- Round 162 report mirror: https://gist.github.com/gomesalexandre/16f81c059d1362ccf450a2b1db1a450c
