### PR TITLE
fix(sdk): export the pure EVM and Solana tx builders

### DIFF
--- a/.changeset/r176-export-rn-tx-builders.md
+++ b/.changeset/r176-export-rn-tx-builders.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+Export the pure EVM and Solana tx builders from the root and React Native SDK entrypoints.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1142,6 +1142,25 @@ export {
 export type { BuildCosmosWasmExecuteOptions, CosmosTxBuilderResult } from './platforms/react-native/chains/cosmos/tx'
 export { buildCosmosWasmExecuteTx } from './platforms/react-native/chains/cosmos/tx'
 
+// The RN-native Solana/EVM tx builders are also environment-neutral pure
+// builders despite their historical RN path. Export them from the root so
+// CLI/backend consumers stop deep-importing or re-implementing tx assembly.
+export type { BuildSolanaSendOptions, SolanaTxBuilderResult } from './platforms/react-native/chains/solana/tx'
+export { buildSolanaSendTx } from './platforms/react-native/chains/solana/tx'
+export type {
+  BuildErc20ApproveOptions,
+  BuildErc20TransferOptions,
+  BuildEvmContractCallOptions,
+  BuildEvmSendOptions,
+  EvmTxBuilderResult,
+} from './platforms/react-native/chains/evm/tx'
+export {
+  buildErc20ApproveTx,
+  buildErc20TransferTx,
+  buildEvmContractCallTx,
+  buildEvmSendTx,
+} from './platforms/react-native/chains/evm/tx'
+
 // Vault-bound gas/fee estimation (chain-specific fee floor for a loaded vault).
 // The pure read-only per-chain gas price lives in `evmGasPrice` above; this
 // service is exposed for callers that already hold a vault and need the richer

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -262,6 +262,7 @@ export { chains } from './chains'
 
 // EVM bridge type surface — consumers can import these directly from the RN
 // entry without reaching through `chains.evm.*`.
+export { buildErc20ApproveTx, buildErc20TransferTx, buildEvmContractCallTx, buildEvmSendTx } from './chains/evm'
 export type {
   BuildErc20ApproveOptions,
   BuildErc20TransferOptions,
@@ -273,6 +274,7 @@ export type {
 // Solana bridge type surface — pure primitive reimplementation that does NOT
 // pull @solana/web3.js (and therefore avoids the rpc-websockets / ws cascade
 // that hangs Hermes at module init).
+export { buildSolanaSendTx } from './chains/solana'
 export type { BroadcastSolanaTxOptions, BuildSolanaSendOptions, SolanaTxBuilderResult } from './chains/solana'
 
 // TON bridge type surface — reimplementation built on @ton/core plus

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -372,6 +372,18 @@ describe('RN entry wires configureCrypto and configureDefaultStorage', () => {
     })
   })
 
+  it('re-exports the pure EVM and Solana tx builders from the RN entrypoint by identity', async () => {
+    const rn = await import('../../../../src/platforms/react-native/index')
+    const evm = await import('../../../../src/platforms/react-native/chains/evm')
+    const solana = await import('../../../../src/platforms/react-native/chains/solana')
+
+    expect(rn.buildEvmSendTx).toBe(evm.buildEvmSendTx)
+    expect(rn.buildErc20TransferTx).toBe(evm.buildErc20TransferTx)
+    expect(rn.buildErc20ApproveTx).toBe(evm.buildErc20ApproveTx)
+    expect(rn.buildEvmContractCallTx).toBe(evm.buildEvmContractCallTx)
+    expect(rn.buildSolanaSendTx).toBe(solana.buildSolanaSendTx)
+  })
+
   it('re-exports the root River helper family on the RN entrypoint', async () => {
     const rn = await import('../../../../src/platforms/react-native/index')
     const river = await import('../../../../src/tools/defi/river')

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -416,6 +416,14 @@ describe('@vultisig/sdk public exports', () => {
     expect(typeof sdk.buildCosmosWasmExecuteTx).toBe('function')
   })
 
+  it('exports the pure EVM and Solana tx builders from the root SDK surface', () => {
+    expect(typeof sdk.buildSolanaSendTx).toBe('function')
+    expect(typeof sdk.buildEvmSendTx).toBe('function')
+    expect(typeof sdk.buildErc20TransferTx).toBe('function')
+    expect(typeof sdk.buildErc20ApproveTx).toBe('function')
+    expect(typeof sdk.buildEvmContractCallTx).toBe('function')
+  })
+
   it('VaultBase prototype exposes prep-only primitives used by mcp-ts execute_* tools', () => {
     // prepareSendTx / prepareSwapTx / prepareContractCallTx are public instance
     // methods on VaultBase — they build a KeysignPayload without broadcasting.


### PR DESCRIPTION
Summary:\n- export the pure Solana send builder on the root and react-native SDK surfaces\n- export the pure EVM raw-tx builder family on the root and react-native SDK surfaces\n- pin the new public surfaces with root and RN export tests and a changeset\n\nCloses 2221\nCloses 2222\n\nTesting:\n- VULTISIG_STRICT_SINGLETON=0 corepack yarn workspace @vultisig/sdk vitest run --config tests/unit/vitest.config.ts tests/unit/utils/publicExports.test.ts tests/unit/platforms/react-native/entry.test.ts\n- corepack yarn workspace @vultisig/sdk build\n- packages/sdk/dist/index.react-native.d.ts contains the new builder exports\n\nNotes:\n- build:shared on clean main is still blocked by the pre-existing Cardano auxiliaryData vs ISigningInput type error\n- Round 176 report: https://gist.github.com/gomesalexandre/5b55c606aef385aaa138f1c221c9d7ea
