### PR TITLE
feat(sdk): export numeric EVM chain ID

### DIFF
--- a/.changeset/stable-numeric-evm-chain-id.md
+++ b/.changeset/stable-numeric-evm-chain-id.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/sdk': patch
+---
+
+Export `getEvmNumericChainId` from the SDK root and React Native public entries. The accessor is derived from the canonical EVM chain registry, and the React Native transaction builder now consumes it instead of maintaining a duplicate numeric chain-id table.

--- a/packages/core/chain/chains/evm/chainInfo.ts
+++ b/packages/core/chain/chains/evm/chainInfo.ts
@@ -102,7 +102,8 @@ const evmDefaultChainInfo: Record<EvmChain, ViemChain> = {
   [EvmChain.Robinhood]: robinhood,
 }
 
-const evmChainId: Record<EvmChain, string> = recordMap(evmDefaultChainInfo, chain => numberToHex(chain.id))
+const evmNumericChainId: Record<EvmChain, number> = recordMap(evmDefaultChainInfo, chain => chain.id)
+const evmChainId: Record<EvmChain, string> = recordMap(evmNumericChainId, numberToHex)
 
 export const evmChainInfo = recordMap(evmDefaultChainInfo, (chain, chainKey) => {
   const rpcUrl = evmChainRpcUrls[chainKey]
@@ -125,6 +126,11 @@ export const getEvmRpcUrl = (chain: EvmChain): string => getCustomRpcOverride(ch
 
 export const getEvmChainId = (chain: EvmChain): string => {
   return evmChainId[chain]
+}
+
+/** Returns the canonical numeric EIP-155 chain ID for a supported EVM chain. */
+export const getEvmNumericChainId = (chain: EvmChain): number => {
+  return evmNumericChainId[chain]
 }
 
 export const getEvmChainByChainId = (chainId: string): EvmChain | undefined => {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -470,10 +470,15 @@ export {
 // hand-maintaining their own copies that can drift (the Hyperliquid 998/999
 // client↔server chainId bug class and the client-side fee-policy fork class).
 // Native tickers are already exported via `chainFeeCoin`. `getEvmChainId`
-// returns the hex chainId; `getEvmChainByChainId` resolves a hex chainId back to
-// its EvmChain; `getEvmRpcUrl` returns the canonical default/custom-RPC-resolved
-// endpoint for that chain.
-export { getEvmChainByChainId, getEvmChainId, getEvmRpcUrl } from '@vultisig/core-chain/chains/evm/chainInfo'
+// returns the hex chainId; `getEvmNumericChainId` returns the EIP-155 number;
+// `getEvmChainByChainId` resolves a hex chainId back to its EvmChain; and
+// `getEvmRpcUrl` returns the canonical default/custom-RPC-resolved endpoint.
+export {
+  getEvmChainByChainId,
+  getEvmChainId,
+  getEvmNumericChainId,
+  getEvmRpcUrl,
+} from '@vultisig/core-chain/chains/evm/chainInfo'
 export { clampEvmPriorityFee } from '@vultisig/core-chain/tx/fee/evm/clampEvmPriorityFee'
 
 // Noon USDC yield vault SDK boundary. Consumers should use these helpers

--- a/packages/sdk/src/platforms/react-native/chains/evm/tx.ts
+++ b/packages/sdk/src/platforms/react-native/chains/evm/tx.ts
@@ -33,34 +33,10 @@
  */
 
 import { EvmChain } from '@vultisig/core-chain/Chain'
+import { getEvmNumericChainId } from '@vultisig/core-chain/chains/evm/chainInfo'
 import { encodeFunctionData, erc20Abi, keccak256, serializeTransaction } from 'viem'
 
-// ---------------------------------------------------------------------------
-// Tx fee format — mirrors packages/core/chain/chains/evm/tx/fee/index.ts
-// ---------------------------------------------------------------------------
-
-const evmChainIds: Record<EvmChain, number> = {
-  Ethereum: 1,
-  Avalanche: 43114,
-  BSC: 56,
-  Polygon: 137,
-  Arbitrum: 42161,
-  Optimism: 10,
-  Base: 8453,
-  Blast: 81457,
-  Zksync: 324,
-  Mantle: 5000,
-  Hyperliquid: 999,
-  Sei: 1329,
-  CronosChain: 25,
-  Robinhood: 4663,
-}
-
-/**
- * Returns the numeric EVM chainId (e.g. 1 for Ethereum). For the hex-string
- * form, use `@vultisig/core-chain/chains/evm/chainInfo#getEvmChainId`.
- */
-export const getEvmNumericChainId = (chain: EvmChain): number => evmChainIds[chain]
+export { getEvmNumericChainId }
 
 // ---------------------------------------------------------------------------
 // Types

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -472,14 +472,15 @@ export {
   resolveEns,
 } from '../../tools/evm'
 
-// EVM chainId ↔ chain mapping plus the canonical priority-fee sanity clamp.
+// EVM chainId ↔ chain mapping plus the canonical numeric accessor and
+// priority-fee sanity clamp.
 // Same single source of truth exported from the generic entry (src/index.ts)
 // — the RN allow-list omitted these so RN consumers (Station) had to
 // hand-maintain their own chainId table and fee sanity policy, risking both
 // the Hyperliquid 998/999 client↔server chainId drift class and EVM fee-policy
 // forks. Pure lookup/policy helpers, no chain-client deps, so safe as static
 // re-exports.
-export { getEvmChainByChainId, getEvmChainId } from '@vultisig/core-chain/chains/evm/chainInfo'
+export { getEvmChainByChainId, getEvmChainId, getEvmNumericChainId } from '@vultisig/core-chain/chains/evm/chainInfo'
 export { clampEvmPriorityFee } from '@vultisig/core-chain/tx/fee/evm/clampEvmPriorityFee'
 
 // Gas / fee primitives (read-only — uses global `fetch` + type-only imports,

--- a/packages/sdk/tests/unit/chains/evmChainId.test.ts
+++ b/packages/sdk/tests/unit/chains/evmChainId.test.ts
@@ -3,8 +3,7 @@ import { getTwChainId } from '@vultisig/core-chain/chains/evm/tx/tw/getTwChainId
 import { beforeAll, describe, expect, it } from 'vitest'
 
 import type { EvmChain } from '../../../src'
-import { Chain, getEvmChainByChainId, getEvmChainId } from '../../../src'
-import { getEvmNumericChainId } from '../../../src/platforms/react-native/chains/evm/tx'
+import { Chain, getEvmChainByChainId, getEvmChainId, getEvmNumericChainId } from '../../../src'
 
 // Canonical EVM chainIds (numeric), the single source of truth the app and
 // agent-backend-ts previously hand-maintained as their own copies. Pinning
@@ -30,13 +29,16 @@ const CANONICAL_EVM_CHAIN_IDS = {
 } satisfies Record<EvmChain, number>
 
 describe('EVM chainId public API', () => {
-  it('exposes getEvmChainId and getEvmChainByChainId from the SDK public entry', () => {
+  it('exposes hex, numeric, and reverse chainId helpers from the SDK public entry', () => {
     expect(typeof getEvmChainId).toBe('function')
+    expect(typeof getEvmNumericChainId).toBe('function')
     expect(typeof getEvmChainByChainId).toBe('function')
   })
 
-  it('pins every EVM chainId (hex) to its canonical numeric value', () => {
+  it('pins every public numeric and hex EVM chainId to the canonical value', () => {
     for (const [chain, numericId] of Object.entries(CANONICAL_EVM_CHAIN_IDS)) {
+      expect(getEvmNumericChainId(chain as EvmChain)).toBe(numericId)
+
       const hex = getEvmChainId(chain as EvmChain)
       expect(hex.startsWith('0x')).toBe(true)
       expect(parseInt(hex, 16)).toBe(numericId)
@@ -51,7 +53,7 @@ describe('EVM chainId public API', () => {
   })
 
   it('pins the Hyperliquid mainnet chainId to 999 (not testnet 998)', () => {
-    expect(parseInt(getEvmChainId(Chain.Hyperliquid), 16)).toBe(999)
+    expect(getEvmNumericChainId(Chain.Hyperliquid)).toBe(999)
   })
 })
 
@@ -59,18 +61,15 @@ describe('EVM chainId public API', () => {
 // source. It says nothing about the chainId that actually lands in the
 // SIGNED preimage on the wallet-core path
 // (`CoinTypeExt.chainId(getCoinType(chain))`, wired through `getTwChainId`),
-// or the hand-mirrored copy the React Native tx builder keeps at
-// `platforms/react-native/chains/evm/tx.ts`. Both were previously unpinned:
-// a wrong `getCoinType` mapping, or a typo'd RN table entry, could silently
-// sign a transaction against the WRONG chainId (a replay/misdirection bug -
-// the signed tx would be valid on a DIFFERENT chain) while every display
-// surface kept showing the right value, and the suite above stayed green.
+// A wrong `getCoinType` mapping could silently sign a transaction against the
+// WRONG chainId (a replay/misdirection bug - the signed tx would be valid on a
+// DIFFERENT chain) while every display surface kept showing the right value,
+// and the suite above stayed green.
 //
-// Both loops below iterate `CANONICAL_EVM_CHAIN_IDS`, which `satisfies
+// The loop below iterates `CANONICAL_EVM_CHAIN_IDS`, which `satisfies
 // Record<EvmChain, number>` keeps exhaustive against the `EvmChain` enum at
-// compile time - a newly added EVM chain is automatically exercised by both
-// assertions the moment its canonical id is added above (and the build
-// fails if it isn't).
+// compile time - a newly added EVM chain is automatically exercised the moment
+// its canonical id is added above (and the build fails if it isn't).
 //
 // Hyperliquid and Sei aren't wallet-core-native coin types (`getCoinType`
 // maps both to `CoinType.ethereum`), so `getTwChainId` special-cases them by
@@ -87,12 +86,6 @@ describe('EVM chainId signed-preimage sources', () => {
   it('pins the wallet-core signed chainId (CoinTypeExt.chainId via getTwChainId) for every EVM chain', () => {
     for (const [chain, numericId] of Object.entries(CANONICAL_EVM_CHAIN_IDS)) {
       expect(getTwChainId({ walletCore, chain: chain as EvmChain })).toBe(String(numericId))
-    }
-  })
-
-  it('pins the React Native hand-mirrored evmChainIds table (platforms/react-native/chains/evm/tx.ts) for every EVM chain', () => {
-    for (const [chain, numericId] of Object.entries(CANONICAL_EVM_CHAIN_IDS)) {
-      expect(getEvmNumericChainId(chain as EvmChain)).toBe(numericId)
     }
   })
 })

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -552,9 +552,11 @@ describe('RN entry exposes toChainAmount + ChainAmountParseError', () => {
     const rn = await import('../../../../src/platforms/react-native/index')
 
     expect(typeof rn.getEvmChainId).toBe('function')
+    expect(typeof rn.getEvmNumericChainId).toBe('function')
     expect(typeof rn.getEvmChainByChainId).toBe('function')
     expect(typeof rn.clampEvmPriorityFee).toBe('function')
     expect(rn.getEvmChainId(rn.Chain.Ethereum)).toBe('0x1')
+    expect(rn.getEvmNumericChainId(rn.Chain.Ethereum)).toBe(1)
     expect(rn.getEvmChainByChainId('0x1')).toBe(rn.Chain.Ethereum)
     expect(
       rn.clampEvmPriorityFee(rn.Chain.Base as Parameters<typeof rn.clampEvmPriorityFee>[0], 75n * 1_000_000_000n)

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -291,10 +291,12 @@ describe('@vultisig/sdk public exports', () => {
 
   it('exports canonical EVM chain-id, RPC, and priority-fee-clamp helpers from the root sdk surface', () => {
     expect(typeof sdk.getEvmChainId).toBe('function')
+    expect(typeof sdk.getEvmNumericChainId).toBe('function')
     expect(typeof sdk.getEvmChainByChainId).toBe('function')
     expect(typeof sdk.getEvmRpcUrl).toBe('function')
     expect(typeof sdk.clampEvmPriorityFee).toBe('function')
     expect(sdk.getEvmChainId(sdk.Chain.Mantle)).toBe('0x1388')
+    expect(sdk.getEvmNumericChainId(sdk.Chain.Mantle)).toBe(5000)
     expect(sdk.getEvmChainByChainId('0x3e7')).toBe(sdk.Chain.Hyperliquid)
     expect(sdk.getEvmRpcUrl(sdk.Chain.Ethereum)).toBe('https://api.vultisig.com/eth/')
     expect(sdk.getEvmRpcUrl(sdk.Chain.Hyperliquid)).toBe('https://api.vultisig.com/hyperevm/')


### PR DESCRIPTION
Closes #2134
Exports a stable numeric EVM chain-ID canonical from the SDK and React Native entrypoints so app and backend consumers can remove duplicated local maps. The existing hex accessor now derives from the same canonical, and the React Native transaction builder consumes the shared SDK value.

Includes focused coverage for all supported EVM chains, public exports, the React Native entrypoint, and the built package. A changeset is included.

Verified on commit 7ad5c1087a5e79da99117be309950dfa723db338 with the repository quality gates and built-package runtime checks.