### PR TITLE
fix(sdk): export discovery and cosmos chain-id canonicals

### DIFF
--- a/.changeset/r174-sdk-discovery-cosmos-exports.md
+++ b/.changeset/r174-sdk-discovery-cosmos-exports.md
@@ -1,0 +1,5 @@
+---
+'@vultisig/sdk': patch
+---
+
+Export `coinFinderChainKinds`, `getCosmosChainId`, and `getCosmosChainByChainId` from the root and React Native SDK entrypoints so first-party consumers can delete local discovery/chain-id mirrors.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -255,10 +255,13 @@ export {
 } from '@vultisig/core-chain/chains/customRpc/customRpcSupportedChains'
 export type { RpcHealthResult } from '@vultisig/core-chain/chains/customRpc/rpcHealthProbe'
 export { probeRpcHealth } from '@vultisig/core-chain/chains/customRpc/rpcHealthProbe'
+export type { CoinFinderChainKind } from '@vultisig/core-chain/coin/find/CoinFinderChainKind'
+export { coinFinderChainKinds } from '@vultisig/core-chain/coin/find/CoinFinderChainKind'
 
 // Cosmos chain metadata — surfaced so consumers stop re-declaring LCD urls /
 // fee denoms / gas limits (e.g. mcp-ts lib/cosmos-chains.ts).
 export { cosmosFeeCoinDenom } from '@vultisig/core-chain/chains/cosmos/cosmosFeeCoinDenom'
+export { getCosmosChainByChainId, getCosmosChainId } from '@vultisig/core-chain/chains/cosmos/chainInfo'
 export {
   getCosmosAllowedFeeDenoms,
   isCosmosFeeDenomAllowed,

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -68,7 +68,10 @@ configureDefaultStorage(() => new ReactNativeStorage())
 
 // Chain enum and types
 export { Chain, IbcEnabledCosmosChain, VaultBasedCosmosChain } from '@vultisig/core-chain/Chain'
+export type { CoinFinderChainKind } from '@vultisig/core-chain/coin/find/CoinFinderChainKind'
+export { coinFinderChainKinds } from '@vultisig/core-chain/coin/find/CoinFinderChainKind'
 export { cosmosFeeCoinDenom } from '@vultisig/core-chain/chains/cosmos/cosmosFeeCoinDenom'
+export { getCosmosChainByChainId, getCosmosChainId } from '@vultisig/core-chain/chains/cosmos/chainInfo'
 export {
   getCosmosAllowedFeeDenoms,
   isCosmosFeeDenomAllowed,

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -1,5 +1,7 @@
 import * as customRpcOverrides from '@vultisig/core-chain/chains/customRpc/customRpcOverrides'
 import * as customRpcSupportedChains from '@vultisig/core-chain/chains/customRpc/customRpcSupportedChains'
+import * as coinFinderChainKindModule from '@vultisig/core-chain/coin/find/CoinFinderChainKind'
+import * as cosmosChainInfoModule from '@vultisig/core-chain/chains/cosmos/chainInfo'
 import { AuthInfo, SignDoc, TxBody } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 
@@ -132,6 +134,17 @@ describe('RN entry wires configureCrypto and configureDefaultStorage', () => {
     expect(rn.IbcEnabledCosmosChain.TerraClassic).toBe('TerraClassic')
     expect(rn.VaultBasedCosmosChain.THORChain).toBe('THORChain')
     expect(Object.values(rn.IbcEnabledCosmosChain)).not.toContain(rn.Chain.THORChain)
+  })
+
+  it('exports coin-finder chain kinds and Cosmos chain-id lookups from the RN entry', async () => {
+    const rn = await import('../../../../src/platforms/react-native/index')
+
+    expect(rn.coinFinderChainKinds).toBe(coinFinderChainKindModule.coinFinderChainKinds)
+    expect(rn.coinFinderChainKinds).toEqual(['evm', 'cosmos', 'solana', 'cardano', 'ripple'])
+    expect(rn.getCosmosChainId).toBe(cosmosChainInfoModule.getCosmosChainId)
+    expect(rn.getCosmosChainByChainId).toBe(cosmosChainInfoModule.getCosmosChainByChainId)
+    expect(rn.getCosmosChainId(rn.Chain.THORChain)).toBe('thorchain-1')
+    expect(rn.getCosmosChainByChainId('noble-1')).toBe(rn.Chain.Noble)
   })
 
   it.each(cosmosTxFeeGasParityCases)(

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -1,5 +1,7 @@
 import * as customRpcOverrides from '@vultisig/core-chain/chains/customRpc/customRpcOverrides'
 import * as customRpcSupportedChains from '@vultisig/core-chain/chains/customRpc/customRpcSupportedChains'
+import * as coinFinderChainKindModule from '@vultisig/core-chain/coin/find/CoinFinderChainKind'
+import * as cosmosChainInfoModule from '@vultisig/core-chain/chains/cosmos/chainInfo'
 import * as isValidTokenIdModule from '@vultisig/core-chain/utils/isValidTokenId'
 import { describe, expect, it } from 'vitest'
 
@@ -156,6 +158,18 @@ describe('@vultisig/sdk public exports', () => {
     expect(sdk.getCustomRpcOverrides()).toEqual({ [sdk.Chain.Ethereum]: 'https://rpc.example' })
     sdk.clearCustomRpcOverride(sdk.Chain.Ethereum)
     expect(sdk.getCustomRpcOverride(sdk.Chain.Ethereum)).toBeUndefined()
+  })
+
+  it('exports the coin-finder chain-kind canonical list from the root SDK entrypoint', () => {
+    expect(sdk.coinFinderChainKinds).toBe(coinFinderChainKindModule.coinFinderChainKinds)
+    expect(sdk.coinFinderChainKinds).toEqual(['evm', 'cosmos', 'solana', 'cardano', 'ripple'])
+  })
+
+  it('exports the canonical Cosmos chain-id lookup helpers from the root SDK entrypoint', () => {
+    expect(sdk.getCosmosChainId).toBe(cosmosChainInfoModule.getCosmosChainId)
+    expect(sdk.getCosmosChainByChainId).toBe(cosmosChainInfoModule.getCosmosChainByChainId)
+    expect(sdk.getCosmosChainId(sdk.Chain.TerraClassic)).toBe('columbus-5')
+    expect(sdk.getCosmosChainByChainId('phoenix-1')).toBe(sdk.Chain.Terra)
   })
 
   it('exports isValidTokenId for non-address token families (Sui struct tags, XRPL currency.issuer)', () => {


### PR DESCRIPTION
## Summary
- export `coinFinderChainKinds` / `CoinFinderChainKind` from the root + React Native SDK surfaces
- export `getCosmosChainId` / `getCosmosChainByChainId` from the root + React Native SDK surfaces
- pin both public-surface families in the root and RN export suites

Closes https://github.com/vultisig/vultisig-sdk/issues/2206
Closes https://github.com/vultisig/vultisig-sdk/issues/2207

## Why
The canonical helpers already existed in core, but first-party consumers were keeping local mirrors because the supported SDK surfaces stopped short of exporting them. This removes two small duplicated-not-imported seams from the campaign's recurring architecture bug class.

## Verification
- `VULTISIG_STRICT_SINGLETON=0 corepack yarn workspace @vultisig/sdk vitest run --config tests/unit/vitest.config.ts tests/unit/utils/publicExports.test.ts tests/unit/platforms/react-native/entry.test.ts` ✅ (112 passed)
- `corepack yarn build:sdk` ⚠️ blocked on pre-existing clean-main Cardano error: `packages/core/mpc/keysign/signingInputs/resolvers/cardano.ts(72,5): error TS2353: Object literal may only specify known properties, and 'auxiliaryData' does not exist in type 'ISigningInput'.`

## Receipts
- Root export test now pins `sdk.coinFinderChainKinds`, `sdk.getCosmosChainId`, and `sdk.getCosmosChainByChainId`
- RN entry test now pins `sdkRn.coinFinderChainKinds`, `sdkRn.getCosmosChainId`, and `sdkRn.getCosmosChainByChainId`

## Report
- /improve round 174 mirror: https://gist.github.com/gomesalexandre/de03b32b08aa640ef34b24e200343510
