### PR TITLE
feat(sdk): add a first-class typed-data signing surface

### DIFF
--- a/.changeset/r172-sdk-sign-typed-data-surface.md
+++ b/.changeset/r172-sdk-sign-typed-data-surface.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+Add a first-class `vault.signTypedData(...)` EIP-712 signing surface and switch the CLI executor to consume it.

--- a/clients/cli/src/agent/__tests__/executor.eip712.test.ts
+++ b/clients/cli/src/agent/__tests__/executor.eip712.test.ts
@@ -41,7 +41,7 @@ async function mockSign(hash: string): Promise<{ signature: string; format: stri
 }
 
 function createSigningMockVault(): VaultBase {
-  return {
+  const vault = {
     name: 'mock-vault',
     id: 'vault-mock-eip712',
     type: 'fast',
@@ -50,6 +50,11 @@ function createSigningMockVault(): VaultBase {
     address: vi.fn().mockResolvedValue(TEST_ADDRESS),
     signBytes: vi.fn(async ({ data }: { data: string }) => mockSign(data)),
   } as unknown as VaultBase
+  ;(vault as VaultBase & { signTypedData: typeof VaultBase.prototype.signTypedData }).signTypedData =
+    async function (params, options) {
+      return VaultBase.prototype.signTypedData.call(this, params, options)
+    }
+  return vault
 }
 
 // Pin a digest against the two independent reference encoders — viem (what

--- a/clients/cli/src/agent/executor.ts
+++ b/clients/cli/src/agent/executor.ts
@@ -1875,86 +1875,31 @@ export class AgentExecutor {
    * Sign a single EIP-712 typed data object.
    */
   private async signSingleTypedData(params: Record<string, unknown>): Promise<Record<string, unknown>> {
-    const domain = params.domain as Record<string, unknown>
-    const types = params.types as Record<string, Array<{ name: string; type: string }>>
-    const message = params.message as Record<string, unknown>
-    const primaryType = (params.primaryType || params.primary_type) as string
-
-    if (!domain || !types || !message || !primaryType) {
-      throw new Error('sign_typed_data requires domain, types, message, and primaryType')
+    const typedData = {
+      domain: params.domain,
+      types: params.types,
+      message: params.message,
+      primaryType: params.primaryType ?? params.primary_type,
     }
-
-    if (this.verbose) process.stderr.write(`[sign_typed_data] primaryType=${primaryType} domain.name=${domain.name}\n`)
-
-    const eip712Hash = computeEip712Hash(domain, types, primaryType, message)
-    if (this.verbose) process.stderr.write(`[sign_typed_data] hash=${eip712Hash}\n`)
-
-    // Resolve chain from domain chainId or explicit chain param
-    const chainName = params.chain as string | undefined
-    const chainId = domain.chainId as number | string | undefined
-    let chain: Chain = Chain.Ethereum
-    if (chainName) {
-      chain = resolveChain(chainName) || Chain.Ethereum
-    } else if (chainId) {
-      chain = resolveChainId(chainId) || Chain.Ethereum
-    }
-
-    const sigResult = await this.vault.signBytes({
-      data: eip712Hash,
-      chain,
+    const explicitChain = typeof params.chain === 'string' ? resolveChain(params.chain) : undefined
+    const signed = await this.vault.signTypedData({
+      typedData,
+      ...(explicitChain ? { chain: explicitChain } : {}),
     })
 
-    if (this.verbose)
-      process.stderr.write(`[sign_typed_data] signed, format=${sigResult.format}, recovery=${sigResult.recovery}\n`)
-
-    // Canonicalize to low-S (EIP-2) — a high-S signature is malleable and
-    // rejected by OpenZeppelin's ECDSA library (which Polymarket's CLOB and
-    // most EVM verifiers use). The recovery parity flips with the fold.
-    const { r, s, recovery } = toCanonicalEvmSignature(sigResult.signature, sigResult.recovery ?? 0)
-    const v = recovery + 27
-
-    // 65-byte Ethereum signature: r (32 bytes) + s (32 bytes) + v (1 byte)
-    const ethSignature = '0x' + r + s + v.toString(16).padStart(2, '0')
-
-    // Recover-verify gate: confirm the assembled signature recovers to this
-    // vault's own EVM address before returning success. Catches a wrong
-    // recovery id, a botched low-S fold, or a digest/keyshare mismatch right
-    // here instead of leaving it to surface as an opaque on-chain/CLOB
-    // rejection. The EVM address is identical across every EVM chain (same
-    // secp256k1 keyshare), so the chain resolved from domain.chainId is fine.
-    const expectedAddress = await this.vault.address(chain)
-    const recoveredAddress = await recoverAddress({
-      hash: eip712Hash as `0x${string}`,
-      signature: ethSignature as `0x${string}`,
-    })
-    if (recoveredAddress.toLowerCase() !== expectedAddress.toLowerCase()) {
-      // Deterministic vault-context error, not a transient signing failure:
-      // the keyshare that produced this signature does not belong to the
-      // vault address the executor expected to sign for (e.g. the wrong vault
-      // is loaded into this executor's context). Retrying signs with the same
-      // keyshare and fails identically, so the message says so explicitly and
-      // names the loaded vault (name + id) rather than leaving a blank failure,
-      // so the operator can tell which vault is in context. The
-      // SIGNATURE_RECOVERY_MISMATCH prefix stays stable for callers that key off it.
-      throw new Error(
-        `SIGNATURE_RECOVERY_MISMATCH: wrong vault context for EIP-712 signing — ` +
-          `the loaded vault "${this.vault.name}" (id ${this.vault.id}) reports EVM address ` +
-          `${expectedAddress} for ${chain}, but the signature recovered to ${recoveredAddress}. ` +
-          `The signing keyshare does not belong to the expected vault address. This is a deterministic ` +
-          `vault-context error, not a transient signing failure — retrying will not help. ` +
-          `Verify the correct vault/keyshare is loaded into the executor context before signing again.`
-      )
+    if (this.verbose) {
+      process.stderr.write(`[sign_typed_data] primaryType=${String(typedData.primaryType)} domain.name=${String((typedData.domain as Record<string, unknown> | undefined)?.name ?? '')}\n`)
+      process.stderr.write(`[sign_typed_data] hash=${signed.hash}\n`)
+      process.stderr.write(`[sign_typed_data] r=${signed.r.slice(2, 18)}... s=${signed.s.slice(2, 18)}... v=${signed.v}\n`)
     }
-
-    if (this.verbose) process.stderr.write(`[sign_typed_data] r=${r.slice(0, 16)}... s=${s.slice(0, 16)}... v=${v}\n`)
 
     return {
-      signature: ethSignature,
-      r: '0x' + r,
-      s: '0x' + s,
-      v,
-      recovery,
-      hash: eip712Hash,
+      signature: signed.signature,
+      r: signed.r,
+      s: signed.s,
+      v: signed.v,
+      hash: signed.hash,
+      address: await this.vault.address(signed.chain),
     }
   }
 

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -308,7 +308,8 @@ export type SignMessageParams = {
 }
 
 export type SignTypedDataParams = {
-  chain: Chain
+  /** Optional explicit chain override. Falls back to domain.chainId, then Ethereum. */
+  chain?: Chain
   typedData: Record<string, unknown>
   password?: string
 }
@@ -608,6 +609,23 @@ export type MessageSignature = {
   chain: Chain
   /** Signature algorithm used */
   algorithm: 'ECDSA' | 'EdDSA'
+}
+
+export type TypedDataSignature = {
+  /** 65-byte Ethereum signature (0x + r + s + v). */
+  signature: string
+  /** Canonical EIP-712 digest that was signed. */
+  hash: string
+  /** Chain resolved for the signing key/address lookup. */
+  chain: Chain
+  /** Low-S canonicalized r component. */
+  r: string
+  /** Low-S canonicalized s component. */
+  s: string
+  /** Ethereum recovery byte (27 or 28). */
+  v: number
+  /** Recovery parity before Ethereum's 27/28 offset. */
+  recovery: number
 }
 
 export type Portfolio = {

--- a/packages/sdk/src/vault/VaultBase.ts
+++ b/packages/sdk/src/vault/VaultBase.ts
@@ -6,6 +6,7 @@ import { toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'
 import { banxaSupportedChains, getBanxaBuyUrl } from '@vultisig/core-chain/banxa'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { getChainKind } from '@vultisig/core-chain/ChainKind'
+import { getEvmChainByChainId } from '@vultisig/core-chain/chains/evm/chainInfo'
 import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { getCoinValue } from '@vultisig/core-chain/coin/utils/getCoinValue'
@@ -21,6 +22,8 @@ import { VaultSchema } from '@vultisig/core-mpc/types/vultisig/vault/v1/vault_pb
 import { vaultContainerFromString } from '@vultisig/core-mpc/vault/utils/vaultContainerFromString'
 import { Vault as CoreVault } from '@vultisig/core-mpc/vault/Vault'
 import { fromBase64 } from '@vultisig/lib-utils/fromBase64'
+import { numberToHex } from '@vultisig/lib-utils/hex/numberToHex'
+import { recoverAddress } from 'viem'
 
 import { DEFAULT_CHAINS } from '../constants'
 // SDK utilities
@@ -55,7 +58,9 @@ import {
   SignDirectInput,
   SigningMode,
   SigningPayload,
+  SignTypedDataParams,
   Token,
+  TypedDataSignature,
   Value,
   VaultData,
 } from '../types'
@@ -63,6 +68,7 @@ import type { ContractCallTxParams } from '../types/contractCall'
 import type { TransactionSimulationResult, TransactionValidationResult } from '../types/security'
 import type { DiscoveredToken, TokenInfo } from '../types/tokens'
 import { computePersonalSignHash } from '../utils/eip191'
+import { coerceEip712ChainId, computeEip712Hash, toCanonicalEvmSignature } from '../utils/eip712'
 import { createVaultBackup } from '../utils/export'
 // Vault services
 import { AddressService } from './services/AddressService'
@@ -1929,6 +1935,64 @@ export abstract class VaultBase extends UniversalEventEmitter<VaultEvents> {
 
     const sig = await this.signBytes({ data: hash, chain }, options)
     return { signature: sig.signature.startsWith('0x') ? sig.signature : '0x' + sig.signature, chain, algorithm }
+  }
+
+  /** Sign EIP-712 typed data with canonical low-S EVM signature assembly. */
+  async signTypedData(
+    params: SignTypedDataParams,
+    options?: { signal?: AbortSignal }
+  ): Promise<TypedDataSignature> {
+    const typedData = (params?.typedData ?? {}) as Record<string, unknown>
+    const domain = (typedData.domain ?? {}) as Record<string, unknown>
+    const types = (typedData.types ?? {}) as Record<string, Array<{ name: string; type: string }>>
+    const message = (typedData.message ?? {}) as Record<string, unknown>
+    const primaryType = (typedData.primaryType ?? typedData.primary_type) as string | undefined
+    if (!domain || !Object.keys(domain).length || !types || !message || !primaryType) {
+      throw new VaultError(
+        VaultErrorCode.InvalidConfig,
+        'signTypedData requires typedData.domain, typedData.types, typedData.message, and typedData.primaryType'
+      )
+    }
+
+    let chain = params.chain
+    if (!chain && domain.chainId !== undefined) {
+      const normalizedChainId = coerceEip712ChainId(domain.chainId)
+      const evmChainId = typeof normalizedChainId === 'bigint' ? `0x${normalizedChainId.toString(16)}` : numberToHex(normalizedChainId)
+      chain = (getEvmChainByChainId(evmChainId) as Chain | undefined) ?? Chain.Ethereum
+    }
+    chain ??= Chain.Ethereum
+
+    const hash = computeEip712Hash(domain, types, primaryType, message)
+    const sig = await this.signBytes({ data: hash, chain }, options)
+    const { r, s, recovery } = toCanonicalEvmSignature(sig.signature, sig.recovery ?? 0)
+    const v = recovery + 27
+    const signature = `0x${r}${s}${v.toString(16).padStart(2, '0')}`
+
+    const expectedAddress = await this.address(chain)
+    const recoveredAddress = await recoverAddress({
+      hash: hash as `0x${string}`,
+      signature: signature as `0x${string}`,
+    })
+    if (recoveredAddress.toLowerCase() !== expectedAddress.toLowerCase()) {
+      throw new Error(
+        `SIGNATURE_RECOVERY_MISMATCH: wrong vault context for EIP-712 signing — ` +
+          `the loaded vault "${this.name}" (id ${this.id}) reports EVM address ` +
+          `${expectedAddress} for ${chain}, but the signature recovered to ${recoveredAddress}. ` +
+          `The signing keyshare does not belong to the expected vault address. This is a deterministic ` +
+          `vault-context error, not a transient signing failure — retrying will not help. ` +
+          `Verify the correct vault/keyshare is loaded into the executor context before signing again.`
+      )
+    }
+
+    return {
+      signature,
+      hash,
+      chain,
+      r: `0x${r}`,
+      s: `0x${s}`,
+      v,
+      recovery,
+    }
   }
 
   /** All balances across configured chains as a flat array. */


### PR DESCRIPTION
## Summary

Add a first-class `vault.signTypedData(...)` EIP-712 signing surface to `@vultisig/sdk` and switch the CLI executor to consume it instead of hand-rolling the full typed-data signing flow locally.

Closes https://github.com/vultisig/vultisig-sdk/issues/2178

## What changed

- added `VaultBase.signTypedData(...)`
- added `TypedDataSignature` result typing and relaxed `SignTypedDataParams.chain` to be optional
- switched `clients/cli/src/agent/executor.ts` to consume the SDK surface
- updated the executor EIP-712 test harness to call the SDK method on its mock vault
- added a changeset

## Receipts

- `corepack yarn build:sdk:bundle` ✅
- `corepack yarn vitest run packages/sdk/tests/unit/utils/eip712.test.ts clients/cli/src/agent/__tests__/executor.eip712.test.ts`
  - `packages/sdk/tests/unit/utils/eip712.test.ts` ✅
  - `clients/cli/src/agent/__tests__/executor.eip712.test.ts` hit a disposable-clone runtime blocker: `Cannot find package 'koffi' imported from /Users/gomes/Sites/vultisig-sdk/packages/sdk/dist/index.node.esm.js`

## Report

- round 172 gist mirror: https://gist.github.com/gomesalexandre/0621e37f662eb218f16880e75e770e90
