### PR TITLE
ci: cross-repo golden corpus sync check

### DIFF
--- a/.github/workflows/golden-corpus-sync.yml
+++ b/.github/workflows/golden-corpus-sync.yml
@@ -16,6 +16,10 @@ on:
     - cron: "37 6 * * 1"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/golden-corpus-sync.yml
+++ b/.github/workflows/golden-corpus-sync.yml
@@ -31,6 +31,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+        with:
+          persist-credentials: false
 
       - name: Fetch sibling corpora
         run: |

--- a/.github/workflows/golden-corpus-sync.yml
+++ b/.github/workflows/golden-corpus-sync.yml
@@ -10,27 +10,38 @@ on:
     branches: [main]
     paths:
       - "packages/core/mpc/keysign/tests/fixtures/mobile/**"
+      - "scripts/check_golden_corpus_sync.py"
+      - ".github/workflows/golden-corpus-sync.yml"
   schedule:
     - cron: "37 6 * * 1"
   workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  ANDROID_CORPUS: app/src/androidTest/assets
+  IOS_CORPUS: VultisigApp/VultisigAppTests/TestData
+  SDK_CORPUS: packages/core/mpc/keysign/tests/fixtures/mobile
 
 jobs:
   corpus-sync:
     name: Cross-repo golden corpus sync
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
 
       - name: Fetch sibling corpora
         run: |
           git clone --depth 1 --filter=blob:none --sparse https://github.com/vultisig/vultisig-android.git "$RUNNER_TEMP/vultisig-android"
-          git -C "$RUNNER_TEMP/vultisig-android" sparse-checkout set app/src/androidTest/assets
+          git -C "$RUNNER_TEMP/vultisig-android" sparse-checkout set "$ANDROID_CORPUS"
           git clone --depth 1 --filter=blob:none --sparse https://github.com/vultisig/vultisig-ios.git "$RUNNER_TEMP/vultisig-ios"
-          git -C "$RUNNER_TEMP/vultisig-ios" sparse-checkout set VultisigApp/VultisigAppTests/TestData
+          git -C "$RUNNER_TEMP/vultisig-ios" sparse-checkout set "$IOS_CORPUS"
 
       - name: Check corpus sync
         run: |
           python3 scripts/check_golden_corpus_sync.py \
-            --android "$RUNNER_TEMP/vultisig-android/app/src/androidTest/assets" \
-            --ios "$RUNNER_TEMP/vultisig-ios/VultisigApp/VultisigAppTests/TestData" \
-            --sdk packages/core/mpc/keysign/tests/fixtures/mobile
+            --android "$RUNNER_TEMP/vultisig-android/$ANDROID_CORPUS" \
+            --ios "$RUNNER_TEMP/vultisig-ios/$IOS_CORPUS" \
+            --sdk "$SDK_CORPUS"

--- a/.github/workflows/golden-corpus-sync.yml
+++ b/.github/workflows/golden-corpus-sync.yml
@@ -1,0 +1,36 @@
+name: Golden Corpus Sync
+
+on:
+  pull_request:
+    paths:
+      - "packages/core/mpc/keysign/tests/fixtures/mobile/**"
+      - "scripts/check_golden_corpus_sync.py"
+      - ".github/workflows/golden-corpus-sync.yml"
+  push:
+    branches: [main]
+    paths:
+      - "packages/core/mpc/keysign/tests/fixtures/mobile/**"
+  schedule:
+    - cron: "37 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  corpus-sync:
+    name: Cross-repo golden corpus sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+
+      - name: Fetch sibling corpora
+        run: |
+          git clone --depth 1 --filter=blob:none --sparse https://github.com/vultisig/vultisig-android.git "$RUNNER_TEMP/vultisig-android"
+          git -C "$RUNNER_TEMP/vultisig-android" sparse-checkout set app/src/androidTest/assets
+          git clone --depth 1 --filter=blob:none --sparse https://github.com/vultisig/vultisig-ios.git "$RUNNER_TEMP/vultisig-ios"
+          git -C "$RUNNER_TEMP/vultisig-ios" sparse-checkout set VultisigApp/VultisigAppTests/TestData
+
+      - name: Check corpus sync
+        run: |
+          python3 scripts/check_golden_corpus_sync.py \
+            --android "$RUNNER_TEMP/vultisig-android/app/src/androidTest/assets" \
+            --ios "$RUNNER_TEMP/vultisig-ios/VultisigApp/VultisigAppTests/TestData" \
+            --sdk packages/core/mpc/keysign/tests/fixtures/mobile

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,5 @@ packages/expo-mpc/
 .cursor/
 .codex/
 .agents/
+__pycache__/
+*.pyc

--- a/scripts/check_golden_corpus_sync.py
+++ b/scripts/check_golden_corpus_sync.py
@@ -36,13 +36,13 @@ def load_corpus(corpus_dir: Path) -> Corpus:
     for path in sorted(corpus_dir.glob("*.json")):
         try:
             cases = json.loads(path.read_text())
-        except json.JSONDecodeError as err:
-            print(f"{path}: unparseable fixture file — {err}", file=sys.stderr)
+            corpus[path.name] = {
+                case["name"]: [h.lower() for h in (case.get("expected_image_hash") or [])]
+                for case in cases
+            }
+        except (json.JSONDecodeError, TypeError, KeyError, AttributeError) as err:
+            print(f"{path}: not a list of golden cases — {err!r}", file=sys.stderr)
             raise SystemExit(2) from None
-        corpus[path.name] = {
-            case["name"]: [h.lower() for h in (case.get("expected_image_hash") or [])]
-            for case in cases
-        }
         if len(corpus[path.name]) != len(cases):
             print(f"{path}: duplicate case names — a duplicate would go uncompared", file=sys.stderr)
             raise SystemExit(2)
@@ -112,8 +112,8 @@ def main() -> int:
 
     if drift:
         print(f"\n{len(drift)} CROSS-REPO HASH DISAGREEMENT(S) — two platforms would sign different bytes:")
-        for entry in drift:
-            print(f"  DRIFT {entry}")
+        for finding in drift:
+            print(f"  DRIFT {finding}")
         print("\nAn intentional vector change must land the same hashes in all three repos.")
         return 1
 

--- a/scripts/check_golden_corpus_sync.py
+++ b/scripts/check_golden_corpus_sync.py
@@ -50,9 +50,9 @@ def diff_case(label: str, hashes_by_repo: dict[str, list[str]]) -> tuple[list[st
     warnings = [f"{label}: no pinned hash on {', '.join(unpinned)}"] if unpinned and pinned else []
     if len(pinned) < 2 or len({tuple(h) for h in pinned.values()}) == 1:
         return [], warnings
-    if len({tuple(sorted(h)) for h in pinned.values()}) == 1:
-        return [], warnings + [f"{label}: same hashes, different order"]
     detail = "; ".join(f"{repo}={hashes}" for repo, hashes in sorted(pinned.items()))
+    if len({tuple(sorted(h)) for h in pinned.values()}) == 1:
+        label += " (same hashes, different order — runners assert ordered equality)"
     return [f"{label}\n    {detail}"], warnings
 
 

--- a/scripts/check_golden_corpus_sync.py
+++ b/scripts/check_golden_corpus_sync.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Cross-repo golden signing corpus sync check.
+
+The shared signing fixture corpus lives as hand-synced copies in three repos:
+  vultisig-android  app/src/androidTest/assets/
+  vultisig-ios      VultisigApp/VultisigAppTests/TestData/
+  vultisig-sdk      packages/core/mpc/keysign/tests/fixtures/mobile/
+
+Each repo re-derives every pre-image hash from its own payload copy and asserts
+against its own pinned expected_image_hash, so cross-repo DISAGREEMENT on a
+pinned hash means two platforms would sign different bytes for the same case.
+
+This check fails (exit 1) only on that disagreement. Missing files or cases are
+reported as coverage warnings, not failures — corpus rollout is staged and the
+gaps are tracked in per-repo issues. Files are compared parsed, never as bytes:
+the copies legitimately differ in formatting and field-name spelling.
+
+Copies of this script live in vultisig-android, vultisig-ios and vultisig-sdk —
+keep them identical.
+
+Usage:
+  check_golden_corpus_sync.py --android DIR --ios DIR --sdk DIR
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPOS = ("android", "ios", "sdk")
+
+
+def load_corpus(corpus_dir: Path) -> dict[str, dict[str, list[str]]]:
+    """Map fixture filename -> case name -> pinned expected_image_hash list."""
+    corpus: dict[str, dict[str, list[str]]] = {}
+    for path in sorted(corpus_dir.glob("*.json")):
+        cases = json.loads(path.read_text())
+        corpus[path.name] = {
+            case["name"]: [h.lower() for h in (case.get("expected_image_hash") or [])]
+            for case in cases
+        }
+    return corpus
+
+
+def compare_case(hashes_by_repo: dict[str, list[str]]) -> str | None:
+    """Return 'drift' | 'order' | 'unpinned' | None for one case across repos."""
+    pinned = {repo: h for repo, h in hashes_by_repo.items() if h}
+    if len(pinned) < len(hashes_by_repo):
+        return "unpinned" if pinned else None
+    if len({tuple(h) for h in pinned.values()}) == 1:
+        return None
+    if len({tuple(sorted(h)) for h in pinned.values()}) == 1:
+        return "order"
+    return "drift"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    for repo in REPOS:
+        parser.add_argument(f"--{repo}", required=True, type=Path)
+    args = parser.parse_args()
+
+    corpora = {repo: load_corpus(getattr(args, repo)) for repo in REPOS}
+    for repo in REPOS:
+        n_cases = sum(len(cases) for cases in corpora[repo].values())
+        print(f"{repo}: {len(corpora[repo])} fixture files, {n_cases} cases")
+
+    drift: list[str] = []
+    warnings: list[str] = []
+    all_files = sorted(set().union(*(c.keys() for c in corpora.values())))
+    for filename in all_files:
+        present = {repo: c[filename] for repo, c in corpora.items() if filename in c}
+        missing_file = [repo for repo in REPOS if repo not in present]
+        if missing_file:
+            warnings.append(f"{filename}: missing on {', '.join(missing_file)}")
+        if len(present) < 2:
+            continue
+        all_cases = sorted(set().union(*(cases.keys() for cases in present.values())))
+        for name in all_cases:
+            shared = {repo: cases[name] for repo, cases in present.items() if name in cases}
+            missing_case = [repo for repo in present if repo not in shared]
+            if missing_case:
+                warnings.append(f"{filename} :: {name}: missing on {', '.join(missing_case)}")
+            if len(shared) < 2:
+                continue
+            verdict = compare_case(shared)
+            if verdict == "drift":
+                detail = "; ".join(f"{repo}={hashes}" for repo, hashes in sorted(shared.items()))
+                drift.append(f"{filename} :: {name}\n    {detail}")
+            elif verdict == "order":
+                warnings.append(f"{filename} :: {name}: same hashes, different order")
+            elif verdict == "unpinned":
+                unpinned = [repo for repo, h in shared.items() if not h]
+                warnings.append(f"{filename} :: {name}: no pinned hash on {', '.join(unpinned)}")
+
+    if warnings:
+        print(f"\n{len(warnings)} coverage warning(s) (non-fatal, tracked in issues):")
+        for warning in warnings:
+            print(f"  WARN  {warning}")
+
+    if drift:
+        print(f"\n{len(drift)} CROSS-REPO HASH DISAGREEMENT(S) — two platforms would sign different bytes:")
+        for entry in drift:
+            print(f"  DRIFT {entry}")
+        print("\nAn intentional vector change must land the same hashes in all three repos.")
+        return 1
+
+    print("\nOK: every case shared between repos agrees on expected_image_hash.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_golden_corpus_sync.py
+++ b/scripts/check_golden_corpus_sync.py
@@ -6,14 +6,11 @@ The shared signing fixture corpus lives as hand-synced copies in three repos:
   vultisig-ios      VultisigApp/VultisigAppTests/TestData/
   vultisig-sdk      packages/core/mpc/keysign/tests/fixtures/mobile/
 
-Each repo re-derives every pre-image hash from its own payload copy and asserts
-against its own pinned expected_image_hash, so cross-repo DISAGREEMENT on a
-pinned hash means two platforms would sign different bytes for the same case.
-
-This check fails (exit 1) only on that disagreement. Missing files or cases are
-reported as coverage warnings, not failures — corpus rollout is staged and the
-gaps are tracked in per-repo issues. Files are compared parsed, never as bytes:
-the copies legitimately differ in formatting and field-name spelling.
+Each repo asserts only its own pinned expected_image_hash, so cross-repo
+disagreement on a shared case means two platforms would sign different bytes —
+that fails this check (exit 1). Missing files or cases only warn: corpus
+rollout is staged and the gaps are tracked in per-repo issues. Files are
+compared parsed, never as bytes — the copies legitimately differ in formatting.
 
 Copies of this script live in vultisig-android, vultisig-ios and vultisig-sdk —
 keep them identical.
@@ -29,71 +26,81 @@ import json
 import sys
 from pathlib import Path
 
-REPOS = ("android", "ios", "sdk")
+# fixture filename -> case name -> pinned expected_image_hash list
+Corpus = dict[str, dict[str, list[str]]]
 
 
-def load_corpus(corpus_dir: Path) -> dict[str, dict[str, list[str]]]:
-    """Map fixture filename -> case name -> pinned expected_image_hash list."""
-    corpus: dict[str, dict[str, list[str]]] = {}
+def load_corpus(corpus_dir: Path) -> Corpus:
+    corpus: Corpus = {}
     for path in sorted(corpus_dir.glob("*.json")):
         cases = json.loads(path.read_text())
         corpus[path.name] = {
             case["name"]: [h.lower() for h in (case.get("expected_image_hash") or [])]
             for case in cases
         }
+        if len(corpus[path.name]) != len(cases):
+            sys.exit(f"{path}: duplicate case names — a duplicate would go uncompared")
     return corpus
 
 
-def compare_case(hashes_by_repo: dict[str, list[str]]) -> str | None:
-    """Return 'drift' | 'order' | 'unpinned' | None for one case across repos."""
-    pinned = {repo: h for repo, h in hashes_by_repo.items() if h}
-    if len(pinned) < len(hashes_by_repo):
-        return "unpinned" if pinned else None
-    if len({tuple(h) for h in pinned.values()}) == 1:
-        return None
+def diff_case(label: str, hashes_by_repo: dict[str, list[str]]) -> tuple[list[str], list[str]]:
+    """Compare one case across the repos that have it; return (drift, warnings)."""
+    pinned = {repo: hashes for repo, hashes in hashes_by_repo.items() if hashes}
+    unpinned = [repo for repo in hashes_by_repo if repo not in pinned]
+    warnings = [f"{label}: no pinned hash on {', '.join(unpinned)}"] if unpinned and pinned else []
+    if len(pinned) < 2 or len({tuple(h) for h in pinned.values()}) == 1:
+        return [], warnings
     if len({tuple(sorted(h)) for h in pinned.values()}) == 1:
-        return "order"
-    return "drift"
+        return [], warnings + [f"{label}: same hashes, different order"]
+    detail = "; ".join(f"{repo}={hashes}" for repo, hashes in sorted(pinned.items()))
+    return [f"{label}\n    {detail}"], warnings
+
+
+def diff_corpora(corpora: dict[str, Corpus]) -> tuple[list[str], list[str]]:
+    """Return (drift, warnings) across all fixture files and cases."""
+    drift: list[str] = []
+    warnings: list[str] = []
+    for filename in sorted(set().union(*(c.keys() for c in corpora.values()))):
+        present = {repo: c[filename] for repo, c in corpora.items() if filename in c}
+        absent = [repo for repo in corpora if repo not in present]
+        if absent:
+            warnings.append(f"{filename}: missing on {', '.join(absent)}")
+        if len(present) < 2:
+            continue
+        for name in sorted(set().union(*(cases.keys() for cases in present.values()))):
+            shared = {repo: cases[name] for repo, cases in present.items() if name in cases}
+            missing = [repo for repo in present if repo not in shared]
+            if missing:
+                warnings.append(f"{filename} :: {name}: missing on {', '.join(missing)}")
+            case_drift, case_warnings = diff_case(f"{filename} :: {name}", shared)
+            drift += case_drift
+            warnings += case_warnings
+    return drift, warnings
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    for repo in REPOS:
-        parser.add_argument(f"--{repo}", required=True, type=Path)
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--android", required=True, type=Path)
+    parser.add_argument("--ios", required=True, type=Path)
+    parser.add_argument("--sdk", required=True, type=Path)
     args = parser.parse_args()
 
-    corpora = {repo: load_corpus(getattr(args, repo)) for repo in REPOS}
-    for repo in REPOS:
-        n_cases = sum(len(cases) for cases in corpora[repo].values())
-        print(f"{repo}: {len(corpora[repo])} fixture files, {n_cases} cases")
+    for repo in ("android", "ios", "sdk"):
+        if not getattr(args, repo).is_dir():
+            parser.error(f"--{repo}: corpus dir not found: {getattr(args, repo)}")
 
-    drift: list[str] = []
-    warnings: list[str] = []
-    all_files = sorted(set().union(*(c.keys() for c in corpora.values())))
-    for filename in all_files:
-        present = {repo: c[filename] for repo, c in corpora.items() if filename in c}
-        missing_file = [repo for repo in REPOS if repo not in present]
-        if missing_file:
-            warnings.append(f"{filename}: missing on {', '.join(missing_file)}")
-        if len(present) < 2:
-            continue
-        all_cases = sorted(set().union(*(cases.keys() for cases in present.values())))
-        for name in all_cases:
-            shared = {repo: cases[name] for repo, cases in present.items() if name in cases}
-            missing_case = [repo for repo in present if repo not in shared]
-            if missing_case:
-                warnings.append(f"{filename} :: {name}: missing on {', '.join(missing_case)}")
-            if len(shared) < 2:
-                continue
-            verdict = compare_case(shared)
-            if verdict == "drift":
-                detail = "; ".join(f"{repo}={hashes}" for repo, hashes in sorted(shared.items()))
-                drift.append(f"{filename} :: {name}\n    {detail}")
-            elif verdict == "order":
-                warnings.append(f"{filename} :: {name}: same hashes, different order")
-            elif verdict == "unpinned":
-                unpinned = [repo for repo, h in shared.items() if not h]
-                warnings.append(f"{filename} :: {name}: no pinned hash on {', '.join(unpinned)}")
+    corpora = {
+        "android": load_corpus(args.android),
+        "ios": load_corpus(args.ios),
+        "sdk": load_corpus(args.sdk),
+    }
+    for repo, corpus in corpora.items():
+        n_cases = sum(len(cases) for cases in corpus.values())
+        print(f"{repo}: {len(corpus)} fixture files, {n_cases} cases")
+
+    drift, warnings = diff_corpora(corpora)
 
     if warnings:
         print(f"\n{len(warnings)} coverage warning(s) (non-fatal, tracked in issues):")

--- a/scripts/check_golden_corpus_sync.py
+++ b/scripts/check_golden_corpus_sync.py
@@ -15,11 +15,12 @@ compared parsed, never as bytes — the copies legitimately differ in formatting
 Copies of this script live in vultisig-android, vultisig-ios and vultisig-sdk —
 keep them identical.
 
+Requires Python 3.9+ (builtin generics). Exit codes: 0 in sync, 1 drift,
+2 unusable corpus (missing dir, unparseable file, duplicate case names).
+
 Usage:
   check_golden_corpus_sync.py --android DIR --ios DIR --sdk DIR
 """
-
-from __future__ import annotations
 
 import argparse
 import json
@@ -33,49 +34,54 @@ Corpus = dict[str, dict[str, list[str]]]
 def load_corpus(corpus_dir: Path) -> Corpus:
     corpus: Corpus = {}
     for path in sorted(corpus_dir.glob("*.json")):
-        cases = json.loads(path.read_text())
+        try:
+            cases = json.loads(path.read_text())
+        except json.JSONDecodeError as err:
+            print(f"{path}: unparseable fixture file — {err}", file=sys.stderr)
+            raise SystemExit(2) from None
         corpus[path.name] = {
             case["name"]: [h.lower() for h in (case.get("expected_image_hash") or [])]
             for case in cases
         }
         if len(corpus[path.name]) != len(cases):
-            sys.exit(f"{path}: duplicate case names — a duplicate would go uncompared")
+            print(f"{path}: duplicate case names — a duplicate would go uncompared", file=sys.stderr)
+            raise SystemExit(2)
     return corpus
 
 
 def diff_case(label: str, hashes_by_repo: dict[str, list[str]]) -> tuple[list[str], list[str]]:
-    """Compare one case across the repos that have it; return (drift, warnings)."""
+    """Compare one case across the repos that have it; return (drift, gaps)."""
     pinned = {repo: hashes for repo, hashes in hashes_by_repo.items() if hashes}
     unpinned = [repo for repo in hashes_by_repo if repo not in pinned]
-    warnings = [f"{label}: no pinned hash on {', '.join(unpinned)}"] if unpinned and pinned else []
+    gaps = [f"{label}: no pinned hash on {', '.join(unpinned)}"] if unpinned else []
     if len(pinned) < 2 or len({tuple(h) for h in pinned.values()}) == 1:
-        return [], warnings
+        return [], gaps
     detail = "; ".join(f"{repo}={hashes}" for repo, hashes in sorted(pinned.items()))
     if len({tuple(sorted(h)) for h in pinned.values()}) == 1:
         label += " (same hashes, different order — runners assert ordered equality)"
-    return [f"{label}\n    {detail}"], warnings
+    return [f"{label}\n    {detail}"], gaps
 
 
 def diff_corpora(corpora: dict[str, Corpus]) -> tuple[list[str], list[str]]:
-    """Return (drift, warnings) across all fixture files and cases."""
+    """Return (drift, gaps) across all fixture files and cases."""
     drift: list[str] = []
-    warnings: list[str] = []
-    for filename in sorted(set().union(*(c.keys() for c in corpora.values()))):
-        present = {repo: c[filename] for repo, c in corpora.items() if filename in c}
+    gaps: list[str] = []
+    for filename in sorted({name for corpus in corpora.values() for name in corpus}):
+        present = {repo: corpus[filename] for repo, corpus in corpora.items() if filename in corpus}
         absent = [repo for repo in corpora if repo not in present]
         if absent:
-            warnings.append(f"{filename}: missing on {', '.join(absent)}")
+            gaps.append(f"{filename}: missing on {', '.join(absent)}")
         if len(present) < 2:
             continue
-        for name in sorted(set().union(*(cases.keys() for cases in present.values()))):
+        for name in sorted({n for cases in present.values() for n in cases}):
             shared = {repo: cases[name] for repo, cases in present.items() if name in cases}
             missing = [repo for repo in present if repo not in shared]
             if missing:
-                warnings.append(f"{filename} :: {name}: missing on {', '.join(missing)}")
-            case_drift, case_warnings = diff_case(f"{filename} :: {name}", shared)
+                gaps.append(f"{filename} :: {name}: missing on {', '.join(missing)}")
+            case_drift, case_gaps = diff_case(f"{filename} :: {name}", shared)
             drift += case_drift
-            warnings += case_warnings
-    return drift, warnings
+            gaps += case_gaps
+    return drift, gaps
 
 
 def main() -> int:
@@ -87,25 +93,22 @@ def main() -> int:
     parser.add_argument("--sdk", required=True, type=Path)
     args = parser.parse_args()
 
-    for repo in ("android", "ios", "sdk"):
-        if not getattr(args, repo).is_dir():
-            parser.error(f"--{repo}: corpus dir not found: {getattr(args, repo)}")
+    corpus_dirs = {"android": args.android, "ios": args.ios, "sdk": args.sdk}
+    for repo, corpus_dir in corpus_dirs.items():
+        if not corpus_dir.is_dir():
+            parser.error(f"--{repo}: corpus dir not found: {corpus_dir}")
 
-    corpora = {
-        "android": load_corpus(args.android),
-        "ios": load_corpus(args.ios),
-        "sdk": load_corpus(args.sdk),
-    }
+    corpora = {repo: load_corpus(corpus_dir) for repo, corpus_dir in corpus_dirs.items()}
     for repo, corpus in corpora.items():
         n_cases = sum(len(cases) for cases in corpus.values())
         print(f"{repo}: {len(corpus)} fixture files, {n_cases} cases")
 
-    drift, warnings = diff_corpora(corpora)
+    drift, gaps = diff_corpora(corpora)
 
-    if warnings:
-        print(f"\n{len(warnings)} coverage warning(s) (non-fatal, tracked in issues):")
-        for warning in warnings:
-            print(f"  WARN  {warning}")
+    if gaps:
+        print(f"\n{len(gaps)} coverage warning(s) (non-fatal, tracked in issues):")
+        for gap in gaps:
+            print(f"  WARN  {gap}")
 
     if drift:
         print(f"\n{len(drift)} CROSS-REPO HASH DISAGREEMENT(S) — two platforms would sign different bytes:")


### PR DESCRIPTION
## What

The mobile golden fixture corpus (\`packages/core/mpc/keysign/tests/fixtures/mobile/\`) is shared with vultisig-android and vultisig-ios, but synced by hand — each repo's tests only assert against its own pinned hashes, so two repos disagreeing on the same case would merge silently on both sides. This adds a small CI job that fails when any case shared between the three repos has different \`expected_image_hash\` values.

## How

- \`scripts/check_golden_corpus_sync.py\` — stdlib-only Python, an identical copy lands in all three repos. Compares \`name → expected_image_hash\` per case, parsed — formatting and field-spelling differences between the copies are ignored.
- \`.github/workflows/golden-corpus-sync.yml\` — runs on PRs touching the corpus, pushes to main, weekly, and on dispatch. Sparse-clones only the two sibling corpus directories, so the job takes seconds.
- **Fails** only on hash disagreement for a shared case. Missing files/cases just **warn** — coverage gaps are tracked in [#2168](https://github.com/vultisig/vultisig-sdk/issues/2168), [#2169](https://github.com/vultisig/vultisig-sdk/issues/2169), [vultisig-android#5673](https://github.com/vultisig/vultisig-android/issues/5673), [vultisig-ios#5242](https://github.com/vultisig/vultisig-ios/issues/5242).
- An intentional change to an existing shared vector fails here until the same hashes land in the sibling repos — that is the intended behavior. New cases and new files only warn, so first-mover corpus additions (like #2148) are unaffected.

CI/tooling only — no package code, so no changeset.

Companion PRs: [vultisig-android#5674](https://github.com/vultisig/vultisig-android/pull/5674), [vultisig-ios#5244](https://github.com/vultisig/vultisig-ios/pull/5244).

## Receipts

Local run against current main of all three repos — exit 0, zero disagreements, 87/87/71 cases loaded, 15 coverage warnings matching the filed issues:

```
android: 27 fixture files, 87 cases
ios: 30 fixture files, 87 cases
sdk: 23 fixture files, 71 cases
15 coverage warning(s) (non-fatal, tracked in issues): ...
OK: every case shared between repos agrees on expected_image_hash.
```

Negative test: corrupting one hash in a local copy → exit 1 naming the case:

```
1 CROSS-REPO HASH DISAGREEMENT(S) — two platforms would sign different bytes:
  DRIFT evm.json :: Send ETH
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated checks to verify that mobile golden-signing corpora remain synchronized across Android, iOS, and SDK repositories.
  * Reports missing cases, duplicate cases, unpinned values, ordering differences, and hash mismatches.
  * Provides clear success or failure results, while retaining non-blocking coverage warnings.

* **Chores**
  * Added scheduled, pull request, push, and manual workflow triggers for synchronization checks.
  * Improved validation of repository paths and corpus comparison results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->