### PR TITLE
Add TRON expired unfreeze withdrawal signing

### DIFF
--- a/.changeset/tron-withdraw-expired-unfreeze.md
+++ b/.changeset/tron-withdraw-expired-unfreeze.md
@@ -1,0 +1,7 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/core-mpc': patch
+'@vultisig/sdk': patch
+---
+
+Add TRON Stake 2.0 expired-unfreeze withdrawal signing with strict native-TRX payload validation and WalletCore 4.7.3 support.

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -2389,7 +2389,7 @@
     "@solana/web3.js": "^1.98.4",
     "@ton/core": "^0.63.1",
     "@ton/crypto": "^3.3.0",
-    "@trustwallet/wallet-core": "^4.7.0",
+    "@trustwallet/wallet-core": "^4.7.3",
     "@vultisig/core-config": "0.9.1",
     "@vultisig/lib-utils": "0.10.6",
     "bip32": "^5.0.1",

--- a/packages/core/mpc/keysign/signingInputs/resolvers/tron.test.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/tron.test.ts
@@ -1,9 +1,12 @@
+import { Buffer } from 'buffer'
 import { create } from '@bufbuild/protobuf'
-import { type WalletCore } from '@trustwallet/wallet-core'
+import { TW, type WalletCore } from '@trustwallet/wallet-core'
 import { Chain } from '@vultisig/core-chain/Chain'
+import { OneInchSwapPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/1inch_swap_payload_pb'
 import { TronSpecificSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
 import { CoinSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/coin_pb'
 import { KeysignPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { TronTransferContractPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/tron_contract_payload_pb'
 import Long from 'long'
 import { describe, expect, it } from 'vitest'
 
@@ -30,6 +33,7 @@ const makeTronSpecific = (gasEstimation = 100_000_000n) =>
   })
 
 const OWNER = 'T9yED5xMV5ARV98BexN97aLZ1UUq7eKSxm'
+const WITHDRAW_EXPIRE_UNFREEZE_MEMO = 'WITHDRAW_EXPIRE_UNFREEZE'
 
 const buildPayload = (memo: string, toAmount = '1000000000') =>
   create(KeysignPayloadSchema, {
@@ -48,6 +52,150 @@ const buildPayload = (memo: string, toAmount = '1000000000') =>
       value: makeTronSpecific(100_000_000n),
     },
   })
+
+const buildWithdrawExpireUnfreezePayload = ({
+  chain = Chain.Tron,
+  ticker = 'TRX',
+  isNativeToken = true,
+  contractAddress = '',
+  toAddress = OWNER,
+  toAmount = '1000000000',
+  memo = WITHDRAW_EXPIRE_UNFREEZE_MEMO,
+  withContractPayload = false,
+  withSwapPayload = false,
+}: {
+  chain?: Chain
+  ticker?: string
+  isNativeToken?: boolean
+  contractAddress?: string
+  toAddress?: string
+  toAmount?: string
+  memo?: string
+  withContractPayload?: boolean
+  withSwapPayload?: boolean
+} = {}) =>
+  create(KeysignPayloadSchema, {
+    coin: create(CoinSchema, {
+      chain,
+      ticker,
+      address: OWNER,
+      decimals: 6,
+      isNativeToken,
+      contractAddress,
+    }),
+    toAddress,
+    toAmount,
+    memo,
+    blockchainSpecific: {
+      case: 'tronSpecific',
+      value: makeTronSpecific(999n),
+    },
+    contractPayload: withContractPayload
+      ? {
+          case: 'tronTransferContractPayload',
+          value: create(TronTransferContractPayloadSchema, {
+            ownerAddress: OWNER,
+            toAddress: OWNER,
+            amount: '1',
+          }),
+        }
+      : undefined,
+    swapPayload: withSwapPayload
+      ? {
+          case: 'oneinchSwapPayload',
+          value: create(OneInchSwapPayloadSchema),
+        }
+      : undefined,
+  })
+
+describe('getTronSigningInputs -- WithdrawExpireUnfreezeContract', () => {
+  it('constructs the exact owner-only WalletCore transaction shape', async () => {
+    const [input] = await getTronSigningInputs({
+      keysignPayload: buildWithdrawExpireUnfreezePayload(),
+      walletCore,
+    })
+
+    const transaction = input.transaction as TW.Tron.Proto.Transaction | undefined
+    expect(transaction?.contractOneof).toBe('withdrawExpireUnfreeze')
+    expect(transaction?.withdrawExpireUnfreeze?.ownerAddress).toBe(OWNER)
+    expect(
+      TW.Tron.Proto.WithdrawExpireUnfreezeContract.toObject(
+        TW.Tron.Proto.WithdrawExpireUnfreezeContract.create(transaction!.withdrawExpireUnfreeze!)
+      )
+    ).toEqual({ ownerAddress: OWNER })
+    expect(transaction?.timestamp?.toString()).toBe('1700000000000')
+    expect(transaction?.expiration?.toString()).toBe('1700003600000')
+    expect(transaction?.feeLimit?.equals(Long.ZERO)).toBe(true)
+    expect(transaction?.memo).toBe('')
+    expect(transaction?.transfer).toBeNull()
+    expect(transaction?.unfreezeBalanceV2).toBeNull()
+    expect(transaction?.blockHeader?.timestamp?.toString()).toBe('1699999940000')
+    expect(transaction?.blockHeader?.number?.toString()).toBe('1234')
+    expect(transaction?.blockHeader?.version).toBe(28)
+    expect(transaction?.blockHeader?.txTrieRoot).toEqual(Buffer.alloc(32))
+    expect(transaction?.blockHeader?.parentHash).toEqual(Buffer.alloc(32))
+    expect(transaction?.blockHeader?.witnessAddress).toEqual(Buffer.alloc(20))
+  })
+
+  it('matches the encoded WalletCore golden and decodes back to the same claim', async () => {
+    const [input] = await getTronSigningInputs({
+      keysignPayload: buildWithdrawExpireUnfreezePayload(),
+      walletCore,
+    })
+
+    const encoded = TW.Tron.Proto.SigningInput.encode(input).finish()
+    expect(Buffer.from(encoded).toString('hex')).toBe(
+      '0a9f010880d095ffbc311080adf180bd311a6608a0fb91ffbc31122000000000000000000000000000000000000000000000000000000000000000001a20000000000000000000000000000000000000000000000000000000000000000038d2094a140000000000000000000000000000000000000000501c2000ba01240a22543979454435784d563541525639384265784e3937614c5a3155557137654b53786d'
+    )
+
+    const decoded = TW.Tron.Proto.SigningInput.decode(encoded)
+    const decodedTransaction = decoded.transaction as TW.Tron.Proto.Transaction | undefined
+    expect(decodedTransaction?.contractOneof).toBe('withdrawExpireUnfreeze')
+    expect(decodedTransaction?.withdrawExpireUnfreeze?.ownerAddress).toBe(OWNER)
+    expect(decodedTransaction?.timestamp?.toString()).toBe('1700000000000')
+    expect(decodedTransaction?.expiration?.toString()).toBe('1700003600000')
+    expect(decodedTransaction?.feeLimit?.equals(Long.ZERO)).toBe(true)
+    expect(decodedTransaction?.blockHeader?.number?.toString()).toBe('1234')
+  })
+
+  it('keeps arbitrary-size display amounts out of the serialized contract', async () => {
+    const amounts = ['0', '12500000', '900719925474099300000000000000000000000000000000001']
+    const encoded = await Promise.all(
+      amounts.map(async toAmount => {
+        const [input] = await getTronSigningInputs({
+          keysignPayload: buildWithdrawExpireUnfreezePayload({ toAmount }),
+          walletCore,
+        })
+        return Buffer.from(TW.Tron.Proto.SigningInput.encode(input).finish()).toString('hex')
+      })
+    )
+
+    expect(new Set(encoded).size).toBe(1)
+  })
+
+  it.each([
+    ['non-native token', { isNativeToken: false, contractAddress: OWNER }],
+    ['wrong ticker', { ticker: 'USDT' }],
+    ['wrong chain', { chain: Chain.Ethereum }],
+    ['native coin with a contract address', { contractAddress: OWNER }],
+    ['foreign destination', { toAddress: 'TDifferentRecipient' }],
+    ['empty amount', { toAmount: '' }],
+    ['negative amount', { toAmount: '-1' }],
+    ['decimal amount', { toAmount: '1.5' }],
+    ['exponential amount', { toAmount: '1e3' }],
+    ['whitespace amount', { toAmount: ' 1' }],
+    ['memo suffix collision', { memo: `${WITHDRAW_EXPIRE_UNFREEZE_MEMO}:1` }],
+    ['contract payload collision', { withContractPayload: true }],
+    ['swap payload collision', { withSwapPayload: true }],
+  ] as const)('rejects %s', (_label, overrides) => {
+    expect(() =>
+      getTronSigningInputs({
+        keysignPayload: buildWithdrawExpireUnfreezePayload(overrides),
+        walletCore,
+      })
+    ).toThrow('Invalid TRON expired-unfreeze claim payload')
+  })
+})
 
 describe('getTronSigningInputs -- FREEZE: / UNFREEZE: feeLimit semantics (BUG-7)', () => {
   it('FREEZE:BANDWIDTH sets feeLimit to 0 regardless of gasEstimation', async () => {

--- a/packages/core/mpc/keysign/signingInputs/resolvers/tron.ts
+++ b/packages/core/mpc/keysign/signingInputs/resolvers/tron.ts
@@ -1,4 +1,5 @@
 import { Buffer } from 'buffer'
+import { Chain } from '@vultisig/core-chain/Chain'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { assertBoundedInt } from '@vultisig/lib-utils/bigint/assertBoundedInt'
 import { bigIntToHex } from '@vultisig/lib-utils/bigint/bigIntToHex'
@@ -18,6 +19,8 @@ import { SigningInputsResolver } from '../resolver'
 // silently two's-complement-wrap (e.g. a wrapped feeLimit authorizing an
 // outsized fee burn).
 const toBoundedTronLong = (value: string) => Long.fromString(assertBoundedInt(value, 'int64'))
+
+const withdrawExpireUnfreezeMemo = 'WITHDRAW_EXPIRE_UNFREEZE'
 
 const createTronBlockHeader = (tronSpecific: {
   blockHeaderTimestamp: bigint | number | string
@@ -40,6 +43,45 @@ export const getTronSigningInputs: SigningInputsResolver<'tron'> = ({ keysignPay
   const tronSpecific = getBlockchainSpecificValue(keysignPayload.blockchainSpecific, 'tronSpecific')
 
   const memo = keysignPayload.memo ?? ''
+
+  // WithdrawExpireUnfreezeContract (Stake 2.0) claims every matured
+  // unfreezing entry for the owner. The contract has no destination, amount,
+  // or resource fields, so the keysign payload carries an exact internal memo
+  // marker and a display-only amount. Fail closed on any marker collision
+  // instead of silently replacing another transaction shape with this claim.
+  if (memo.startsWith(withdrawExpireUnfreezeMemo)) {
+    const coin = shouldBePresent(keysignPayload.coin)
+    const ownerAddress = shouldBePresent(coin.address)
+    const isNativeTrx =
+      coin.chain === Chain.Tron && coin.ticker === 'TRX' && coin.isNativeToken && !coin.contractAddress
+    const hasAlternatePayload =
+      keysignPayload.contractPayload.case !== undefined || keysignPayload.swapPayload.case !== undefined
+    const hasValidDisplayAmount = /^\d+$/.test(keysignPayload.toAmount)
+
+    if (
+      memo !== withdrawExpireUnfreezeMemo ||
+      !isNativeTrx ||
+      keysignPayload.toAddress !== ownerAddress ||
+      !hasValidDisplayAmount ||
+      hasAlternatePayload
+    ) {
+      throw new Error('Invalid TRON expired-unfreeze claim payload')
+    }
+
+    const input = TW.Tron.Proto.SigningInput.create({
+      transaction: TW.Tron.Proto.Transaction.create({
+        withdrawExpireUnfreeze: TW.Tron.Proto.WithdrawExpireUnfreezeContract.create({
+          ownerAddress,
+        }),
+        timestamp: Long.fromString(tronSpecific.timestamp.toString()),
+        expiration: Long.fromString(tronSpecific.expiration.toString()),
+        feeLimit: Long.ZERO,
+        blockHeader: createTronBlockHeader(tronSpecific),
+      }),
+    })
+
+    return [input]
+  }
 
   // FreezeBalanceV2 (Stake 2.0) — dispatch based on memo prefix
   if (memo.startsWith('FREEZE:')) {

--- a/packages/core/mpc/package.json
+++ b/packages/core/mpc/package.json
@@ -1093,7 +1093,7 @@
     "@mysten/sui": "^2.22.1",
     "@noble/hashes": "^2.2.0",
     "@solana/web3.js": "^1.98.4",
-    "@trustwallet/wallet-core": "^4.7.0",
+    "@trustwallet/wallet-core": "^4.7.3",
     "@vultisig/core-chain": "4.0.0",
     "@vultisig/core-config": "0.9.1",
     "@vultisig/lib-dkls": "0.9.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -323,7 +323,7 @@
     "@solana/web3.js": "^1.98.4",
     "@ton/core": "^0.63.1",
     "@ton/crypto": "^3.3.0",
-    "@trustwallet/wallet-core": "^4.7.0",
+    "@trustwallet/wallet-core": "^4.7.3",
     "@vultisig/lib-dkls": "workspace:*",
     "@vultisig/lib-mldsa": "workspace:*",
     "@vultisig/lib-schnorr": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6165,12 +6165,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@trustwallet/wallet-core@npm:^4.7.0":
-  version: 4.7.0
-  resolution: "@trustwallet/wallet-core@npm:4.7.0"
+"@trustwallet/wallet-core@npm:^4.7.3":
+  version: 4.7.3
+  resolution: "@trustwallet/wallet-core@npm:4.7.3"
   dependencies:
     protobufjs: "npm:>=6.11.3"
-  checksum: 10c0/b40814760940e40f2a907364440c70be6b2d2dcdb5be2ef270ffc66909642d07dcdb24d644f750ccabfe5dfd5a8756cce95ae24ea88c442adfaf633b700f6ef3
+  checksum: 10c0/c7692400bc1dabfe0e7bdd8e868dc534294cd0c6c249abcf51a6765d0f3c61a94e346750eb1c14adb3f2767f35543c38774fa3e7beb775e848e24ee08c0254a7
   languageName: node
   linkType: hard
 
@@ -7057,7 +7057,7 @@ __metadata:
     "@solana/web3.js": "npm:^1.98.4"
     "@ton/core": "npm:^0.63.1"
     "@ton/crypto": "npm:^3.3.0"
-    "@trustwallet/wallet-core": "npm:^4.7.0"
+    "@trustwallet/wallet-core": "npm:^4.7.3"
     "@vultisig/core-config": "npm:0.9.1"
     "@vultisig/lib-utils": "npm:0.10.6"
     bip32: "npm:^5.0.1"
@@ -7091,7 +7091,7 @@ __metadata:
     "@mysten/sui": "npm:^2.22.1"
     "@noble/hashes": "npm:^2.2.0"
     "@solana/web3.js": "npm:^1.98.4"
-    "@trustwallet/wallet-core": "npm:^4.7.0"
+    "@trustwallet/wallet-core": "npm:^4.7.3"
     "@vultisig/core-chain": "npm:4.0.0"
     "@vultisig/core-config": "npm:0.9.1"
     "@vultisig/lib-dkls": "npm:0.9.0"
@@ -7314,7 +7314,7 @@ __metadata:
     "@solana/web3.js": "npm:^1.98.4"
     "@ton/core": "npm:^0.63.1"
     "@ton/crypto": "npm:^3.3.0"
-    "@trustwallet/wallet-core": "npm:^4.7.0"
+    "@trustwallet/wallet-core": "npm:^4.7.3"
     "@types/chrome": "npm:^0.2.2"
     "@types/events": "npm:^3"
     "@types/node": "npm:^26.1.1"


### PR DESCRIPTION
Adds strict owner-only native TRX `WITHDRAW_EXPIRE_UNFREEZE` serialization, validates destination and display amounts without leaking them into the contract, upgrades WalletCore to 4.7.3, and covers the actual built core-mpc CLI replay with deterministic tests.

Supports https://github.com/vultisig/vultisig-windows/issues/4678 as a cross-repository SDK dependency; the Windows implementation and live-chain QA remain separate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for signing TRON Stake 2.0 expired-unfreeze withdrawal transactions.
  * Added validation for native TRX withdrawal details, recipients, amounts, and transaction metadata.

* **Bug Fixes**
  * Improved handling of invalid or mismatched TRON withdrawal payloads.

* **Chores**
  * Updated WalletCore support to version 4.7.3 for improved transaction compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->