### PR TITLE
fix(sdk): publish services and token public subpaths

### DIFF
--- a/.changeset/r175-sdk-services-token-subpaths.md
+++ b/.changeset/r175-sdk-services-token-subpaths.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+Publish dedicated `@vultisig/sdk/tools/token` and `@vultisig/sdk/services` subpaths with matching JS and type bundles.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -202,6 +202,32 @@
       "import": "./dist/tools/gas/index.js",
       "require": "./dist/tools/gas/index.cjs",
       "default": "./dist/tools/gas/index.cjs"
+    },
+    "./tools/token": {
+      "types": "./dist/tools/token/index.d.ts",
+      "browser": "./dist/tools/token/index.js",
+      "worker": "./dist/tools/token/index.js",
+      "react-native": "./dist/tools/token/index.js",
+      "node": {
+        "import": "./dist/tools/token/index.js",
+        "require": "./dist/tools/token/index.cjs"
+      },
+      "import": "./dist/tools/token/index.js",
+      "require": "./dist/tools/token/index.cjs",
+      "default": "./dist/tools/token/index.cjs"
+    },
+    "./services": {
+      "types": "./dist/services/index.d.ts",
+      "browser": "./dist/services/index.js",
+      "worker": "./dist/services/index.js",
+      "react-native": "./dist/services/index.js",
+      "node": {
+        "import": "./dist/services/index.js",
+        "require": "./dist/services/index.cjs"
+      },
+      "import": "./dist/services/index.js",
+      "require": "./dist/services/index.cjs",
+      "default": "./dist/services/index.cjs"
     }
   },
   "scripts": {

--- a/packages/sdk/rollup.platforms.config.js
+++ b/packages/sdk/rollup.platforms.config.js
@@ -337,6 +337,10 @@ const configs = {
       distBase: 'tools/gas',
     }),
     ...createSubpathConfigs({
+      input: './src/tools/token/index.ts',
+      distBase: 'tools/token',
+    }),
+    ...createSubpathConfigs({
       input: './src/tools/bridge/index.ts',
       distBase: 'tools/bridge',
     }),
@@ -363,6 +367,10 @@ const configs = {
     ...createSubpathConfigs({
       input: './src/tx/index.ts',
       distBase: 'tx',
+    }),
+    ...createSubpathConfigs({
+      input: './src/services/index.ts',
+      distBase: 'services',
     }),
   ],
   browser: {

--- a/packages/sdk/rollup.types.config.js
+++ b/packages/sdk/rollup.types.config.js
@@ -124,6 +124,7 @@ export default defineConfig([
   createSubpathTypesConfig('src/tools/parse/index.ts', 'dist/tools/parse/index.d.ts'),
   createSubpathTypesConfig('src/tools/defi/index.ts', 'dist/tools/defi/index.d.ts'),
   createSubpathTypesConfig('src/tools/gas/index.ts', 'dist/tools/gas/index.d.ts'),
+  createSubpathTypesConfig('src/tools/token/index.ts', 'dist/tools/token/index.d.ts'),
   createSubpathTypesConfig('src/tools/bridge/index.ts', 'dist/tools/bridge/index.d.ts'),
   createSubpathTypesConfig('src/tools/balance/index.ts', 'dist/tools/balance/index.d.ts'),
   createSubpathTypesConfig('src/chains/tron/index.ts', 'dist/chains/tron/index.d.ts'),
@@ -133,4 +134,5 @@ export default defineConfig([
   createSubpathTypesConfig('src/seedphrase/index.ts', 'dist/seedphrase/index.d.ts'),
   createSubpathTypesConfig('src/tools/decode/index.ts', 'dist/tools/decode/index.d.ts'),
   createSubpathTypesConfig('src/tx/index.ts', 'dist/tx/index.d.ts'),
+  createSubpathTypesConfig('src/services/index.ts', 'dist/services/index.d.ts'),
 ])

--- a/packages/sdk/tests/unit/public-api/toolsSubpathExports.test.ts
+++ b/packages/sdk/tests/unit/public-api/toolsSubpathExports.test.ts
@@ -15,11 +15,13 @@ describe('public API subpath exports', () => {
     const defiExport = sdkPackageJson.exports['./tools/defi']
     const bridgeExport = sdkPackageJson.exports['./tools/bridge']
     const gasExport = sdkPackageJson.exports['./tools/gas']
+    const tokenExport = sdkPackageJson.exports['./tools/token']
     const balanceExport = sdkPackageJson.exports['./tools/balance']
     const tronExport = sdkPackageJson.exports['./chains/tron']
     const utxoExport = sdkPackageJson.exports['./chains/utxo']
     const decodeExport = sdkPackageJson.exports['./tools/decode']
     const txExport = sdkPackageJson.exports['./tx']
+    const servicesExport = sdkPackageJson.exports['./services']
 
     expect(parseExport).toMatchObject({
       types: './dist/tools/parse/index.d.ts',
@@ -44,6 +46,12 @@ describe('public API subpath exports', () => {
       import: './dist/tools/gas/index.js',
       require: './dist/tools/gas/index.cjs',
       default: './dist/tools/gas/index.cjs',
+    })
+    expect(tokenExport).toMatchObject({
+      types: './dist/tools/token/index.d.ts',
+      import: './dist/tools/token/index.js',
+      require: './dist/tools/token/index.cjs',
+      default: './dist/tools/token/index.cjs',
     })
     expect(balanceExport).toMatchObject({
       types: './dist/tools/balance/index.d.ts',
@@ -75,16 +83,24 @@ describe('public API subpath exports', () => {
       require: './dist/tx/index.cjs',
       default: './dist/tx/index.cjs',
     })
+    expect(servicesExport).toMatchObject({
+      types: './dist/services/index.d.ts',
+      import: './dist/services/index.js',
+      require: './dist/services/index.cjs',
+      default: './dist/services/index.cjs',
+    })
 
     expect(JSON.stringify(parseExport)).not.toContain('dist/index.node')
     expect(JSON.stringify(defiExport)).not.toContain('dist/index.node')
     expect(JSON.stringify(bridgeExport)).not.toContain('dist/index.node')
     expect(JSON.stringify(gasExport)).not.toContain('dist/index.node')
+    expect(JSON.stringify(tokenExport)).not.toContain('dist/index.node')
     expect(JSON.stringify(balanceExport)).not.toContain('dist/index.node')
     expect(JSON.stringify(tronExport)).not.toContain('dist/index.node')
     expect(JSON.stringify(utxoExport)).not.toContain('dist/index.node')
     expect(JSON.stringify(decodeExport)).not.toContain('dist/index.node')
     expect(JSON.stringify(txExport)).not.toContain('dist/index.node')
+    expect(JSON.stringify(servicesExport)).not.toContain('dist/index.node')
   })
 
   it('keeps dedicated JS and d.ts bundle generation wired for every narrow public surface', () => {
@@ -96,6 +112,8 @@ describe('public API subpath exports', () => {
     expect(platformRollupConfig).toContain("distBase: 'tools/bridge'")
     expect(platformRollupConfig).toContain("input: './src/tools/gas/index.ts'")
     expect(platformRollupConfig).toContain("distBase: 'tools/gas'")
+    expect(platformRollupConfig).toContain("input: './src/tools/token/index.ts'")
+    expect(platformRollupConfig).toContain("distBase: 'tools/token'")
     expect(platformRollupConfig).toContain("input: './src/tools/balance/index.ts'")
     expect(platformRollupConfig).toContain("distBase: 'tools/balance'")
     expect(platformRollupConfig).toContain("input: './src/chains/tron/index.ts'")
@@ -106,6 +124,8 @@ describe('public API subpath exports', () => {
     expect(platformRollupConfig).toContain("distBase: 'tools/decode'")
     expect(platformRollupConfig).toContain("input: './src/tx/index.ts'")
     expect(platformRollupConfig).toContain("distBase: 'tx'")
+    expect(platformRollupConfig).toContain("input: './src/services/index.ts'")
+    expect(platformRollupConfig).toContain("distBase: 'services'")
 
     expect(typesRollupConfig).toContain(
       "createSubpathTypesConfig('src/tools/parse/index.ts', 'dist/tools/parse/index.d.ts')"
@@ -120,6 +140,9 @@ describe('public API subpath exports', () => {
       "createSubpathTypesConfig('src/tools/gas/index.ts', 'dist/tools/gas/index.d.ts')"
     )
     expect(typesRollupConfig).toContain(
+      "createSubpathTypesConfig('src/tools/token/index.ts', 'dist/tools/token/index.d.ts')"
+    )
+    expect(typesRollupConfig).toContain(
       "createSubpathTypesConfig('src/tools/balance/index.ts', 'dist/tools/balance/index.d.ts')"
     )
     expect(typesRollupConfig).toContain(
@@ -132,5 +155,8 @@ describe('public API subpath exports', () => {
       "createSubpathTypesConfig('src/tools/decode/index.ts', 'dist/tools/decode/index.d.ts')"
     )
     expect(typesRollupConfig).toContain("createSubpathTypesConfig('src/tx/index.ts', 'dist/tx/index.d.ts')")
+    expect(typesRollupConfig).toContain(
+      "createSubpathTypesConfig('src/services/index.ts', 'dist/services/index.d.ts')"
+    )
   })
 })


### PR DESCRIPTION
## Summary
- publish additive `@vultisig/sdk/services` and `@vultisig/sdk/tools/token` subpaths
- wire dedicated JS and d.ts bundle generation for both subpaths
- extend public-export coverage so the package map, rollup config, and type bundles stay in sync

Closes #2215
Closes #2216

## Why
The SDK already owned both canonical surfaces, but consumers still could not import them through stable narrow package subpaths. That kept ceremony/session orchestration and token canonicals less reusable than sibling helper families.

## Verification
- `corepack yarn workspace @vultisig/sdk vitest run --config tests/unit/vitest.config.ts tests/unit/public-api/toolsSubpathExports.test.ts` ✅
- `corepack yarn build:sdk` ⚠️ blocked on clean main by pre-existing Cardano typing failure in `packages/core/mpc/keysign/signingInputs/resolvers/cardano.ts` (`auxiliaryData` not accepted by `ISigningInput`)
- `corepack yarn build:platform:node` from `packages/sdk` ✅
- direct built-dist runtime smoke ✅
  - imported `./packages/sdk/dist/tools/token/index.js`
  - imported `./packages/sdk/dist/services/index.js`
- packed-tarball temp-consumer runtime smoke ✅
  - `import('@vultisig/sdk/tools/token')`
  - `import('@vultisig/sdk/services')`

## Report
- https://gist.github.com/gomesalexandre/9887625b6dee7130ea46c505907f9bbd
