### PR TITLE
fix(blockaid): exclude native legs from simulation headlines only on gas evidence

### DIFF
--- a/packages/core/chain/security/blockaid/tx/simulation/api/core.test.ts
+++ b/packages/core/chain/security/blockaid/tx/simulation/api/core.test.ts
@@ -1,7 +1,14 @@
 import { EvmChain } from '@vultisig/core-chain/Chain'
 import { describe, expect, it } from 'vitest'
 
-import { BlockaidEVMSimulation, parseBlockaidEvmSimulation } from './core'
+import {
+  BlockaidEVMSimulation,
+  BlockaidSolanaSimulation,
+  BlockaidSuiSimulation,
+  parseBlockaidEvmSimulation,
+  parseBlockaidSolanaSimulation,
+  parseBlockaidSuiSimulation,
+} from './core'
 
 type AssetDiff = BlockaidEVMSimulation['account_summary']['assets_diffs'][number]
 type Asset = AssetDiff['asset']
@@ -315,5 +322,226 @@ describe('parseBlockaidEvmSimulation', () => {
       amount: 100n,
     })
     expect(result?.changes[0].coin.ticker).toBe('ETH')
+  })
+})
+
+type SolanaDiff = BlockaidSolanaSimulation['account_summary']['account_assets_diff'][number]
+type SolanaAsset = SolanaDiff['asset']
+type SolanaSide = NonNullable<SolanaDiff['in']>
+
+const WSOL_MINT = 'So11111111111111111111111111111111111111112'
+
+const solSide = (rawValue: string): SolanaSide => ({
+  usd_price: 0,
+  summary: '',
+  value: 0,
+  raw_value: rawValue,
+})
+
+const nativeSol: SolanaAsset = { type: 'SOL', symbol: 'SOL', decimals: 9, logo: '' }
+
+const splToken = (address: string, symbol: string, decimals = 9): SolanaAsset => ({
+  type: 'TOKEN',
+  symbol,
+  address,
+  decimals,
+  logo: '',
+})
+
+const solDiff = (asset: SolanaAsset, sides: { in?: SolanaSide; out?: SolanaSide }): SolanaDiff => ({
+  asset,
+  asset_type: asset.type,
+  in: sides.in ?? null,
+  out: sides.out ?? null,
+})
+
+const solanaSimulation = (diffs: SolanaDiff[]): BlockaidSolanaSimulation => ({
+  account_summary: { account_assets_diff: diffs },
+})
+
+const SPL_A = splToken('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 'AAA', 6)
+const SPL_B = splToken('BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB', 'BBB', 6)
+const RECEIPT = splToken('ReCeIpT111111111111111111111111111111111111', 'rcpt')
+const WSOL = splToken(WSOL_MINT, 'wSOL')
+
+describe('parseBlockaidSolanaSimulation', () => {
+  // The sdk#2091 counterexample: a wrapped-SOL withdrawal netting to SOL
+  // received. Reporting any remaining out-leg would state money LEAVING on a
+  // transaction that nets to money received — a reversed approval direction.
+  it('declines a three-diff withdrawal whose native leg is the principal inflow', async () => {
+    const simulation = solanaSimulation([
+      solDiff(nativeSol, { in: solSide('1500000000') }),
+      solDiff(WSOL, { out: solSide('2039280') }),
+      solDiff(RECEIPT, { out: solSide('1490000000') }),
+    ])
+
+    await expect(parseBlockaidSolanaSimulation(simulation)).rejects.toThrow()
+  })
+
+  it('declines a three-diff deposit whose native leg is the principal outflow', async () => {
+    const simulation = solanaSimulation([
+      solDiff(nativeSol, { out: solSide('500000000') }),
+      solDiff(WSOL, { out: solSide('2039280') }),
+      solDiff(RECEIPT, { in: solSide('490000000') }),
+    ])
+
+    await expect(parseBlockaidSolanaSimulation(simulation)).rejects.toThrow()
+  })
+
+  it('still nets a token swap by excluding a gas-sized native out-leg', async () => {
+    const simulation = solanaSimulation([
+      solDiff(SPL_A, { out: solSide('1000000') }),
+      solDiff(SPL_B, { in: solSide('2500000') }),
+      solDiff(nativeSol, { out: solSide('5000') }),
+    ])
+
+    expect(await parseBlockaidSolanaSimulation(simulation)).toEqual({
+      swap: {
+        fromMint: SPL_A.address,
+        toMint: SPL_B.address,
+        fromAmount: 1000000n,
+        toAmount: 2500000n,
+        toAssetDecimal: 6,
+      },
+    })
+  })
+
+  it('keeps a rent-refund-sized native in-leg from blocking a token swap headline', async () => {
+    const simulation = solanaSimulation([
+      solDiff(SPL_A, { out: solSide('1000000') }),
+      solDiff(SPL_B, { in: solSide('2500000') }),
+      solDiff(nativeSol, { in: solSide('2039280') }),
+    ])
+
+    expect(await parseBlockaidSolanaSimulation(simulation)).toEqual({
+      swap: {
+        fromMint: SPL_A.address,
+        toMint: SPL_B.address,
+        fromAmount: 1000000n,
+        toAmount: 2500000n,
+        toAssetDecimal: 6,
+      },
+    })
+  })
+
+  it('reports a token send after excluding the gas-sized native out-leg', async () => {
+    const simulation = solanaSimulation([
+      solDiff(SPL_A, { out: solSide('750000') }),
+      solDiff(nativeSol, { out: solSide('5000') }),
+    ])
+
+    expect(await parseBlockaidSolanaSimulation(simulation)).toEqual({
+      transfer: { fromMint: SPL_A.address, fromAmount: 750000n },
+    })
+  })
+
+  it('locks the swap direction regardless of diff order', async () => {
+    const simulation = solanaSimulation([
+      solDiff(SPL_B, { in: solSide('2500000') }),
+      solDiff(SPL_A, { out: solSide('1000000') }),
+    ])
+
+    expect(await parseBlockaidSolanaSimulation(simulation)).toEqual({
+      swap: {
+        fromMint: SPL_A.address,
+        toMint: SPL_B.address,
+        fromAmount: 1000000n,
+        toAmount: 2500000n,
+        toAssetDecimal: 6,
+      },
+    })
+  })
+
+  it('declines two simultaneous spends rather than reporting only the first', async () => {
+    const simulation = solanaSimulation([
+      solDiff(SPL_A, { out: solSide('1000000') }),
+      solDiff(SPL_B, { out: solSide('2500000') }),
+    ])
+
+    await expect(parseBlockaidSolanaSimulation(simulation)).rejects.toThrow()
+  })
+
+  it('reports a lone gas-sized native send instead of filtering it away', async () => {
+    const simulation = solanaSimulation([solDiff(nativeSol, { out: solSide('5000000') })])
+
+    expect(await parseBlockaidSolanaSimulation(simulation)).toEqual({
+      transfer: { fromMint: WSOL_MINT, fromAmount: 5000000n },
+    })
+  })
+
+  it('declines a SOL-to-wrapped-SOL pair instead of calling it a swap', async () => {
+    const simulation = solanaSimulation([
+      solDiff(nativeSol, { out: solSide('1000000000') }),
+      solDiff(WSOL, { in: solSide('1000000000') }),
+    ])
+
+    await expect(parseBlockaidSolanaSimulation(simulation)).rejects.toThrow()
+  })
+})
+
+type SuiDiff = NonNullable<NonNullable<BlockaidSuiSimulation['account_summary']>['account_assets_diffs']>[number]
+type SuiAsset = SuiDiff['asset']
+
+const nativeSuiAsset: SuiAsset = { type: 'NATIVE', symbol: 'SUI', decimals: 9 }
+
+const suiCoin = (id: string, symbol: string): SuiAsset => ({
+  type: 'COIN',
+  id,
+  symbol,
+  decimals: 9,
+})
+
+const suiDiff = (asset: SuiAsset, sides: { in?: number; out?: number }): SuiDiff => ({
+  asset,
+  in: sides.in === undefined ? null : { raw_value: sides.in },
+  out: sides.out === undefined ? null : { raw_value: sides.out },
+})
+
+const suiSimulation = (diffs: SuiDiff[]): BlockaidSuiSimulation => ({
+  account_summary: { account_assets_diffs: diffs },
+})
+
+const SUI_COIN_A = suiCoin('0xaaa::coin::AAA', 'AAA')
+const SUI_COIN_B = suiCoin('0xbbb::coin::BBB', 'BBB')
+
+describe('parseBlockaidSuiSimulation', () => {
+  it('declines when the native leg is the principal outflow instead of hiding it', async () => {
+    const simulation = suiSimulation([
+      suiDiff(nativeSuiAsset, { out: 5_000_000_000 }),
+      suiDiff(SUI_COIN_A, { out: 1_000_000 }),
+      suiDiff(SUI_COIN_B, { in: 2_500_000 }),
+    ])
+
+    expect(await parseBlockaidSuiSimulation(simulation)).toBeNull()
+  })
+
+  it('still nets a coin swap by excluding a gas-sized native out-leg', async () => {
+    const simulation = suiSimulation([
+      suiDiff(SUI_COIN_A, { out: 1_000_000 }),
+      suiDiff(SUI_COIN_B, { in: 2_500_000 }),
+      suiDiff(nativeSuiAsset, { out: 3_000_000 }),
+    ])
+
+    const result = await parseBlockaidSuiSimulation(simulation)
+    expect(result).toMatchObject({
+      swap: {
+        from: { coinType: '0xaaa::coin::AAA' },
+        to: { coinType: '0xbbb::coin::BBB' },
+        fromAmount: 1000000n,
+        toAmount: 2500000n,
+      },
+    })
+  })
+
+  it('reports a coin send after excluding the gas-sized native out-leg', async () => {
+    const simulation = suiSimulation([
+      suiDiff(SUI_COIN_A, { out: 750_000 }),
+      suiDiff(nativeSuiAsset, { out: 3_000_000 }),
+    ])
+
+    const result = await parseBlockaidSuiSimulation(simulation)
+    expect(result).toMatchObject({
+      transfer: { from: { coinType: '0xaaa::coin::AAA' }, fromAmount: 750000n },
+    })
   })
 })

--- a/packages/core/chain/security/blockaid/tx/simulation/api/core.ts
+++ b/packages/core/chain/security/blockaid/tx/simulation/api/core.ts
@@ -88,11 +88,27 @@ const toBigInt = (raw: number | string): bigint | null => {
   return BigInt(raw)
 }
 
+// A native leg may be excluded from the headline only on evidence that it
+// is gas noise: a single-sided movement bounded by a generous fee ceiling.
+// Excluding on array shape alone can delete the transaction's principal
+// leg and hide — or reverse — the displayed direction (vultisig-sdk#2091).
+const SUI_GAS_AND_STORAGE_CEILING = 50_000_000n // 0.05 SUI in MIST
+
+const isSuiGasNoiseDiff = (diff: BlockaidSuiRawAssetDiff): boolean => {
+  if (!isNativeSui(diff.asset)) return false
+  const side = diff.out && !diff.in ? diff.out : diff.in && !diff.out ? diff.in : null
+  if (!side) return false
+  const raw = toBigInt(side.raw_value)
+  return raw !== null && raw >= 0n && raw <= SUI_GAS_AND_STORAGE_CEILING
+}
+
 /**
  * Parse a Blockaid Sui simulation into the user's net balance changes,
  * mirroring how Solana classifies into a `swap` or `transfer` headline.
  *
- * Only emits a headline when the relevant diff set is unambiguous:
+ * Only emits a headline when the diff set is unambiguous after excluding
+ * at most one gas-sized native leg (a native leg is never excluded on
+ * position alone — a principal SUI movement stays in the summary):
  *   - exactly one out-only diff → `transfer`
  *   - exactly two diffs, one out-only + one in-only on different assets
  *     → `swap`
@@ -108,14 +124,11 @@ export const parseBlockaidSuiSimulation = async (
   const assetDiffs = simulation.account_summary?.account_assets_diffs ?? simulation.account_summary?.account_assets_diff
   if (!assetDiffs || assetDiffs.length === 0) return null
 
-  // When we have 3 items and one is native SUI, filter it out and use the
-  // other two tokens — the native SUI is likely the gas charge, not part of
-  // the swap itself. Same heuristic as Solana.
   let relevantDiffs = assetDiffs
-  if (assetDiffs.length === 3) {
-    const nativeIdx = assetDiffs.findIndex(diff => isNativeSui(diff.asset))
-    if (nativeIdx !== -1) {
-      relevantDiffs = assetDiffs.filter((_, i) => i !== nativeIdx)
+  if (assetDiffs.length > 1) {
+    const gasNoiseIdx = assetDiffs.findIndex(isSuiGasNoiseDiff)
+    if (gasNoiseIdx !== -1) {
+      relevantDiffs = assetDiffs.filter((_, i) => i !== gasNoiseIdx)
     }
   }
 
@@ -247,83 +260,110 @@ export type BlockaidEVMSimulation = {
   }
 }
 
+type BlockaidSolanaAssetDiff = BlockaidSolanaSimulation['account_summary']['account_assets_diff'][number]
+
+const WRAPPED_SOL_MINT = 'So11111111111111111111111111111111111111112'
+
+const isNativeSol = (diff: BlockaidSolanaAssetDiff): boolean => diff.asset.type === 'SOL' || diff.asset_type === 'SOL'
+
+// Native SOL and the wrapped-SOL token map to the same mint on purpose:
+// a SOL↔WSOL pair is a wrap, not a swap, and gets declined by the
+// same-mint check below rather than shown as an exchange.
+const solanaMintOf = (asset: BlockaidSolanaAssetDiff['asset']): string =>
+  asset.type === 'SOL' ? WRAPPED_SOL_MINT : shouldBePresent(asset.address)
+
+// A native-SOL leg may be excluded from the headline only on evidence that
+// it is gas noise — a single-sided movement bounded by what a fee payer can
+// plausibly lose (or regain) to fees, priority fees, and rent on temporary
+// accounts. Excluding on array shape alone can delete the transaction's
+// principal leg and reverse the displayed direction (vultisig-sdk#2091).
+const SOL_GAS_AND_RENT_CEILING = 10_000_000n // 0.01 SOL in lamports
+
+const isSolGasNoiseDiff = (diff: BlockaidSolanaAssetDiff): boolean => {
+  if (!isNativeSol(diff)) return false
+  const side = diff.out && !diff.in ? diff.out : diff.in && !diff.out ? diff.in : null
+  if (!side) return false
+  const raw = toBigInt(side.raw_value)
+  return raw !== null && raw >= 0n && raw <= SOL_GAS_AND_RENT_CEILING
+}
+
+/**
+ * Parse a Blockaid Solana simulation into a `swap` or `transfer` headline
+ * for the approval screen.
+ *
+ * Emits a headline only when the diff set is unambiguous after excluding
+ * at most one gas-sized native-SOL leg (a native leg is never excluded on
+ * position alone — a principal SOL movement stays in the summary):
+ *   - exactly one out-only diff → `transfer`
+ *   - exactly two diffs, one out-only + one in-only on different mints
+ *     → `swap`
+ *
+ * Anything else throws: a headline computed from a subset of the legs can
+ * hide a movement or reverse the displayed direction (vultisig-sdk#2091).
+ * Callers treat the throw as "no preview" and fall back to their raw or
+ * decoded transaction view.
+ */
 export const parseBlockaidSolanaSimulation = async (
   simulation: BlockaidSolanaSimulation
 ): Promise<BlockaidSolanaSimulationInfo> => {
   const assetDiffs = simulation.account_summary.account_assets_diff
 
-  // When we have 3 items and one is native SOL, filter it out and use the other two tokens.
-  // The native SOL is likely the transaction fee, not part of the swap itself.
   let relevantDiffs = assetDiffs
-  if (assetDiffs.length === 3) {
-    const nativeSolIndex = assetDiffs.findIndex(diff => diff.asset.type === 'SOL' || diff.asset_type === 'SOL')
-    if (nativeSolIndex !== -1) {
-      relevantDiffs = assetDiffs.filter((_, index) => index !== nativeSolIndex)
+  if (assetDiffs.length > 1) {
+    const gasNoiseIndex = assetDiffs.findIndex(isSolGasNoiseDiff)
+    if (gasNoiseIndex !== -1) {
+      relevantDiffs = assetDiffs.filter((_, index) => index !== gasNoiseIndex)
     }
   }
 
   if (relevantDiffs.length === 1) {
-    const [potentialOutAsset] = relevantDiffs
+    const [diff] = relevantDiffs
 
-    if (!potentialOutAsset.out) {
-      throw new Error('Invalid simulation data: no out value for transfer')
+    // A diff that also carries an `in` side is not a plain send — the net
+    // could even be a receive, so a "you're sending" headline would lie.
+    if (!diff.out || diff.in) {
+      throw new Error('Invalid simulation data: no unambiguous out value for transfer')
+    }
+
+    const fromAmount = toBigInt(diff.out.raw_value)
+    if (fromAmount === null) {
+      throw new Error('Invalid simulation data: malformed transfer amount')
     }
 
     return {
       transfer: {
-        fromMint:
-          potentialOutAsset.asset.type === 'SOL'
-            ? 'So11111111111111111111111111111111111111112'
-            : shouldBePresent(potentialOutAsset.asset.address),
-        fromAmount: BigInt(shouldBePresent(potentialOutAsset.out).raw_value),
+        fromMint: solanaMintOf(diff.asset),
+        fromAmount,
       },
     }
   }
 
-  if (relevantDiffs.length > 1) {
-    const [potentialOutAsset, potentialInAsset] = relevantDiffs
-    const { inAsset, inValue } = potentialInAsset.in
-      ? {
-          inAsset: potentialInAsset.asset,
-          inValue: potentialInAsset.in,
-        }
-      : {
-          inAsset: potentialOutAsset.asset,
-          inValue: potentialOutAsset.in,
-        }
+  if (relevantDiffs.length === 2) {
+    const [a, b] = relevantDiffs
+    const outDiff = !a.in && a.out ? a : !b.in && b.out ? b : null
+    const inDiff = !a.out && a.in ? a : !b.out && b.in ? b : null
 
-    const { outAsset, outValue } = potentialOutAsset.out
-      ? {
-          outAsset: potentialOutAsset.asset,
-          outValue: potentialOutAsset.out,
+    if (outDiff && inDiff) {
+      const fromMint = solanaMintOf(outDiff.asset)
+      const toMint = solanaMintOf(inDiff.asset)
+      const fromAmount = toBigInt(shouldBePresent(outDiff.out).raw_value)
+      const toAmount = toBigInt(shouldBePresent(inDiff.in).raw_value)
+
+      if (fromMint !== toMint && fromAmount !== null && toAmount !== null) {
+        return {
+          swap: {
+            fromMint,
+            toMint,
+            fromAmount,
+            toAmount,
+            toAssetDecimal: inDiff.asset.decimals,
+          },
         }
-      : {
-          outAsset: potentialInAsset.asset,
-          outValue: potentialInAsset.out,
-        }
-    if (outAsset && inAsset && outValue && inValue) {
-      return {
-        swap: {
-          fromMint:
-            outAsset.type === 'SOL' ? 'So11111111111111111111111111111111111111112' : shouldBePresent(outAsset.address),
-          toMint:
-            inAsset.type === 'SOL' ? 'So11111111111111111111111111111111111111112' : shouldBePresent(inAsset.address),
-          fromAmount: BigInt(shouldBePresent(outValue).raw_value),
-          toAmount: BigInt(shouldBePresent(inValue).raw_value),
-          toAssetDecimal: inAsset.decimals,
-        },
-      }
-    } else if (outAsset && outValue) {
-      return {
-        transfer: {
-          fromMint:
-            outAsset.type === 'SOL' ? 'So11111111111111111111111111111111111111112' : shouldBePresent(outAsset.address),
-          fromAmount: BigInt(shouldBePresent(outValue).raw_value),
-        },
       }
     }
   }
-  throw new Error('Invalid simulation data')
+
+  throw new Error('Invalid simulation data: ambiguous asset diffs')
 }
 
 type EvmAssetDiff = BlockaidEVMSimulation['account_summary']['assets_diffs'][number]


### PR DESCRIPTION
Closes #2091

`parseBlockaidSolanaSimulation` dropped a native-SOL diff purely because the response contained exactly three diffs, assuming it was the transaction fee. When the native leg is the principal movement — the issue's counterexample is a wrapped-SOL withdrawal returning native SOL in + a WSOL rent residual out + a receipt token out — the parser deleted the principal, the two remaining out-only legs failed the swap guard, and the `outAsset && outValue` fallback reported a transfer OUT of the WSOL residual: a reversed approval direction on a net-receive transaction. Reproduced exactly that output by running the fixture against the published dist that vultisig-windows consumes (vultisig/vultisig-windows#4728).

Fixed in `packages/core/chain/security/blockaid/tx/simulation/api/core.ts`:

- A native leg is excluded only on evidence that it is gas noise: single-sided (in xor out) and bounded by a ceiling (0.01 SOL / 0.05 SUI). A principal native movement stays in the summary regardless of diff count or position.
- Solana classification is now strict, mirroring the Sui parser: exactly one out-only diff → `transfer`; exactly two diffs forming an out-only + in-only pair on different mints → `swap`; anything else throws, which callers already treat as "no preview" before falling back to their raw/decoded views. This also fixes the secondary finding in the issue — two simultaneous spends no longer render as a transfer of just the first one.
- Native SOL and the wrapped-SOL token map to the same mint, so a SOL↔WSOL wrap pair declines instead of rendering as a swap.
- `parseBlockaidSuiSimulation`'s copy of the heuristic gets the same evidence gate. Side effect: a coin send + gas fee on Sui (2 diffs) now yields a `transfer` headline where it previously returned `null`.

Added direction-locking tests: the #2091 withdrawal counterexample, the deposit variant (principal native out), hidden second spend, SOL↔WSOL wrap, plus the preserved legitimate shapes (token swap with a fee-sized native out, token send + fee, rent-refund-sized native in, diff-order independence, lone dust send) and three Sui cases. Six of them fail against the previous parser.

The tradeoff is deliberate per the issue: shapes the old code headlined from a subset of legs (e.g. a 3-diff swap whose native leg exceeds the ceiling) now decline to the fallback view — "no headline" over "confidently wrong headline". The ceiling constants are the tuning knobs if real payloads show a common legitimate shape declining too often.

## what I ran
`yarn test:core` — 3096 passed / 1 skipped; `tsc --project .config/tsconfig.json --noEmit`, eslint and prettier on the touched files — all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction simulation parsing for Solana and Sui.
  * More accurately filters gas, storage, and rent-related native-asset movements.
  * Improved detection of swaps and transfers, including wrapped SOL handling.
  * Added validation for transfer direction, amounts, and ambiguous transaction data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->