### PR TITLE
fix(sdk): export waitForRelayPeerCommittee on supported surfaces

### DIFF
--- a/.changeset/r170-relay-peer-committee-export.md
+++ b/.changeset/r170-relay-peer-committee-export.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+Export `waitForRelayPeerCommittee` from the root and React Native SDK surfaces so headless secure-join coordinators can reuse the canonical relay committee poller without deep-importing internal service paths.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -515,6 +515,7 @@ export type { PerformReshareParams } from './services/SecureVaultCreationService
 
 // QR payload parsing / generation (for programmatic multi-device coordination)
 export { buildKeygenPairingQrPayload } from './services/buildKeygenPairingQrPayload'
+export { waitForRelayPeerCommittee } from './services/waitForRelayPeerCommittee'
 export type { ParsedKeygenQR } from './utils/parseKeygenQR'
 export { parseKeygenQR } from './utils/parseKeygenQR'
 

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -782,6 +782,7 @@ export { decode, decodeCosmosTx, decodeEvmTx, decodeFromToolResult } from '../..
 // chain client dependency. Re-export them here so RN consumers do not have to
 // deep-import internal service/util paths.
 export { buildKeygenPairingQrPayload } from '../../services/buildKeygenPairingQrPayload'
+export { waitForRelayPeerCommittee } from '../../services/waitForRelayPeerCommittee'
 export { computeNotificationVaultId } from '../../utils/computeNotificationVaultId'
 export type {
   AmountDirection,

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -390,6 +390,13 @@ describe('RN entry wires configureCrypto and configureDefaultStorage', () => {
     ])
   })
 
+  it('exports the secure-join relay committee poller on the RN entrypoint', async () => {
+    const rn = await import('../../../../src/platforms/react-native/index')
+    const service = await import('../../../../src/services/waitForRelayPeerCommittee')
+
+    expect(rn.waitForRelayPeerCommittee).toBe(service.waitForRelayPeerCommittee)
+  })
+
   it('exports the RN vault-backup helpers and constants from the RN entry', async () => {
     const rn = await import('../../../../src/platforms/react-native/index')
     const rnEncrypt = await import('../../../../src/platforms/react-native/polyfills/encryptVaultBackupWithPassword')

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -279,6 +279,10 @@ describe('@vultisig/sdk public exports', () => {
     expect(typeof sdk.parseThorSwapMemo).toBe('function')
   })
 
+  it('exports the secure-join relay committee poller for headless coordinators', () => {
+    expect(typeof sdk.waitForRelayPeerCommittee).toBe('function')
+  })
+
   it('exports the shared THORChain secured-asset catalog helpers', () => {
     expect(typeof sdk.getThorchainSecuredAssetCatalog).toBe('function')
     expect(typeof sdk.createThorchainSecuredAssetCatalog).toBe('function')


### PR DESCRIPTION
## Summary

Closes #2172.

Export `waitForRelayPeerCommittee` from the supported SDK surfaces that headless secure-join coordinators actually consume:
- root `@vultisig/sdk`
- curated React Native entry `@vultisig/sdk/react-native`

This lets downstream coordinators reuse the canonical relay committee poller without deep-importing an internal service path.

Report mirror: https://gist.github.com/gomesalexandre/9c129a26179de0b9b8eb2c93823d09a2
Campaign index artifact: https://claude.ai/code/artifact/be2deadf-6195-4dfa-a910-b269b9af7a84

## Changes

- export `waitForRelayPeerCommittee` from `packages/sdk/src/index.ts`
- re-export the same helper from `packages/sdk/src/platforms/react-native/index.ts`
- add root public-export coverage
- add RN-entry identity coverage
- add a changeset

## Receipts

### Focused public-surface tests
```bash
VULTISIG_STRICT_SINGLETON=0 corepack yarn workspace @vultisig/sdk vitest run --config tests/unit/vitest.config.ts tests/unit/utils/publicExports.test.ts tests/unit/platforms/react-native/entry.test.ts
```

Result: ✅ `2 passed`, `111 passed`

### Narrow public-surface build
```bash
corepack yarn workspace @vultisig/sdk build
```

Result: ✅

### Packed consumer smoke
```bash
node --input-type=module -e "import * as sdk from '@vultisig/sdk'; console.log(JSON.stringify({waitForRelayPeerCommittee: typeof sdk.waitForRelayPeerCommittee, parseKeygenQR: typeof sdk.parseKeygenQR}))"
```

Result: ✅ `{"waitForRelayPeerCommittee":"function","parseKeygenQR":"function"}`

### React Native shipped declaration surface
Checked `packages/sdk/dist/index.react-native.d.ts` after build.

Result: ✅ contains `waitForRelayPeerCommittee`

## Known blocker outside this diff

The broader repo-wide build still fails on clean current main with the pre-existing Cardano typing error:

```text
packages/core/mpc/keysign/signingInputs/resolvers/cardano.ts(72,5): error TS2353: Object literal may only specify known properties, and 'auxiliaryData' does not exist in type 'ISigningInput'.
```

So I used the narrower successful package build + packed-consumer receipt instead of claiming a green `yarn build:sdk`.
