### PR TITLE
fix(sdk-rn): export seedphrase import helpers

### DIFF
--- a/.changeset/r164-rn-seedphrase-import-helpers.md
+++ b/.changeset/r164-rn-seedphrase-import-helpers.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+Export the seedphrase import support policy and prelude helpers from `@vultisig/sdk/react-native` so mobile consumers can use the SDK-owned import flow without deep imports or local copies.

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -158,8 +158,21 @@ export { deriveAddress, getCoinType, getPublicKey, isValidAddress, isValidTokenI
 // MPC keysign (uses MpcEngine — no direct WASM imports)
 export { keysign } from '@vultisig/core-mpc/keysign'
 
-// Seedphrase validation (uses @scure/bip39, RN-compatible)
+// Seedphrase validation + import prelude (uses @scure/bip39, RN-compatible)
+export {
+  prepareSeedphraseImportPrelude,
+  type SeedphraseImportPreludeInput,
+  type SeedphraseImportPreludeProgressLabels,
+  type SeedphraseImportPreludeResult,
+} from '../../seedphrase/prepareSeedphraseImportPrelude'
 export { validateSeedphrase } from '../../seedphrase/SeedphraseValidator'
+export {
+  assertSeedphraseImportSupportsChains,
+  getUnsupportedSeedphraseImportChains,
+  isSeedphraseImportSupportedChain,
+  SEEDPHRASE_IMPORT_SUPPORTED_CHAINS,
+  SEEDPHRASE_IMPORT_UNSUPPORTED_CHAINS,
+} from '../../constants'
 export { SEEDPHRASE_WORD_COUNTS } from '../../seedphrase/types'
 
 // Vault-backup import/export crypto contract. The RN-safe implementations live

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -117,6 +117,19 @@ describe('RN entry wires configureCrypto and configureDefaultStorage', () => {
     expect(rn.DEFAULT_CHAINS).toEqual(['Bitcoin', 'Ethereum', 'THORChain', 'Solana', 'BSC'])
   })
 
+  it('exports the seedphrase import support policy + prelude helpers on the RN entrypoint', async () => {
+    const rn = await import('../../../../src/platforms/react-native/index')
+
+    expect(typeof rn.prepareSeedphraseImportPrelude).toBe('function')
+    expect(typeof rn.assertSeedphraseImportSupportsChains).toBe('function')
+    expect(typeof rn.getUnsupportedSeedphraseImportChains).toBe('function')
+    expect(typeof rn.isSeedphraseImportSupportedChain).toBe('function')
+    expect(Array.isArray(rn.SEEDPHRASE_IMPORT_SUPPORTED_CHAINS)).toBe(true)
+    expect(Array.isArray(rn.SEEDPHRASE_IMPORT_UNSUPPORTED_CHAINS)).toBe(true)
+    expect(rn.SEEDPHRASE_IMPORT_UNSUPPORTED_CHAINS).toContain(rn.Chain.Cardano)
+    expect(rn.isSeedphraseImportSupportedChain(rn.Chain.Bitcoin)).toBe(true)
+  })
+
   it('exports the canonical Cosmos fee helpers, gas-limit tables, and cosmos chain subsets from the RN entry', async () => {
     const rn = await import('../../../../src/platforms/react-native/index')
 


### PR DESCRIPTION
## Summary
- export the seedphrase import support policy + prelude helpers from `@vultisig/sdk/react-native`
- add RN entry regression coverage for the newly supported imports
- add a changeset for the public-surface expansion

## Test Plan
- `VULTISIG_STRICT_SINGLETON=0 corepack yarn workspace @vultisig/sdk vitest run --config tests/unit/vitest.config.ts tests/unit/platforms/react-native/entry.test.ts --testTimeout=15000`
- `corepack yarn workspace @vultisig/sdk build`
- `corepack yarn build:sdk` *(blocked on pre-existing mainline Cardano typing error in `packages/core/mpc/keysign/signingInputs/resolvers/cardano.ts`: `auxiliaryData` not accepted by `ISigningInput`)*
- temp-consumer `import '@vultisig/sdk/react-native'` smoke *(blocked by missing native package deps like `@vultisig/mpc-native` in the throwaway consumer env, not by this export diff)*

Closes #2159
