### PR TITLE
feat(sdk): add canonical tx-ready envelope parser

### DIFF
--- a/.changeset/canonical-tx-ready-parser.md
+++ b/.changeset/canonical-tx-ready-parser.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/sdk': minor
+'@vultisig/cli': patch
+---
+
+Export a canonical typed parser for backend `tx_ready` and execute-prep envelopes, and migrate the CLI's non-EVM and THOR/Maya execution routing to that shared contract.

--- a/clients/cli/src/agent/__tests__/parseNonEvmEnvelope.test.ts
+++ b/clients/cli/src/agent/__tests__/parseNonEvmEnvelope.test.ts
@@ -6,8 +6,8 @@
  * agent path on 2026-05-10 (see task 100526-sdk-cli-non-evm-signing.md).
  *
  * Critical invariants locked here:
- * - `txArgs.amount` is base-unit integer string; parser converts via
- *   `formatUnits(BigInt(amount), chainDecimals)` before vault.send.
+ * - `txArgs.amount` is a base-unit integer string; parser converts via
+ *   native or resolved token decimals before vault.send.
  * - For native sends, `symbol` is undefined (vault.send defaults to
  *   native chain coin).
  * - Memo passes through unchanged when present, undefined when empty.
@@ -98,6 +98,43 @@ describe('parseNonEvmEnvelope', () => {
       expect(args.amount).toBe('0.001')
       expect(args.to).toBe('iwMx27vvAiaQteMhdpSBVDRztiSt1Cxwcfkm6SQBpxA')
       expect(args.symbol).toBeUndefined()
+    })
+
+    it('converts known SPL token base units with token decimals', () => {
+      const tokenEnvelope = {
+        ...solEnvelope,
+        resolved: {
+          labels: {
+            resolved_amount: '1 USDC',
+            token: 'USDC (SPL token on Solana, 6 dec)',
+            token_resolved: 'USDC',
+          },
+        },
+      }
+
+      const args = parseNonEvmEnvelope(tokenEnvelope, Chain.Solana)
+      expect(args.amount).toBe('1')
+      expect(args.symbol).toBe('USDC')
+    })
+
+    it('forwards vault-configured token metadata to the canonical parser', () => {
+      const customEnvelope = {
+        ...solEnvelope,
+        resolved: { labels: { token_resolved: 'CUSTOM' } },
+        txArgs: { ...solEnvelope.txArgs, amount: '123456' },
+      }
+      const args = parseNonEvmEnvelope(customEnvelope, Chain.Solana, [
+        {
+          id: 'custom-mint',
+          symbol: 'CUSTOM',
+          name: 'Custom',
+          decimals: 5,
+          chainId: Chain.Solana,
+        },
+      ])
+
+      expect(args.amount).toBe('1.23456')
+      expect(args.symbol).toBe('CUSTOM')
     })
   })
 

--- a/clients/cli/src/agent/executor.ts
+++ b/clients/cli/src/agent/executor.ts
@@ -1020,7 +1020,7 @@ export class AgentExecutor {
       )
     }
 
-    const parsed = parseTxReadyForCli(serverTxData, chain, this.vault.getTokens(chain))
+    const parsed = parseTxReadyForCli(serverTxData, chain, this.vault.getTokens?.(chain) ?? [])
     if (parsed.kind === 'thor-swap-deposit') {
       return this.signThorMsgDepositSwap(parsed)
     }

--- a/clients/cli/src/agent/executor.ts
+++ b/clients/cli/src/agent/executor.ts
@@ -21,7 +21,6 @@ import {
   getChainKind,
   getEvmRpcUrl,
   knownTokensIndex,
-  parseThorSwapMemo,
   parseTxReadyEnvelope,
   pollTxStatusUntilFinal,
   resolveChainReference,

--- a/clients/cli/src/agent/executor.ts
+++ b/clients/cli/src/agent/executor.ts
@@ -6,17 +6,25 @@
  * Each handler takes `(toolCallId, input)` and returns a `RecentAction` ready
  * to be flushed into the next outbound `context.recent_actions`.
  */
-import type { EvmChain, VaultBase, Vultisig } from '@vultisig/sdk'
+import type {
+  EvmChain,
+  ParsedTxReadyEnvelope,
+  ParsedTxReadySend,
+  ParsedTxReadyThorLpDeposit,
+  ParsedTxReadyThorSwapDeposit,
+  VaultBase,
+  Vultisig,
+} from '@vultisig/sdk'
 import {
   Chain,
-  chainFeeCoin,
   computeEip712Hash,
   getChainKind,
   getEvmRpcUrl,
   knownTokensIndex,
-  parseThorSwapMemo,
+  parseTxReadyEnvelope,
   resolveChainReference,
   toCanonicalEvmSignature,
+  TxReadyParseError,
   VaultError,
   VaultErrorCode,
   Vultisig as VultisigSdk,
@@ -974,8 +982,8 @@ export class AgentExecutor {
   }
 
   /**
-   * Non-EVM signing path: parse the agent's tx_ready envelope into a
-   * `vault.send`-shaped argument bag and call through. The SDK already
+   * Non-EVM signing path: parse the agent's tx_ready envelope through the
+   * SDK's canonical discriminated contract and call through. The SDK already
    * handles per-chain prepare/sign/broadcast internally via
    * `VaultBase.prepareSendTx` virtuals — sdk-cli only owns envelope
    * parsing here, not chain-specific signing logic.
@@ -1012,27 +1020,20 @@ export class AgentExecutor {
       )
     }
 
-    // THORChain / MayaChain MsgDeposit branch — agent emitted a deposit
-    // envelope sourcing from the cosmos chain natively. Dispatch by memo
-    // prefix: `=:` is a swap (Phase D), `+:` / `-:` are LP add/remove
-    // (Phase E). Anything else is loan / validator ops, out of scope.
-    if (txArgs.msg_type === 'deposit' && (chain === Chain.THORChain || chain === Chain.MayaChain)) {
-      const memo: string = typeof txArgs.memo === 'string' ? txArgs.memo : ''
-      if (memo.startsWith('=:')) {
-        return this.signThorMsgDepositSwap(serverTxData, chain)
-      }
-      if (memo.startsWith('+:') || memo.startsWith('-:')) {
-        return this.signThorMsgDepositLp(serverTxData, chain)
-      }
+    const parsed = parseTxReadyForCli(serverTxData, chain)
+    if (parsed.kind === 'thor-swap-deposit') {
+      return this.signThorMsgDepositSwap(parsed)
+    }
+    if (parsed.kind === 'thor-lp-deposit') {
+      return this.signThorMsgDepositLp(parsed)
+    }
+    if (parsed.kind !== 'send') {
       throw new VaultError(
-        VaultErrorCode.NotImplemented,
-        `signNonEvmServerTx: MsgDeposit memo prefix not supported on ${chain}: '${memo}'. ` +
-          `Supported prefixes: '=:' (swap), '+:' (LP add), '-:' (LP remove). ` +
-          `Loan / validator ops are out of scope.`
+        VaultErrorCode.InvalidConfig,
+        `signNonEvmServerTx: expected a non-EVM send/deposit envelope, got ${parsed.kind}`
       )
     }
-
-    const args = parseNonEvmEnvelope(serverTxData, chain)
+    const args = parsed
     if (this.verbose)
       process.stderr.write(
         `[sign_non_evm_server_tx] chain=${chain}, to=${args.to}, amount=${args.amount}${args.symbol ? ` ${args.symbol}` : ''}, memo=${args.memo ? `"${args.memo}"` : '(none)'}\n`
@@ -1086,47 +1087,21 @@ export class AgentExecutor {
    * cross-account route cannot be silently replaced with the vault's address.
    * An omitted destination keeps the existing self-swap default.
    */
-  private async signThorMsgDepositSwap(serverTxData: any, chain: Chain): Promise<Record<string, unknown>> {
-    const txArgs = serverTxData?.txArgs ?? {}
-    const memo: string = typeof txArgs.memo === 'string' ? txArgs.memo : ''
-    const parsed = parseThorSwapMemo(memo)
-    if (/\s/.test(parsed.destAddress)) {
-      throw new VaultError(
-        VaultErrorCode.InvalidConfig,
-        `signThorMsgDepositSwap: destination address in memo '${memo}' must not contain whitespace.`
-      )
-    }
-
-    const toChain = parsed.toChain
-
-    // From-asset: derived from the source chain's native ticker (RUNE on
-    // THORChain, CACAO on MayaChain).
-    const fromSymbol = chain === Chain.THORChain ? 'RUNE' : 'CACAO'
-
-    // Convert base-units amount → decimal string for vault.swap. We refuse
-    // to fall through with a default (e.g. '0') because that would mask
-    // malformed envelopes by silently submitting a zero-value swap.
-    const amountRaw = typeof txArgs.amount === 'string' ? txArgs.amount : undefined
-    if (!amountRaw) {
-      throw new VaultError(
-        VaultErrorCode.InvalidConfig,
-        `signThorMsgDepositSwap: missing or non-string 'amount' field on ${chain} envelope`
-      )
-    }
-    const amountDecimal = convertBaseUnitsToDecimal(chain, amountRaw, 'signThorMsgDepositSwap')
+  private async signThorMsgDepositSwap(parsed: ParsedTxReadyThorSwapDeposit): Promise<Record<string, unknown>> {
+    const { amount, chain, fromSymbol, memo, recipient, toChain, toSymbol } = parsed
 
     if (this.verbose)
       process.stderr.write(
-        `[sign_thor_msg_deposit_swap] ${fromSymbol}@${chain} → ${parsed.destAsset}@${toChain}, amount=${amountDecimal}, memo='${memo}'\n`
+        `[sign_thor_msg_deposit_swap] ${fromSymbol}@${chain} → ${toSymbol}@${toChain}, amount=${amount}, memo='${memo}'\n`
       )
 
     const result = await this.vault.swap({
       fromChain: chain,
       fromSymbol,
       toChain,
-      toSymbol: parsed.destAsset,
-      amount: amountDecimal,
-      ...(parsed.destAddress && { recipient: parsed.destAddress }),
+      toSymbol,
+      amount,
+      ...(recipient && { recipient }),
     })
 
     if (result.dryRun) {
@@ -1162,32 +1137,17 @@ export class AgentExecutor {
    * as base units directly (no decimal conversion) since the agent
    * already emits RUNE / CACAO in base units.
    */
-  private async signThorMsgDepositLp(serverTxData: any, chain: Chain): Promise<Record<string, unknown>> {
-    const txArgs = serverTxData?.txArgs ?? {}
-    const memo: string = typeof txArgs.memo === 'string' ? txArgs.memo : ''
-    const amountRaw: string | undefined = typeof txArgs.amount === 'string' ? txArgs.amount : undefined
-    if (!amountRaw) {
-      throw new VaultError(
-        VaultErrorCode.InvalidConfig,
-        `signThorMsgDepositLp: missing or non-string 'amount' field on ${chain} envelope`
-      )
-    }
-    // Defense against magnitude-bug envelopes (mirrors parseNonEvmEnvelope's
-    // 26-digit cap). Pass base units through to vault.signMsgDeposit verbatim.
-    if (amountRaw.length > MAX_AMOUNT_DIGITS) {
-      throw new VaultError(
-        VaultErrorCode.InvalidAmount,
-        `signThorMsgDepositLp: amount '${amountRaw}' for ${chain} exceeds ${MAX_AMOUNT_DIGITS}-digit safety bound. ` +
-          'Likely a quote-side bug. Refusing to sign.'
-      )
-    }
+  private async signThorMsgDepositLp(parsed: ParsedTxReadyThorLpDeposit): Promise<Record<string, unknown>> {
+    const { amountBaseUnits, chain, memo } = parsed
 
     if (this.verbose)
-      process.stderr.write(`[sign_thor_msg_deposit_lp] chain=${chain}, memo='${memo}', amountBaseUnits=${amountRaw}\n`)
+      process.stderr.write(
+        `[sign_thor_msg_deposit_lp] chain=${chain}, memo='${memo}', amountBaseUnits=${amountBaseUnits}\n`
+      )
 
     const result = await this.vault.signMsgDeposit({
       chain,
-      amountBaseUnits: amountRaw,
+      amountBaseUnits,
       memo,
     })
     this.pendingPayloads.clear()
@@ -2116,15 +2076,7 @@ export function extractNestedTx(txReadyData: any): any {
 /**
  * Argument bag for `vault.send`, parsed from a non-EVM tx_ready envelope.
  */
-export type NonEvmSendArgs = {
-  chain: Chain
-  to: string
-  /** Decimal amount string (human units), suitable for `vault.send`. */
-  amount: string
-  /** Optional token symbol; omit for native sends. */
-  symbol?: string
-  memo?: string
-}
+export type NonEvmSendArgs = Omit<ParsedTxReadySend, 'kind' | 'envelope'>
 
 /**
  * Parse a tx_ready envelope from the agent into `vault.send`-shaped args.
@@ -2164,84 +2116,36 @@ export type NonEvmSendArgs = {
  * never reach those branches today (envelopes for those chains hit the
  * stale-CLI-build error pre-PR-D), but the throw is defensive.
  */
-const MAX_AMOUNT_DIGITS = 26
-
-/**
- * Convert a base-unit integer-string amount → decimal string using the
- * chain's native fee-coin decimals. Used by both `parseNonEvmEnvelope`
- * (non-EVM send dispatch) and `signThorMsgDepositSwap` (RUNE/CACAO swap
- * dispatch). Keeping the validation logic in one place ensures both paths
- * fail closed identically on:
- *
- * 1. **Magnitude-bug envelopes** — amount strings longer than 26 digits
- *    (10^26 wei = 10^8 ETH = ~$300B). Defensive bound against quote-side
- *    bugs producing magnitude-wrong envelopes.
- * 2. **Unregistered chain decimals** — `chainFeeCoin[chain]?.decimals`
- *    must not silently fall back to a default. A missing registry entry
- *    on a chain this dispatcher claims to support is a real bug; we
- *    throw `UnsupportedChain` instead of substituting 8 and producing a
- *    magnitude-wrong swap.
- * 3. **Non-numeric / overflow amounts** — `BigInt()` parse failures are
- *    surfaced as `InvalidAmount` with context.
- */
-function convertBaseUnitsToDecimal(chain: Chain, amountRaw: string, context: string): string {
-  if (amountRaw.length > MAX_AMOUNT_DIGITS) {
-    throw new VaultError(
-      VaultErrorCode.InvalidAmount,
-      `${context}: amount '${amountRaw}' for ${chain} exceeds ${MAX_AMOUNT_DIGITS}-digit safety bound. ` +
-        'Likely a quote-side bug. Refusing to sign.'
-    )
-  }
-  const decimals = chainFeeCoin[chain]?.decimals
-  if (decimals === undefined) {
-    throw new VaultError(VaultErrorCode.UnsupportedChain, `${context}: no native decimals registered for ${chain}`)
-  }
+function parseTxReadyForCli(serverTxData: unknown, defaultChain: Chain): ParsedTxReadyEnvelope {
   try {
-    return formatUnits(BigInt(amountRaw), decimals)
-  } catch (err: any) {
-    throw new VaultError(
-      VaultErrorCode.InvalidAmount,
-      `${context}: failed to convert amount '${amountRaw}' for ${chain}: ${err?.message ?? err}`
-    )
+    return parseTxReadyEnvelope(serverTxData, { defaultChain })
+  } catch (error) {
+    if (!(error instanceof TxReadyParseError)) throw error
+    const code =
+      error.code === 'INVALID_AMOUNT'
+        ? VaultErrorCode.InvalidAmount
+        : error.code === 'UNKNOWN_CHAIN'
+          ? VaultErrorCode.UnsupportedChain
+          : error.code === 'UNSUPPORTED_DEPOSIT' || error.code === 'UNSUPPORTED_ENVELOPE'
+            ? VaultErrorCode.NotImplemented
+            : VaultErrorCode.InvalidConfig
+    throw new VaultError(code, error.message)
   }
 }
 
 export function parseNonEvmEnvelope(serverTxData: any, chain: Chain): NonEvmSendArgs {
-  const txArgs = serverTxData?.txArgs ?? serverTxData
-  if (!txArgs || typeof txArgs !== 'object') {
+  if (!serverTxData || typeof serverTxData !== 'object') {
     throw new VaultError(VaultErrorCode.InvalidConfig, 'parseNonEvmEnvelope: envelope missing txArgs')
   }
-
-  const to: string | undefined = typeof txArgs.to === 'string' ? txArgs.to : undefined
-  if (!to) {
-    throw new VaultError(VaultErrorCode.InvalidConfig, `parseNonEvmEnvelope: missing 'to' field for ${chain}`)
+  const parsed = parseTxReadyForCli(serverTxData, chain)
+  if (parsed.kind !== 'send') {
+    throw new VaultError(
+      VaultErrorCode.InvalidConfig,
+      `parseNonEvmEnvelope: expected send envelope, got ${parsed.kind}`
+    )
   }
-
-  const amountRaw: string | undefined = typeof txArgs.amount === 'string' ? txArgs.amount : undefined
-  if (!amountRaw) {
-    throw new VaultError(VaultErrorCode.InvalidConfig, `parseNonEvmEnvelope: missing 'amount' field for ${chain}`)
-  }
-
-  // Convert base units (e.g. "1000" sats) → decimal string ("0.00001")
-  // using the chain's native fee-coin decimals. vault.send's parseAmount
-  // re-multiplies by the same decimals to recover bigint base units.
-  const amountDecimal = convertBaseUnitsToDecimal(chain, amountRaw, 'parseNonEvmEnvelope')
-
-  // Token symbol — for native sends, leave undefined (vault.send defaults
-  // to native). resolved.labels.token_resolved is the agent-resolved
-  // symbol; for native it equals the chain's native ticker (BTC/SOL/RUNE).
-  // Phase D PR 0 only wires native sends; non-native (e.g. SPL, TRC-20)
-  // is PR 1+ scope.
-  let symbol: string | undefined
-  const tokenResolved = serverTxData?.resolved?.labels?.token_resolved
-  const nativeTicker = chainFeeCoin[chain]?.ticker
-  if (typeof tokenResolved === 'string' && tokenResolved !== nativeTicker) {
-    symbol = tokenResolved
-  }
-
-  const memo: string | undefined = typeof txArgs.memo === 'string' && txArgs.memo.length > 0 ? txArgs.memo : undefined
-
-  return { chain, to, amount: amountDecimal, symbol, memo }
+  const { amount, memo, symbol, to } = parsed
+  return { chain: parsed.chain, to, amount, symbol, memo }
 }
 
 /**

--- a/clients/cli/src/agent/executor.ts
+++ b/clients/cli/src/agent/executor.ts
@@ -1020,7 +1020,7 @@ export class AgentExecutor {
       )
     }
 
-    const parsed = parseTxReadyForCli(serverTxData, chain)
+    const parsed = parseTxReadyForCli(serverTxData, chain, this.vault.getTokens(chain))
     if (parsed.kind === 'thor-swap-deposit') {
       return this.signThorMsgDepositSwap(parsed)
     }
@@ -2096,12 +2096,12 @@ export type NonEvmSendArgs = Omit<ParsedTxReadySend, 'kind' | 'envelope'>
  *       }
  *     }
  *
- * `amount` is ALWAYS base-unit integer (sats / lamports / uatom-equiv /
- * wei) **by contract** — confirmed via live envelope capture across BTC,
- * SOL, RUNE on 2026-05-10. We convert to a decimal string before passing
- * to `vault.send`, which then re-parses to bigint via the chain's native
- * decimals. Round-trip is lossless via viem's `formatUnits` /
- * `parseUnits`.
+ * `amount` is ALWAYS a base-unit integer **by contract** — confirmed via
+ * live envelope capture across BTC, SOL, and RUNE on 2026-05-10. Native
+ * sends use the chain coin's decimals; token sends use the canonical token
+ * resolver with vault-configured tokens. We convert to a decimal string
+ * before passing to `vault.send`, which re-parses it with the same token
+ * metadata. Round-trip is lossless via viem's `formatUnits` / `parseUnits`.
  *
  * **Defensive amount-length bound** (per PR #439 review finding 4): if
  * THORChain or mcp-ts ever returns a 26+ digit amount (10^26 wei = 10^8
@@ -2116,9 +2116,13 @@ export type NonEvmSendArgs = Omit<ParsedTxReadySend, 'kind' | 'envelope'>
  * never reach those branches today (envelopes for those chains hit the
  * stale-CLI-build error pre-PR-D), but the throw is defensive.
  */
-function parseTxReadyForCli(serverTxData: unknown, defaultChain: Chain): ParsedTxReadyEnvelope {
+function parseTxReadyForCli(
+  serverTxData: unknown,
+  defaultChain: Chain,
+  tokens: ReturnType<VaultBase['getTokens']> = []
+): ParsedTxReadyEnvelope {
   try {
-    return parseTxReadyEnvelope(serverTxData, { defaultChain })
+    return parseTxReadyEnvelope(serverTxData, { defaultChain, tokens })
   } catch (error) {
     if (!(error instanceof TxReadyParseError)) throw error
     const code =
@@ -2133,11 +2137,15 @@ function parseTxReadyForCli(serverTxData: unknown, defaultChain: Chain): ParsedT
   }
 }
 
-export function parseNonEvmEnvelope(serverTxData: any, chain: Chain): NonEvmSendArgs {
+export function parseNonEvmEnvelope(
+  serverTxData: any,
+  chain: Chain,
+  tokens: ReturnType<VaultBase['getTokens']> = []
+): NonEvmSendArgs {
   if (!serverTxData || typeof serverTxData !== 'object') {
     throw new VaultError(VaultErrorCode.InvalidConfig, 'parseNonEvmEnvelope: envelope missing txArgs')
   }
-  const parsed = parseTxReadyForCli(serverTxData, chain)
+  const parsed = parseTxReadyForCli(serverTxData, chain, tokens)
   if (parsed.kind !== 'send') {
     throw new VaultError(
       VaultErrorCode.InvalidConfig,

--- a/clients/cli/src/agent/types.ts
+++ b/clients/cli/src/agent/types.ts
@@ -4,7 +4,7 @@
  * Types for the agent chat system including SSE events,
  * backend API types, action execution, and UI interfaces.
  */
-import type { Vultisig } from '@vultisig/sdk'
+import type { TxReadyEnvelope, TxReadyObject, Vultisig } from '@vultisig/sdk'
 
 import type { AgentErrorCode } from './agentErrors'
 import type {
@@ -313,13 +313,8 @@ export type InstallRequired = {
   description?: string
 }
 
-/**
- * Summary transaction row from non-streaming JSON responses.
- *
- * Permissive tx_ready payload shape while the backend schema evolves.
- * TODO: replace with a concrete interface or union when tx_ready stabilizes.
- */
-export type TxReadyPayloadFields = Record<string, unknown>
+/** Summary transaction row from non-streaming JSON responses. */
+export type TxReadyPayloadFields = TxReadyObject
 
 export type Transaction = {
   sequence: number
@@ -338,40 +333,8 @@ export type Transaction = {
   tx?: TxReadyPayloadFields
 }
 
-/**
- * SSE `tx_ready` payload — backend may nest swap/send payloads or attach `tx`.
- * Kept separate from {@link Transaction} so optional nested fields type-check.
- */
-export type TxReadyPayload = {
-  sequence?: number
-  chain?: string
-  chain_id?: string
-  action?: string
-  signing_mode?: string
-  unsigned_tx_hex?: string
-  tx_details?: Record<string, unknown>
-  keysign_payload?: string
-  swap_tx?: Record<string, unknown>
-  send_tx?: Record<string, unknown>
-  tx?: Record<string, unknown>
-  /**
-   * Multi-leg (approve + main) envelope legs. The executor's
-   * `storeServerTransaction` buffers both legs and `signMultiLeg` signs the
-   * approve, waits for its receipt, then signs the main leg. Each leg nests its
-   * own flat tx under `.tx`. Populated by the client-side tool-output enrichment
-   * for a bundled approve→main (see `toolOutputSigning.ts`) and by mcp-ts
-   * `execute_*` envelopes.
-   */
-  approvalTxArgs?: Record<string, unknown>
-  txArgs?: Record<string, unknown>
-  /**
-   * Internal marker: this signable envelope was synthesized client-side by
-   * `toolOutputSigning.ts` from a `tool-output-available` frame, not received on
-   * the `tx_ready` channel. Used only to render an accurate confirm-gate summary
-   * (`AgentExecutor.getPendingSummary`); inert to signing.
-   */
-  __buildTx?: boolean
-}
+/** SDK-owned wire contract for SSE `tx_ready` and execute-prep payloads. */
+export type TxReadyPayload = TxReadyEnvelope
 
 export type TokenSearchResult = {
   tokens: TokenInfo[]

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -39,7 +39,7 @@ export {
 export { ValidationHelpers } from './utils/validation'
 
 // ============================================================================
-// PUBLIC API - Conversion / Normalization Utilities (vault-free)
+// PUBLIC API - Transaction Preparation / Normalization Utilities (vault-free)
 // ============================================================================
 
 export type {
@@ -137,8 +137,22 @@ export { isValidTokenId } from '@vultisig/core-chain/utils/isValidTokenId'
 // multi-tx build results (approve+swap, generic transactions[]) into ordered
 // legs. Ports the normalize/split half of the agent-backend's
 // enrichBuildResult + splitMultiTx; SSE/Redis sequencing stays in the backend.
-export type { NormalizeArgs, NormalizedTx } from './tx'
-export { normalizeTx, splitMultiTx, TxNormalizeError } from './tx'
+export type {
+  NormalizeArgs,
+  NormalizedTx,
+  ParsedTxReadyEnvelope,
+  ParsedTxReadyRawEvm,
+  ParsedTxReadySend,
+  ParsedTxReadyThorLpDeposit,
+  ParsedTxReadyThorSwapDeposit,
+  ParseTxReadyOptions,
+  TxReadyEnvelope,
+  TxReadyEvmLeg,
+  TxReadyObject,
+  TxReadyParseErrorCode,
+  TxReadyTxArgs,
+} from './tx'
+export { normalizeTx, parseTxReadyEnvelope, splitMultiTx, TxNormalizeError, TxReadyParseError } from './tx'
 
 // ============================================================================
 // PUBLIC API - Canonical Contract / Token Registry (knownContracts)

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -823,7 +823,20 @@ export async function fiatToAmount(...args: unknown[]) {
 export type { ParseChainResult, ParseTickerResult } from '../../tools/parse'
 export { chainSchema, parseChain, parseTicker, tickerSchema } from '../../tools/parse'
 export type { NormalizeArgs, NormalizedTx } from '../../tx'
-export { normalizeTx, splitMultiTx, TxNormalizeError } from '../../tx'
+export type {
+  ParsedTxReadyEnvelope,
+  ParsedTxReadyRawEvm,
+  ParsedTxReadySend,
+  ParsedTxReadyThorLpDeposit,
+  ParsedTxReadyThorSwapDeposit,
+  ParseTxReadyOptions,
+  TxReadyEnvelope,
+  TxReadyEvmLeg,
+  TxReadyObject,
+  TxReadyParseErrorCode,
+  TxReadyTxArgs,
+} from '../../tx'
+export { normalizeTx, parseTxReadyEnvelope, splitMultiTx, TxNormalizeError, TxReadyParseError } from '../../tx'
 export { computePersonalSignHash, formatEcdsaSignature65 } from '../../utils/eip191'
 export { coerceEip712ChainId, computeEip712Hash, toCanonicalEvmSignature } from '../../utils/eip712'
 export {

--- a/packages/sdk/src/tx/index.ts
+++ b/packages/sdk/src/tx/index.ts
@@ -1,2 +1,16 @@
 export type { NormalizeArgs, NormalizedTx } from './normalize'
 export { normalizeTx, splitMultiTx, TxNormalizeError } from './normalize'
+export type {
+  ParsedTxReadyEnvelope,
+  ParsedTxReadyRawEvm,
+  ParsedTxReadySend,
+  ParsedTxReadyThorLpDeposit,
+  ParsedTxReadyThorSwapDeposit,
+  ParseTxReadyOptions,
+  TxReadyEnvelope,
+  TxReadyEvmLeg,
+  TxReadyObject,
+  TxReadyParseErrorCode,
+  TxReadyTxArgs,
+} from './parseTxReady'
+export { parseTxReadyEnvelope, TxReadyParseError } from './parseTxReady'

--- a/packages/sdk/src/tx/parseTxReady.ts
+++ b/packages/sdk/src/tx/parseTxReady.ts
@@ -3,8 +3,10 @@ import { getChainKind } from '@vultisig/core-chain/ChainKind'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { formatUnits } from 'viem'
 
+import type { Token } from '../types'
 import { resolveChainReference } from '../utils/resolveChainReference'
 import { parseThorSwapMemo } from '../utils/thorSwapMemo'
+import { resolveTokenRef } from '../vault/tokenRef'
 
 export type TxReadyObject = Record<string, unknown>
 
@@ -125,6 +127,8 @@ export class TxReadyParseError extends Error {
 export type ParseTxReadyOptions = {
   /** Consumer-owned fallback for legacy envelopes that omit chain metadata. */
   defaultChain?: Chain
+  /** Vault-configured tokens used to resolve non-native send decimals. */
+  tokens?: Token[]
 }
 
 const MAX_AMOUNT_DIGITS = 26
@@ -242,14 +246,14 @@ const assertAmount = (amountRaw: unknown, chain: Chain, context: string): string
   return amountRaw
 }
 
-const toDecimalAmount = (amountRaw: unknown, chain: Chain, context: string): string => {
+const toDecimalAmount = (amountRaw: unknown, chain: Chain, context: string, decimals?: number): string => {
   const amount = assertAmount(amountRaw, chain, context)
-  const decimals = chainFeeCoin[chain]?.decimals
-  if (decimals === undefined) {
+  const resolvedDecimals = decimals ?? chainFeeCoin[chain]?.decimals
+  if (resolvedDecimals === undefined) {
     throw new TxReadyParseError('UNKNOWN_CHAIN', `${context}: no native decimals registered for ${chain}`)
   }
   try {
-    return formatUnits(BigInt(amount), decimals)
+    return formatUnits(BigInt(amount), resolvedDecimals)
   } catch (error) {
     throw new TxReadyParseError(
       'INVALID_AMOUNT',
@@ -409,14 +413,30 @@ export const parseTxReadyEnvelope = (value: unknown, options: ParseTxReadyOption
 
   const tokenResolved = envelope.resolved?.labels?.['token_resolved']
   const nativeTicker = chainFeeCoin[chain]?.ticker
-  const symbol = typeof tokenResolved === 'string' && tokenResolved !== nativeTicker ? tokenResolved : undefined
+  const symbol =
+    typeof tokenResolved === 'string' && tokenResolved.toUpperCase() !== nativeTicker?.toUpperCase()
+      ? tokenResolved
+      : undefined
   const memo = typeof sendArgs['memo'] === 'string' && sendArgs['memo'].length > 0 ? sendArgs['memo'] : undefined
+
+  let decimals: number | undefined
+  if (symbol) {
+    try {
+      decimals = resolveTokenRef(chain, symbol, options.tokens ?? []).decimals
+    } catch (error) {
+      throw new TxReadyParseError(
+        'INVALID_ENVELOPE',
+        `tx_ready send: token decimals unavailable for '${symbol}' on ${chain}`,
+        { cause: error }
+      )
+    }
+  }
 
   return {
     kind: 'send',
     chain,
     to,
-    amount: toDecimalAmount(sendArgs['amount'], chain, 'tx_ready send'),
+    amount: toDecimalAmount(sendArgs['amount'], chain, 'tx_ready send', decimals),
     ...(symbol && { symbol }),
     ...(memo && { memo }),
     envelope,

--- a/packages/sdk/src/tx/parseTxReady.ts
+++ b/packages/sdk/src/tx/parseTxReady.ts
@@ -1,0 +1,424 @@
+import { Chain, type EvmChain } from '@vultisig/core-chain/Chain'
+import { getChainKind } from '@vultisig/core-chain/ChainKind'
+import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
+import { formatUnits } from 'viem'
+
+import { resolveChainReference } from '../utils/resolveChainReference'
+import { parseThorSwapMemo } from '../utils/thorSwapMemo'
+
+export type TxReadyObject = Record<string, unknown>
+
+export type TxReadyTxArgs = TxReadyObject & {
+  chain?: string
+  chain_id?: string | number
+  tx_encoding?: string
+  to?: string
+  amount?: string
+  memo?: string
+  msg_type?: string
+  tx?: TxReadyObject
+}
+
+/**
+ * Wire-level transaction envelope accepted from backend `tx_ready` events or
+ * `execute_*` preparation tool output.
+ *
+ * The backend may add presentation metadata over time, so unknown fields stay
+ * available to consumers while the signing-relevant fields are typed here.
+ */
+export type TxReadyEnvelope = TxReadyObject & {
+  sequence?: number
+  sequence_id?: string
+  sequence_index?: number
+  sequence_total?: number
+  chain?: string
+  chain_id?: string | number
+  from_chain?: string
+  action?: string
+  signing_mode?: string
+  unsigned_tx_hex?: string
+  tx_details?: TxReadyObject
+  keysign_payload?: string
+  swap_tx?: TxReadyObject
+  send_tx?: TxReadyObject
+  tx?: TxReadyObject
+  approvalTxArgs?: TxReadyTxArgs
+  txArgs?: TxReadyTxArgs
+  resolved?: {
+    labels?: Record<string, unknown>
+  }
+  stepperConfig?: TxReadyObject
+  __buildTx?: boolean
+}
+
+export type TxReadyEvmLeg = {
+  role: 'single' | 'approval' | 'main'
+  txArgs: TxReadyTxArgs | undefined
+  tx: TxReadyObject
+}
+
+export type ParsedTxReadyRawEvm = {
+  kind: 'raw-evm'
+  chain: EvmChain
+  legs: [TxReadyEvmLeg] | [TxReadyEvmLeg, TxReadyEvmLeg]
+  envelope: TxReadyEnvelope
+}
+
+export type ParsedTxReadySend = {
+  kind: 'send'
+  chain: Chain
+  to: string
+  /** Human-unit decimal amount suitable for `VaultBase.send`. */
+  amount: string
+  symbol?: string
+  memo?: string
+  envelope: TxReadyEnvelope
+}
+
+export type ParsedTxReadyThorSwapDeposit = {
+  kind: 'thor-swap-deposit'
+  chain: typeof Chain.THORChain | typeof Chain.MayaChain
+  fromSymbol: 'RUNE' | 'CACAO'
+  toChain: Chain
+  toSymbol: string
+  amount: string
+  recipient?: string
+  memo: string
+  envelope: TxReadyEnvelope
+}
+
+export type ParsedTxReadyThorLpDeposit = {
+  kind: 'thor-lp-deposit'
+  chain: typeof Chain.THORChain | typeof Chain.MayaChain
+  amountBaseUnits: string
+  memo: string
+  envelope: TxReadyEnvelope
+}
+
+/** Canonical, execution-oriented interpretation of a tx-ready wire envelope. */
+export type ParsedTxReadyEnvelope =
+  | ParsedTxReadyRawEvm
+  | ParsedTxReadySend
+  | ParsedTxReadyThorSwapDeposit
+  | ParsedTxReadyThorLpDeposit
+
+export type TxReadyParseErrorCode =
+  | 'INVALID_ENVELOPE'
+  | 'UNKNOWN_CHAIN'
+  | 'CHAIN_MISMATCH'
+  | 'INVALID_AMOUNT'
+  | 'UNSUPPORTED_ENVELOPE'
+  | 'UNSUPPORTED_DEPOSIT'
+
+export class TxReadyParseError extends Error {
+  override readonly name = 'TxReadyParseError'
+
+  constructor(
+    readonly code: TxReadyParseErrorCode,
+    message: string,
+    options?: ErrorOptions
+  ) {
+    super(message, options)
+  }
+}
+
+export type ParseTxReadyOptions = {
+  /** Consumer-owned fallback for legacy envelopes that omit chain metadata. */
+  defaultChain?: Chain
+}
+
+const MAX_AMOUNT_DIGITS = 26
+
+const isObject = (value: unknown): value is TxReadyObject =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const asEnvelope = (value: unknown): TxReadyEnvelope => {
+  if (!isObject(value)) {
+    throw new TxReadyParseError('INVALID_ENVELOPE', 'tx_ready payload must be a JSON object')
+  }
+  return value as TxReadyEnvelope
+}
+
+const resolveReference = (value: unknown): Chain | undefined => {
+  if (typeof value !== 'string' && typeof value !== 'number') return undefined
+  return resolveChainReference(value)
+}
+
+const resolveObjectChain = (value: TxReadyObject | undefined, context: string): Chain | undefined => {
+  if (!value) return undefined
+  const candidates = (['chain', 'from_chain', 'chain_id'] as const).flatMap(key => {
+    const reference = value[key]
+    if (reference === undefined) return []
+    const resolved = resolveReference(reference)
+    if (!resolved) {
+      throw new TxReadyParseError(
+        'UNKNOWN_CHAIN',
+        `${context} contains an unrecognized ${key} reference '${String(reference)}'`
+      )
+    }
+    return [[key, resolved] as [string, Chain]]
+  })
+  const chain = candidates[0]?.[1]
+  const mismatch = candidates.find(([, candidate]) => candidate !== chain)
+  if (chain && mismatch) {
+    throw new TxReadyParseError(
+      'CHAIN_MISMATCH',
+      `${context} chain references disagree: ${candidates.map(([key, candidate]) => `${key}=${candidate}`).join(', ')}`
+    )
+  }
+  return chain
+}
+
+const resolveTransactionChain = (tx: TxReadyObject | undefined, context: string): Chain | undefined => {
+  const reference = tx?.['chainId']
+  if (reference === undefined) return undefined
+  const chain = resolveReference(reference)
+  if (!chain) {
+    throw new TxReadyParseError(
+      'UNKNOWN_CHAIN',
+      `${context} contains an unrecognized chainId reference '${String(reference)}'`
+    )
+  }
+  return chain
+}
+
+const extractRawTx = (
+  envelope: TxReadyEnvelope
+): { tx: TxReadyObject; txArgs: TxReadyTxArgs | undefined } | undefined => {
+  const candidates: Array<{ value: unknown; txArgs: TxReadyTxArgs | undefined }> = [
+    { value: envelope.swap_tx, txArgs: undefined },
+    { value: envelope.send_tx, txArgs: undefined },
+    { value: envelope.tx, txArgs: undefined },
+    { value: envelope.txArgs?.tx, txArgs: envelope.txArgs },
+  ]
+  const candidate = candidates.find(({ value }) => isObject(value))
+  return candidate ? { tx: candidate.value as TxReadyObject, txArgs: candidate.txArgs } : undefined
+}
+
+const resolveEnvelopeChain = (envelope: TxReadyEnvelope, defaultChain?: Chain): Chain => {
+  const outerChain = resolveObjectChain(envelope, 'tx_ready envelope')
+  const innerChain = resolveObjectChain(envelope.txArgs, 'tx_ready txArgs')
+  const nestedChain = extractRawTx(envelope)
+  const txChain = resolveTransactionChain(nestedChain?.tx, 'tx_ready transaction')
+
+  if (outerChain && innerChain && outerChain !== innerChain) {
+    throw new TxReadyParseError(
+      'CHAIN_MISMATCH',
+      `tx_ready envelope chain '${outerChain}' disagrees with txArgs chain '${innerChain}'`
+    )
+  }
+
+  const metadataChain = outerChain ?? innerChain
+  if (metadataChain && txChain && metadataChain !== txChain) {
+    throw new TxReadyParseError(
+      'CHAIN_MISMATCH',
+      `tx_ready metadata chain '${metadataChain}' disagrees with transaction chainId '${txChain}'`
+    )
+  }
+
+  const chain = metadataChain ?? txChain ?? defaultChain
+  if (!chain) {
+    throw new TxReadyParseError('UNKNOWN_CHAIN', 'tx_ready envelope is missing a recognized chain reference')
+  }
+  return chain
+}
+
+const assertAmount = (amountRaw: unknown, chain: Chain, context: string): string => {
+  if (typeof amountRaw !== 'string' || amountRaw.length === 0) {
+    throw new TxReadyParseError('INVALID_ENVELOPE', `${context}: missing 'amount' field for ${chain}`)
+  }
+  if (!/^\d+$/.test(amountRaw)) {
+    throw new TxReadyParseError(
+      'INVALID_AMOUNT',
+      `${context}: failed to convert amount '${amountRaw}' for ${chain}: value must be an unsigned base-10 integer string`
+    )
+  }
+  if (amountRaw.length > MAX_AMOUNT_DIGITS) {
+    throw new TxReadyParseError(
+      'INVALID_AMOUNT',
+      `${context}: amount '${amountRaw}' for ${chain} exceeds ${MAX_AMOUNT_DIGITS}-digit safety bound. Likely a quote-side bug. Refusing to sign.`
+    )
+  }
+  return amountRaw
+}
+
+const toDecimalAmount = (amountRaw: unknown, chain: Chain, context: string): string => {
+  const amount = assertAmount(amountRaw, chain, context)
+  const decimals = chainFeeCoin[chain]?.decimals
+  if (decimals === undefined) {
+    throw new TxReadyParseError('UNKNOWN_CHAIN', `${context}: no native decimals registered for ${chain}`)
+  }
+  try {
+    return formatUnits(BigInt(amount), decimals)
+  } catch (error) {
+    throw new TxReadyParseError(
+      'INVALID_AMOUNT',
+      `${context}: failed to convert amount '${amount}' for ${chain}: ${(error as Error).message}`,
+      { cause: error }
+    )
+  }
+}
+
+const parseThorDeposit = (
+  envelope: TxReadyEnvelope,
+  chain: typeof Chain.THORChain | typeof Chain.MayaChain,
+  txArgs: TxReadyTxArgs
+): ParsedTxReadyThorSwapDeposit | ParsedTxReadyThorLpDeposit => {
+  const memo = typeof txArgs.memo === 'string' ? txArgs.memo : ''
+
+  if (memo.startsWith('=:')) {
+    let parsedMemo: ReturnType<typeof parseThorSwapMemo>
+    try {
+      parsedMemo = parseThorSwapMemo(memo)
+    } catch (error) {
+      const code = isObject(error) && error['code'] === 'UNSUPPORTED_CHAIN' ? 'UNKNOWN_CHAIN' : 'INVALID_ENVELOPE'
+      throw new TxReadyParseError(code, (error as Error).message, { cause: error })
+    }
+    if (/\s/.test(parsedMemo.destAddress)) {
+      throw new TxReadyParseError(
+        'INVALID_ENVELOPE',
+        `tx_ready THOR swap destination address in memo '${memo}' must not contain whitespace`
+      )
+    }
+
+    return {
+      kind: 'thor-swap-deposit',
+      chain,
+      fromSymbol: chain === Chain.THORChain ? 'RUNE' : 'CACAO',
+      toChain: parsedMemo.toChain,
+      toSymbol: parsedMemo.destAsset,
+      amount: toDecimalAmount(txArgs.amount, chain, 'tx_ready THOR swap deposit'),
+      ...(parsedMemo.destAddress && { recipient: parsedMemo.destAddress }),
+      memo,
+      envelope,
+    }
+  }
+
+  if (memo.startsWith('+:') || memo.startsWith('-:')) {
+    return {
+      kind: 'thor-lp-deposit',
+      chain,
+      amountBaseUnits: assertAmount(txArgs.amount, chain, 'tx_ready THOR LP deposit'),
+      memo,
+      envelope,
+    }
+  }
+
+  throw new TxReadyParseError(
+    'UNSUPPORTED_DEPOSIT',
+    `tx_ready MsgDeposit memo prefix not supported on ${chain}: '${memo}'. Supported prefixes: '=:' (swap), '+:' (LP add), '-:' (LP remove). Loan / validator ops are out of scope.`
+  )
+}
+
+const assertRawTransaction = (tx: TxReadyObject, context: string): void => {
+  if (tx['status'] === 'error' || tx['error']) {
+    throw new TxReadyParseError(
+      'INVALID_ENVELOPE',
+      `${context} reports an error: ${String(tx['error'] ?? 'unknown error')}`
+    )
+  }
+  if (typeof tx['to'] !== 'string' || tx['to'] === '') {
+    throw new TxReadyParseError('INVALID_ENVELOPE', `${context} is missing required 'to' field`)
+  }
+}
+
+const parseRawEvm = (envelope: TxReadyEnvelope, chain: Chain): ParsedTxReadyRawEvm => {
+  if (getChainKind(chain) !== 'evm') {
+    throw new TxReadyParseError(
+      'UNSUPPORTED_ENVELOPE',
+      `tx_ready raw transaction envelope resolved to non-EVM chain ${chain}`
+    )
+  }
+
+  const approvalArgs = isObject(envelope.approvalTxArgs) ? (envelope.approvalTxArgs as TxReadyTxArgs) : undefined
+  const mainArgs = isObject(envelope.txArgs) ? (envelope.txArgs as TxReadyTxArgs) : undefined
+
+  if (approvalArgs && mainArgs) {
+    const approvalChain = resolveObjectChain(approvalArgs, 'tx_ready approvalTxArgs')
+    const mainChain = resolveObjectChain(mainArgs, 'tx_ready txArgs')
+    if (!approvalChain || !mainChain || approvalChain !== mainChain || approvalChain !== chain) {
+      throw new TxReadyParseError(
+        'CHAIN_MISMATCH',
+        `tx_ready multi-leg chain mismatch: parent=${chain}, approval=${approvalChain ?? 'unresolved'}, main=${mainChain ?? 'unresolved'}`
+      )
+    }
+    if (!isObject(approvalArgs.tx) || !isObject(mainArgs.tx)) {
+      throw new TxReadyParseError('INVALID_ENVELOPE', 'tx_ready multi-leg envelope requires tx objects in both legs')
+    }
+    assertRawTransaction(approvalArgs.tx, 'tx_ready approval transaction')
+    assertRawTransaction(mainArgs.tx, 'tx_ready main transaction')
+    const approvalTxChain = resolveTransactionChain(approvalArgs.tx, 'tx_ready approval transaction')
+    const mainTxChain = resolveTransactionChain(mainArgs.tx, 'tx_ready main transaction')
+    if ((approvalTxChain && approvalTxChain !== chain) || (mainTxChain && mainTxChain !== chain)) {
+      throw new TxReadyParseError(
+        'CHAIN_MISMATCH',
+        `tx_ready multi-leg transaction chain mismatch: parent=${chain}, approval=${approvalTxChain ?? 'unspecified'}, main=${mainTxChain ?? 'unspecified'}`
+      )
+    }
+    return {
+      kind: 'raw-evm',
+      chain: chain as EvmChain,
+      legs: [
+        { role: 'approval', txArgs: approvalArgs, tx: approvalArgs.tx },
+        { role: 'main', txArgs: mainArgs, tx: mainArgs.tx },
+      ],
+      envelope,
+    }
+  }
+
+  const raw = extractRawTx(envelope)
+  if (!raw) {
+    throw new TxReadyParseError('INVALID_ENVELOPE', 'tx_ready raw EVM envelope is missing a transaction object')
+  }
+  assertRawTransaction(raw.tx, 'tx_ready raw EVM transaction')
+
+  return {
+    kind: 'raw-evm',
+    chain: chain as EvmChain,
+    legs: [{ role: 'single', txArgs: raw.txArgs, tx: raw.tx }],
+    envelope,
+  }
+}
+
+/**
+ * Parse a backend `tx_ready` or `execute_*` preparation envelope into the
+ * canonical execution shape consumed by SDK clients.
+ *
+ * This function is pure and vault-free. It validates chain continuity,
+ * converts send/swap base units exactly, and never signs or broadcasts.
+ */
+export const parseTxReadyEnvelope = (value: unknown, options: ParseTxReadyOptions = {}): ParsedTxReadyEnvelope => {
+  const envelope = asEnvelope(value)
+  const chain = resolveEnvelopeChain(envelope, options.defaultChain)
+  const txArgs = isObject(envelope.txArgs) ? (envelope.txArgs as TxReadyTxArgs) : undefined
+
+  if (txArgs?.msg_type === 'deposit' && (chain === Chain.THORChain || chain === Chain.MayaChain)) {
+    return parseThorDeposit(envelope, chain, txArgs)
+  }
+
+  const hasMultiLeg = isObject(envelope.approvalTxArgs) && isObject(envelope.txArgs)
+  if (hasMultiLeg || extractRawTx(envelope)) {
+    return parseRawEvm(envelope, chain)
+  }
+
+  const sendArgs = txArgs ?? envelope
+  const to = typeof sendArgs['to'] === 'string' ? sendArgs['to'] : undefined
+  if (!to) {
+    throw new TxReadyParseError('INVALID_ENVELOPE', `tx_ready send envelope missing 'to' field for ${chain}`)
+  }
+
+  const tokenResolved = envelope.resolved?.labels?.['token_resolved']
+  const nativeTicker = chainFeeCoin[chain]?.ticker
+  const symbol = typeof tokenResolved === 'string' && tokenResolved !== nativeTicker ? tokenResolved : undefined
+  const memo = typeof sendArgs['memo'] === 'string' && sendArgs['memo'].length > 0 ? sendArgs['memo'] : undefined
+
+  return {
+    kind: 'send',
+    chain,
+    to,
+    amount: toDecimalAmount(sendArgs['amount'], chain, 'tx_ready send'),
+    ...(symbol && { symbol }),
+    ...(memo && { memo }),
+    envelope,
+  }
+}

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -449,6 +449,8 @@ describe('RN entry exposes pure chain helpers and registry', () => {
     expect(rn.normalizeTx).toBe(tx.normalizeTx)
     expect(rn.splitMultiTx).toBe(tx.splitMultiTx)
     expect(rn.TxNormalizeError).toBe(tx.TxNormalizeError)
+    expect(rn.parseTxReadyEnvelope).toBe(tx.parseTxReadyEnvelope)
+    expect(rn.TxReadyParseError).toBe(tx.TxReadyParseError)
     expect(rn.decodeFromToolResult).toBe(decode.decodeFromToolResult)
     expect(rn.decodeCosmosTx).toBe(decode.decodeCosmosTx)
     expect(rn.decodeEvmTx).toBe(decode.decodeEvmTx)

--- a/packages/sdk/tests/unit/tx/parseTxReady.test.ts
+++ b/packages/sdk/tests/unit/tx/parseTxReady.test.ts
@@ -1,0 +1,219 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { describe, expect, it } from 'vitest'
+
+import { parseTxReadyEnvelope, TxReadyParseError } from '../../../src/tx'
+
+const EVM_TX = {
+  to: '0x000000000000000000000000000000000000dEaD',
+  value: '1000000000000000',
+  data: '0x',
+}
+
+describe('parseTxReadyEnvelope', () => {
+  it('parses a top-level tx_ready EVM envelope', () => {
+    const parsed = parseTxReadyEnvelope({ chain: 'Ethereum', tx: EVM_TX })
+
+    expect(parsed).toMatchObject({
+      kind: 'raw-evm',
+      chain: Chain.Ethereum,
+      legs: [{ role: 'single', tx: EVM_TX }],
+    })
+  })
+
+  it('parses a single-leg execute-prep EVM envelope', () => {
+    const parsed = parseTxReadyEnvelope({
+      stepperConfig: { flow: 'send' },
+      txArgs: { chain: 'Polygon', chain_id: '137', tx_encoding: 'evm-tx', tx: EVM_TX },
+    })
+
+    expect(parsed.kind).toBe('raw-evm')
+    expect(parsed.chain).toBe(Chain.Polygon)
+    if (parsed.kind === 'raw-evm') expect(parsed.legs[0].txArgs?.tx_encoding).toBe('evm-tx')
+  })
+
+  it('parses an execute-prep approval/main pair in signing order', () => {
+    const approval = { ...EVM_TX, to: '0x0000000000000000000000000000000000000001' }
+    const main = { ...EVM_TX, to: '0x0000000000000000000000000000000000000002' }
+    const parsed = parseTxReadyEnvelope({
+      chain: 'BSC',
+      approvalTxArgs: { chain: 'BSC', chain_id: '56', tx: approval },
+      txArgs: { chain: 'BSC', chain_id: '56', tx: main },
+    })
+
+    expect(parsed).toMatchObject({
+      kind: 'raw-evm',
+      chain: Chain.BSC,
+      legs: [
+        { role: 'approval', tx: approval },
+        { role: 'main', tx: main },
+      ],
+    })
+  })
+
+  it('parses a non-EVM execute-send envelope into vault.send units', () => {
+    const parsed = parseTxReadyEnvelope({
+      chain: 'Bitcoin',
+      resolved: { labels: { token_resolved: 'BTC' } },
+      txArgs: {
+        chain: 'Bitcoin',
+        tx_encoding: 'utxo-psbt',
+        to: 'bc1qrecipient',
+        amount: '1000',
+        memo: '',
+      },
+    })
+
+    expect(parsed).toMatchObject({
+      kind: 'send',
+      chain: Chain.Bitcoin,
+      to: 'bc1qrecipient',
+      amount: '0.00001',
+    })
+    if (parsed.kind === 'send') {
+      expect(parsed.symbol).toBeUndefined()
+      expect(parsed.memo).toBeUndefined()
+    }
+  })
+
+  it('parses a THORChain swap deposit into canonical vault.swap args', () => {
+    const parsed = parseTxReadyEnvelope({
+      chain: 'THORChain',
+      txArgs: {
+        chain: 'THORChain',
+        tx_encoding: 'cosmos-msg',
+        msg_type: 'deposit',
+        amount: '1000000',
+        memo: '=:BTC.BTC:bc1qrecipient::v0:50',
+      },
+    })
+
+    expect(parsed).toMatchObject({
+      kind: 'thor-swap-deposit',
+      chain: Chain.THORChain,
+      fromSymbol: 'RUNE',
+      toChain: Chain.Bitcoin,
+      toSymbol: 'BTC',
+      amount: '0.01',
+      recipient: 'bc1qrecipient',
+    })
+  })
+
+  it('parses a MayaChain LP deposit without changing base units or memo', () => {
+    const parsed = parseTxReadyEnvelope({
+      chain: 'MayaChain',
+      txArgs: {
+        chain: 'MayaChain',
+        tx_encoding: 'cosmos-msg',
+        msg_type: 'deposit',
+        amount: '10000000000',
+        memo: '+:BTC.BTC:bc1qpaired',
+      },
+    })
+
+    expect(parsed).toMatchObject({
+      kind: 'thor-lp-deposit',
+      chain: Chain.MayaChain,
+      amountBaseUnits: '10000000000',
+      memo: '+:BTC.BTC:bc1qpaired',
+    })
+  })
+
+  it('rejects parent/inner chain drift', () => {
+    expect(() =>
+      parseTxReadyEnvelope({
+        chain: 'THORChain',
+        txArgs: { chain: 'Bitcoin', to: 'bc1qrecipient', amount: '1000' },
+      })
+    ).toThrow(/disagrees/)
+  })
+
+  it('rejects self-conflicting chain names and IDs', () => {
+    expect(() =>
+      parseTxReadyEnvelope({
+        chain: 'Base',
+        chain_id: 1,
+        tx: EVM_TX,
+      })
+    ).toThrow(/chain references disagree/)
+  })
+
+  it('rejects raw transaction chainId drift from envelope metadata', () => {
+    expect(() =>
+      parseTxReadyEnvelope({
+        chain: 'Base',
+        tx: { ...EVM_TX, chainId: 1 },
+      })
+    ).toThrow(/disagrees with transaction chainId/)
+  })
+
+  it('rejects nested approval transaction chainId drift in a multi-leg envelope', () => {
+    expect(() =>
+      parseTxReadyEnvelope({
+        chain: 'Base',
+        approvalTxArgs: { chain: 'Base', chain_id: 8453, tx: { ...EVM_TX, chainId: 1 } },
+        txArgs: { chain: 'Base', chain_id: 8453, tx: { ...EVM_TX, chainId: 8453 } },
+      })
+    ).toThrow(/multi-leg transaction chain mismatch/)
+  })
+
+  it('rejects a multi-leg envelope whose approval transaction is not signable', () => {
+    expect(() =>
+      parseTxReadyEnvelope({
+        chain: 'Base',
+        approvalTxArgs: { chain: 'Base', chain_id: 8453, tx: { value: '0', data: '0x' } },
+        txArgs: { chain: 'Base', chain_id: 8453, tx: { ...EVM_TX, chainId: 8453 } },
+      })
+    ).toThrow(/approval transaction is missing required 'to' field/)
+  })
+
+  it('rejects an unrecognized provided chain reference instead of falling back', () => {
+    try {
+      parseTxReadyEnvelope({
+        chain: 'Bitcoin',
+        chain_id: 'not-a-chain',
+        txArgs: { to: 'bc1qrecipient', amount: '1000' },
+      })
+      expect.fail('expected parse failure')
+    } catch (error) {
+      expect(error).toBeInstanceOf(TxReadyParseError)
+      expect((error as TxReadyParseError).code).toBe('UNKNOWN_CHAIN')
+    }
+  })
+
+  it('rejects unsupported MsgDeposit memo families with a typed error', () => {
+    try {
+      parseTxReadyEnvelope({
+        chain: 'THORChain',
+        txArgs: { chain: 'THORChain', msg_type: 'deposit', amount: '1', memo: 'BOND:thornode1' },
+      })
+      expect.fail('expected parse failure')
+    } catch (error) {
+      expect(error).toBeInstanceOf(TxReadyParseError)
+      expect((error as TxReadyParseError).code).toBe('UNSUPPORTED_DEPOSIT')
+    }
+  })
+
+  it('rejects an oversized base-unit amount', () => {
+    expect(() =>
+      parseTxReadyEnvelope({
+        chain: 'Bitcoin',
+        txArgs: { chain: 'Bitcoin', to: 'bc1qrecipient', amount: '1'.padEnd(27, '0') },
+      })
+    ).toThrow(/exceeds 26-digit safety bound/)
+  })
+
+  it.each(['-1', '1e3', '0x10', ' 1'])('rejects non-decimal base-unit amount %j', amount => {
+    expect(() =>
+      parseTxReadyEnvelope({
+        chain: 'Bitcoin',
+        txArgs: { chain: 'Bitcoin', to: 'bc1qrecipient', amount },
+      })
+    ).toThrow(/unsigned base-10 integer string/)
+  })
+
+  it('supports an explicit consumer fallback for legacy chainless envelopes', () => {
+    const parsed = parseTxReadyEnvelope({ tx: EVM_TX }, { defaultChain: Chain.Ethereum })
+    expect(parsed.kind).toBe('raw-evm')
+    expect(parsed.chain).toBe(Chain.Ethereum)
+  })
+})

--- a/packages/sdk/tests/unit/tx/parseTxReady.test.ts
+++ b/packages/sdk/tests/unit/tx/parseTxReady.test.ts
@@ -75,6 +75,50 @@ describe('parseTxReadyEnvelope', () => {
     }
   })
 
+  it('uses known token decimals for non-native sends', () => {
+    const parsed = parseTxReadyEnvelope({
+      chain: 'Solana',
+      resolved: { labels: { token_resolved: 'USDC' } },
+      txArgs: {
+        chain: 'Solana',
+        tx_encoding: 'solana-tx',
+        to: 'solana-recipient',
+        amount: '1000000',
+      },
+    })
+
+    expect(parsed).toMatchObject({
+      kind: 'send',
+      chain: Chain.Solana,
+      amount: '1',
+      symbol: 'USDC',
+    })
+  })
+
+  it('uses configured token decimals and rejects unresolved token sends', () => {
+    const envelope = {
+      chain: 'Solana',
+      resolved: { labels: { token_resolved: 'CUSTOM' } },
+      txArgs: { chain: 'Solana', to: 'solana-recipient', amount: '123456' },
+    }
+
+    expect(
+      parseTxReadyEnvelope(envelope, {
+        tokens: [
+          {
+            id: 'custom-mint',
+            symbol: 'CUSTOM',
+            name: 'Custom',
+            decimals: 5,
+            chainId: Chain.Solana,
+          },
+        ],
+      })
+    ).toMatchObject({ kind: 'send', amount: '1.23456', symbol: 'CUSTOM' })
+
+    expect(() => parseTxReadyEnvelope(envelope)).toThrow(/token decimals unavailable/)
+  })
+
   it('parses a THORChain swap deposit into canonical vault.swap args', () => {
     const parsed = parseTxReadyEnvelope({
       chain: 'THORChain',

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -66,10 +66,12 @@ describe('@vultisig/sdk public exports', () => {
     expect(typeof sdk.extendChainRegistry).toBe('function')
   })
 
-  it('exports tx-shape normalization primitives (normalizeTx, splitMultiTx)', () => {
+  it('exports tx-shape normalization and tx-ready parsing primitives', () => {
     expect(typeof sdk.normalizeTx).toBe('function')
     expect(typeof sdk.splitMultiTx).toBe('function')
     expect(typeof sdk.TxNormalizeError).toBe('function')
+    expect(typeof sdk.parseTxReadyEnvelope).toBe('function')
+    expect(typeof sdk.TxReadyParseError).toBe('function')
   })
 
   it('exports the knownContracts canonical registry + lookup helpers', () => {


### PR DESCRIPTION
Closes #2162
Exports a strict canonical tx_ready and execute-prep envelope parser from the SDK root, tx subpath, and React Native entrypoint; migrates the CLI consumer; and adds exact parser/export contract coverage. Built-package ESM and CommonJS runtime proof plus the full repository CI gate passed. Closes #2162.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added canonical parsing for transaction-ready envelopes across EVM, Bitcoin, THORChain, and MayaChain transactions.
  * Added validation for transaction details, chains, amounts, signability, and supported formats.
  * Exposed transaction parsing APIs and structured errors through SDK entry points, including React Native.
  * Added support for resolving token metadata and decimals during parsing.
  * Expanded React Native seedphrase and derivation utilities.

* **Bug Fixes**
  * Improved CLI transaction routing using validated transaction data.
  * Improved token amount handling and confirmation summaries.
  * Improved EVM receipt polling reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->