### PR TITLE
fix(chain): don't report a trading halt when an aggregator could still fill

### DIFF
--- a/.changeset/swap-halt-aggregator-retry.md
+++ b/.changeset/swap-halt-aggregator-retry.md
@@ -1,0 +1,8 @@
+---
+'@vultisig/core-chain': patch
+'@vultisig/sdk': patch
+---
+
+fix(swap): stop reporting a native trading halt when an aggregator could still fill
+
+`findSwapQuotes` collapsed a THORChain/MayaChain halt plus a transient aggregator failure into `TradingHalted` for the whole pair, so an ETH→SOL quote surfaced "trading halted" whenever LiFi/SwapKit happened to time out. A halt is scoped to the native protocol that raised it: those aggregators now get one automatic re-attempt, and when they are still unreachable the error reports the transient failure instead of a halt the user cannot retry out of. Halt-only pairs still throw `TradingHalted`.

--- a/packages/core/chain/swap/quote/__tests__/swapQuoteFixtures.ts
+++ b/packages/core/chain/swap/quote/__tests__/swapQuoteFixtures.ts
@@ -25,6 +25,26 @@ export const evmSameChainCoins = {
   },
 } as const
 
+/**
+ * Ethereum → Solana: the cross-chain pair from the trading-halt report. It
+ * registers exactly three fetchers — THORChain (native), LiFi and SwapKit — so a
+ * halt on the native leg still leaves two aggregators that can fill the swap.
+ */
+export const evmToSolanaCoins = {
+  from: {
+    chain: Chain.Ethereum,
+    address: '0xsender',
+    decimals: 18,
+    ticker: 'ETH',
+  },
+  to: {
+    chain: Chain.Solana,
+    address: 'SoLsender',
+    decimals: 9,
+    ticker: 'SOL',
+  },
+} as const
+
 /** An aggregator quote with the minimal fields ranking and binding need. */
 export function minimalGeneralQuote(
   dstAmount: string,

--- a/packages/core/chain/swap/quote/findSwapQuote.halt.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.halt.test.ts
@@ -1,0 +1,137 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { getLifiSwapQuote } from '@vultisig/core-chain/swap/general/lifi/api/getLifiSwapQuote'
+import { getSwapKitQuote } from '@vultisig/core-chain/swap/general/swapkit/api/getSwapKitQuote'
+import { getNativeSwapQuote } from '@vultisig/core-chain/swap/native/api/getNativeSwapQuote'
+import { getNativeSwapTradingHalt } from '@vultisig/core-chain/swap/native/halts/getNativeSwapTradingHalt'
+import { getNativeSwapMinAmountIn } from '@vultisig/core-chain/swap/native/minimum/getNativeSwapMinAmountIn'
+import { SwapError, SwapErrorCode } from '@vultisig/core-chain/swap/SwapError'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { evmToSolanaCoins, minimalGeneralQuote } from './__tests__/swapQuoteFixtures'
+import { findSwapQuotes } from './findSwapQuote'
+
+vi.mock('@vultisig/core-chain/swap/native/minimum/getNativeSwapMinAmountIn', () => ({
+  getNativeSwapMinAmountIn: vi.fn(),
+}))
+vi.mock('@vultisig/core-chain/swap/native/halts/getNativeSwapTradingHalt', () => ({
+  getNativeSwapTradingHalt: vi.fn(),
+}))
+vi.mock('@vultisig/core-chain/swap/native/api/getNativeSwapQuote', () => ({ getNativeSwapQuote: vi.fn() }))
+vi.mock('@vultisig/core-chain/swap/general/lifi/api/getLifiSwapQuote', () => ({ getLifiSwapQuote: vi.fn() }))
+vi.mock('@vultisig/core-chain/swap/general/swapkit/api/getSwapKitQuote', () => ({ getSwapKitQuote: vi.fn() }))
+
+const timeoutError = () => new Error('swap quote fetch timed out after 30000ms')
+const noRouteError = () => new Error('no swap routes found for this pair')
+
+const haltThorchain = () =>
+  vi.mocked(getNativeSwapTradingHalt).mockResolvedValue({
+    swapChain: Chain.THORChain,
+    haltedChains: ['ETH'],
+    reasons: ['ETH chain trading paused'],
+  })
+
+const quoteEthToSol = () => findSwapQuotes({ ...evmToSolanaCoins, amount: 10n ** 18n })
+
+describe('findSwapQuotes with a halted native protocol', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    // ETH -> SOL registers THORChain, LiFi and SwapKit; each test opts providers in.
+    vi.mocked(getNativeSwapQuote).mockRejectedValue(new Error('native unavailable'))
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(noRouteError())
+    vi.mocked(getSwapKitQuote).mockRejectedValue(noRouteError())
+    vi.mocked(getNativeSwapTradingHalt).mockResolvedValue(null)
+    vi.mocked(getNativeSwapMinAmountIn).mockResolvedValue(null)
+  })
+
+  it('returns the aggregator quote when THORChain is halted and LiFi answers', async () => {
+    haltThorchain()
+    vi.mocked(getLifiSwapQuote).mockResolvedValue(minimalGeneralQuote('500', 'li.fi'))
+
+    const { best } = await quoteEthToSol()
+
+    expect('general' in best.quote && best.quote.general.provider).toBe('li.fi')
+    expect(getLifiSwapQuote).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries a transiently-failed aggregator once and returns its quote instead of a halt', async () => {
+    haltThorchain()
+    vi.mocked(getLifiSwapQuote)
+      .mockRejectedValueOnce(timeoutError())
+      .mockResolvedValue(minimalGeneralQuote('500', 'li.fi'))
+
+    const { best } = await quoteEthToSol()
+
+    expect('general' in best.quote && best.quote.general.provider).toBe('li.fi')
+    expect(getLifiSwapQuote).toHaveBeenCalledTimes(2)
+    // The halt belongs to THORChain — re-asking it would only re-confirm the halt.
+    expect(getNativeSwapQuote).toHaveBeenCalledTimes(0)
+    expect(getNativeSwapTradingHalt).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries every transiently-failed aggregator, not just the first', async () => {
+    haltThorchain()
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(timeoutError())
+    vi.mocked(getSwapKitQuote)
+      .mockRejectedValueOnce(new Error('fetch failed'))
+      .mockResolvedValue(minimalGeneralQuote('700', 'swapkit'))
+
+    const { best } = await quoteEthToSol()
+
+    expect('general' in best.quote && best.quote.general.provider).toBe('swapkit')
+    expect(getLifiSwapQuote).toHaveBeenCalledTimes(2)
+    expect(getSwapKitQuote).toHaveBeenCalledTimes(2)
+  })
+
+  it('reports the transient failure rather than a halt when the retry also fails', async () => {
+    haltThorchain()
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(timeoutError())
+
+    const error = await quoteEthToSol().catch((e: unknown) => e)
+
+    expect(error).toBeInstanceOf(SwapError)
+    expect((error as SwapError).code).toBe(SwapErrorCode.AllProvidersFailed)
+    expect((error as SwapError).message).toContain('LiFi')
+    expect((error as SwapError).message).toContain('retry the same swap shortly')
+    expect(getLifiSwapQuote).toHaveBeenCalledTimes(2)
+  })
+
+  it('still throws TradingHalted when every aggregator structurally declined the pair', async () => {
+    haltThorchain()
+
+    const error = await quoteEthToSol().catch((e: unknown) => e)
+
+    expect(error).toBeInstanceOf(SwapError)
+    expect((error as SwapError).code).toBe(SwapErrorCode.TradingHalted)
+    // A structural "no route" is a genuine answer, so nothing is retried.
+    expect(getLifiSwapQuote).toHaveBeenCalledTimes(1)
+    expect(getSwapKitQuote).toHaveBeenCalledTimes(1)
+  })
+
+  it('still throws TradingHalted when THORChain is the only route for the pair', async () => {
+    haltThorchain()
+
+    const error = await findSwapQuotes({
+      ...evmToSolanaCoins,
+      amount: 10n ** 18n,
+      excludeProviders: ['li.fi', 'swapkit'],
+    }).catch((e: unknown) => e)
+
+    expect(error).toBeInstanceOf(SwapError)
+    expect((error as SwapError).code).toBe(SwapErrorCode.TradingHalted)
+    expect(getLifiSwapQuote).not.toHaveBeenCalled()
+    expect(getSwapKitQuote).not.toHaveBeenCalled()
+  })
+
+  it('does not retry transient aggregator failures when no native protocol is halted', async () => {
+    vi.mocked(getLifiSwapQuote).mockRejectedValue(timeoutError())
+    vi.mocked(getSwapKitQuote).mockRejectedValue(timeoutError())
+    vi.mocked(getNativeSwapQuote).mockRejectedValue(timeoutError())
+
+    const error = await quoteEthToSol().catch((e: unknown) => e)
+
+    expect((error as SwapError).code).toBe(SwapErrorCode.AllProvidersFailed)
+    expect(getLifiSwapQuote).toHaveBeenCalledTimes(1)
+    expect(getSwapKitQuote).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/chain/swap/quote/findSwapQuote.halt.test.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.halt.test.ts
@@ -7,7 +7,7 @@ import { getNativeSwapMinAmountIn } from '@vultisig/core-chain/swap/native/minim
 import { SwapError, SwapErrorCode } from '@vultisig/core-chain/swap/SwapError'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { evmToSolanaCoins, minimalGeneralQuote } from './__tests__/swapQuoteFixtures'
+import { evmSameChainCoins, evmToSolanaCoins, minimalGeneralQuote } from './__tests__/swapQuoteFixtures'
 import { findSwapQuotes } from './findSwapQuote'
 
 vi.mock('@vultisig/core-chain/swap/native/minimum/getNativeSwapMinAmountIn', () => ({
@@ -121,6 +121,28 @@ describe('findSwapQuotes with a halted native protocol', () => {
     expect((error as SwapError).code).toBe(SwapErrorCode.TradingHalted)
     expect(getLifiSwapQuote).not.toHaveBeenCalled()
     expect(getSwapKitQuote).not.toHaveBeenCalled()
+  })
+
+  it('reports a second native protocol that timed out as unreachable, not halted', async () => {
+    // Ethereum -> Ethereum routes through both THORChain and MayaChain; excluding
+    // every aggregator leaves the two native protocols on their own.
+    vi.mocked(getNativeSwapTradingHalt).mockImplementation(async ({ swapChain }) =>
+      swapChain === Chain.THORChain
+        ? { swapChain: Chain.THORChain, haltedChains: ['ETH'], reasons: ['ETH chain trading paused'] }
+        : null
+    )
+    vi.mocked(getNativeSwapQuote).mockRejectedValue(timeoutError())
+
+    const error = await findSwapQuotes({
+      ...evmSameChainCoins,
+      amount: 10n ** 18n,
+      excludeProviders: ['cowswap', 'kyber', '1inch', 'li.fi', 'swapkit'],
+    }).catch((e: unknown) => e)
+
+    expect((error as SwapError).code).toBe(SwapErrorCode.AllProvidersFailed)
+    expect((error as SwapError).message).toContain('MayaChain')
+    // Native fetchers stay out of the retry set — only MayaChain was ever asked.
+    expect(getNativeSwapQuote).toHaveBeenCalledTimes(1)
   })
 
   it('does not retry transient aggregator failures when no native protocol is halted', async () => {

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -140,6 +140,14 @@ type RankedSwapQuote = SwapQuoteCandidate & {
 
 const QUOTE_FETCH_TIMEOUT_MS = 30_000
 /**
+ * Budget for the single automatic re-attempt of an aggregator that failed
+ * transiently while a native protocol reported a halt (see
+ * `retryTransientFetchersAfterNativeHalt`). Deliberately shorter than the first
+ * attempt: the provider has already had the full budget and is warm, so a second
+ * full window would only double the wait before the all-fail classification.
+ */
+const QUOTE_FETCH_RETRY_TIMEOUT_MS = 10_000
+/**
  * General aggregators do not expose a uniform quote deadline. Keep the bound
  * transaction usable for a normal review-and-sign round trip while the SDK's
  * presentation layer continues to recommend a refresh after 60 seconds.
@@ -368,6 +376,142 @@ const isTransientProviderFailure = (reason: unknown): boolean => {
     /\b429\b/.test(lower) ||
     lower.includes('skip api network error') ||
     TRANSIENT_PROVIDER_CODE_RE.test(msg)
+  )
+}
+
+/**
+ * The providers whose failure can legitimately mean "this pair is halted".
+ * `assertNativeTradingOpen` only ever runs inside a THORChain/MayaChain fetcher,
+ * so a halt is scoped to the native protocol that raised it — every other
+ * fetcher is an aggregator with its own, independent route.
+ */
+const nativeSwapProviderNames: ReadonlySet<SwapQuoteProviderName> = new Set(['THORChain', 'MayaChain'])
+
+const isTradingHaltedRejection = (reason: unknown): boolean =>
+  asTradingHaltedSwapError(reason) !== null ||
+  isTradingHaltedMsg(reason instanceof Error ? reason.message : String(reason))
+
+/** Indexes of the rejected non-native fetchers that failed transiently. */
+const getTransientAggregatorIndexes = (
+  settled: PromiseSettledResult<RankedSwapQuote>[],
+  fetchers: SwapQuoteFetcher[]
+): number[] =>
+  settled.flatMap((result, index) =>
+    result.status === 'rejected' &&
+    !nativeSwapProviderNames.has(fetchers[index].providerName) &&
+    isTransientProviderFailure(result.reason)
+      ? [index]
+      : []
+  )
+
+type RetryTransientFetchersAfterNativeHaltInput = {
+  settled: PromiseSettledResult<RankedSwapQuote>[]
+  fetchers: SwapQuoteFetcher[]
+  runFetchers: (fetchers: SwapQuoteFetcher[], timeoutMs: number) => Promise<PromiseSettledResult<RankedSwapQuote>[]>
+}
+
+/**
+ * One extra attempt at the aggregators that failed transiently while a native
+ * protocol reported a halt. Without it a THORChain halt plus a LiFi/SwapKit
+ * timeout collapses into "trading halted" for the whole pair, even though the
+ * aggregator — which the halt never applied to — usually answers on the very
+ * next tap. Returns the results unchanged when nothing qualifies, otherwise the
+ * original results with each retried outcome merged back in at its fetcher index.
+ */
+const retryTransientFetchersAfterNativeHalt = async ({
+  settled,
+  fetchers,
+  runFetchers,
+}: RetryTransientFetchersAfterNativeHaltInput): Promise<PromiseSettledResult<RankedSwapQuote>[]> => {
+  const nativeHalted = settled.some(
+    (result, index) =>
+      result.status === 'rejected' &&
+      nativeSwapProviderNames.has(fetchers[index].providerName) &&
+      isTradingHaltedRejection(result.reason)
+  )
+
+  if (!nativeHalted) {
+    return settled
+  }
+
+  const retryIndexes = getTransientAggregatorIndexes(settled, fetchers)
+  if (isEmpty(retryIndexes)) {
+    return settled
+  }
+
+  const retried = await runFetchers(
+    retryIndexes.map(index => fetchers[index]),
+    QUOTE_FETCH_RETRY_TIMEOUT_MS
+  )
+
+  const merged = [...settled]
+  retryIndexes.forEach((fetcherIndex, retryIndex) => {
+    merged[fetcherIndex] = retried[retryIndex]
+  })
+
+  return merged
+}
+
+type HaltAllFailErrorInput = {
+  settled: PromiseSettledResult<RankedSwapQuote>[]
+  fetchers: SwapQuoteFetcher[]
+  proactiveTradingHalt: SwapError | null
+  haltedProviders: ReadonlySet<SwapQuoteProviderName>
+}
+
+/**
+ * How an all-fail round in which some provider reported a halt should be
+ * reported, or `null` when nothing halted and the caller should fall through to
+ * its size/no-route classification.
+ *
+ * Trading-halt takes precedence over the speculative computed minimum and the
+ * generic fallback: when a protocol reports a halt, NO amount can route through
+ * it,
+ * so telling the user to "increase the amount" would be actively misleading. A
+ * genuine provider-reported below-minimum (handled by the caller first) still
+ * wins, since that provider is responding and the amount is the actionable
+ * lever. (#604)
+ *
+ * The halt only speaks for the provider that raised it, though. An aggregator
+ * still unreachable after its retry never declined this pair, so reporting a halt
+ * would send the user off to wait out an outage that was never blocking their
+ * route — while the truthful answer is that the route which could have filled
+ * simply could not be reached. (#2167)
+ */
+const getHaltAllFailError = ({
+  settled,
+  fetchers,
+  proactiveTradingHalt,
+  haltedProviders,
+}: HaltAllFailErrorInput): SwapError | null => {
+  if (!proactiveTradingHalt && haltedProviders.size === 0) {
+    return null
+  }
+
+  const unreachableProviders = getTransientAggregatorIndexes(settled, fetchers).map(
+    index => fetchers[index].providerName
+  )
+
+  if (isEmpty(unreachableProviders)) {
+    return (
+      proactiveTradingHalt ??
+      new SwapError(
+        SwapErrorCode.TradingHalted,
+        formatTradingHaltedMessage(`trading is halted on ${[...haltedProviders].join(', ')}`)
+      )
+    )
+  }
+
+  // Worded to stay classifiable downstream: it names the transient category
+  // (which `isTransientProviderFailure` and agent-backend-ts's
+  // `isTransientQuoteError` both key off) and deliberately avoids the halt
+  // wordings, so a consumer re-classifying this message does not read it back as
+  // a hard halt.
+  return new SwapError(
+    SwapErrorCode.AllProvidersFailed,
+    `Swap quote lookup failed: ${unreachableProviders.join(', ')} could not be reached due to a transient ` +
+      `network/timeout error, and the remaining route(s) (${[...haltedProviders].join(', ')}) are ` +
+      `temporarily unavailable. This is not a missing route — retry the same swap shortly.`
   )
 }
 
@@ -1012,26 +1156,34 @@ export const findSwapQuotes = async (input: FindSwapQuoteInput): Promise<FindSwa
     }
   }
 
-  const settled = await Promise.allSettled(
-    fetchers.map(async (fetcher): Promise<RankedSwapQuote> => {
-      const quote = bindQuoteSafetyMetadata(
-        await withTimeout(fetcher.fetch(), QUOTE_FETCH_TIMEOUT_MS),
-        from,
-        to,
-        amount
-      )
-      return {
-        quote,
-        outputAmount: getComparableOutputAmount(quote, to, fetcher.providerName),
-        sourceGasUnits: getSameChainEvmSourceGasUnits(quote, from, to),
-        providerName: fetcher.providerName,
-      }
-    })
-  )
+  const runFetchers = (list: SwapQuoteFetcher[], timeoutMs: number): Promise<PromiseSettledResult<RankedSwapQuote>[]> =>
+    Promise.allSettled(
+      list.map(async (fetcher): Promise<RankedSwapQuote> => {
+        const quote = bindQuoteSafetyMetadata(await withTimeout(fetcher.fetch(), timeoutMs), from, to, amount)
+        return {
+          quote,
+          outputAmount: getComparableOutputAmount(quote, to, fetcher.providerName),
+          sourceGasUnits: getSameChainEvmSourceGasUnits(quote, from, to),
+          providerName: fetcher.providerName,
+        }
+      })
+    )
+
+  let settled = await runFetchers(fetchers, QUOTE_FETCH_TIMEOUT_MS)
   const best = selectBestEligibleQuote(settled)
 
   if (best) {
     return { best, ranked: rankQuoteCandidates(settled) }
+  }
+
+  // A native halt is not a verdict on the aggregators that ran alongside it, so
+  // give the ones that merely blipped (timeout / network / 5xx) a second chance
+  // before the all-fail classification below can report the pair as halted.
+  settled = await retryTransientFetchersAfterNativeHalt({ settled, fetchers, runFetchers })
+  const bestAfterRetry = selectBestEligibleQuote(settled)
+
+  if (bestAfterRetry) {
+    return { best: bestAfterRetry, ranked: rankQuoteCandidates(settled) }
   }
 
   // Scan rejected results for actionable size-related signals. Prefer the most
@@ -1087,7 +1239,10 @@ export const findSwapQuotes = async (input: FindSwapQuoteInput): Promise<FindSwa
       belowMinimumByProvider.set(fetchers[i].providerName, msg)
     }
 
-    if (isTradingHaltedMsg(msg)) {
+    // Matches the typed `SwapError` from `assertNativeTradingOpen` as well as a
+    // provider's halt wording, so the halt reporting below always knows which
+    // protocol raised it.
+    if (isTradingHaltedRejection(result.reason)) {
       haltedProviders.add(fetchers[i].providerName)
     }
   }
@@ -1104,20 +1259,9 @@ export const findSwapQuotes = async (input: FindSwapQuoteInput): Promise<FindSwa
     )
   }
 
-  if (proactiveTradingHalt) {
-    throw proactiveTradingHalt
-  }
-
-  // Trading-halt takes precedence over the speculative computed minimum and the
-  // generic fallback: when a native protocol reports a halt, NO amount can route,
-  // so telling the user to "increase the amount" would be actively misleading. A
-  // genuine provider-reported below-minimum (handled above) still wins, since
-  // that provider is responding and the amount is the actionable lever. (#604)
-  if (haltedProviders.size > 0) {
-    throw new SwapError(
-      SwapErrorCode.TradingHalted,
-      formatTradingHaltedMessage(`trading is halted on ${[...haltedProviders].join(', ')}`)
-    )
+  const haltError = getHaltAllFailError({ settled, fetchers, proactiveTradingHalt, haltedProviders })
+  if (haltError) {
+    throw haltError
   }
 
   // No provider returned a parseable below-minimum hint. Before falling back to

--- a/packages/core/chain/swap/quote/findSwapQuote.ts
+++ b/packages/core/chain/swap/quote/findSwapQuote.ts
@@ -391,7 +391,11 @@ const isTradingHaltedRejection = (reason: unknown): boolean =>
   asTradingHaltedSwapError(reason) !== null ||
   isTradingHaltedMsg(reason instanceof Error ? reason.message : String(reason))
 
-/** Indexes of the rejected non-native fetchers that failed transiently. */
+/**
+ * Indexes of the rejected non-native fetchers that failed transiently — the
+ * retry set. Native fetchers are excluded: re-asking the protocol that raised
+ * the halt would only re-confirm it.
+ */
 const getTransientAggregatorIndexes = (
   settled: PromiseSettledResult<RankedSwapQuote>[],
   fetchers: SwapQuoteFetcher[]
@@ -401,6 +405,26 @@ const getTransientAggregatorIndexes = (
     !nativeSwapProviderNames.has(fetchers[index].providerName) &&
     isTransientProviderFailure(result.reason)
       ? [index]
+      : []
+  )
+
+/**
+ * Providers that failed transiently without reporting a halt themselves — routes
+ * that never declined this pair and could still fill it. A halt raised elsewhere
+ * cannot speak for them, so their presence rules out reporting the pair as
+ * halted. Unlike the retry set this includes a non-halted native protocol: when
+ * THORChain is halted and MayaChain merely timed out, MayaChain is unreachable,
+ * not halted.
+ */
+const getUnreachableProviderNames = (
+  settled: PromiseSettledResult<RankedSwapQuote>[],
+  fetchers: SwapQuoteFetcher[]
+): SwapQuoteProviderName[] =>
+  settled.flatMap((result, index) =>
+    result.status === 'rejected' &&
+    !isTradingHaltedRejection(result.reason) &&
+    isTransientProviderFailure(result.reason)
+      ? [fetchers[index].providerName]
       : []
   )
 
@@ -472,11 +496,12 @@ type HaltAllFailErrorInput = {
  * wins, since that provider is responding and the amount is the actionable
  * lever. (#604)
  *
- * The halt only speaks for the provider that raised it, though. An aggregator
- * still unreachable after its retry never declined this pair, so reporting a halt
- * would send the user off to wait out an outage that was never blocking their
- * route — while the truthful answer is that the route which could have filled
- * simply could not be reached. (#2167)
+ * The halt only speaks for the provider that raised it, though. Any other route
+ * that was merely unreachable — an aggregator still failing after its retry, or a
+ * second native protocol that timed out — never declined this pair, so reporting
+ * a halt would send the user off to wait out an outage that was never blocking
+ * their route, while the truthful answer is that the route which could have
+ * filled simply could not be reached. (#2167)
  */
 const getHaltAllFailError = ({
   settled,
@@ -488,9 +513,7 @@ const getHaltAllFailError = ({
     return null
   }
 
-  const unreachableProviders = getTransientAggregatorIndexes(settled, fetchers).map(
-    index => fetchers[index].providerName
-  )
+  const unreachableProviders = getUnreachableProviderNames(settled, fetchers)
 
   if (isEmpty(unreachableProviders)) {
     return (


### PR DESCRIPTION
## Description

`findSwapQuotes` treated a native trading halt as a verdict on the whole pair. For ETH→SOL the eligible fetchers are THORChain, LiFi and SwapKit, so a THOR halt plus a LiFi/SwapKit timeout ended in `throw TradingHalted` — the user saw "Trading Halted" and only got a quote by tapping again, once the aggregator was warm.

A halt is scoped to the provider that raised it, so it should never speak for an aggregator that was merely unreachable.

Fixes #2167

### How

- **One automatic retry.** `retryTransientFetchersAfterNativeHalt` re-runs only the non-native fetchers that failed transiently (timeout / network / 5xx / rate limit), and only when a native fetcher actually reported a halt. Results merge back at their fetcher index, so ranking and the below-minimum / no-route classification see the fresh outcomes. Native fetchers are never re-asked — that would only re-confirm the halt.
- **Shorter retry budget** (`QUOTE_FETCH_RETRY_TIMEOUT_MS` = 10s, vs 30s for the first attempt), so the worst case on the all-fail path is 40s rather than 60s. The provider already had the full budget and is warm.
- **Halt reporting is scoped.** `getHaltAllFailError` returns `TradingHalted` only when nothing else was merely unreachable: a halt-only pair, or providers that structurally declined ("no route"). Anything that failed transiently without reporting a halt itself — an aggregator still failing after its retry, or a second native protocol that timed out — returns `AllProvidersFailed` with transient wording instead. That message deliberately avoids the halt wordings, so `isTransientProviderFailure` — and agent-backend-ts's `isTransientQuoteError`, which keys off the same categories — don't re-read it as a hard halt.
- `thorIsSoleRoute` pre-flight and `assertNativeTradingOpen` inside the THOR fetcher are untouched, and aggregators still always run alongside the native fetchers.

### Acceptance criteria

- [x] ETH→SOL, THOR halted, LiFi fulfills → `best` is LiFi
- [x] ETH→SOL, THOR halted, LiFi times out then succeeds on retry → quote, no `TradingHalted`
- [x] THOR-only pair still throws `TradingHalted`

### Scope note

The retry set and the unreachable check are deliberately different sets. Only aggregators are retried — re-asking the protocol that raised the halt would just re-confirm it — but the unreachable check covers *any* provider that failed transiently without reporting a halt itself. That second half was added in `b3db483` after review: a THORChain halt alongside a MayaChain timeout was still reporting `TradingHalted`, which is the same misclassification for a pair both native protocols can route.

## Which feature is affected?

- [x] Swap — quote-selection only; no signing or broadcast path is touched, so there is no tx to attach.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional context

New `findSwapQuote.halt.test.ts` covers 8 cases: the three acceptance criteria, that every transiently-failed aggregator is retried (not just the first), that a still-unreachable aggregator reports the transient failure, that a structural decline is not retried, that nothing is retried when no protocol halted, and the native-vs-native case above. Mostly over the real ETH→SOL fetcher set (THORChain + LiFi + SwapKit); the native-vs-native case uses a same-chain EVM pair with the aggregators excluded, so only THORChain and MayaChain remain. Each behavioural case was verified to fail against the code it fixes; the guard cases pass either way.

Local checks: 3140 core tests pass, `lint` / `format:check` / `knip` clean, `changeset:check-sdk-bundle` passes, and the cognitive-complexity gate on `findSwapQuotes` stays within budget (the halt reporting is extracted for that reason). Two pre-existing failures on this checkout are unrelated and reproduce on a clean `main`: `@scure/bip39/wordlists/*.js` resolution (typecheck + 19 sdk test files) and a `packages/rujira/src/client.ts` `GasPrice` mismatch.

Downstream: vultisig/vultisig-windows#4716 tracks the version bump — it needs no client-side change, since `resolveMarketSwapErrorMessage` already maps `AllProvidersFailed` to a "temporarily unavailable, try again in a moment" string.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved swap quote handling when THORChain or MayaChain is temporarily halted.
  - Automatically retries aggregator quotes after transient failures.
  - Reports a temporary network failure when providers remain unreachable.
  - Preserves clear `TradingHalted` errors for routes blocked by a protocol halt.
  - Improved identification and reporting of affected swap providers.

- **Tests**
  - Added coverage for halted protocols, fallback behavior, retries, provider timeouts, and error reporting across supported swap routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->