### PR TITLE
fix(cli): expose secure-join seedphrase path flags

### DIFF
--- a/.changeset/r167-cli-join-seedphrase-path-flags.md
+++ b/.changeset/r167-cli-join-seedphrase-path-flags.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/cli': patch
+---
+
+Expose `join secure` flags for the existing SDK seedphrase-path join options so KEYIMPORT sessions can pass Phantom Solana and Terra/TerraClassic Cosmos path settings through the CLI.

--- a/clients/cli/README.md
+++ b/clients/cli/README.md
@@ -296,6 +296,14 @@ vultisig delete "Test Vault" --yes
 - `--chains <chains>` - Specific chains to enable (comma-separated)
 - `--use-phantom-solana-path` - Use Phantom wallet derivation path for Solana
 
+**Join secure options:**
+
+- `--qr <payload>` / `--qr-file <path>` - Pairing QR payload from the initiator
+- `--mnemonic <words>` - Required for seedphrase-based (`KEYIMPORT`) sessions
+- `--devices <n>` - Total devices in the session (default: 2)
+- `--use-phantom-solana-path` - Match the initiator's Phantom Solana derivation setting
+- `--use-cosmos-path-terra` - Match the initiator's Terra / TerraClassic Cosmos coin-type path setting
+
 **Export options:**
 
 - `[path]` - Output file or directory (defaults to SDK-generated filename in current directory)

--- a/clients/cli/src/commands/joinSecure.test.ts
+++ b/clients/cli/src/commands/joinSecure.test.ts
@@ -1,0 +1,57 @@
+import type { VaultBase } from '@vultisig/sdk'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { CommandContext } from '../core'
+import { configureOutput, resetOutput } from '../lib/output'
+import { executeJoinSecure } from './vault-management'
+
+describe('executeJoinSecure', () => {
+  afterEach(() => {
+    resetOutput()
+    vi.restoreAllMocks()
+  })
+
+  it('forwards seedphrase path flags to sdk.joinSecureVault', async () => {
+    configureOutput({ format: 'json' })
+
+    const joinSecureVault = vi.fn(async () => ({
+      vault: { name: 'Joined Vault' } as unknown as VaultBase,
+      vaultId: 'vault-123',
+    }))
+    const ctx = {
+      sdk: { joinSecureVault },
+      setActiveVault: vi.fn(async () => {}),
+    } as unknown as CommandContext
+
+    const output = await import('../lib/output')
+    vi.spyOn(output, 'createSpinner').mockReturnValue({
+      text: '',
+      succeed: vi.fn(),
+      fail: vi.fn(),
+      stop: vi.fn(),
+    } as never)
+
+    const ui = await import('../ui')
+    vi.spyOn(ui, 'setupVaultEvents').mockImplementation(() => {})
+
+    await executeJoinSecure(ctx, {
+      qrPayload: 'vultisig://example',
+      mnemonic: 'seed phrase words',
+      password: 'pw',
+      devices: 3,
+      usePhantomSolanaPath: true,
+      useCosmosPathTerra: true,
+    })
+
+    expect(joinSecureVault).toHaveBeenCalledWith(
+      'vultisig://example',
+      expect.objectContaining({
+        mnemonic: 'seed phrase words',
+        password: 'pw',
+        devices: 3,
+        usePhantomSolanaPath: true,
+        useCosmosPathTerra: true,
+      })
+    )
+  })
+})

--- a/clients/cli/src/commands/vault-management.ts
+++ b/clients/cli/src/commands/vault-management.ts
@@ -1186,6 +1186,10 @@ export type JoinSecureOptions = {
   mnemonic?: string
   password?: string
   devices?: number
+  /** Use Phantom wallet derivation path for Solana */
+  usePhantomSolanaPath?: boolean
+  /** Use Cosmos coin-type path for Terra / TerraClassic */
+  useCosmosPathTerra?: boolean
   signal?: AbortSignal
 }
 
@@ -1193,7 +1197,7 @@ export type JoinSecureOptions = {
  * Join an existing SecureVault creation session
  */
 export async function executeJoinSecure(ctx: CommandContext, options: JoinSecureOptions): Promise<VaultBase> {
-  const { qrPayload, mnemonic, password, devices, signal } = options
+  const { qrPayload, mnemonic, password, devices, usePhantomSolanaPath, useCosmosPathTerra, signal } = options
 
   if (!devices || devices < 2) {
     throw new Error('devices is required when joining a SecureVault (minimum 2)')
@@ -1207,6 +1211,8 @@ export async function executeJoinSecure(ctx: CommandContext, options: JoinSecure
         mnemonic,
         password,
         devices,
+        usePhantomSolanaPath,
+        useCosmosPathTerra,
         onProgress: step => {
           spinner.text = `${step.message} (${step.progress}%)`
         },

--- a/clients/cli/src/index.ts
+++ b/clients/cli/src/index.ts
@@ -560,9 +560,19 @@ joinCmd
   .option('--mnemonic <words>', 'Seedphrase (required for seedphrase-based sessions)')
   .option('--password <password>', 'Vault password (optional)')
   .option('--devices <n>', 'Total devices in session', '2')
+  .option('--use-phantom-solana-path', 'Use Phantom wallet derivation path for Solana')
+  .option('--use-cosmos-path-terra', 'Use Cosmos coin-type path for Terra / TerraClassic')
   .action(
     withExit(
-      async (options: { qr?: string; qrFile?: string; mnemonic?: string; password?: string; devices: string }) => {
+      async (options: {
+        qr?: string
+        qrFile?: string
+        mnemonic?: string
+        password?: string
+        devices: string
+        usePhantomSolanaPath?: boolean
+        useCosmosPathTerra?: boolean
+      }) => {
         const context = await init(program.opts().vault)
 
         // Get QR payload from flag, file, or prompt
@@ -592,6 +602,8 @@ joinCmd
           mnemonic,
           password: options.password,
           devices: parseInt(options.devices, 10),
+          usePhantomSolanaPath: options.usePhantomSolanaPath,
+          useCosmosPathTerra: options.useCosmosPathTerra,
         })
       }
     )


### PR DESCRIPTION
## Summary
- expose  and 
- thread both flags through  into 
- document the new CLI options and add a focused forwarding test

## Why
Round 167 found that KEYIMPORT pairing QR payloads still omit derivation-path settings that the join flow documents as initiator-critical. This patch is a small mitigation: it lets CLI users pass the already-supported SDK settings explicitly.

## Verification
- 
[1m[30m[46m RUN [49m[39m[22m [36mv4.1.8 [39m[90m/private/tmp/vultisig-sdk-r167[39m

{
  "success": true,
  "v": 1,
  "data": {
    "vault": {
      "id": "vault-123",
      "name": "Joined Vault",
      "type": "secure"
    }
  }
}
 [32m✓[39m clients/cli/src/commands/joinSecure.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 3[2mms[22m[39m
 [31m❯[39m clients/cli/src/join-secure-nontty.test.ts [2m([22m[2m1 test[22m[2m | [22m[31m1 failed[39m[2m)[22m[32m 273[2mms[22m[39m
[31m     [31m×[31m fails closed (exit 12) without writing the seedphrase guidance to stdout[39m[32m 273[2mms[22m[39m

[2m Test Files [22m [1m[31m1 failed[39m[22m[2m | [22m[1m[32m1 passed[39m[22m[90m (2)[39m
[2m      Tests [22m [1m[31m1 failed[39m[22m[2m | [22m[1m[32m1 passed[39m[22m[90m (2)[39m
[2m   Start at [22m 19:55:41
[2m   Duration [22m 2.92s[2m (transform 3.86s, setup 0ms, import 5.22s, tests 276ms, environment 0ms)[22m
  -  ✅
  -  blocked by a pre-existing disposable-clone runtime import failure under :  not found
- direct disposable-clone CLI runtime invocation hit the same pre-existing runtime import failure, so I am **not** claiming a clean runtime receipt from this environment

## Related issue
- partial for https://github.com/vultisig/vultisig-sdk/issues/2165

## Report
- https://gist.github.com/gomesalexandre/7b02ef62bcd5b7310394d87e19d9744f
