### PR TITLE
Add RUJI Trade swap route for RUNE and bRUNE

### DIFF
--- a/.changeset/w1-1868.md
+++ b/.changeset/w1-1868.md
@@ -1,0 +1,7 @@
+---
+'@vultisig/core-chain': minor
+'@vultisig/core-mpc': minor
+'@vultisig/sdk': minor
+---
+
+Add RUJI Trade quoting and CosmWasm execution for native RUNE and bRUNE swaps through the SDK's normal swap flow.

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -1853,6 +1853,16 @@
       "import": "./dist/swap/general/priceImpactGuard.js",
       "default": "./dist/swap/general/priceImpactGuard.js"
     },
+    "./swap/general/ruji/api/getRujiTradeSwapQuote": {
+      "types": "./dist/swap/general/ruji/api/getRujiTradeSwapQuote.d.ts",
+      "import": "./dist/swap/general/ruji/api/getRujiTradeSwapQuote.js",
+      "default": "./dist/swap/general/ruji/api/getRujiTradeSwapQuote.js"
+    },
+    "./swap/general/ruji/config": {
+      "types": "./dist/swap/general/ruji/config.d.ts",
+      "import": "./dist/swap/general/ruji/config.js",
+      "default": "./dist/swap/general/ruji/config.js"
+    },
     "./swap/general/swapkit/api/getSwapKitQuote": {
       "types": "./dist/swap/general/swapkit/api/getSwapKitQuote.d.ts",
       "import": "./dist/swap/general/swapkit/api/getSwapKitQuote.js",

--- a/packages/core/chain/swap/general/GeneralSwapProvider.ts
+++ b/packages/core/chain/swap/general/GeneralSwapProvider.ts
@@ -1,4 +1,4 @@
-export const generalSwapProviders = ['1inch', 'li.fi', 'kyber', 'swapkit', 'cowswap', 'jupiter'] as const
+export const generalSwapProviders = ['1inch', 'li.fi', 'kyber', 'swapkit', 'cowswap', 'jupiter', 'ruji'] as const
 
 export type GeneralSwapProvider = (typeof generalSwapProviders)[number]
 
@@ -9,4 +9,5 @@ export const generalSwapProviderName: Record<GeneralSwapProvider, string> = {
   swapkit: 'SwapKit',
   cowswap: 'CowSwap',
   jupiter: 'Jupiter',
+  ruji: 'RUJI Trade',
 }

--- a/packages/core/chain/swap/general/GeneralSwapQuote.ts
+++ b/packages/core/chain/swap/general/GeneralSwapQuote.ts
@@ -72,9 +72,17 @@ export type GeneralSwapTx =
         permitRequired?: true
       }
     }
+  | {
+      cosmosWasm: {
+        sender: string
+        contract: string
+        executeMsg: string
+        funds: Array<{ denom: string; amount: string }>
+      }
+    }
 
 /**
- * Quote returned by an EVM/Solana general-purpose swap aggregator.
+ * Quote returned by a general-purpose swap provider.
  *
  * Consumers building a "View on Explorer" link should call
  * `getSwapExplorerUrl({ provider, txHash, fromChain })` from
@@ -87,6 +95,8 @@ export type GeneralSwapQuote = {
   dstAmount: string
   provider: GeneralSwapProvider
   routeProvider?: string
+  /** Absolute provider quote expiry in milliseconds, when supplied. */
+  expiresAt?: number
   /**
    * Signed price impact of the route as a FRACTION, not a percent: `0.0133`
    * means 1.33% of output lost, and a negative value is a favorable trade.

--- a/packages/core/chain/swap/general/ruji/api/getRujiTradeSwapQuote.test.ts
+++ b/packages/core/chain/swap/general/ruji/api/getRujiTradeSwapQuote.test.ts
@@ -92,6 +92,41 @@ describe('getRujiTradeSwapQuote', () => {
     ).rejects.toThrow('contract config does not match')
   })
 
+  it('fails closed when discovery returns duplicate FIN denominations', async () => {
+    vi.mocked(queryUrl)
+      .mockResolvedValueOnce(marketResponse)
+      .mockResolvedValueOnce({ data: { denoms: ['rune', 'rune'] } })
+      .mockResolvedValueOnce({ data: { returned: '998124', fee: '1500' } })
+
+    await expect(
+      getRujiTradeSwapQuote({ from: rune, to: brune, amount: 1_000_000n, destination: address })
+    ).rejects.toThrow('contract config does not match')
+  })
+
+  it('normalizes validated THORChain addresses before building the route', async () => {
+    vi.mocked(queryUrl)
+      .mockResolvedValueOnce({
+        data: { fin: [{ ...marketResponse.data.fin[0], address: ` ${address} ` }] },
+      })
+      .mockResolvedValueOnce({ data: { denoms: ['x/brune', 'rune'] } })
+      .mockResolvedValueOnce({ data: { returned: '998124', fee: '1500' } })
+
+    const quote = await getRujiTradeSwapQuote({
+      from: { ...rune, address: ` ${address} ` },
+      to: brune,
+      amount: 1_000_000n,
+      destination: ` ${address} `,
+    })
+
+    expect(quote.tx).toMatchObject({
+      cosmosWasm: {
+        sender: address,
+        contract: address,
+        executeMsg: JSON.stringify({ swap: { min: { min_return: '988142', to: address } } }),
+      },
+    })
+  })
+
   it('recognizes only the two supported THORChain assets', () => {
     expect(isRujiTradeSwapPair(rune, brune)).toBe(true)
     expect(isRujiTradeSwapPair(brune, rune)).toBe(true)

--- a/packages/core/chain/swap/general/ruji/api/getRujiTradeSwapQuote.test.ts
+++ b/packages/core/chain/swap/general/ruji/api/getRujiTradeSwapQuote.test.ts
@@ -103,6 +103,16 @@ describe('getRujiTradeSwapQuote', () => {
     ).rejects.toThrow('contract config does not match')
   })
 
+  it('fails closed when discovery returns a valid but untrusted FIN contract', async () => {
+    vi.mocked(queryUrl).mockResolvedValueOnce({
+      data: { fin: [{ ...marketResponse.data.fin[0], address: 'thor12a9rpf9u2ulwuezxkh6uas4au7xnde8umdua5t' }] },
+    })
+
+    await expect(
+      getRujiTradeSwapQuote({ from: rune, to: brune, amount: 1_000_000n, destination: address })
+    ).rejects.toThrow('untrusted RUNE ↔ bRUNE FIN contract')
+  })
+
   it('normalizes validated THORChain addresses before building the route', async () => {
     vi.mocked(queryUrl)
       .mockResolvedValueOnce({

--- a/packages/core/chain/swap/general/ruji/api/getRujiTradeSwapQuote.test.ts
+++ b/packages/core/chain/swap/general/ruji/api/getRujiTradeSwapQuote.test.ts
@@ -113,6 +113,24 @@ describe('getRujiTradeSwapQuote', () => {
     ).rejects.toThrow('untrusted RUNE ↔ bRUNE FIN contract')
   })
 
+  it('selects the pinned market when an untrusted pair match is returned first', async () => {
+    vi.mocked(queryUrl)
+      .mockResolvedValueOnce({
+        data: {
+          fin: [
+            { ...marketResponse.data.fin[0], address: 'thor12a9rpf9u2ulwuezxkh6uas4au7xnde8umdua5t' },
+            marketResponse.data.fin[0],
+          ],
+        },
+      })
+      .mockResolvedValueOnce({ data: { denoms: ['x/brune', 'rune'] } })
+      .mockResolvedValueOnce({ data: { returned: '998124', fee: '1500' } })
+
+    await expect(
+      getRujiTradeSwapQuote({ from: rune, to: brune, amount: 1_000_000n, destination: address })
+    ).resolves.toMatchObject({ tx: { cosmosWasm: { contract: address } } })
+  })
+
   it('normalizes validated THORChain addresses before building the route', async () => {
     vi.mocked(queryUrl)
       .mockResolvedValueOnce({

--- a/packages/core/chain/swap/general/ruji/api/getRujiTradeSwapQuote.test.ts
+++ b/packages/core/chain/swap/general/ruji/api/getRujiTradeSwapQuote.test.ts
@@ -1,0 +1,119 @@
+import { toBech32 } from '@cosmjs/encoding'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getRujiTradeSwapQuote, isRujiTradeSwapPair } from './getRujiTradeSwapQuote'
+
+vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({ queryUrl: vi.fn() }))
+
+const address = 'thor1vk6trmz42cjrh4zcxczeaacnsv3snv4f22x8ccu203dqde7vtaxsyevlec'
+const rune: AccountCoin = {
+  chain: Chain.THORChain,
+  address,
+  ticker: 'RUNE',
+  decimals: 8,
+}
+const brune: AccountCoin = {
+  chain: Chain.THORChain,
+  address,
+  id: 'x/brune',
+  ticker: 'bRUNE',
+  decimals: 8,
+}
+
+const marketResponse = {
+  data: {
+    fin: [
+      {
+        address,
+        assetBase: { asset: 'x/brune' },
+        assetQuote: { asset: 'THOR.RUNE' },
+      },
+    ],
+  },
+}
+
+const decodeSmartQuery = (url: string): unknown => {
+  const encoded = url.split('/smart/')[1]
+  return JSON.parse(Buffer.from(encoded, 'base64').toString('utf8'))
+}
+
+describe('getRujiTradeSwapQuote', () => {
+  beforeEach(() => {
+    vi.mocked(queryUrl).mockReset()
+  })
+
+  it.each([
+    { label: 'RUNE → bRUNE', from: rune, to: brune, denom: 'rune' },
+    { label: 'bRUNE → RUNE', from: brune, to: rune, denom: 'x/brune' },
+  ])('builds a guarded FIN CosmWasm route for $label', async ({ from, to, denom }) => {
+    vi.mocked(queryUrl)
+      .mockResolvedValueOnce(marketResponse)
+      .mockResolvedValueOnce({ data: { denoms: ['x/brune', 'rune'] } })
+      .mockResolvedValueOnce({ data: { returned: '998124', fee: '1500' } })
+
+    const quote = await getRujiTradeSwapQuote({
+      from,
+      to,
+      amount: 1_000_000n,
+      destination: address,
+      slippageBps: 250,
+    })
+
+    expect(quote.provider).toBe('ruji')
+    expect(quote.dstAmount).toBe('998124')
+    expect(quote.tx).toEqual({
+      cosmosWasm: {
+        sender: address,
+        contract: address,
+        executeMsg: JSON.stringify({
+          swap: { min: { min_return: '973170', to: address } },
+        }),
+        funds: [{ denom, amount: '1000000' }],
+      },
+    })
+
+    expect(decodeSmartQuery(String(vi.mocked(queryUrl).mock.calls[1][0]))).toEqual({ config: {} })
+    expect(decodeSmartQuery(String(vi.mocked(queryUrl).mock.calls[2][0]))).toEqual({
+      simulate: { denom, amount: '1000000' },
+    })
+  })
+
+  it('fails closed when discovery points at a contract whose denoms are not the bRUNE/RUNE pair', async () => {
+    vi.mocked(queryUrl)
+      .mockResolvedValueOnce(marketResponse)
+      .mockResolvedValueOnce({ data: { denoms: ['x/brune', 'x/ruji'] } })
+      .mockResolvedValueOnce({ data: { returned: '998124', fee: '1500' } })
+
+    await expect(
+      getRujiTradeSwapQuote({ from: rune, to: brune, amount: 1_000_000n, destination: address })
+    ).rejects.toThrow('contract config does not match')
+  })
+
+  it('recognizes only the two supported THORChain assets', () => {
+    expect(isRujiTradeSwapPair(rune, brune)).toBe(true)
+    expect(isRujiTradeSwapPair(brune, rune)).toBe(true)
+    expect(
+      isRujiTradeSwapPair(rune, {
+        ...brune,
+        id: 'x/ruji',
+        ticker: 'RUJI',
+      })
+    ).toBe(false)
+  })
+
+  it('rejects a checksummed THOR address with a noncanonical payload length', async () => {
+    const invalidAddress = toBech32('thor', new Uint8Array(10).fill(1))
+
+    await expect(
+      getRujiTradeSwapQuote({
+        from: { ...rune, address: invalidAddress },
+        to: brune,
+        amount: 1_000_000n,
+        destination: address,
+      })
+    ).rejects.toThrow('sender must be a valid THORChain address')
+  })
+})

--- a/packages/core/chain/swap/general/ruji/api/getRujiTradeSwapQuote.ts
+++ b/packages/core/chain/swap/general/ruji/api/getRujiTradeSwapQuote.ts
@@ -66,15 +66,19 @@ export const isRujiTradeSwapPair = (from: AccountCoin, to: AccountCoin): boolean
   return !!fromAsset && !!toAsset && fromAsset !== toAsset
 }
 
-const assertThorAddress = (address: string, label: string): void => {
+const assertThorAddress = (address: string, label: string): string => {
+  const normalized = address.trim()
+
   try {
-    const decoded = fromBech32(address.trim())
+    const decoded = fromBech32(normalized)
     if (decoded.prefix !== 'thor' || (decoded.data.length !== 20 && decoded.data.length !== 32)) {
       throw new Error('wrong prefix')
     }
   } catch {
     throw new Error(`RUJI Trade ${label} must be a valid THORChain address.`)
   }
+
+  return normalized
 }
 
 const assertUnsignedInteger = (value: string | undefined, label: string): string => {
@@ -106,8 +110,7 @@ const findFinMarket = async (fromAsset: RujiTradeAsset, toAsset: RujiTradeAsset)
     throw new Error(`No RUJI Trade FIN market found for ${fromAsset.quoteAsset} ↔ ${toAsset.quoteAsset}.`)
   }
 
-  assertThorAddress(market.address, 'market contract')
-  return market
+  return { ...market, address: assertThorAddress(market.address, 'market contract') }
 }
 
 const calculateMinimumOutput = (expectedOutput: string, slippageBps: number): string => {
@@ -146,8 +149,8 @@ export const getRujiTradeSwapQuote = async ({
   if (!Number.isInteger(slippageBps) || slippageBps < 0 || slippageBps > 5_000) {
     throw new Error('RUJI Trade slippage must be an integer between 0 and 5000 basis points.')
   }
-  assertThorAddress(from.address, 'sender')
-  assertThorAddress(destination, 'destination')
+  const sender = assertThorAddress(from.address, 'sender')
+  const normalizedDestination = assertThorAddress(destination, 'destination')
 
   const market = await findFinMarket(fromAsset, toAsset)
   const configUrl = getCosmosWasmSmartQueryUrl({ chain: Chain.THORChain, id: market.address }, { config: {} })
@@ -163,7 +166,12 @@ export const getRujiTradeSwapQuote = async ({
 
   const denoms = configResponse.data?.denoms?.map(denom => denom.toLowerCase())
   const expectedDenoms = new Set<string>([rujiTradeAsset.rune.finDenom, rujiTradeAsset.brune.finDenom])
-  if (!denoms || denoms.length !== expectedDenoms.size || !denoms.every(denom => expectedDenoms.has(denom))) {
+  const actualDenoms = denoms ? new Set(denoms) : undefined
+  if (
+    !actualDenoms ||
+    actualDenoms.size !== expectedDenoms.size ||
+    ![...actualDenoms].every(denom => expectedDenoms.has(denom))
+  ) {
     throw new Error('RUJI Trade FIN contract config does not match the RUNE ↔ bRUNE market.')
   }
 
@@ -177,7 +185,7 @@ export const getRujiTradeSwapQuote = async ({
     swap: {
       min: {
         min_return: calculateMinimumOutput(expectedOutput, slippageBps),
-        to: destination,
+        to: normalizedDestination,
       },
     },
   })
@@ -188,7 +196,7 @@ export const getRujiTradeSwapQuote = async ({
     expiresAt: Date.now() + rujiTradeQuoteTtlMs,
     tx: {
       cosmosWasm: {
-        sender: from.address,
+        sender,
         contract: market.address,
         executeMsg,
         funds: [{ denom: fromAsset.finDenom, amount: amount.toString() }],

--- a/packages/core/chain/swap/general/ruji/api/getRujiTradeSwapQuote.ts
+++ b/packages/core/chain/swap/general/ruji/api/getRujiTradeSwapQuote.ts
@@ -102,20 +102,22 @@ const findFinMarket = async (fromAsset: RujiTradeAsset, toAsset: RujiTradeAsset)
   }
 
   const expected = new Set([fromAsset.quoteAsset.toLowerCase(), toAsset.quoteAsset.toLowerCase()])
-  const market = response.data?.fin?.find(candidate => {
+  const matchingMarkets = response.data?.fin?.filter(candidate => {
     const actual = new Set([candidate.assetBase.asset.toLowerCase(), candidate.assetQuote.asset.toLowerCase()])
     return actual.size === expected.size && [...actual].every(asset => expected.has(asset))
   })
+  const market = matchingMarkets?.find(
+    candidate => candidate.address.trim().toLowerCase() === rujiTradeRuneBruneMarketContract
+  )
 
   if (!market) {
+    if (matchingMarkets?.length) {
+      throw new Error('RUJI Trade market discovery returned an untrusted RUNE ↔ bRUNE FIN contract.')
+    }
     throw new Error(`No RUJI Trade FIN market found for ${fromAsset.quoteAsset} ↔ ${toAsset.quoteAsset}.`)
   }
 
   const address = assertThorAddress(market.address, 'market contract')
-  if (address.toLowerCase() !== rujiTradeRuneBruneMarketContract) {
-    throw new Error('RUJI Trade market discovery returned an untrusted RUNE ↔ bRUNE FIN contract.')
-  }
-
   return { ...market, address }
 }
 

--- a/packages/core/chain/swap/general/ruji/api/getRujiTradeSwapQuote.ts
+++ b/packages/core/chain/swap/general/ruji/api/getRujiTradeSwapQuote.ts
@@ -1,0 +1,198 @@
+import { fromBech32 } from '@cosmjs/encoding'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { getCosmosWasmSmartQueryUrl } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
+import { rujiraGraphQlEndpoint } from '@vultisig/core-chain/chains/cosmos/thor/rujira/config'
+import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+import { GeneralSwapQuote } from '@vultisig/core-chain/swap/general/GeneralSwapQuote'
+import {
+  rujiTradeAsset,
+  rujiTradeDefaultSlippageBps,
+  rujiTradeQuoteTtlMs,
+} from '@vultisig/core-chain/swap/general/ruji/config'
+import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+
+type FinMarket = {
+  address: string
+  assetBase: { asset: string }
+  assetQuote: { asset: string }
+}
+
+type FinGraphQlResponse = {
+  data?: { fin?: FinMarket[] }
+  errors?: Array<{ message?: string }>
+}
+
+type SmartQueryResponse<T> = { data?: T }
+
+type FinConfig = {
+  denoms?: string[]
+}
+
+type FinSimulation = {
+  returned?: string
+  fee?: string
+}
+
+type RujiTradeAsset = (typeof rujiTradeAsset)[keyof typeof rujiTradeAsset]
+
+const finMarketsQuery = `
+  query FinMarkets {
+    fin {
+      address
+      assetBase { asset }
+      assetQuote { asset }
+    }
+  }
+`
+
+const getRujiTradeAsset = (coin: AccountCoin): RujiTradeAsset | null => {
+  if (coin.chain !== Chain.THORChain) return null
+
+  if (coin.id?.toLowerCase() === rujiTradeAsset.brune.finDenom) {
+    return rujiTradeAsset.brune
+  }
+
+  if (coin.id === undefined && coin.ticker.toUpperCase() === 'RUNE') {
+    return rujiTradeAsset.rune
+  }
+
+  return null
+}
+
+export const isRujiTradeSwapPair = (from: AccountCoin, to: AccountCoin): boolean => {
+  const fromAsset = getRujiTradeAsset(from)
+  const toAsset = getRujiTradeAsset(to)
+
+  return !!fromAsset && !!toAsset && fromAsset !== toAsset
+}
+
+const assertThorAddress = (address: string, label: string): void => {
+  try {
+    const decoded = fromBech32(address.trim())
+    if (decoded.prefix !== 'thor' || (decoded.data.length !== 20 && decoded.data.length !== 32)) {
+      throw new Error('wrong prefix')
+    }
+  } catch {
+    throw new Error(`RUJI Trade ${label} must be a valid THORChain address.`)
+  }
+}
+
+const assertUnsignedInteger = (value: string | undefined, label: string): string => {
+  if (!value || !/^\d+$/.test(value)) {
+    throw new Error(`RUJI Trade returned an invalid ${label}.`)
+  }
+
+  return value
+}
+
+const findFinMarket = async (fromAsset: RujiTradeAsset, toAsset: RujiTradeAsset): Promise<FinMarket> => {
+  const response = await queryUrl<FinGraphQlResponse>(rujiraGraphQlEndpoint, {
+    body: { query: finMarketsQuery },
+  })
+
+  if (response.errors?.length) {
+    throw new Error(
+      `RUJI Trade market discovery failed: ${response.errors.map(error => error.message ?? 'unknown error').join('; ')}`
+    )
+  }
+
+  const expected = new Set([fromAsset.quoteAsset.toLowerCase(), toAsset.quoteAsset.toLowerCase()])
+  const market = response.data?.fin?.find(candidate => {
+    const actual = new Set([candidate.assetBase.asset.toLowerCase(), candidate.assetQuote.asset.toLowerCase()])
+    return actual.size === expected.size && [...actual].every(asset => expected.has(asset))
+  })
+
+  if (!market) {
+    throw new Error(`No RUJI Trade FIN market found for ${fromAsset.quoteAsset} ↔ ${toAsset.quoteAsset}.`)
+  }
+
+  assertThorAddress(market.address, 'market contract')
+  return market
+}
+
+const calculateMinimumOutput = (expectedOutput: string, slippageBps: number): string => {
+  const minimumOutput = (BigInt(expectedOutput) * BigInt(10_000 - slippageBps)) / 10_000n
+  if (minimumOutput <= 0n) {
+    throw new Error('RUJI Trade quote is too small to retain a non-zero slippage guard.')
+  }
+
+  return minimumOutput.toString()
+}
+
+export type GetRujiTradeSwapQuoteInput = {
+  from: AccountCoin
+  to: AccountCoin
+  amount: bigint
+  destination: string
+  slippageBps?: number
+}
+
+export const getRujiTradeSwapQuote = async ({
+  from,
+  to,
+  amount,
+  destination,
+  slippageBps = rujiTradeDefaultSlippageBps,
+}: GetRujiTradeSwapQuoteInput): Promise<GeneralSwapQuote> => {
+  const fromAsset = getRujiTradeAsset(from)
+  const toAsset = getRujiTradeAsset(to)
+
+  if (!fromAsset || !toAsset || fromAsset === toAsset) {
+    throw new Error('RUJI Trade only supports THORChain RUNE ↔ bRUNE swaps.')
+  }
+  if (amount <= 0n) {
+    throw new Error('RUJI Trade swap amount must be greater than zero.')
+  }
+  if (!Number.isInteger(slippageBps) || slippageBps < 0 || slippageBps > 5_000) {
+    throw new Error('RUJI Trade slippage must be an integer between 0 and 5000 basis points.')
+  }
+  assertThorAddress(from.address, 'sender')
+  assertThorAddress(destination, 'destination')
+
+  const market = await findFinMarket(fromAsset, toAsset)
+  const configUrl = getCosmosWasmSmartQueryUrl({ chain: Chain.THORChain, id: market.address }, { config: {} })
+  const simulationUrl = getCosmosWasmSmartQueryUrl(
+    { chain: Chain.THORChain, id: market.address },
+    { simulate: { denom: fromAsset.finDenom, amount: amount.toString() } }
+  )
+
+  const [configResponse, simulationResponse] = await Promise.all([
+    queryUrl<SmartQueryResponse<FinConfig>>(configUrl),
+    queryUrl<SmartQueryResponse<FinSimulation>>(simulationUrl),
+  ])
+
+  const denoms = configResponse.data?.denoms?.map(denom => denom.toLowerCase())
+  const expectedDenoms = new Set<string>([rujiTradeAsset.rune.finDenom, rujiTradeAsset.brune.finDenom])
+  if (!denoms || denoms.length !== expectedDenoms.size || !denoms.every(denom => expectedDenoms.has(denom))) {
+    throw new Error('RUJI Trade FIN contract config does not match the RUNE ↔ bRUNE market.')
+  }
+
+  const expectedOutput = assertUnsignedInteger(simulationResponse.data?.returned, 'simulated output')
+  assertUnsignedInteger(simulationResponse.data?.fee, 'protocol fee')
+  if (BigInt(expectedOutput) <= 0n) {
+    throw new Error('RUJI Trade returned a zero-output quote.')
+  }
+
+  const executeMsg = JSON.stringify({
+    swap: {
+      min: {
+        min_return: calculateMinimumOutput(expectedOutput, slippageBps),
+        to: destination,
+      },
+    },
+  })
+
+  return {
+    dstAmount: expectedOutput,
+    provider: 'ruji',
+    expiresAt: Date.now() + rujiTradeQuoteTtlMs,
+    tx: {
+      cosmosWasm: {
+        sender: from.address,
+        contract: market.address,
+        executeMsg,
+        funds: [{ denom: fromAsset.finDenom, amount: amount.toString() }],
+      },
+    },
+  }
+}

--- a/packages/core/chain/swap/general/ruji/api/getRujiTradeSwapQuote.ts
+++ b/packages/core/chain/swap/general/ruji/api/getRujiTradeSwapQuote.ts
@@ -8,6 +8,7 @@ import {
   rujiTradeAsset,
   rujiTradeDefaultSlippageBps,
   rujiTradeQuoteTtlMs,
+  rujiTradeRuneBruneMarketContract,
 } from '@vultisig/core-chain/swap/general/ruji/config'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
@@ -110,7 +111,12 @@ const findFinMarket = async (fromAsset: RujiTradeAsset, toAsset: RujiTradeAsset)
     throw new Error(`No RUJI Trade FIN market found for ${fromAsset.quoteAsset} ↔ ${toAsset.quoteAsset}.`)
   }
 
-  return { ...market, address: assertThorAddress(market.address, 'market contract') }
+  const address = assertThorAddress(market.address, 'market contract')
+  if (address.toLowerCase() !== rujiTradeRuneBruneMarketContract) {
+    throw new Error('RUJI Trade market discovery returned an untrusted RUNE ↔ bRUNE FIN contract.')
+  }
+
+  return { ...market, address }
 }
 
 const calculateMinimumOutput = (expectedOutput: string, slippageBps: number): string => {

--- a/packages/core/chain/swap/general/ruji/config.ts
+++ b/packages/core/chain/swap/general/ruji/config.ts
@@ -1,0 +1,19 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+
+export const rujiTradeSwapEnabledChains = [Chain.THORChain] as const
+
+export const rujiTradeAsset = {
+  rune: {
+    quoteAsset: 'THOR.RUNE',
+    finDenom: 'rune',
+  },
+  brune: {
+    quoteAsset: 'x/brune',
+    finDenom: 'x/brune',
+  },
+} as const
+
+export const rujiTradeDefaultSlippageBps = 100
+// RUJI's native swap module treats a two-minute quote as non-executable during its final minute.
+// Expose that same effective signing window so callers refresh before the safety buffer begins.
+export const rujiTradeQuoteTtlMs = 60_000

--- a/packages/core/chain/swap/general/ruji/config.ts
+++ b/packages/core/chain/swap/general/ruji/config.ts
@@ -2,6 +2,9 @@ import { Chain } from '@vultisig/core-chain/Chain'
 
 export const rujiTradeSwapEnabledChains = [Chain.THORChain] as const
 
+/** Supported FIN market for the only supported RUJI Trade pair: THOR.RUNE ↔ x/brune. */
+export const rujiTradeRuneBruneMarketContract = 'thor1vk6trmz42cjrh4zcxczeaacnsv3snv4f22x8ccu203dqde7vtaxsyevlec'
+
 export const rujiTradeAsset = {
   rune: {
     quoteAsset: 'THOR.RUNE',

--- a/packages/core/chain/swap/keysign/getSwapDestinationAddress.test.ts
+++ b/packages/core/chain/swap/keysign/getSwapDestinationAddress.test.ts
@@ -78,4 +78,26 @@ describe('getSwapDestinationAddress', () => {
 
     expect(getSwapDestinationAddress({ quote, fromCoin })).toBe('bc1qdeposit')
   })
+
+  it('returns the FIN contract for RUJI Trade CosmWasm routes', () => {
+    const quote: SwapQuote = {
+      discounts: [],
+      quote: {
+        general: {
+          dstAmount: '998124',
+          provider: 'ruji',
+          tx: {
+            cosmosWasm: {
+              sender: 'thor1sender',
+              contract: 'thor1fincontract',
+              executeMsg: '{"swap":{}}',
+              funds: [{ denom: 'rune', amount: '1000000' }],
+            },
+          },
+        },
+      },
+    }
+
+    expect(getSwapDestinationAddress({ quote, fromCoin })).toBe('thor1fincontract')
+  })
 })

--- a/packages/core/chain/swap/keysign/getSwapDestinationAddress.ts
+++ b/packages/core/chain/swap/keysign/getSwapDestinationAddress.ts
@@ -20,6 +20,7 @@ export const getSwapDestinationAddress = ({ quote, fromCoin }: GetSwapDestinatio
         evm: ({ to }) => to,
         solana: () => '',
         transfer: ({ to }) => to,
+        cosmosWasm: ({ contract }) => contract,
         // CowSwap orders are settled by the solver network. The destination
         // address used for ERC-20 allowance checks (build.ts spender) must be
         // the GPv2VaultRelayer contract — NOT the settlement contract or empty

--- a/packages/core/chain/swap/quote/SwapQuote.ts
+++ b/packages/core/chain/swap/quote/SwapQuote.ts
@@ -16,6 +16,8 @@ export type SwapQuoteResult = {
 export type SwapQuote = {
   quote: SwapQuoteResult
   discounts: SwapDiscount[]
+  /** Effective output recipient bound by `findSwapQuote`. Absent on legacy/manually constructed quotes. */
+  recipient?: string
   /** Source amount, in base units, bound by `findSwapQuote`. Absent on legacy/manually constructed quotes. */
   requestedAmount?: bigint
   /** Absolute quote expiry in milliseconds, bound by `findSwapQuote`. Absent on legacy/manually constructed quotes. */

--- a/packages/core/chain/swap/quote/findSwapQuote.ranked.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ranked.test.ts
@@ -110,6 +110,7 @@ describe('findSwapQuotes ranked candidate set', () => {
       expect(quote.safetyFingerprint).toBe(
         getSwapQuoteSafetyFingerprint({
           ...evmSameChainCoins,
+          recipient: evmSameChainCoins.to.address,
           requestedAmount,
           expiresAt: quote.expiresAt,
           quote: quote.quote,

--- a/packages/core/chain/swap/quote/findSwapQuote.ruji.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ruji.test.ts
@@ -1,0 +1,105 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+import { GeneralSwapQuote } from '@vultisig/core-chain/swap/general/GeneralSwapQuote'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getRujiTradeSwapQuote: vi.fn(),
+  getNativeSwapQuote: vi.fn(),
+  getNativeSwapMinAmountIn: vi.fn(),
+  getNativeSwapTradingHalt: vi.fn(),
+}))
+
+vi.mock('@vultisig/core-chain/swap/general/ruji/api/getRujiTradeSwapQuote', async importOriginal => ({
+  ...(await importOriginal<typeof import('@vultisig/core-chain/swap/general/ruji/api/getRujiTradeSwapQuote')>()),
+  getRujiTradeSwapQuote: mocks.getRujiTradeSwapQuote,
+}))
+vi.mock('@vultisig/core-chain/swap/native/api/getNativeSwapQuote', () => ({
+  getNativeSwapQuote: mocks.getNativeSwapQuote,
+}))
+vi.mock('@vultisig/core-chain/swap/native/minimum/getNativeSwapMinAmountIn', () => ({
+  getNativeSwapMinAmountIn: mocks.getNativeSwapMinAmountIn,
+}))
+vi.mock('@vultisig/core-chain/swap/native/halts/getNativeSwapTradingHalt', () => ({
+  getNativeSwapTradingHalt: mocks.getNativeSwapTradingHalt,
+}))
+
+import { findSwapQuotes } from './findSwapQuote'
+
+const address = 'thor1vk6trmz42cjrh4zcxczeaacnsv3snv4f22x8ccu203dqde7vtaxsyevlec'
+const rune: AccountCoin = {
+  chain: Chain.THORChain,
+  address,
+  ticker: 'RUNE',
+  decimals: 8,
+}
+const brune: AccountCoin = {
+  chain: Chain.THORChain,
+  address,
+  id: 'x/brune',
+  ticker: 'bRUNE',
+  decimals: 8,
+}
+
+const quoteFor = (from: AccountCoin): GeneralSwapQuote => ({
+  provider: 'ruji',
+  dstAmount: '998124',
+  expiresAt: Date.now() + 120_000,
+  tx: {
+    cosmosWasm: {
+      sender: from.address,
+      contract: address,
+      executeMsg: JSON.stringify({ swap: { min: { min_return: '988142', to: address } } }),
+      funds: [{ denom: from.id === 'x/brune' ? 'x/brune' : 'rune', amount: '1000000' }],
+    },
+  },
+})
+
+describe('findSwapQuotes RUJI Trade routing', () => {
+  beforeEach(() => {
+    mocks.getRujiTradeSwapQuote.mockReset()
+    mocks.getNativeSwapQuote.mockReset().mockRejectedValue(new Error('pool does not exist'))
+    mocks.getNativeSwapMinAmountIn.mockReset().mockResolvedValue(null)
+    mocks.getNativeSwapTradingHalt.mockReset().mockResolvedValue(null)
+  })
+
+  it.each([
+    { label: 'RUNE → bRUNE', from: rune, to: brune },
+    { label: 'bRUNE → RUNE', from: brune, to: rune },
+  ])('registers RUJI Trade in the normal quote flow for $label', async ({ from, to }) => {
+    mocks.getRujiTradeSwapQuote.mockResolvedValueOnce(quoteFor(from))
+
+    const result = await findSwapQuotes({
+      from,
+      to,
+      amount: 1_000_000n,
+      slippageTolerance: 1.25,
+      excludeProviders: ['SwapKit'],
+    })
+
+    expect(result.ranked).toHaveLength(1)
+    expect(result.ranked[0].providerName).toBe('RUJI Trade')
+    expect(result.best.quote).toHaveProperty('general.provider', 'ruji')
+    expect(mocks.getRujiTradeSwapQuote).toHaveBeenCalledWith({
+      from,
+      to,
+      amount: 1_000_000n,
+      destination: address,
+      slippageBps: 125,
+    })
+  })
+
+  it('forwards an explicit THORChain recipient because the FIN execute message supports it', async () => {
+    mocks.getRujiTradeSwapQuote.mockResolvedValueOnce(quoteFor(rune))
+
+    await findSwapQuotes({
+      from: rune,
+      to: brune,
+      amount: 1_000_000n,
+      recipient: address,
+      excludeProviders: ['SwapKit'],
+    })
+
+    expect(mocks.getRujiTradeSwapQuote).toHaveBeenCalledWith(expect.objectContaining({ destination: address }))
+  })
+})

--- a/packages/core/chain/swap/quote/findSwapQuote.ruji.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ruji.test.ts
@@ -27,6 +27,7 @@ vi.mock('@vultisig/core-chain/swap/native/halts/getNativeSwapTradingHalt', () =>
 import { findSwapQuotes } from './findSwapQuote'
 
 const address = 'thor1vk6trmz42cjrh4zcxczeaacnsv3snv4f22x8ccu203dqde7vtaxsyevlec'
+const customRecipient = 'thor12a9rpf9u2ulwuezxkh6uas4au7xnde8umdua5t'
 const rune: AccountCoin = {
   chain: Chain.THORChain,
   address,
@@ -41,7 +42,7 @@ const brune: AccountCoin = {
   decimals: 8,
 }
 
-const quoteFor = (from: AccountCoin): GeneralSwapQuote => ({
+const quoteFor = (from: AccountCoin, recipient = address): GeneralSwapQuote => ({
   provider: 'ruji',
   dstAmount: '998124',
   expiresAt: Date.now() + 120_000,
@@ -49,7 +50,7 @@ const quoteFor = (from: AccountCoin): GeneralSwapQuote => ({
     cosmosWasm: {
       sender: from.address,
       contract: address,
-      executeMsg: JSON.stringify({ swap: { min: { min_return: '988142', to: address } } }),
+      executeMsg: JSON.stringify({ swap: { min: { min_return: '988142', to: recipient } } }),
       funds: [{ denom: from.id === 'x/brune' ? 'x/brune' : 'rune', amount: '1000000' }],
     },
   },
@@ -80,6 +81,7 @@ describe('findSwapQuotes RUJI Trade routing', () => {
     expect(result.ranked).toHaveLength(1)
     expect(result.ranked[0].providerName).toBe('RUJI Trade')
     expect(result.best.quote).toHaveProperty('general.provider', 'ruji')
+    expect(result.best.recipient).toBe(address)
     expect(mocks.getRujiTradeSwapQuote).toHaveBeenCalledWith({
       from,
       to,
@@ -90,16 +92,17 @@ describe('findSwapQuotes RUJI Trade routing', () => {
   })
 
   it('forwards an explicit THORChain recipient because the FIN execute message supports it', async () => {
-    mocks.getRujiTradeSwapQuote.mockResolvedValueOnce(quoteFor(rune))
+    mocks.getRujiTradeSwapQuote.mockResolvedValueOnce(quoteFor(rune, customRecipient))
 
-    await findSwapQuotes({
+    const result = await findSwapQuotes({
       from: rune,
       to: brune,
       amount: 1_000_000n,
-      recipient: address,
+      recipient: ` ${customRecipient} `,
       excludeProviders: ['SwapKit'],
     })
 
-    expect(mocks.getRujiTradeSwapQuote).toHaveBeenCalledWith(expect.objectContaining({ destination: address }))
+    expect(result.best.recipient).toBe(customRecipient)
+    expect(mocks.getRujiTradeSwapQuote).toHaveBeenCalledWith(expect.objectContaining({ destination: customRecipient }))
   })
 })

--- a/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.selection.test.ts
@@ -158,6 +158,7 @@ describe('findSwapQuote parallel selection', () => {
     expect(quote.safetyFingerprint).toBe(
       getSwapQuoteSafetyFingerprint({
         ...evmSameChainCoins,
+        recipient: evmSameChainCoins.to.address,
         requestedAmount,
         expiresAt: quote.expiresAt as number,
         quote: quote.quote,
@@ -197,6 +198,7 @@ describe('findSwapQuote parallel selection', () => {
       getSwapQuoteSafetyFingerprint({
         from: expectedFrom,
         to: expectedTo,
+        recipient: expectedTo.address,
         requestedAmount: input.amount,
         expiresAt: quote.expiresAt as number,
         quote: quote.quote,
@@ -206,6 +208,7 @@ describe('findSwapQuote parallel selection', () => {
       getSwapQuoteSafetyFingerprint({
         from: input.from,
         to: input.to,
+        recipient: expectedTo.address,
         requestedAmount: input.amount,
         expiresAt: quote.expiresAt as number,
         quote: quote.quote,

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -21,6 +21,10 @@ import {
   OneInchAffiliateConfig,
 } from '@vultisig/core-chain/swap/general/oneInch/api/getOneInchSwapQuote'
 import { oneInchSwapEnabledChains } from '@vultisig/core-chain/swap/general/oneInch/OneInchSwapEnabledChains'
+import {
+  getRujiTradeSwapQuote,
+  isRujiTradeSwapPair,
+} from '@vultisig/core-chain/swap/general/ruji/api/getRujiTradeSwapQuote'
 import { getSwapKitQuote } from '@vultisig/core-chain/swap/general/swapkit/api/getSwapKitQuote'
 import {
   swapKitEnabledChains,
@@ -75,8 +79,8 @@ export type FindSwapQuoteInput = Record<TransferDirection, AccountCoin> & {
    * Optional external recipient for the swapped output. When omitted the swap
    * pays out to the user's own derived address (existing behavior). When set,
    * only providers that route the output to an explicit address are used —
-   * native THORChain/MayaChain (memo destination) and CowSwap (order
-   * `receiver`); aggregators that would silently pay the initiator are skipped
+   * native THORChain/MayaChain (memo destination), CowSwap (order `receiver`),
+   * and RUJI Trade (FIN execute `to`); aggregators that would silently pay the initiator are skipped
    * so funds are never sent to the wrong address.
    */
   recipient?: string
@@ -84,7 +88,7 @@ export type FindSwapQuoteInput = Record<TransferDirection, AccountCoin> & {
    * Optional slippage tolerance, expressed in PERCENT (e.g. `0.5` = 0.5%,
    * `3` = 3%). When omitted each provider keeps its own default. Applied to the
    * general aggregators that accept a slippage override (1inch, KyberSwap, LiFi,
-   * SwapKit); CowSwap (RFQ limit order) and the native THORChain/MayaChain
+   * SwapKit, RUJI Trade); CowSwap (RFQ limit order) and the native THORChain/MayaChain
    * protocols use their own protection mechanisms and ignore this value.
    */
   slippageTolerance?: number
@@ -109,6 +113,7 @@ export type SwapQuoteProviderName =
   | 'LiFi'
   | 'SwapKit'
   | 'Jupiter'
+  | 'RUJI Trade'
   | 'THORChain'
   | 'MayaChain'
 
@@ -162,7 +167,10 @@ const bindQuoteSafetyMetadata = (
   requestedAmount: bigint
 ): BoundSwapQuote => {
   const now = Date.now()
-  const expiresAt = 'native' in quote.quote ? quote.quote.native.expiry * 1000 : now + GENERAL_QUOTE_PREPARATION_TTL_MS
+  const expiresAt =
+    'native' in quote.quote
+      ? quote.quote.native.expiry * 1000
+      : (quote.quote.general.expiresAt ?? now + GENERAL_QUOTE_PREPARATION_TTL_MS)
   const effectiveExpiresAt =
     'general' in quote.quote && 'cowswap_order' in quote.quote.general.tx
       ? Math.min(expiresAt, quote.quote.general.tx.cowswap_order.validTo * 1000)
@@ -214,6 +222,7 @@ export const providerPreferenceOrder: readonly SwapQuoteProviderName[] = [
   // competes for same-chain ERC-20 EVM pairs (see fetcher registration below);
   // for every other pair it simply isn't in the candidate set.
   'CowSwap',
+  'RUJI Trade',
   'THORChain',
   'MayaChain',
   // Jupiter is slotted ahead of the EVM/multi-chain aggregators: it only enters
@@ -244,6 +253,7 @@ const swapQuoteProviderExcludeAlias: Record<GeneralSwapProvider, SwapQuoteProvid
   swapkit: 'SwapKit',
   cowswap: 'CowSwap',
   jupiter: 'Jupiter',
+  ruji: 'RUJI Trade',
 }
 
 const swapQuoteProviderExcludeNames = new Set<SwapQuoteProviderExcludeName>([
@@ -579,7 +589,8 @@ const getGeneralDestinationSideFeeAmount = ({ quote, to }: { quote: SwapQuote; t
     general.provider === 'kyber' ||
     general.provider === 'swapkit' ||
     general.provider === 'jupiter' ||
-    general.provider === 'cowswap'
+    general.provider === 'cowswap' ||
+    general.provider === 'ruji'
   if (!providerAlreadyNet && explicitFee && isSameCoinKey(explicitFee, to)) {
     return rebaseDecimals(explicitFee.amount, explicitFee.decimals, to.decimals)
   }
@@ -809,6 +820,7 @@ type ProviderSlippage = {
   lifiFraction: number | undefined
   kyberBps: number | undefined
   jupiterBps: number | undefined
+  rujiBps: number | undefined
 }
 const toProviderSlippage = (slippageTolerance: number | undefined): ProviderSlippage => {
   const bps = slippageTolerance !== undefined ? Math.round(slippageTolerance * 100) : undefined
@@ -820,6 +832,7 @@ const toProviderSlippage = (slippageTolerance: number | undefined): ProviderSlip
     lifiFraction: slippageTolerance !== undefined ? slippageTolerance / 100 : undefined,
     kyberBps: bps,
     jupiterBps: bps,
+    rujiBps: bps,
   }
 }
 
@@ -881,8 +894,8 @@ export const findSwapQuotes = async (input: FindSwapQuoteInput): Promise<FindSwa
   const referralDiscount: SwapDiscount[] = referral ? [{ referral: {} }] : []
 
   // When the caller requests an external recipient, restrict routing to the
-  // providers that send the swapped output to an explicit address (native +
-  // CowSwap). Aggregators that pay the initiator would silently misroute funds,
+  // providers that send the swapped output to an explicit address (native,
+  // CowSwap, and RUJI Trade). Aggregators that pay the initiator would silently misroute funds,
   // so they are not offered for custom-recipient swaps until they thread the
   // receiver through (tracked in vultisig/vultisig-windows#4131).
   // Trim and treat empty/whitespace strings as no recipient, so route gating
@@ -908,6 +921,7 @@ export const findSwapQuotes = async (input: FindSwapQuoteInput): Promise<FindSwa
     lifiFraction: lifiSlippageFraction,
     kyberBps: kyberSlippageBps,
     jupiterBps: jupiterSlippageBps,
+    rujiBps: rujiSlippageBps,
     nativeBps: nativeSlippageBps,
   } = toProviderSlippage(slippageTolerance)
 
@@ -950,6 +964,23 @@ export const findSwapQuotes = async (input: FindSwapQuoteInput): Promise<FindSwa
     const fromChain = from.chain
     const toChain = to.chain
     const chainAmount = amount
+
+    if (isRujiTradeSwapPair(from, to)) {
+      result.push({
+        providerName: 'RUJI Trade',
+        fetch: async (): Promise<UnboundSwapQuote> => {
+          const general = await getRujiTradeSwapQuote({
+            from,
+            to,
+            amount: chainAmount,
+            destination: normalizedRecipient ?? to.address,
+            slippageBps: rujiSlippageBps,
+          })
+
+          return { quote: { general }, discounts: [] }
+        },
+      })
+    }
 
     // CowSwap (Phase 2 — off-chain RFQ orders). Gated to same-chain ERC-20 →
     // ERC-20 pairs on a CowSwap-supported EVM chain. Both sides must be ERC-20
@@ -1224,6 +1255,7 @@ export const findSwapQuotes = async (input: FindSwapQuoteInput): Promise<FindSwa
   // resolution order. (#535 r3 — NeO preferably-blocking response.)
   const belowMinimumProviderOrder: SwapQuoteProviderName[] = [
     'CowSwap',
+    'RUJI Trade',
     'KyberSwap',
     '1inch',
     'Jupiter',

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -124,7 +124,7 @@ type SwapQuoteFetcher = {
   fetch: () => Promise<UnboundSwapQuote>
 }
 
-type UnboundSwapQuote = Omit<SwapQuote, 'requestedAmount' | 'expiresAt' | 'safetyFingerprint'>
+type UnboundSwapQuote = Omit<SwapQuote, 'recipient' | 'requestedAmount' | 'expiresAt' | 'safetyFingerprint'>
 
 /**
  * A single fetched swap route: the fully bound quote (request amount, expiry,
@@ -164,6 +164,7 @@ const bindQuoteSafetyMetadata = (
   quote: UnboundSwapQuote,
   from: AccountCoin,
   to: AccountCoin,
+  recipient: string,
   requestedAmount: bigint
 ): BoundSwapQuote => {
   const now = Date.now()
@@ -178,11 +179,13 @@ const bindQuoteSafetyMetadata = (
 
   return {
     ...quote,
+    recipient,
     requestedAmount,
     expiresAt: effectiveExpiresAt,
     safetyFingerprint: getSwapQuoteSafetyFingerprint({
       from,
       to,
+      recipient,
       requestedAmount,
       expiresAt: effectiveExpiresAt,
       quote: quote.quote,
@@ -1213,7 +1216,13 @@ export const findSwapQuotes = async (input: FindSwapQuoteInput): Promise<FindSwa
   const runFetchers = (list: SwapQuoteFetcher[], timeoutMs: number): Promise<PromiseSettledResult<RankedSwapQuote>[]> =>
     Promise.allSettled(
       list.map(async (fetcher): Promise<RankedSwapQuote> => {
-        const quote = bindQuoteSafetyMetadata(await withTimeout(fetcher.fetch(), timeoutMs), from, to, amount)
+        const quote = bindQuoteSafetyMetadata(
+          await withTimeout(fetcher.fetch(), timeoutMs),
+          from,
+          to,
+          normalizedRecipient ?? to.address,
+          amount
+        )
         return {
           quote,
           outputAmount: getComparableOutputAmount(quote, to, fetcher.providerName),

--- a/packages/core/chain/swap/quote/getSwapQuoteProviderName.test.ts
+++ b/packages/core/chain/swap/quote/getSwapQuoteProviderName.test.ts
@@ -15,12 +15,16 @@ describe('getSwapQuoteProviderName', () => {
   })
 
   it('maps each general swap provider to its display name', () => {
-    const cases: Array<{ provider: '1inch' | 'li.fi' | 'kyber' | 'swapkit' | 'jupiter'; label: string }> = [
+    const cases: Array<{
+      provider: '1inch' | 'li.fi' | 'kyber' | 'swapkit' | 'jupiter' | 'ruji'
+      label: string
+    }> = [
       { provider: '1inch', label: '1Inch' },
       { provider: 'li.fi', label: 'LI.FI' },
       { provider: 'kyber', label: 'KyberSwap' },
       { provider: 'swapkit', label: 'SwapKit' },
       { provider: 'jupiter', label: 'Jupiter' },
+      { provider: 'ruji', label: 'RUJI Trade' },
     ]
 
     for (const { provider, label } of cases) {

--- a/packages/core/chain/swap/quote/getSwapQuoteSafetyFingerprint.test.ts
+++ b/packages/core/chain/swap/quote/getSwapQuoteSafetyFingerprint.test.ts
@@ -20,6 +20,16 @@ const fingerprint = (value: unknown) =>
     quote: { general: { value } } as never,
   })
 
+const recipientFingerprint = (recipient: string) =>
+  getSwapQuoteSafetyFingerprint({
+    from: coin,
+    to: coin,
+    recipient,
+    requestedAmount: 1n,
+    expiresAt: 1,
+    quote: { general: { value: 'quote' } } as never,
+  })
+
 describe('getSwapQuoteSafetyFingerprint', () => {
   it('keeps canonical bigint tags distinct from provider object keys', () => {
     expect(fingerprint(5n)).not.toBe(fingerprint({ $bigint: '5' }))
@@ -27,5 +37,9 @@ describe('getSwapQuoteSafetyFingerprint', () => {
 
   it('canonicalizes explicit undefined array values and sparse holes consistently', () => {
     expect(fingerprint([undefined])).toBe(fingerprint(new Array(1)))
+  })
+
+  it('binds the effective output recipient', () => {
+    expect(recipientFingerprint('thor1recipient')).not.toBe(recipientFingerprint('thor1other'))
   })
 })

--- a/packages/core/chain/swap/quote/getSwapQuoteSafetyFingerprint.ts
+++ b/packages/core/chain/swap/quote/getSwapQuoteSafetyFingerprint.ts
@@ -7,6 +7,7 @@ import type { SwapQuoteResult } from './SwapQuote'
 type Input = {
   from: AccountCoin
   to: AccountCoin
+  recipient?: string
   requestedAmount: bigint
   expiresAt: number
   quote: SwapQuoteResult
@@ -72,7 +73,14 @@ const coinIdentity = ({ chain, address, id, ticker, decimals }: AccountCoin) => 
  * Pure and platform-neutral so preparation can recompute the same value before
  * any wallet/key/payload work.
  */
-export const getSwapQuoteSafetyFingerprint = ({ from, to, requestedAmount, expiresAt, quote }: Input): string =>
+export const getSwapQuoteSafetyFingerprint = ({
+  from,
+  to,
+  recipient,
+  requestedAmount,
+  expiresAt,
+  quote,
+}: Input): string =>
   bytesToHex(
     sha256(
       new TextEncoder().encode(
@@ -80,6 +88,7 @@ export const getSwapQuoteSafetyFingerprint = ({ from, to, requestedAmount, expir
           version: 1,
           from: coinIdentity(from),
           to: coinIdentity(to),
+          recipient,
           requestedAmount,
           expiresAt,
           quote,

--- a/packages/core/chain/swap/swapEnabledChains.test.ts
+++ b/packages/core/chain/swap/swapEnabledChains.test.ts
@@ -6,6 +6,7 @@ import { jupiterSwapEnabledChains } from './general/jupiter/JupiterSwapEnabledCh
 import { kyberSwapEnabledChains } from './general/kyber/chains'
 import { lifiSwapEnabledChains } from './general/lifi/LifiSwapEnabledChains'
 import { oneInchSwapEnabledChains } from './general/oneInch/OneInchSwapEnabledChains'
+import { rujiTradeSwapEnabledChains } from './general/ruji/config'
 import { swapKitEnabledChains } from './general/swapkit/SwapKitEnabledChains'
 import { nativeSwapEnabledChains } from './native/NativeSwapChain'
 import { swapEnabledChains } from './swapEnabledChains'
@@ -24,6 +25,7 @@ describe('swapEnabledChains aggregate (sdk#1151)', () => {
     swapKit: swapKitEnabledChains,
     jupiter: jupiterSwapEnabledChains,
     cowSwap: cowSwapSupportedChains,
+    rujiTrade: rujiTradeSwapEnabledChains,
   }
 
   it.each(Object.entries(providerLists))('covers every %s chain', (_provider, chains) => {

--- a/packages/core/chain/swap/swapEnabledChains.ts
+++ b/packages/core/chain/swap/swapEnabledChains.ts
@@ -3,6 +3,7 @@ import { jupiterSwapEnabledChains } from '@vultisig/core-chain/swap/general/jupi
 import { kyberSwapEnabledChains } from '@vultisig/core-chain/swap/general/kyber/chains'
 import { lifiSwapEnabledChains } from '@vultisig/core-chain/swap/general/lifi/LifiSwapEnabledChains'
 import { oneInchSwapEnabledChains } from '@vultisig/core-chain/swap/general/oneInch/OneInchSwapEnabledChains'
+import { rujiTradeSwapEnabledChains } from '@vultisig/core-chain/swap/general/ruji/config'
 import { swapKitEnabledChains } from '@vultisig/core-chain/swap/general/swapkit/SwapKitEnabledChains'
 import { nativeSwapEnabledChains } from '@vultisig/core-chain/swap/native/NativeSwapChain'
 
@@ -18,6 +19,7 @@ export const swapEnabledChains = [
   ...kyberSwapEnabledChains,
   ...oneInchSwapEnabledChains,
   ...jupiterSwapEnabledChains,
+  ...rujiTradeSwapEnabledChains,
   ...lifiSwapEnabledChains,
   ...swapKitEnabledChains,
 ] as const

--- a/packages/core/chain/swap/utils/getSwapExplorerUrl/index.test.ts
+++ b/packages/core/chain/swap/utils/getSwapExplorerUrl/index.test.ts
@@ -185,11 +185,21 @@ describe('getSwapExplorerUrl', () => {
         })
       ).toBe(`https://solscan.io/tx/${SOL_TX_HASH}`)
     })
+
+    it('RUJI Trade falls back to the THORChain block explorer', () => {
+      expect(
+        getSwapExplorerUrl({
+          provider: 'ruji',
+          txHash: THOR_TX_HASH_NO_PREFIX,
+          fromChain: Chain.THORChain,
+        })
+      ).toBe(`https://runescan.io/tx/${THOR_TX_HASH_NO_PREFIX}`)
+    })
   })
 
   it('exposes every provider via swapExplorerProviders', () => {
     expect([...swapExplorerProviders].sort()).toEqual(
-      ['1inch', 'kyber', 'li.fi', 'mayachain', 'swapkit', 'cowswap', 'jupiter', 'thorchain'].sort()
+      ['1inch', 'kyber', 'li.fi', 'mayachain', 'swapkit', 'cowswap', 'jupiter', 'ruji', 'thorchain'].sort()
     )
   })
 })

--- a/packages/core/chain/swap/utils/getSwapExplorerUrl/index.ts
+++ b/packages/core/chain/swap/utils/getSwapExplorerUrl/index.ts
@@ -10,7 +10,7 @@ import { getBlockExplorerUrl } from '@vultisig/core-chain/utils/getBlockExplorer
  * - `li.fi` → scan.li.fi (or orb.helius.dev for Solana settlement)
  * - `swapkit` → track.swapkit.dev
  * - `cowswap` → explorer.cow.fi order page
- * - `thorchain` / `mayachain` → native chain scanner
+ * - `thorchain` / `ruji` / `mayachain` → native chain scanner
  * - `1inch`, `kyber`, `jupiter` → source-chain explorer fallback
  *
  * Keep this union in sync with iOS `ExplorerLinkBuilder.swift` and Android
@@ -57,6 +57,7 @@ export const getSwapExplorerUrl = ({ provider, txHash, fromChain }: GetSwapExplo
       }
       return `https://scan.li.fi/tx/${txHash}`
     case 'thorchain':
+    case 'ruji':
       return `https://runescan.io/tx/${stripHexPrefix(txHash)}`
     case 'mayachain':
       return `https://www.explorer.mayachain.info/tx/${stripHexPrefix(txHash)}`

--- a/packages/core/mpc/keysign/swap/build.rujiTrade.test.ts
+++ b/packages/core/mpc/keysign/swap/build.rujiTrade.test.ts
@@ -1,0 +1,101 @@
+import { create } from '@bufbuild/protobuf'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { SwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
+import {
+  THORChainSpecificSchema,
+  TransactionType,
+} from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getChainSpecific: vi.fn(async () => ({
+    case: 'thorchainSpecific' as const,
+    value: create(THORChainSpecificSchema, {
+      accountNumber: 1n,
+      sequence: 2n,
+      fee: 2_000_000n,
+      transactionType: TransactionType.GENERIC_CONTRACT,
+    }),
+  })),
+  getKeysignUtxoInfo: vi.fn(async () => []),
+}))
+
+vi.mock('@vultisig/core-mpc/keysign/chainSpecific', () => ({ getChainSpecific: mocks.getChainSpecific }))
+vi.mock('@vultisig/core-mpc/keysign/utxo/getKeysignUtxoInfo', () => ({
+  getKeysignUtxoInfo: mocks.getKeysignUtxoInfo,
+}))
+
+import { buildSwapKeysignPayload } from './build'
+
+const address = 'thor1vk6trmz42cjrh4zcxczeaacnsv3snv4f22x8ccu203dqde7vtaxsyevlec'
+const publicKey = { data: () => new Uint8Array([1, 2, 3]) } as never
+
+const buildInput = {
+  fromCoin: { chain: Chain.THORChain, address, ticker: 'RUNE', decimals: 8 },
+  toCoin: { chain: Chain.THORChain, address, id: 'x/brune', ticker: 'bRUNE', decimals: 8 },
+  amount: 1,
+  vaultId: 'vault-id',
+  localPartyId: 'local-party',
+  fromPublicKey: publicKey,
+  toPublicKey: publicKey,
+  libType: 'DKLS' as const,
+  walletCore: {} as never,
+}
+
+const makeQuote = (denom = 'rune'): SwapQuote => ({
+  discounts: [],
+  quote: {
+    general: {
+      provider: 'ruji',
+      dstAmount: '998124',
+      tx: {
+        cosmosWasm: {
+          sender: address,
+          contract: address,
+          executeMsg: JSON.stringify({ swap: { min: { min_return: '988142', to: address } } }),
+          funds: [{ denom, amount: '1000000' }],
+        },
+      },
+    },
+  },
+})
+
+describe('buildSwapKeysignPayload RUJI Trade', () => {
+  beforeEach(() => {
+    mocks.getChainSpecific.mockClear()
+  })
+
+  it('builds a GENERIC_CONTRACT payload that signs the exact FIN execute message and funds', async () => {
+    const payload = await buildSwapKeysignPayload({ ...buildInput, swapQuote: makeQuote() })
+
+    expect(payload.toAddress).toBe(address)
+    expect(payload.toAmount).toBe('1000000')
+    expect(payload.contractPayload).toMatchObject({
+      case: 'wasmExecuteContractPayload',
+      value: {
+        senderAddress: address,
+        contractAddress: address,
+        executeMsg: JSON.stringify({ swap: { min: { min_return: '988142', to: address } } }),
+        coins: [{ denom: 'rune', amount: '1000000' }],
+      },
+    })
+    expect(payload.swapPayload).toMatchObject({
+      case: 'oneinchSwapPayload',
+      value: {
+        provider: 'ruji',
+        fromAmount: '1000000',
+        quote: { tx: { to: address, value: '1000000' } },
+      },
+    })
+    expect(mocks.getChainSpecific).toHaveBeenCalledWith(
+      expect.objectContaining({ transactionType: TransactionType.GENERIC_CONTRACT })
+    )
+  })
+
+  it('fails closed when the attached denom does not match the source coin', async () => {
+    await expect(buildSwapKeysignPayload({ ...buildInput, swapQuote: makeQuote('x/brune') })).rejects.toThrow(
+      'exactly one rune fund'
+    )
+    expect(mocks.getChainSpecific).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/mpc/keysign/swap/build.rujiTrade.test.ts
+++ b/packages/core/mpc/keysign/swap/build.rujiTrade.test.ts
@@ -110,6 +110,19 @@ describe('buildSwapKeysignPayload RUJI Trade', () => {
     expect(mocks.getChainSpecific).not.toHaveBeenCalled()
   })
 
+  it('fails closed when the route targets an untrusted FIN contract', async () => {
+    const quote = makeQuote()
+    if (!('general' in quote.quote) || !('cosmosWasm' in quote.quote.general.tx)) {
+      throw new Error('Expected RUJI Trade CosmWasm quote')
+    }
+    quote.quote.general.tx.cosmosWasm.contract = customRecipient
+
+    await expect(buildSwapKeysignPayload({ ...buildInput, swapQuote: quote })).rejects.toThrow(
+      'untrusted RUNE ↔ bRUNE FIN contract'
+    )
+    expect(mocks.getChainSpecific).not.toHaveBeenCalled()
+  })
+
   it('accepts the effective custom recipient instead of requiring the destination account', async () => {
     const payload = await buildSwapKeysignPayload({
       ...buildInput,

--- a/packages/core/mpc/keysign/swap/build.rujiTrade.test.ts
+++ b/packages/core/mpc/keysign/swap/build.rujiTrade.test.ts
@@ -42,7 +42,7 @@ const buildInput = {
   walletCore: {} as never,
 }
 
-const makeQuote = (denom = 'rune'): SwapQuote => ({
+const makeQuote = (denom = 'rune', recipient = address): SwapQuote => ({
   discounts: [],
   quote: {
     general: {
@@ -52,7 +52,7 @@ const makeQuote = (denom = 'rune'): SwapQuote => ({
         cosmosWasm: {
           sender: address,
           contract: address,
-          executeMsg: JSON.stringify({ swap: { min: { min_return: '988142', to: address } } }),
+          executeMsg: JSON.stringify({ swap: { min: { min_return: '988142', to: recipient } } }),
           funds: [{ denom, amount: '1000000' }],
         },
       },
@@ -96,6 +96,16 @@ describe('buildSwapKeysignPayload RUJI Trade', () => {
     await expect(buildSwapKeysignPayload({ ...buildInput, swapQuote: makeQuote('x/brune') })).rejects.toThrow(
       'exactly one rune fund'
     )
+    expect(mocks.getChainSpecific).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when the FIN recipient does not match the destination account', async () => {
+    await expect(
+      buildSwapKeysignPayload({
+        ...buildInput,
+        swapQuote: makeQuote('rune', 'thor1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqm7g9t'),
+      })
+    ).rejects.toThrow('guarded FIN swap execute message')
     expect(mocks.getChainSpecific).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/mpc/keysign/swap/build.rujiTrade.test.ts
+++ b/packages/core/mpc/keysign/swap/build.rujiTrade.test.ts
@@ -33,7 +33,7 @@ const publicKey = { data: () => new Uint8Array([1, 2, 3]) } as never
 const buildInput = {
   fromCoin: { chain: Chain.THORChain, address, ticker: 'RUNE', decimals: 8 },
   toCoin: { chain: Chain.THORChain, address, id: 'x/brune', ticker: 'bRUNE', decimals: 8 },
-  amount: 1,
+  amount: 0.01,
   vaultId: 'vault-id',
   localPartyId: 'local-party',
   fromPublicKey: publicKey,
@@ -42,7 +42,7 @@ const buildInput = {
   walletCore: {} as never,
 }
 
-const makeQuote = (denom = 'rune', recipient = address): SwapQuote => ({
+const makeQuote = (denom = 'rune', recipient = address, fundAmount = '1000000'): SwapQuote => ({
   discounts: [],
   quote: {
     general: {
@@ -53,7 +53,7 @@ const makeQuote = (denom = 'rune', recipient = address): SwapQuote => ({
           sender: address,
           contract: address,
           executeMsg: JSON.stringify({ swap: { min: { min_return: '988142', to: recipient } } }),
-          funds: [{ denom, amount: '1000000' }],
+          funds: [{ denom, amount: fundAmount }],
         },
       },
     },
@@ -106,6 +106,19 @@ describe('buildSwapKeysignPayload RUJI Trade', () => {
         swapQuote: makeQuote('rune', 'thor1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqm7g9t'),
       })
     ).rejects.toThrow('guarded FIN swap execute message')
+    expect(mocks.getChainSpecific).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    { label: 'smaller', fundAmount: '999999' },
+    { label: 'larger', fundAmount: '1000001' },
+  ])('fails closed when the FIN fund amount is $label than requested', async ({ fundAmount }) => {
+    await expect(
+      buildSwapKeysignPayload({
+        ...buildInput,
+        swapQuote: makeQuote('rune', address, fundAmount),
+      })
+    ).rejects.toThrow('fund amount does not match the requested swap amount')
     expect(mocks.getChainSpecific).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/mpc/keysign/swap/build.rujiTrade.test.ts
+++ b/packages/core/mpc/keysign/swap/build.rujiTrade.test.ts
@@ -28,6 +28,7 @@ vi.mock('@vultisig/core-mpc/keysign/utxo/getKeysignUtxoInfo', () => ({
 import { buildSwapKeysignPayload } from './build'
 
 const address = 'thor1vk6trmz42cjrh4zcxczeaacnsv3snv4f22x8ccu203dqde7vtaxsyevlec'
+const customRecipient = 'thor12a9rpf9u2ulwuezxkh6uas4au7xnde8umdua5t'
 const publicKey = { data: () => new Uint8Array([1, 2, 3]) } as never
 
 const buildInput = {
@@ -104,6 +105,30 @@ describe('buildSwapKeysignPayload RUJI Trade', () => {
       buildSwapKeysignPayload({
         ...buildInput,
         swapQuote: makeQuote('rune', 'thor1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqm7g9t'),
+      })
+    ).rejects.toThrow('guarded FIN swap execute message')
+    expect(mocks.getChainSpecific).not.toHaveBeenCalled()
+  })
+
+  it('accepts the effective custom recipient instead of requiring the destination account', async () => {
+    const payload = await buildSwapKeysignPayload({
+      ...buildInput,
+      recipient: ` ${customRecipient.toUpperCase()} `,
+      swapQuote: makeQuote('rune', customRecipient),
+    })
+
+    expect(payload.contractPayload).toMatchObject({
+      case: 'wasmExecuteContractPayload',
+      value: { executeMsg: expect.stringContaining(customRecipient) },
+    })
+  })
+
+  it('fails closed when the FIN recipient does not match the effective custom recipient', async () => {
+    await expect(
+      buildSwapKeysignPayload({
+        ...buildInput,
+        recipient: customRecipient,
+        swapQuote: makeQuote(),
       })
     ).rejects.toThrow('guarded FIN swap execute message')
     expect(mocks.getChainSpecific).not.toHaveBeenCalled()

--- a/packages/core/mpc/keysign/swap/build.ts
+++ b/packages/core/mpc/keysign/swap/build.ts
@@ -64,7 +64,7 @@ export type BuildSwapKeysignPayloadInput = {
 type TransferSwapTx = Extract<GeneralSwapTx, { transfer: unknown }>['transfer']
 type CosmosWasmSwapTx = Extract<GeneralSwapTx, { cosmosWasm: unknown }>['cosmosWasm']
 
-const getRujiTradeFundAmount = (tx: CosmosWasmSwapTx, fromCoin: AccountCoin): bigint => {
+const getRujiTradeFundAmount = (tx: CosmosWasmSwapTx, fromCoin: AccountCoin, toCoin: AccountCoin): bigint => {
   const expectedDenom =
     fromCoin.chain === Chain.THORChain && fromCoin.id === undefined && fromCoin.ticker.toUpperCase() === 'RUNE'
       ? 'rune'
@@ -100,7 +100,7 @@ const getRujiTradeFundAmount = (tx: CosmosWasmSwapTx, fromCoin: AccountCoin): bi
     !/^\d+$/.test(min.min_return) ||
     BigInt(min.min_return) <= 0n ||
     typeof min.to !== 'string' ||
-    !min.to.trim()
+    min.to !== toCoin.address
   ) {
     throw new Error('RUJI Trade CosmWasm route must contain a guarded FIN swap execute message.')
   }
@@ -235,7 +235,7 @@ export const buildSwapKeysignPayload = async ({
       return result
     },
   })
-  const cosmosWasmAmount = cosmosWasmTx ? getRujiTradeFundAmount(cosmosWasmTx, fromCoin) : undefined
+  const cosmosWasmAmount = cosmosWasmTx ? getRujiTradeFundAmount(cosmosWasmTx, fromCoin, toCoin) : undefined
   const chainAmount = transferTx?.amount ?? cosmosWasmAmount ?? toChainAmount(amount, fromCoin.decimals)
 
   const fromCoinHexPublicKey = Buffer.from(fromPublicKey.data()).toString('hex')

--- a/packages/core/mpc/keysign/swap/build.ts
+++ b/packages/core/mpc/keysign/swap/build.ts
@@ -13,6 +13,7 @@ import { areEqualCoins } from '@vultisig/core-chain/coin/Coin'
 import { COW_VAULT_RELAYER_ADDRESS } from '@vultisig/core-chain/swap/general/cowswap/config'
 import { encodeCowSwapKeysignData } from '@vultisig/core-chain/swap/general/cowswap/keysign/cowSwapKeysignData'
 import { GeneralSwapTx } from '@vultisig/core-chain/swap/general/GeneralSwapQuote'
+import { rujiTradeRuneBruneMarketContract } from '@vultisig/core-chain/swap/general/ruji/config'
 import { getSwapDestinationAddress } from '@vultisig/core-chain/swap/keysign/getSwapDestinationAddress'
 import { nativeSwapQuoteToSwapPayload } from '@vultisig/core-mpc/swap/native/utils/nativeSwapQuoteToSwapPayload'
 import { SwapQuote, SwapQuoteResult } from '@vultisig/core-chain/swap/quote/SwapQuote'
@@ -101,6 +102,9 @@ const getRujiTradeFundAmount = (tx: CosmosWasmSwapTx, fromCoin: AccountCoin, eff
   }
   if (!tx.contract.trim() || !tx.executeMsg.trim()) {
     throw new Error('RUJI Trade CosmWasm route is missing its contract or execute message.')
+  }
+  if (!areEqualThorAddresses(tx.contract, rujiTradeRuneBruneMarketContract)) {
+    throw new Error('RUJI Trade CosmWasm route targets an untrusted RUNE ↔ bRUNE FIN contract.')
   }
   if (tx.funds.length !== 1 || tx.funds[0].denom.toLowerCase() !== expectedDenom) {
     throw new Error(`RUJI Trade CosmWasm route must attach exactly one ${expectedDenom} fund.`)

--- a/packages/core/mpc/keysign/swap/build.ts
+++ b/packages/core/mpc/keysign/swap/build.ts
@@ -1,5 +1,6 @@
 import { Buffer } from 'buffer'
 import { create } from '@bufbuild/protobuf'
+import { fromBech32 } from '@cosmjs/encoding'
 import { buildSignBitcoinFromPsbt } from '@vultisig/core-chain/chains/utxo/tx/buildSignBitcoinFromPsbt'
 import { fromChainAmountDisplay } from '@vultisig/core-chain/amount/fromChainAmountExact'
 import { toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'
@@ -45,6 +46,8 @@ import { Psbt } from 'bitcoinjs-lib'
 export type BuildSwapKeysignPayloadInput = {
   fromCoin: AccountCoin
   toCoin: AccountCoin
+  /** Effective output recipient. Defaults to `toCoin.address` for legacy callers. */
+  recipient?: string
   amount: string | number
   swapQuote: SwapQuote
   vaultId: string
@@ -64,7 +67,25 @@ export type BuildSwapKeysignPayloadInput = {
 type TransferSwapTx = Extract<GeneralSwapTx, { transfer: unknown }>['transfer']
 type CosmosWasmSwapTx = Extract<GeneralSwapTx, { cosmosWasm: unknown }>['cosmosWasm']
 
-const getRujiTradeFundAmount = (tx: CosmosWasmSwapTx, fromCoin: AccountCoin, toCoin: AccountCoin): bigint => {
+const getThorAddressIdentity = (address: string): string | undefined => {
+  try {
+    const decoded = fromBech32(address.trim())
+    if (decoded.prefix.toLowerCase() !== 'thor' || (decoded.data.length !== 20 && decoded.data.length !== 32)) {
+      return undefined
+    }
+
+    return Buffer.from(decoded.data).toString('hex')
+  } catch {
+    return undefined
+  }
+}
+
+const areEqualThorAddresses = (left: string, right: string): boolean => {
+  const leftIdentity = getThorAddressIdentity(left)
+  return leftIdentity !== undefined && leftIdentity === getThorAddressIdentity(right)
+}
+
+const getRujiTradeFundAmount = (tx: CosmosWasmSwapTx, fromCoin: AccountCoin, effectiveRecipient: string): bigint => {
   const expectedDenom =
     fromCoin.chain === Chain.THORChain && fromCoin.id === undefined && fromCoin.ticker.toUpperCase() === 'RUNE'
       ? 'rune'
@@ -75,7 +96,7 @@ const getRujiTradeFundAmount = (tx: CosmosWasmSwapTx, fromCoin: AccountCoin, toC
   if (!expectedDenom) {
     throw new Error('RUJI Trade CosmWasm swaps require a THORChain RUNE or bRUNE source coin.')
   }
-  if (tx.sender !== fromCoin.address) {
+  if (!areEqualThorAddresses(tx.sender, fromCoin.address)) {
     throw new Error('RUJI Trade CosmWasm sender does not match the source account.')
   }
   if (!tx.contract.trim() || !tx.executeMsg.trim()) {
@@ -100,7 +121,7 @@ const getRujiTradeFundAmount = (tx: CosmosWasmSwapTx, fromCoin: AccountCoin, toC
     !/^\d+$/.test(min.min_return) ||
     BigInt(min.min_return) <= 0n ||
     typeof min.to !== 'string' ||
-    min.to !== toCoin.address
+    !areEqualThorAddresses(min.to, effectiveRecipient)
   ) {
     throw new Error('RUJI Trade CosmWasm route must contain a guarded FIN swap execute message.')
   }
@@ -196,6 +217,7 @@ const getSwapKitSignData = (fromCoin: AccountCoin, transfer: TransferSwapTx): Ke
 export const buildSwapKeysignPayload = async ({
   fromCoin,
   toCoin,
+  recipient,
   amount,
   swapQuote,
   vaultId,
@@ -235,7 +257,9 @@ export const buildSwapKeysignPayload = async ({
       return result
     },
   })
-  const cosmosWasmAmount = cosmosWasmTx ? getRujiTradeFundAmount(cosmosWasmTx, fromCoin, toCoin) : undefined
+  const cosmosWasmAmount = cosmosWasmTx
+    ? getRujiTradeFundAmount(cosmosWasmTx, fromCoin, recipient ?? toCoin.address)
+    : undefined
   const requestedChainAmount = toChainAmount(amount, fromCoin.decimals)
   if (cosmosWasmAmount !== undefined && cosmosWasmAmount !== requestedChainAmount) {
     throw new Error('RUJI Trade CosmWasm fund amount does not match the requested swap amount.')

--- a/packages/core/mpc/keysign/swap/build.ts
+++ b/packages/core/mpc/keysign/swap/build.ts
@@ -32,7 +32,11 @@ import {
 import { Erc20ApprovePayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/erc20_approve_payload_pb'
 import { KeysignPayload, KeysignPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
 import { SwapKitSwapPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/swapkit_swap_payload_pb'
-import { SignSuiSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/wasm_execute_contract_payload_pb'
+import { TransactionType } from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
+import {
+  SignSuiSchema,
+  WasmExecuteContractPayloadSchema,
+} from '@vultisig/core-mpc/types/vultisig/keysign/v1/wasm_execute_contract_payload_pb'
 import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
 import { WalletCore } from '@trustwallet/wallet-core'
 import { PublicKey } from '@trustwallet/wallet-core/dist/src/wallet-core'
@@ -58,6 +62,51 @@ export type BuildSwapKeysignPayloadInput = {
 }
 
 type TransferSwapTx = Extract<GeneralSwapTx, { transfer: unknown }>['transfer']
+type CosmosWasmSwapTx = Extract<GeneralSwapTx, { cosmosWasm: unknown }>['cosmosWasm']
+
+const getRujiTradeFundAmount = (tx: CosmosWasmSwapTx, fromCoin: AccountCoin): bigint => {
+  const expectedDenom =
+    fromCoin.chain === Chain.THORChain && fromCoin.id === undefined && fromCoin.ticker.toUpperCase() === 'RUNE'
+      ? 'rune'
+      : fromCoin.chain === Chain.THORChain && fromCoin.id?.toLowerCase() === 'x/brune'
+        ? 'x/brune'
+        : undefined
+
+  if (!expectedDenom) {
+    throw new Error('RUJI Trade CosmWasm swaps require a THORChain RUNE or bRUNE source coin.')
+  }
+  if (tx.sender !== fromCoin.address) {
+    throw new Error('RUJI Trade CosmWasm sender does not match the source account.')
+  }
+  if (!tx.contract.trim() || !tx.executeMsg.trim()) {
+    throw new Error('RUJI Trade CosmWasm route is missing its contract or execute message.')
+  }
+  if (tx.funds.length !== 1 || tx.funds[0].denom.toLowerCase() !== expectedDenom) {
+    throw new Error(`RUJI Trade CosmWasm route must attach exactly one ${expectedDenom} fund.`)
+  }
+  if (!/^\d+$/.test(tx.funds[0].amount) || BigInt(tx.funds[0].amount) <= 0n) {
+    throw new Error('RUJI Trade CosmWasm route contains an invalid fund amount.')
+  }
+
+  let executeMsg: unknown
+  try {
+    executeMsg = JSON.parse(tx.executeMsg)
+  } catch {
+    throw new Error('RUJI Trade CosmWasm route contains an invalid execute message.')
+  }
+  const min = (executeMsg as { swap?: { min?: { min_return?: unknown; to?: unknown } } })?.swap?.min
+  if (
+    typeof min?.min_return !== 'string' ||
+    !/^\d+$/.test(min.min_return) ||
+    BigInt(min.min_return) <= 0n ||
+    typeof min.to !== 'string' ||
+    !min.to.trim()
+  ) {
+    throw new Error('RUJI Trade CosmWasm route must contain a guarded FIN swap execute message.')
+  }
+
+  return BigInt(tx.funds[0].amount)
+}
 
 const isSwapKitBitcoinPsbt = (fromCoin: AccountCoin, transfer: TransferSwapTx) =>
   fromCoin.chain === Chain.Bitcoin && transfer.txType?.toUpperCase() === 'PSBT'
@@ -164,10 +213,30 @@ export const buildSwapKeysignPayload = async ({
         evm: () => undefined,
         solana: () => undefined,
         transfer: tx => tx,
+        cosmosWasm: () => undefined,
         cowswap_order: () => undefined,
       }),
   })
-  const chainAmount = transferTx?.amount ?? toChainAmount(amount, fromCoin.decimals)
+  const cosmosWasmTx = matchRecordUnion<SwapQuoteResult, CosmosWasmSwapTx | undefined>(swapQuote.quote, {
+    native: () => undefined,
+    general: ({ provider, tx }) => {
+      const result = matchRecordUnion<GeneralSwapTx, CosmosWasmSwapTx | undefined>(tx, {
+        evm: () => undefined,
+        solana: () => undefined,
+        transfer: () => undefined,
+        cosmosWasm: tx => tx,
+        cowswap_order: () => undefined,
+      })
+
+      if ((provider === 'ruji') !== !!result) {
+        throw new Error('RUJI Trade quotes must use the CosmWasm transaction route.')
+      }
+
+      return result
+    },
+  })
+  const cosmosWasmAmount = cosmosWasmTx ? getRujiTradeFundAmount(cosmosWasmTx, fromCoin) : undefined
+  const chainAmount = transferTx?.amount ?? cosmosWasmAmount ?? toChainAmount(amount, fromCoin.decimals)
 
   const fromCoinHexPublicKey = Buffer.from(fromPublicKey.data()).toString('hex')
   const toCoinHexPublicKey = Buffer.from(toPublicKey.data()).toString('hex')
@@ -179,6 +248,7 @@ export const buildSwapKeysignPayload = async ({
         evm: ({ gasLimit }) => gasLimit,
         solana: () => undefined,
         transfer: () => undefined,
+        cosmosWasm: () => undefined,
         cowswap_order: () => undefined,
       }),
   })
@@ -207,9 +277,21 @@ export const buildSwapKeysignPayload = async ({
           evm: () => undefined,
           solana: () => undefined,
           transfer: ({ memo }) => memo,
+          cosmosWasm: () => undefined,
           cowswap_order: () => undefined,
         }),
     }),
+    contractPayload: cosmosWasmTx
+      ? {
+          case: 'wasmExecuteContractPayload',
+          value: create(WasmExecuteContractPayloadSchema, {
+            senderAddress: cosmosWasmTx.sender,
+            contractAddress: cosmosWasmTx.contract,
+            executeMsg: cosmosWasmTx.executeMsg,
+            coins: cosmosWasmTx.funds,
+          }),
+        }
+      : undefined,
   })
 
   keysignPayload.swapPayload = matchRecordUnion<SwapQuoteResult, KeysignPayload['swapPayload']>(swapQuote.quote, {
@@ -218,6 +300,7 @@ export const buildSwapKeysignPayload = async ({
         evm: () => undefined,
         solana: () => undefined,
         transfer: tx => tx,
+        cosmosWasm: () => undefined,
         cowswap_order: () => undefined,
       })
 
@@ -286,6 +369,15 @@ export const buildSwapKeysignPayload = async ({
           to,
           data: '',
           value: '',
+          gasPrice: '',
+          gas: 0n,
+          swapFee: '',
+        }),
+        cosmosWasm: ({ sender, contract, executeMsg, funds }) => ({
+          from: sender,
+          to: contract,
+          data: executeMsg,
+          value: funds[0]?.amount ?? '',
           gasPrice: '',
           gas: 0n,
           swapFee: '',
@@ -374,6 +466,7 @@ export const buildSwapKeysignPayload = async ({
     keysignPayload,
     walletCore,
     thirdPartyGasLimitEstimation,
+    transactionType: cosmosWasmTx ? TransactionType.GENERIC_CONTRACT : undefined,
     isDeposit: matchRecordUnion<SwapQuoteResult, boolean>(swapQuote.quote, {
       native: ({ swapChain }) => areEqualCoins(fromCoin, chainFeeCoin[swapChain]),
       general: () => false,

--- a/packages/core/mpc/keysign/swap/build.ts
+++ b/packages/core/mpc/keysign/swap/build.ts
@@ -236,7 +236,11 @@ export const buildSwapKeysignPayload = async ({
     },
   })
   const cosmosWasmAmount = cosmosWasmTx ? getRujiTradeFundAmount(cosmosWasmTx, fromCoin, toCoin) : undefined
-  const chainAmount = transferTx?.amount ?? cosmosWasmAmount ?? toChainAmount(amount, fromCoin.decimals)
+  const requestedChainAmount = toChainAmount(amount, fromCoin.decimals)
+  if (cosmosWasmAmount !== undefined && cosmosWasmAmount !== requestedChainAmount) {
+    throw new Error('RUJI Trade CosmWasm fund amount does not match the requested swap amount.')
+  }
+  const chainAmount = transferTx?.amount ?? cosmosWasmAmount ?? requestedChainAmount
 
   const fromCoinHexPublicKey = Buffer.from(fromPublicKey.data()).toString('hex')
   const toCoinHexPublicKey = Buffer.from(toPublicKey.data()).toString('hex')

--- a/packages/sdk/src/tools/prep/swap.ts
+++ b/packages/sdk/src/tools/prep/swap.ts
@@ -65,6 +65,7 @@ const assertQuoteSafetyBinding = (params: PrepareSwapTxFromKeysParams, requested
   const expectedFingerprint = getSwapQuoteSafetyFingerprint({
     from: params.fromCoin,
     to: params.toCoin,
+    recipient: swapQuote.recipient,
     requestedAmount: boundAmount,
     expiresAt,
     quote: swapQuote.quote,
@@ -195,6 +196,7 @@ export const prepareSwapTxFromKeys = async (
   return buildSwapKeysignPayload({
     fromCoin: safeParams.fromCoin,
     toCoin: safeParams.toCoin,
+    recipient: safeParams.swapQuote.recipient ?? safeParams.toCoin.address,
     amount: safeParams.amount,
     swapQuote: safeParams.swapQuote,
     vaultId: identity.ecdsaPublicKey,

--- a/packages/sdk/src/tools/prep/swap.ts
+++ b/packages/sdk/src/tools/prep/swap.ts
@@ -94,11 +94,12 @@ const assertCowQuoteNotExpired = (validTo: number): void => {
   }
 }
 
-// Defense-in-depth for CoW: the quote-level requested amount must also match the gross value
-// committed to the EIP-712 order. Native/evm/solana do not expose a separate committed-sell
-// field here, so they intentionally fail open after the quote-level amount binding above;
-// `transfer.amount` may legitimately differ (for example, 100_000n -> 99_999n) because providers
-// subtract deposit-channel fees.
+// Defense-in-depth for providers whose tx shape carries an exact source amount: the quote-level
+// requested amount must also match the gross value committed to the EIP-712 order or CosmWasm
+// funds. Native/evm/solana do not expose a separate committed-sell field here, so they
+// intentionally fail open after the quote-level amount binding above; `transfer.amount` may
+// legitimately differ (for example, 100_000n -> 99_999n) because providers subtract
+// deposit-channel fees.
 const assertAmountMatchesCommittedSellAmount = (params: PrepareSwapTxFromKeysParams): void => {
   const { quote } = params.swapQuote
   if (!('general' in quote)) return
@@ -107,6 +108,13 @@ const assertAmountMatchesCommittedSellAmount = (params: PrepareSwapTxFromKeysPar
     evm: () => undefined,
     solana: () => undefined,
     transfer: () => undefined,
+    cosmosWasm: ({ funds }) => {
+      if (funds.length !== 1 || !/^[1-9]\d*$/.test(funds[0].amount)) {
+        throw new Error('prepareSwapTxFromKeys: CosmWasm route must commit exactly one positive integer source fund')
+      }
+
+      return BigInt(funds[0].amount)
+    },
     cowswap_order: order => BigInt(order.sellAmount) + BigInt(order.feeAmount),
   })
   if (committed === undefined) return
@@ -114,7 +122,7 @@ const assertAmountMatchesCommittedSellAmount = (params: PrepareSwapTxFromKeysPar
   const requested = toChainAmount(params.amount, params.fromCoin.decimals)
   if (requested !== committed) {
     throw new Error(
-      `prepareSwapTxFromKeys: requested amount (${requested} base units) does not match the CoW order's committed gross sell amount (${committed} base units) — the quote may be stale or for a different request`
+      `prepareSwapTxFromKeys: requested amount (${requested} base units) does not match the route's committed source amount (${committed} base units) — the quote may be stale or for a different request`
     )
   }
 }

--- a/packages/sdk/tests/unit/tools/prep/swap.test.ts
+++ b/packages/sdk/tests/unit/tools/prep/swap.test.ts
@@ -69,16 +69,19 @@ const bindSwapQuote = (
     expiresAt = Date.now() + 600_000,
     fromCoin = ethCoin,
     toCoin = btcCoin,
-  }: { expiresAt?: number; fromCoin?: any; toCoin?: any } = {}
+    recipient,
+  }: { expiresAt?: number; fromCoin?: any; toCoin?: any; recipient?: string } = {}
 ) =>
   ({
     quote,
     discounts: [],
+    recipient,
     requestedAmount,
     expiresAt,
     safetyFingerprint: getSwapQuoteSafetyFingerprint({
       from: fromCoin,
       to: toCoin,
+      recipient,
       requestedAmount,
       expiresAt,
       quote,
@@ -459,6 +462,36 @@ describe('prepareSwapTxFromKeys — amount consistency (ABTS/plan 005)', () => {
         swapQuote: quote,
       })
     ).resolves.toBeDefined()
+  })
+
+  it('forwards the safety-bound effective RUJI recipient to keysign validation', async () => {
+    mockBuildSwapKeysignPayload.mockResolvedValue({ __mock: 'payload' })
+    const recipient = 'thor1customrecipient'
+    const quote = bindSwapQuote(
+      {
+        general: {
+          tx: {
+            cosmosWasm: {
+              sender: thorCoin.address,
+              contract: 'thor1contract',
+              executeMsg: JSON.stringify({ swap: { min: { min_return: '1', to: recipient } } }),
+              funds: [{ denom: 'rune', amount: '100000000' }],
+            },
+          },
+        },
+      },
+      100_000_000n,
+      { fromCoin: thorCoin, toCoin: bruneCoin, recipient }
+    )
+
+    await prepareSwapTxFromKeys(baseIdentity, {
+      fromCoin: thorCoin,
+      toCoin: bruneCoin,
+      amount: '1',
+      swapQuote: quote,
+    })
+
+    expect(mockBuildSwapKeysignPayload).toHaveBeenCalledWith(expect.objectContaining({ recipient }))
   })
 
   it('rejects a RUJI Trade CosmWasm route without exactly one positive source fund', async () => {

--- a/packages/sdk/tests/unit/tools/prep/swap.test.ts
+++ b/packages/sdk/tests/unit/tools/prep/swap.test.ts
@@ -47,6 +47,14 @@ const thorCoin = {
   ticker: 'RUNE',
 } as any
 
+const bruneCoin = {
+  chain: Chain.THORChain,
+  address: 'thor1from',
+  id: 'x/brune',
+  decimals: 8,
+  ticker: 'bRUNE',
+} as any
+
 const btcCoin = {
   chain: Chain.Bitcoin,
   address: 'bc1from',
@@ -361,7 +369,7 @@ describe('prepareSwapTxFromKeys — amount consistency (ABTS/plan 005)', () => {
         amount: '1',
         swapQuote: quote,
       })
-    ).rejects.toThrow(/does not match the CoW order's committed gross sell amount/)
+    ).rejects.toThrow(/does not match the route's committed source amount/)
 
     expect(mockBuildSwapKeysignPayload).not.toHaveBeenCalled()
   })
@@ -392,6 +400,95 @@ describe('prepareSwapTxFromKeys — amount consistency (ABTS/plan 005)', () => {
         swapQuote: quote,
       })
     ).resolves.toBeDefined()
+  })
+
+  it('throws when RUJI Trade CosmWasm funds do not match the bound source amount', async () => {
+    const quote = bindSwapQuote(
+      {
+        general: {
+          tx: {
+            cosmosWasm: {
+              sender: thorCoin.address,
+              contract: 'thor1contract',
+              executeMsg: '{"swap":{}}',
+              funds: [{ denom: 'rune', amount: '99999999' }],
+            },
+          },
+        },
+      },
+      100_000_000n,
+      { fromCoin: thorCoin, toCoin: bruneCoin }
+    )
+
+    await expect(
+      prepareSwapTxFromKeys(baseIdentity, {
+        fromCoin: thorCoin,
+        toCoin: bruneCoin,
+        amount: '1',
+        swapQuote: quote,
+      })
+    ).rejects.toThrow(/does not match the route's committed source amount/)
+
+    expect(mockBuildSwapKeysignPayload).not.toHaveBeenCalled()
+  })
+
+  it('builds when RUJI Trade CosmWasm funds match the bound source amount', async () => {
+    mockBuildSwapKeysignPayload.mockResolvedValue({ __mock: 'payload' })
+    const quote = bindSwapQuote(
+      {
+        general: {
+          tx: {
+            cosmosWasm: {
+              sender: thorCoin.address,
+              contract: 'thor1contract',
+              executeMsg: '{"swap":{}}',
+              funds: [{ denom: 'rune', amount: '100000000' }],
+            },
+          },
+        },
+      },
+      100_000_000n,
+      { fromCoin: thorCoin, toCoin: bruneCoin }
+    )
+
+    await expect(
+      prepareSwapTxFromKeys(baseIdentity, {
+        fromCoin: thorCoin,
+        toCoin: bruneCoin,
+        amount: '1',
+        swapQuote: quote,
+      })
+    ).resolves.toBeDefined()
+  })
+
+  it('rejects a RUJI Trade CosmWasm route without exactly one positive source fund', async () => {
+    const quote = bindSwapQuote(
+      {
+        general: {
+          tx: {
+            cosmosWasm: {
+              sender: thorCoin.address,
+              contract: 'thor1contract',
+              executeMsg: '{"swap":{}}',
+              funds: [],
+            },
+          },
+        },
+      },
+      100_000_000n,
+      { fromCoin: thorCoin, toCoin: bruneCoin }
+    )
+
+    await expect(
+      prepareSwapTxFromKeys(baseIdentity, {
+        fromCoin: thorCoin,
+        toCoin: bruneCoin,
+        amount: '1',
+        swapQuote: quote,
+      })
+    ).rejects.toThrow(/exactly one positive integer source fund/)
+
+    expect(mockBuildSwapKeysignPayload).not.toHaveBeenCalled()
   })
 
   it('throws when an EVM-general quote was fetched for a different source amount', async () => {


### PR DESCRIPTION
Closes #1868
Adds RUJI Trade routing for RUNE ↔ bRUNE through the SDK normal swap and THORChain signing paths.

Real-flow QA remains partial: quote selection, signing, broadcast, and chain inclusion were exercised, but the configured RUJI proxy still returns HTTP 401 `token expired`, so cross-platform FIN discovery and a successful state transition are not proven. This must not be treated as end-to-end success.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RUJI Trade swap quotes for native THORChain RUNE ↔ bRUNE conversions.
  * Added CosmWasm contract execution through the standard swap flow.
  * Added slippage protection, quote expiration, destination routing, and transaction explorer support.
  * Added RUJI Trade to supported providers and swap availability checks.
  * Bound quotes and safety checks to the selected recipient address.

* **Bug Fixes**
  * Improved validation of committed source amounts and attached swap funds.

* **Tests**
  * Added coverage for quote generation, routing, transaction construction, validation, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->