### PR TITLE
fix(sdk): canonicalize fast-vault detection

### DIFF
--- a/.changeset/fix-fast-vault-detection.md
+++ b/.changeset/fix-fast-vault-detection.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/core-mpc': patch
+'@vultisig/sdk': patch
+---
+
+Export canonical server-signer helpers from the SDK root and React Native entrypoints, recognize legacy `VultiServer-*` signers, and route SDK fast-vault classification through the shared detector.

--- a/packages/core/mpc/devices/localPartyId.test.ts
+++ b/packages/core/mpc/devices/localPartyId.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { generateLocalPartyId, hasServer, parseLocalPartyId } from './localPartyId'
+import { generateLocalPartyId, hasServer, isServer, parseLocalPartyId } from './localPartyId'
 
 describe('localPartyId', () => {
   it('generates a CSPRNG-backed hex suffix for SDK parties', () => {
@@ -14,6 +14,24 @@ describe('localPartyId', () => {
 
     expect(id).toMatch(/^Server-[0-9a-f]{16}$/)
     expect(hasServer([id])).toBe(true)
+  })
+
+  it.each(['Server-current', 'server-current', 'VultiServer-legacy', 'vultiserver-legacy'])(
+    'recognizes current and legacy server party ID %s',
+    id => {
+      expect(isServer(id)).toBe(true)
+    }
+  )
+
+  it.each(['Serverless-device', 'VultiServerBackup-device', 'desktop-server-device'])(
+    'does not classify prefix lookalike %s as a server party',
+    id => {
+      expect(isServer(id)).toBe(false)
+    }
+  )
+
+  it('detects a legacy VultiServer signer in a hybrid signer list', () => {
+    expect(hasServer(['iPhone-current', 'VultiServer-legacy'])).toBe(true)
   })
 
   it('parses generated party IDs into device name and suffix', () => {

--- a/packages/core/mpc/devices/localPartyId.ts
+++ b/packages/core/mpc/devices/localPartyId.ts
@@ -5,6 +5,7 @@ import { MpcDevice, mpcDeviceFromDeviceName } from './MpcDevice'
 
 const localPartyIdSeparator = '-'
 const localPartyIdEntropyBytes = 8
+const legacyServerDeviceName = 'vultiserver'
 
 export const generateLocalPartyId = (device: MpcDevice) => {
   const deviceName = device === 'server' ? capitalizeFirstLetter(device) : device
@@ -20,6 +21,10 @@ export const parseLocalPartyId = (localPartyId: string) => {
   return { deviceName, hash }
 }
 
-export const hasServer = (signers: string[]) => signers.some(isServer)
+export const hasServer = (signers: readonly string[]) => signers.some(isServer)
 
-export const isServer = (device: string) => mpcDeviceFromDeviceName(parseLocalPartyId(device).deviceName) === 'server'
+export const isServer = (device: string) => {
+  const { deviceName } = parseLocalPartyId(device)
+
+  return mpcDeviceFromDeviceName(deviceName) === 'server' || deviceName.toLowerCase() === legacyServerDeviceName
+}

--- a/packages/sdk/src/VaultManager.ts
+++ b/packages/sdk/src/VaultManager.ts
@@ -155,9 +155,13 @@ export class VaultManager {
       if (!Number.isSafeInteger(currentRevision) || currentRevision < 0) {
         throw new VaultError(VaultErrorCode.InvalidVault, `Vault ${current.id} has an invalid storage revision`)
       }
+      const nextRevision = currentRevision + 1
+      if (!Number.isSafeInteger(nextRevision)) {
+        throw new VaultError(VaultErrorCode.InvalidVault, `Vault ${current.id} has an invalid storage revision`)
+      }
       const repairedPersisted = {
         ...repaired,
-        revision: currentRevision + 1,
+        revision: nextRevision,
         lastModified: Date.now(),
       }
 

--- a/packages/sdk/src/VaultManager.ts
+++ b/packages/sdk/src/VaultManager.ts
@@ -1,4 +1,5 @@
 import { fromBinary, toBinary } from '@bufbuild/protobuf'
+import { hasServer } from '@vultisig/core-mpc/devices/localPartyId'
 import { fromCommVault } from '@vultisig/core-mpc/types/utils/commVault'
 import {
   type VaultContainer,
@@ -445,7 +446,7 @@ export class VaultManager {
       await this.validateImportConflict(existingVault, parsedVault, password, options.conflictResolution ?? 'reject')
 
       // Determine vault type from parsed vault
-      const vaultType = parsedVault.signers.some((s: string) => s.startsWith('Server-')) ? 'fast' : 'secure'
+      const vaultType = hasServer(parsedVault.signers) ? 'fast' : 'secure'
 
       // Create vault context from SDK context
       const vaultContext = this.createVaultContext()

--- a/packages/sdk/src/VaultManager.ts
+++ b/packages/sdk/src/VaultManager.ts
@@ -646,9 +646,10 @@ export class VaultManager {
       const storedVaultData = await this.storage.get<VaultData>(key)
 
       if (storedVaultData) {
+        const vaultData = await this.repairStoredLegacyFastVaultType(key, storedVaultData)
+        if (!vaultData) continue
+
         try {
-          const vaultData = await this.repairStoredLegacyFastVaultType(key, storedVaultData)
-          if (!vaultData) continue
           vaults.push(this.createVaultInstance(vaultData))
         } catch {
           // Skip vaults that can't be instantiated (e.g., encrypted vault

--- a/packages/sdk/src/VaultManager.ts
+++ b/packages/sdk/src/VaultManager.ts
@@ -24,6 +24,7 @@ import { FastSigningService } from './services/FastSigningService'
 import { VaultData } from './types'
 import { FastVault } from './vault/FastVault'
 import { SecureVault } from './vault/SecureVault'
+import { canonicalizeVaultData } from './vault/utils/canonicalizeVaultData'
 import { VaultBase } from './vault/VaultBase'
 import {
   VaultConflictError,
@@ -133,15 +134,11 @@ export class VaultManager {
     }
   }
 
-  private repairLegacyFastVaultType(vaultData: VaultData): VaultData {
-    return vaultData.type === 'secure' && hasServer(vaultData.signers) ? { ...vaultData, type: 'fast' } : vaultData
-  }
-
   private async repairStoredLegacyFastVaultType(key: string, vaultData: VaultData): Promise<VaultData | null> {
     let current = vaultData
 
     for (let attempt = 0; attempt < 3; attempt++) {
-      const repaired = this.repairLegacyFastVaultType(current)
+      const repaired = canonicalizeVaultData(current)
       if (repaired === current) return current
 
       if (!this.storage.compareAndSet) {
@@ -419,7 +416,7 @@ export class VaultManager {
     // already-persisted legacy `VultiServer-*` records before subclass
     // dispatch so they can be loaded again. Storage-backed load paths also
     // persist the canonical type before constructing the vault.
-    const repairedVaultData = this.repairLegacyFastVaultType(vaultData)
+    const repairedVaultData = canonicalizeVaultData(vaultData)
 
     // Fail early if vault is encrypted but no password callback provided
     if (repairedVaultData.isEncrypted && !this.context.config.onPasswordRequired) {
@@ -646,15 +643,15 @@ export class VaultManager {
       const storedVaultData = await this.storage.get<VaultData>(key)
 
       if (storedVaultData) {
-        const vaultData = await this.repairStoredLegacyFastVaultType(key, storedVaultData)
-        if (!vaultData) continue
-
         try {
+          const vaultData = await this.repairStoredLegacyFastVaultType(key, storedVaultData)
+          if (!vaultData) continue
           vaults.push(this.createVaultInstance(vaultData))
         } catch {
-          // Skip vaults that can't be instantiated (e.g., encrypted vault
-          // without onPasswordRequired). They're still accessible individually
-          // via getVaultById() once the callback is provided.
+          // Skip vaults that can't be repaired or instantiated. A malformed
+          // record must not prevent callers from enumerating healthy vaults.
+          // The record remains accessible individually via getVaultById(),
+          // which reports the underlying error.
         }
       }
     }

--- a/packages/sdk/src/VaultManager.ts
+++ b/packages/sdk/src/VaultManager.ts
@@ -133,6 +133,35 @@ export class VaultManager {
     }
   }
 
+  private repairLegacyFastVaultType(vaultData: VaultData): VaultData {
+    return vaultData.type === 'secure' && hasServer(vaultData.signers) ? { ...vaultData, type: 'fast' } : vaultData
+  }
+
+  private async repairStoredLegacyFastVaultType(key: string, vaultData: VaultData): Promise<VaultData | null> {
+    let current = vaultData
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const repaired = this.repairLegacyFastVaultType(current)
+      if (repaired === current) return current
+
+      if (!this.storage.compareAndSet) {
+        await this.storage.set(key, repaired)
+        return repaired
+      }
+
+      if (await this.storage.compareAndSet(key, current, repaired)) return repaired
+
+      const latest = await this.storage.get<VaultData>(key)
+      if (!latest) return null
+      current = latest
+    }
+
+    throw new VaultError(
+      VaultErrorCode.InvalidVault,
+      `Vault "${vaultData.name}" changed repeatedly while repairing its legacy fast-vault type`
+    )
+  }
+
   private decodeVaultPayload(vultContent: string, password?: string): CoreVault {
     const container = vaultContainerFromString(vultContent.trim())
     let vaultBase64 = container.vault
@@ -370,11 +399,17 @@ export class VaultManager {
    * Returns appropriate subclass based on vault type
    */
   createVaultInstance(vaultData: VaultData, persisted = true): VaultBase {
+    // Older SDKs classified only `Server-*` signers as fast vaults. Repair
+    // already-persisted legacy `VultiServer-*` records before subclass
+    // dispatch so they can be loaded again. Storage-backed load paths also
+    // persist the canonical type before constructing the vault.
+    const repairedVaultData = this.repairLegacyFastVaultType(vaultData)
+
     // Fail early if vault is encrypted but no password callback provided
-    if (vaultData.isEncrypted && !this.context.config.onPasswordRequired) {
+    if (repairedVaultData.isEncrypted && !this.context.config.onPasswordRequired) {
       throw new VaultError(
         VaultErrorCode.InvalidConfig,
-        `Vault "${vaultData.name}" is password-protected but no onPasswordRequired callback was provided. ` +
+        `Vault "${repairedVaultData.name}" is password-protected but no onPasswordRequired callback was provided. ` +
           'Pass onPasswordRequired in the Vultisig constructor: ' +
           'new Vultisig({ onPasswordRequired: async () => password })'
       )
@@ -383,11 +418,11 @@ export class VaultManager {
     const vaultContext = this.createVaultContext()
 
     // Factory pattern - return appropriate subclass based on vault type
-    if (vaultData.type === 'fast') {
+    if (repairedVaultData.type === 'fast') {
       const fastSigningService = new FastSigningService(this.context.serverManager, this.context.wasmProvider)
-      return FastVault.fromStorage(vaultData, fastSigningService, vaultContext, persisted)
+      return FastVault.fromStorage(repairedVaultData, fastSigningService, vaultContext, persisted)
     } else {
-      return SecureVault.fromStorage(vaultData, vaultContext, persisted)
+      return SecureVault.fromStorage(repairedVaultData, vaultContext, persisted)
     }
   }
 
@@ -592,10 +627,12 @@ export class VaultManager {
     const vaults: VaultBase[] = []
 
     for (const key of vaultKeys) {
-      const vaultData = await this.storage.get<VaultData>(key)
+      const storedVaultData = await this.storage.get<VaultData>(key)
 
-      if (vaultData) {
+      if (storedVaultData) {
         try {
+          const vaultData = await this.repairStoredLegacyFastVaultType(key, storedVaultData)
+          if (!vaultData) continue
           vaults.push(this.createVaultInstance(vaultData))
         } catch {
           // Skip vaults that can't be instantiated (e.g., encrypted vault
@@ -623,11 +660,15 @@ export class VaultManager {
    * ```
    */
   async getVaultById(id: string): Promise<VaultBase | null> {
-    const vaultData = await this.storage.get<VaultData>(`vault:${id}`)
+    const key = `vault:${id}`
+    const storedVaultData = await this.storage.get<VaultData>(key)
 
-    if (!vaultData) {
+    if (!storedVaultData) {
       return null
     }
+
+    const vaultData = await this.repairStoredLegacyFastVaultType(key, storedVaultData)
+    if (!vaultData) return null
 
     return this.createVaultInstance(vaultData)
   }

--- a/packages/sdk/src/VaultManager.ts
+++ b/packages/sdk/src/VaultManager.ts
@@ -145,7 +145,9 @@ export class VaultManager {
       if (repaired === current) return current
 
       if (!this.storage.compareAndSet) {
-        await this.storage.set(key, repaired)
+        // Legacy adapters cannot persist the repair without risking a stale
+        // snapshot overwriting a concurrent vault update. Load the canonical
+        // instance now and let a later ordinary save use its revision checks.
         return repaired
       }
 

--- a/packages/sdk/src/VaultManager.ts
+++ b/packages/sdk/src/VaultManager.ts
@@ -151,7 +151,17 @@ export class VaultManager {
         return repaired
       }
 
-      if (await this.storage.compareAndSet(key, current, repaired)) return repaired
+      const currentRevision = current.revision ?? 0
+      if (!Number.isSafeInteger(currentRevision) || currentRevision < 0) {
+        throw new VaultError(VaultErrorCode.InvalidVault, `Vault ${current.id} has an invalid storage revision`)
+      }
+      const repairedPersisted = {
+        ...repaired,
+        revision: currentRevision + 1,
+        lastModified: Date.now(),
+      }
+
+      if (await this.storage.compareAndSet(key, current, repairedPersisted)) return repairedPersisted
 
       const latest = await this.storage.get<VaultData>(key)
       if (!latest) return null

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -22,6 +22,8 @@ export type { VaultConfig, VaultSaveOptions } from './vault'
 export {
   BroadcastPartialFailureError,
   FastVault,
+  hasServer,
+  isServer,
   SecureVault,
   VaultBase,
   VaultConflictError,

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -192,7 +192,7 @@ export { configureMpc, ensureMpcEngine, getMpcEngine } from '@vultisig/mpc-types
 
 // Vault + fast vault lifecycle classes
 export { FastVaultFromSeedphraseService } from '../../services/FastVaultFromSeedphraseService'
-export { FastVault } from '../../vault/FastVault'
+export { FastVault, hasServer, isServer } from '../../vault'
 export type { VaultImportConflictResolution, VaultImportOptions } from '../../VaultManager'
 export { VaultManager } from '../../VaultManager'
 export type { VultisigConfig } from '../../Vultisig'

--- a/packages/sdk/src/services/FastSigningService.ts
+++ b/packages/sdk/src/services/FastSigningService.ts
@@ -1,4 +1,5 @@
 import { Chain } from '@vultisig/core-chain/Chain'
+import { hasServer } from '@vultisig/core-mpc/devices/localPartyId'
 import { Vault as CoreVault } from '@vultisig/core-mpc/vault/Vault'
 
 import type { WasmProvider } from '../context/SdkContext'
@@ -160,7 +161,7 @@ export class FastSigningService {
    * @throws Error if vault doesn't have server signer
    */
   private validateFastVault(vault: CoreVault): void {
-    const hasFastVaultServer = vault.signers.some((signer: string) => signer.startsWith('Server-'))
+    const hasFastVaultServer = hasServer(vault.signers)
 
     if (!hasFastVaultServer) {
       throw new Error(

--- a/packages/sdk/src/vault/FastVault.ts
+++ b/packages/sdk/src/vault/FastVault.ts
@@ -19,6 +19,7 @@ import type {
 } from '../types'
 import { normalizeToHex } from '../utils/bytes'
 import { createVaultBackup } from '../utils/export'
+import { canonicalizeVaultData } from './utils/canonicalizeVaultData'
 import { VaultBase } from './VaultBase'
 import { VaultError, VaultErrorCode } from './VaultError'
 
@@ -473,6 +474,8 @@ export class FastVault extends VaultBase {
     context: VaultContext,
     persisted = true
   ): FastVault {
+    vaultData = canonicalizeVaultData(vaultData)
+
     // Validate vault type
     if (vaultData.type !== 'fast') {
       throw new VaultError(VaultErrorCode.InvalidVault, `Cannot create FastVault from ${vaultData.type} vault data`)

--- a/packages/sdk/src/vault/SecureVault.ts
+++ b/packages/sdk/src/vault/SecureVault.ts
@@ -23,6 +23,7 @@ import type {
 import { normalizeToHex } from '../utils/bytes'
 import { computeNotificationVaultId } from '../utils/computeNotificationVaultId'
 import { createVaultBackup } from '../utils/export'
+import { canonicalizeVaultData } from './utils/canonicalizeVaultData'
 import { VaultBase } from './VaultBase'
 import { VaultError, VaultErrorCode } from './VaultError'
 
@@ -533,6 +534,8 @@ export class SecureVault extends VaultBase {
    * @param context - Vault context with dependencies
    */
   static fromStorage(vaultData: VaultData, context: VaultContext, persisted = true): SecureVault {
+    vaultData = canonicalizeVaultData(vaultData)
+
     // Validate vault type
     if (vaultData.type !== 'secure') {
       throw new VaultError(VaultErrorCode.InvalidVault, `Cannot create SecureVault from ${vaultData.type} vault data`)

--- a/packages/sdk/src/vault/VaultBase.ts
+++ b/packages/sdk/src/vault/VaultBase.ts
@@ -942,6 +942,9 @@ export abstract class VaultBase extends UniversalEventEmitter<VaultEvents> {
   /** @internal Replaces constructor defaults with a stored or pending snapshot. */
   protected restorePersistedVaultData(vaultData: VaultData, persisted = true): void {
     const snapshot = cloneVaultData(vaultData)
+    if (snapshot.type === 'secure' && hasServer(snapshot.signers)) {
+      snapshot.type = 'fast'
+    }
     getVaultRevision(snapshot)
     this.vaultData = snapshot
     this.persistedVaultData = cloneVaultData(snapshot)

--- a/packages/sdk/src/vault/VaultBase.ts
+++ b/packages/sdk/src/vault/VaultBase.ts
@@ -79,6 +79,7 @@ import { TransactionBuilder } from './services/TransactionBuilder'
 // Swap types
 import type { SwapPrepareResult, SwapQuoteParams, SwapQuoteResult, SwapTxParams } from './swap-types'
 import { type ResolvedTokenInfo, resolveTokenRef, resolveTokenRefId } from './tokenRef'
+import { canonicalizeVaultData } from './utils/canonicalizeVaultData'
 import { VaultConflictError, VaultError, VaultErrorCode } from './VaultError'
 import { VaultConfig } from './VaultServices'
 
@@ -941,9 +942,7 @@ export abstract class VaultBase extends UniversalEventEmitter<VaultEvents> {
 
   /** @internal Replaces constructor defaults with a stored or pending snapshot. */
   protected restorePersistedVaultData(vaultData: VaultData, persisted = true): void {
-    const snapshot = cloneVaultData(vaultData)
-    const canonicalSnapshot =
-      snapshot.type === 'secure' && hasServer(snapshot.signers) ? { ...snapshot, type: 'fast' as const } : snapshot
+    const canonicalSnapshot = canonicalizeVaultData(cloneVaultData(vaultData))
     getVaultRevision(canonicalSnapshot)
     this.vaultData = canonicalSnapshot
     this.persistedVaultData = cloneVaultData(canonicalSnapshot)

--- a/packages/sdk/src/vault/VaultBase.ts
+++ b/packages/sdk/src/vault/VaultBase.ts
@@ -14,6 +14,7 @@ import { getTxStatus as coreTxStatus } from '@vultisig/core-chain/tx/status'
 import type { TxStatusResult } from '@vultisig/core-chain/tx/status/resolver'
 import { isValidAddress } from '@vultisig/core-chain/utils/isValidAddress'
 import { vaultConfig } from '@vultisig/core-config'
+import { hasServer } from '@vultisig/core-mpc/devices/localPartyId'
 import { FeeSettings } from '@vultisig/core-mpc/keysign/chainSpecific/FeeSettings'
 import { fromCommVault } from '@vultisig/core-mpc/types/utils/commVault'
 import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
@@ -87,15 +88,6 @@ export type VaultSaveOptions = {
    * local and persisted edits touch different top-level mutable fields.
    */
   conflictStrategy?: 'reject' | 'merge-metadata'
-}
-
-/**
- * Determine vault type based on signer names
- * Fast vaults have one signer that starts with "Server-"
- * Secure vaults have only device signers (no "Server-" prefix)
- */
-function determineVaultType(signers: string[]): 'fast' | 'secure' {
-  return signers.some(signer => signer.startsWith('Server-')) ? 'fast' : 'secure'
 }
 
 // ===== Vault-name / export-filename safety policy (single source of truth) =====
@@ -362,7 +354,7 @@ export abstract class VaultBase extends UniversalEventEmitter<VaultEvents> {
     }
 
     // Determine vault type
-    const vaultType = determineVaultType(this.coreVault.signers as string[])
+    const vaultType = hasServer(this.coreVault.signers) ? 'fast' : 'secure'
 
     // Build VaultData
     this.vaultData = {

--- a/packages/sdk/src/vault/VaultBase.ts
+++ b/packages/sdk/src/vault/VaultBase.ts
@@ -942,12 +942,11 @@ export abstract class VaultBase extends UniversalEventEmitter<VaultEvents> {
   /** @internal Replaces constructor defaults with a stored or pending snapshot. */
   protected restorePersistedVaultData(vaultData: VaultData, persisted = true): void {
     const snapshot = cloneVaultData(vaultData)
-    if (snapshot.type === 'secure' && hasServer(snapshot.signers)) {
-      snapshot.type = 'fast'
-    }
-    getVaultRevision(snapshot)
-    this.vaultData = snapshot
-    this.persistedVaultData = cloneVaultData(snapshot)
+    const canonicalSnapshot =
+      snapshot.type === 'secure' && hasServer(snapshot.signers) ? { ...snapshot, type: 'fast' as const } : snapshot
+    getVaultRevision(canonicalSnapshot)
+    this.vaultData = canonicalSnapshot
+    this.persistedVaultData = cloneVaultData(canonicalSnapshot)
     this.hasPersistedRecord = persisted
   }
 

--- a/packages/sdk/src/vault/index.ts
+++ b/packages/sdk/src/vault/index.ts
@@ -11,6 +11,10 @@ import { VaultBase } from './VaultBase'
 export { FastVault, SecureVault, VaultBase }
 export type { VaultSaveOptions } from './VaultBase'
 
+// Canonical Fast Vault / server-signer detection. This recognizes both current
+// Server-* party IDs and legacy VultiServer-* backups.
+export { hasServer, isServer } from '@vultisig/core-mpc/devices/localPartyId'
+
 // Export errors
 export { BroadcastPartialFailureError } from './services/BroadcastService'
 export { VaultConflictError, VaultError, VaultErrorCode, VaultImportError, VaultImportErrorCode } from './VaultError'

--- a/packages/sdk/src/vault/utils/canonicalizeVaultData.ts
+++ b/packages/sdk/src/vault/utils/canonicalizeVaultData.ts
@@ -1,0 +1,7 @@
+import { hasServer } from '@vultisig/core-mpc/devices/localPartyId'
+
+import type { VaultData } from '../../types'
+
+/** Canonicalizes vault metadata written by SDKs that did not recognize legacy server party IDs. */
+export const canonicalizeVaultData = (vaultData: VaultData): VaultData =>
+  vaultData.type === 'secure' && hasServer(vaultData.signers) ? { ...vaultData, type: 'fast' } : vaultData

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -71,6 +71,14 @@ beforeAll(async () => {
 }, 120_000)
 
 describe('RN entry wires configureCrypto and configureDefaultStorage', () => {
+  it('exports canonical fast-vault detection helpers', async () => {
+    const canonical = await import('@vultisig/core-mpc/devices/localPartyId')
+
+    expect(reactNativeEntry.hasServer).toBe(canonical.hasServer)
+    expect(reactNativeEntry.isServer).toBe(canonical.isServer)
+    expect(reactNativeEntry.hasServer(['Android-current', 'VultiServer-legacy'])).toBe(true)
+  })
+
   it.each([
     'EVM_DANGEROUS_ADDRESSES',
     'SOLANA_DANGEROUS_ADDRESSES',

--- a/packages/sdk/tests/unit/public/fastVaultDetectionRootExports.test.ts
+++ b/packages/sdk/tests/unit/public/fastVaultDetectionRootExports.test.ts
@@ -1,0 +1,16 @@
+import * as canonical from '@vultisig/core-mpc/devices/localPartyId'
+import { describe, expect, it } from 'vitest'
+
+import * as sdk from '../../../src/index'
+
+describe('fast-vault detection root exports', () => {
+  it('exports the canonical server-signer helpers by identity', () => {
+    expect(sdk.hasServer).toBe(canonical.hasServer)
+    expect(sdk.isServer).toBe(canonical.isServer)
+  })
+
+  it('detects legacy VultiServer signers from the supported SDK root', () => {
+    expect(sdk.hasServer(['iPhone-current', 'VultiServer-legacy'])).toBe(true)
+    expect(sdk.isServer('VultiServer-legacy')).toBe(true)
+  })
+})

--- a/packages/sdk/tests/unit/vault/VaultManager.test.ts
+++ b/packages/sdk/tests/unit/vault/VaultManager.test.ts
@@ -35,6 +35,7 @@ import { createSdkContext } from '../../../src/context/SdkContextBuilder'
 import { FileStorage } from '../../../src/platforms/node/storage'
 import { MemoryStorage } from '../../../src/storage/MemoryStorage'
 import type { Storage } from '../../../src/storage/types'
+import { FastVault } from '../../../src/vault/FastVault'
 import { VaultConflictError, VaultImportErrorCode } from '../../../src/vault/VaultError'
 import { VaultManager } from '../../../src/VaultManager'
 
@@ -264,6 +265,19 @@ describe('VaultManager', () => {
       const vult = encodeEncryptedVult(buildMinimalSecureVaultBinary(), pwd)
       const vault = await vaultManager.importVault(vult, pwd)
       expect(vault.id).toBe(SYNTH_ECDSA_PK)
+    })
+
+    it('imports a legacy VultiServer signer backup as a fast vault', async () => {
+      const vult = encodeUnencryptedVult(
+        buildMinimalSecureVaultBinary({
+          signers: ['SyntheticDevice', 'VultiServer-legacy'],
+        })
+      )
+
+      const vault = await vaultManager.importVault(vult)
+
+      expect(vault).toBeInstanceOf(FastVault)
+      expect(vault.type).toBe('fast')
     })
 
     it('rejects an exact duplicate unless replacement is explicit', async () => {

--- a/packages/sdk/tests/unit/vault/VaultManager.test.ts
+++ b/packages/sdk/tests/unit/vault/VaultManager.test.ts
@@ -319,7 +319,9 @@ describe('VaultManager', () => {
 
       const staleSecure = SecureVault.fromStorage(
         staleData,
-        (vaultManager as unknown as { createVaultContext(): Parameters<typeof SecureVault.fromStorage>[1] }).createVaultContext()
+        (
+          vaultManager as unknown as { createVaultContext(): Parameters<typeof SecureVault.fromStorage>[1] }
+        ).createVaultContext()
       )
       const loaded = await vaultManager.getVaultById(imported.id)
 

--- a/packages/sdk/tests/unit/vault/VaultManager.test.ts
+++ b/packages/sdk/tests/unit/vault/VaultManager.test.ts
@@ -303,6 +303,57 @@ describe('VaultManager', () => {
       expect(await memoryStorage.get<{ type: string }>(`vault:${imported.id}`)).toMatchObject({ type: 'fast' })
     })
 
+    it('does not overwrite a concurrent update when legacy storage cannot persist the type repair atomically', async () => {
+      const vult = encodeUnencryptedVult(
+        buildMinimalSecureVaultBinary({
+          signers: ['SyntheticDevice', 'VultiServer-legacy'],
+        })
+      )
+      const imported = await vaultManager.importVault(vult)
+      const key = `vault:${imported.id}`
+      const stored = await memoryStorage.get<typeof imported.data>(key)
+      expect(stored).not.toBeNull()
+      await memoryStorage.set(key, { ...stored!, type: 'secure' })
+
+      let concurrentUpdateInjected = false
+      let setCalls = 0
+      const legacyStorage: Storage = {
+        async get<T>(storageKey: string): Promise<T | null> {
+          const value = await memoryStorage.get<T>(storageKey)
+          if (storageKey === key && value && !concurrentUpdateInjected) {
+            concurrentUpdateInjected = true
+            await memoryStorage.set(key, { ...(value as typeof stored), name: 'Concurrent rename' })
+          }
+          return value
+        },
+        async set<T>(storageKey: string, value: T): Promise<void> {
+          setCalls += 1
+          await memoryStorage.set(storageKey, value)
+        },
+        remove: memoryStorage.remove.bind(memoryStorage),
+        list: memoryStorage.list.bind(memoryStorage),
+        clear: memoryStorage.clear.bind(memoryStorage),
+      }
+      const legacyManager = new VaultManager(
+        createSdkContext({
+          storage: legacyStorage,
+          serverEndpoints: {
+            fastVault: 'https://test-api.vultisig.com/vault',
+            messageRelay: 'https://test-api.vultisig.com/router',
+          },
+          defaultChains: [Chain.Bitcoin, Chain.Ethereum, Chain.Solana],
+          defaultCurrency: 'USD',
+        })
+      )
+
+      const loaded = await legacyManager.getVaultById(imported.id)
+
+      expect(loaded).toBeInstanceOf(FastVault)
+      expect(loaded?.type).toBe('fast')
+      expect(setCalls).toBe(0)
+      expect(await memoryStorage.get(key)).toMatchObject({ name: 'Concurrent rename', type: 'secure' })
+    })
+
     it('rejects an exact duplicate unless replacement is explicit', async () => {
       const vult = encodeUnencryptedVult(buildMinimalSecureVaultBinary())
       await vaultManager.importVault(vult)

--- a/packages/sdk/tests/unit/vault/VaultManager.test.ts
+++ b/packages/sdk/tests/unit/vault/VaultManager.test.ts
@@ -280,6 +280,29 @@ describe('VaultManager', () => {
       expect(vault.type).toBe('fast')
     })
 
+    it('repairs a legacy VultiServer vault persisted with the stale secure type', async () => {
+      const vult = encodeUnencryptedVult(
+        buildMinimalSecureVaultBinary({
+          signers: ['SyntheticDevice', 'VultiServer-legacy'],
+        })
+      )
+      const imported = await vaultManager.importVault(vult)
+      const stored = await memoryStorage.get<typeof imported.data>(`vault:${imported.id}`)
+      expect(stored).not.toBeNull()
+      await memoryStorage.set(`vault:${imported.id}`, {
+        ...stored!,
+        type: 'secure',
+      })
+
+      const loaded = await vaultManager.getVaultById(imported.id)
+
+      expect(loaded).toBeInstanceOf(FastVault)
+      expect(loaded?.type).toBe('fast')
+      expect(await memoryStorage.get<{ type: string }>(`vault:${imported.id}`)).toMatchObject({ type: 'fast' })
+      await loaded?.save()
+      expect(await memoryStorage.get<{ type: string }>(`vault:${imported.id}`)).toMatchObject({ type: 'fast' })
+    })
+
     it('rejects an exact duplicate unless replacement is explicit', async () => {
       const vult = encodeUnencryptedVult(buildMinimalSecureVaultBinary())
       await vaultManager.importVault(vult)

--- a/packages/sdk/tests/unit/vault/VaultManager.test.ts
+++ b/packages/sdk/tests/unit/vault/VaultManager.test.ts
@@ -36,6 +36,7 @@ import { FileStorage } from '../../../src/platforms/node/storage'
 import { MemoryStorage } from '../../../src/storage/MemoryStorage'
 import type { Storage } from '../../../src/storage/types'
 import { FastVault } from '../../../src/vault/FastVault'
+import { SecureVault } from '../../../src/vault/SecureVault'
 import { VaultConflictError, VaultImportErrorCode } from '../../../src/vault/VaultError'
 import { VaultManager } from '../../../src/VaultManager'
 
@@ -301,6 +302,30 @@ describe('VaultManager', () => {
       expect(await memoryStorage.get<{ type: string }>(`vault:${imported.id}`)).toMatchObject({ type: 'fast' })
       await loaded?.save()
       expect(await memoryStorage.get<{ type: string }>(`vault:${imported.id}`)).toMatchObject({ type: 'fast' })
+    })
+
+    it('rejects a stale secure instance after repairing a persisted legacy fast vault type', async () => {
+      const vult = encodeUnencryptedVult(
+        buildMinimalSecureVaultBinary({
+          signers: ['SyntheticDevice', 'VultiServer-legacy'],
+        })
+      )
+      const imported = await vaultManager.importVault(vult)
+      const key = `vault:${imported.id}`
+      const stored = await memoryStorage.get<typeof imported.data>(key)
+      expect(stored).not.toBeNull()
+      const staleData = { ...stored!, type: 'secure' as const }
+      await memoryStorage.set(key, staleData)
+
+      const staleSecure = SecureVault.fromStorage(
+        staleData,
+        (vaultManager as unknown as { createVaultContext(): Parameters<typeof SecureVault.fromStorage>[1] }).createVaultContext()
+      )
+      const loaded = await vaultManager.getVaultById(imported.id)
+
+      expect(loaded).toBeInstanceOf(FastVault)
+      await expect(staleSecure.rename('Stale writer')).rejects.toBeInstanceOf(VaultConflictError)
+      expect(await memoryStorage.get<{ type: string }>(key)).toMatchObject({ type: 'fast' })
     })
 
     it('does not overwrite a concurrent update when legacy storage cannot persist the type repair atomically', async () => {

--- a/packages/sdk/tests/unit/vault/VaultManager.test.ts
+++ b/packages/sdk/tests/unit/vault/VaultManager.test.ts
@@ -304,7 +304,7 @@ describe('VaultManager', () => {
       expect(await memoryStorage.get<{ type: string }>(`vault:${imported.id}`)).toMatchObject({ type: 'fast' })
     })
 
-    it('rejects a stale secure instance after repairing a persisted legacy fast vault type', async () => {
+    it('rejects direct SecureVault construction for legacy fast-vault data', async () => {
       const vult = encodeUnencryptedVult(
         buildMinimalSecureVaultBinary({
           signers: ['SyntheticDevice', 'VultiServer-legacy'],
@@ -317,16 +317,17 @@ describe('VaultManager', () => {
       const staleData = { ...stored!, type: 'secure' as const }
       await memoryStorage.set(key, staleData)
 
-      const staleSecure = SecureVault.fromStorage(
-        staleData,
-        (
-          vaultManager as unknown as { createVaultContext(): Parameters<typeof SecureVault.fromStorage>[1] }
-        ).createVaultContext()
-      )
+      expect(() =>
+        SecureVault.fromStorage(
+          staleData,
+          (
+            vaultManager as unknown as { createVaultContext(): Parameters<typeof SecureVault.fromStorage>[1] }
+          ).createVaultContext()
+        )
+      ).toThrow('Cannot create SecureVault from fast vault data')
       const loaded = await vaultManager.getVaultById(imported.id)
 
       expect(loaded).toBeInstanceOf(FastVault)
-      await expect(staleSecure.rename('Stale writer')).rejects.toBeInstanceOf(VaultConflictError)
       expect(await memoryStorage.get<{ type: string }>(key)).toMatchObject({ type: 'fast' })
     })
 
@@ -340,13 +341,22 @@ describe('VaultManager', () => {
       const key = `vault:${imported.id}`
       const stored = await memoryStorage.get<typeof imported.data>(key)
       expect(stored).not.toBeNull()
+      const healthy = await vaultManager.importVault(
+        encodeUnencryptedVult(
+          buildMinimalSecureVaultBinary({
+            name: 'Healthy vault',
+            ecdsaPublicKey: `03${'33'.repeat(32)}`,
+            eddsaPublicKey: '44'.repeat(32),
+          })
+        )
+      )
       await memoryStorage.set(key, {
         ...stored!,
         type: 'secure',
         revision: Number.MAX_SAFE_INTEGER,
       })
 
-      await expect(vaultManager.listVaults()).rejects.toThrow('invalid storage revision')
+      await expect(vaultManager.listVaults()).resolves.toMatchObject([{ id: healthy.id, name: 'Healthy vault' }])
       await expect(vaultManager.getVaultById(imported.id)).rejects.toThrow('invalid storage revision')
       expect(await memoryStorage.get<{ revision: number; type: string }>(key)).toMatchObject({
         revision: Number.MAX_SAFE_INTEGER,

--- a/packages/sdk/tests/unit/vault/VaultManager.test.ts
+++ b/packages/sdk/tests/unit/vault/VaultManager.test.ts
@@ -346,6 +346,7 @@ describe('VaultManager', () => {
         revision: Number.MAX_SAFE_INTEGER,
       })
 
+      await expect(vaultManager.listVaults()).rejects.toThrow('invalid storage revision')
       await expect(vaultManager.getVaultById(imported.id)).rejects.toThrow('invalid storage revision')
       expect(await memoryStorage.get<{ revision: number; type: string }>(key)).toMatchObject({
         revision: Number.MAX_SAFE_INTEGER,
@@ -402,6 +403,11 @@ describe('VaultManager', () => {
       expect(loaded?.type).toBe('fast')
       expect(setCalls).toBe(0)
       expect(await memoryStorage.get(key)).toMatchObject({ name: 'Concurrent rename', type: 'secure' })
+
+      await loaded?.load()
+      expect(loaded?.type).toBe('fast')
+      await loaded?.save()
+      expect(await memoryStorage.get(key)).toMatchObject({ name: 'Concurrent rename', type: 'fast' })
     })
 
     it('rejects an exact duplicate unless replacement is explicit', async () => {

--- a/packages/sdk/tests/unit/vault/VaultManager.test.ts
+++ b/packages/sdk/tests/unit/vault/VaultManager.test.ts
@@ -330,6 +330,29 @@ describe('VaultManager', () => {
       expect(await memoryStorage.get<{ type: string }>(key)).toMatchObject({ type: 'fast' })
     })
 
+    it('rejects a legacy type repair that would overflow the storage revision', async () => {
+      const vult = encodeUnencryptedVult(
+        buildMinimalSecureVaultBinary({
+          signers: ['SyntheticDevice', 'VultiServer-legacy'],
+        })
+      )
+      const imported = await vaultManager.importVault(vult)
+      const key = `vault:${imported.id}`
+      const stored = await memoryStorage.get<typeof imported.data>(key)
+      expect(stored).not.toBeNull()
+      await memoryStorage.set(key, {
+        ...stored!,
+        type: 'secure',
+        revision: Number.MAX_SAFE_INTEGER,
+      })
+
+      await expect(vaultManager.getVaultById(imported.id)).rejects.toThrow('invalid storage revision')
+      expect(await memoryStorage.get<{ revision: number; type: string }>(key)).toMatchObject({
+        revision: Number.MAX_SAFE_INTEGER,
+        type: 'secure',
+      })
+    })
+
     it('does not overwrite a concurrent update when legacy storage cannot persist the type repair atomically', async () => {
       const vult = encodeUnencryptedVult(
         buildMinimalSecureVaultBinary({

--- a/packages/sdk/tests/unit/vault/fastVaultDetection.test.ts
+++ b/packages/sdk/tests/unit/vault/fastVaultDetection.test.ts
@@ -1,0 +1,54 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import type { Vault as CoreVault } from '@vultisig/core-mpc/vault/Vault'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { WasmProvider } from '../../../src/context/SdkContext'
+import type { ServerManager } from '../../../src/server/ServerManager'
+import { FastSigningService } from '../../../src/services/FastSigningService'
+import { hasServer, isServer } from '../../../src/vault'
+
+const legacyFastVault = {
+  name: 'Legacy Fast Vault',
+  publicKeys: { ecdsa: 'ecdsa', eddsa: 'eddsa' },
+  signers: ['iPhone-current', 'VultiServer-legacy'],
+  hexChainCode: '00'.repeat(32),
+  localPartyId: 'iPhone-current',
+  keyShares: { ecdsa: 'ecdsa-share', eddsa: 'eddsa-share' },
+  resharePrefix: '',
+  libType: 'DKLS',
+  createdAt: 1,
+  isBackedUp: true,
+  order: 0,
+} as CoreVault
+
+describe('canonical fast-vault detection', () => {
+  it('recognizes current and legacy server signers without accepting prefix lookalikes', () => {
+    expect(isServer('Server-current')).toBe(true)
+    expect(isServer('server-current')).toBe(true)
+    expect(isServer('VultiServer-legacy')).toBe(true)
+    expect(isServer('vultiserver-legacy')).toBe(true)
+
+    expect(isServer('Serverless-device')).toBe(false)
+    expect(isServer('VultiServerBackup-device')).toBe(false)
+  })
+
+  it('classifies a hybrid legacy signer list as a fast vault', () => {
+    expect(hasServer(legacyFastVault.signers)).toBe(true)
+  })
+
+  it('allows legacy fast vaults through the signing-service validation gate', async () => {
+    const coordinateFastSigning = vi.fn().mockResolvedValue({ signature: 'signature', format: 'ECDSA' })
+    const serverManager = { coordinateFastSigning } as unknown as ServerManager
+    const wasmProvider = { getWalletCore: vi.fn().mockResolvedValue({}) } as unknown as WasmProvider
+    const service = new FastSigningService(serverManager, wasmProvider)
+
+    await expect(
+      service.signWithServer(
+        legacyFastVault,
+        { chain: Chain.Ethereum, transaction: {}, messageHashes: ['hash'] },
+        'password'
+      )
+    ).resolves.toEqual({ signature: 'signature', format: 'ECDSA' })
+    expect(coordinateFastSigning).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
Closes #2125
Expose canonical isServer and hasServer helpers from the SDK root and React Native entry, recognize exact legacy VultiServer party IDs without accepting prefix lookalikes, and route SDK fast-vault consumers through the shared detector. Runtime proof from the actual built Node SDK bundle returned the expected current, legacy, lookalike-rejection, and hybrid-signers results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fast-vault detection for current and legacy server signer formats.
  * Legacy `VultiServer-*` backups are now correctly recognized and repaired as fast vaults.
  * Prevented similar-looking signer IDs from being incorrectly classified as server signers.
  * Applied consistent detection across vault loading and fast signing.

* **New Features**
  * Added public SDK helpers for identifying server signers and vaults, including React Native support.
  * Expanded SDK exports for signing payloads, transaction broadcasting, token validation, decoding, and swap utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->