### PR TITLE
fix(sdk): export bridge and gas namespace handles

### DIFF
--- a/.changeset/r161-sdk-bridge-gas-namespaces.md
+++ b/.changeset/r161-sdk-bridge-gas-namespaces.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+Add the documented `sdk.bridge.*` and `sdk.gas.cosmos.*` namespace handles to the root and React Native SDK surfaces without removing the existing flat exports.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -924,6 +924,7 @@ export {
   buildAstroportSwap,
   buildBalancerV3SwapCalldata,
   buildBuyPt,
+  bridge,
   buildCctpBridge,
   buildCctpClaim,
   buildCosmosWasmExecuteMsg,

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -48,8 +48,10 @@ import { NativeWalletCore } from '@vultisig/walletcore-native'
 import { configureDefaultStorage } from '../../context/defaultStorage'
 import { configureWasm } from '../../context/wasmRuntime'
 import { configureCrypto } from '../../crypto'
+import * as bridge from '../../tools/bridge'
 import * as cosmos from '../../tools/cosmos'
 import * as evm from '../../tools/evm'
+import * as gas from '../../tools/gas'
 import * as token from '../../tools/token'
 import { ReactNativeCrypto } from './crypto'
 import { ReactNativeStorage } from './storage'
@@ -266,8 +268,9 @@ export type {
 // src/platforms/react-native/shims/tiny-secp256k1.ts.
 
 // Public namespace handles documented by the SDK changelog. Keep these as
-// explicit module objects so Rollup preserves the nested `cosmos.gov` handle.
-export { cosmos, evm, token }
+// explicit module objects so Rollup preserves nested handles such as
+// `cosmos.gov`, `gas.cosmos`, and `bridge.*`.
+export { bridge, cosmos, evm, gas, token }
 
 // Vault-free prep helpers (KeysignPayload construction without an instantiated vault)
 export type {

--- a/packages/sdk/src/tools/gas/index.ts
+++ b/packages/sdk/src/tools/gas/index.ts
@@ -1,3 +1,5 @@
+import * as cosmos from './cosmos'
+
 export type {
   CompareCostsEntry,
   CompareCostsParams,
@@ -19,3 +21,7 @@ export {
   getCosmosGasLimit,
   getCosmosSwapGasLimit,
 } from './cosmos'
+
+// Namespace handle so callers can use the documented `sdk.gas.cosmos.*`
+// family alongside the flat named exports.
+export { cosmos }

--- a/packages/sdk/src/tools/index.ts
+++ b/packages/sdk/src/tools/index.ts
@@ -47,6 +47,11 @@ export { decode, decodeCosmosTx, decodeEvmTx, decodeFromToolResult } from './dec
 // DEX primitives (read-only / pure math + on-chain quotes — no signing, no broadcast)
 export * as dex from './dex'
 
+// Bridge — Circle CCTP unsigned bridge/claim calldata builders
+import * as bridge from './bridge'
+
+export { bridge }
+
 // Gas / fee fan-out
 export type { CompareCostsEntry, CompareCostsParams, CompareCostsResult, CompareCostsSkipped, GasTxType } from './gas'
 export { compareCosts, DEFAULT_COMPARE_CHAINS, GAS_UNITS, getChainGasPriceGwei } from './gas'

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -109,6 +109,15 @@ describe('RN entry wires configureCrypto and configureDefaultStorage', () => {
     expect(sdkRn.JUPITER_PLATFORM_FEE_BPS).toBe(50)
   })
 
+  it('exports the documented bridge and gas namespace handles on the RN entrypoint', async () => {
+    const bridgeTools = await import('../../../../src/tools/bridge')
+    const gasTools = await import('../../../../src/tools/gas')
+
+    expect(sdkRn.bridge.getCctpChain).toBe(bridgeTools.getCctpChain)
+    expect(sdkRn.gas.compareCosts).toBe(gasTools.compareCosts)
+    expect(sdkRn.gas.cosmos.getCosmosGasLimit).toBe(gasTools.getCosmosGasLimit)
+  })
+
   it('exports default chain canonicals on the RN entrypoint', async () => {
     const rn = await import('../../../../src/platforms/react-native/index')
 

--- a/packages/sdk/tests/unit/public/toolNamespaceRootExports.test.ts
+++ b/packages/sdk/tests/unit/public/toolNamespaceRootExports.test.ts
@@ -1,15 +1,19 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  bridge,
   cosmos,
   encodeErc20Approve,
   evm,
+  gas,
+  getCosmosGasLimit,
   getCosmosGovernanceProposals,
+  getCctpChain,
   prepareCosmosVote,
   resolveContract,
   token,
 } from '@/index'
-import { cosmos as cosmosFromTools, evm as evmFromTools, token as tokenFromTools } from '@/tools'
+import { bridge as bridgeFromTools, cosmos as cosmosFromTools, evm as evmFromTools, gas as gasFromTools, token as tokenFromTools } from '@/tools'
 
 describe('SDK root tool namespaces', () => {
   it('exposes the EVM helper family without removing flat exports', () => {
@@ -22,9 +26,19 @@ describe('SDK root tool namespaces', () => {
     expect(token.resolveContract).toBe(resolveContract)
   })
 
+  it('exposes the bridge helper family without removing flat exports', () => {
+    expect(bridge).toBe(bridgeFromTools)
+    expect(bridge.getCctpChain).toBe(getCctpChain)
+  })
+
   it('exposes Cosmos governance under sdk.cosmos.gov without removing flat exports', () => {
     expect(cosmos).toBe(cosmosFromTools)
     expect(cosmos.gov.getCosmosGovernanceProposals).toBe(getCosmosGovernanceProposals)
     expect(cosmos.gov.prepareCosmosVote).toBe(prepareCosmosVote)
+  })
+
+  it('exposes gas helpers under sdk.gas.cosmos without removing flat exports', () => {
+    expect(gas).toBe(gasFromTools)
+    expect(gas.cosmos.getCosmosGasLimit).toBe(getCosmosGasLimit)
   })
 })


### PR DESCRIPTION
## Summary
- export the documented `sdk.bridge.*` namespace on the root and React Native surfaces
- export the documented `sdk.gas.cosmos.*` namespace without removing flat gas exports
- pin the root/RN namespace identities in focused unit tests

Closes #2155

## Receipts
- `corepack yarn workspace @vultisig/sdk vitest run --config tests/unit/vitest.config.ts tests/unit/public/toolNamespaceRootExports.test.ts tests/unit/platforms/react-native/entry.test.ts` ✅
- `corepack yarn build:shared` ⚠️ blocked by pre-existing mainline failure in `packages/core/mpc/keysign/signingInputs/resolvers/cardano.ts` (`auxiliaryData` not accepted by `ISigningInput`), unrelated to this diff
- Report mirror: https://gist.github.com/gomesalexandre/3d0b54ea118a13c23add5f4075022b11

## Why this shape
The canonical bridge/gas helpers already lived in the SDK, but the grouped namespace contract was still incomplete. This patch keeps the existing flat exports for compatibility and adds the missing grouped handles so downstream consumers stop inventing local wrapper objects.
