### PR TITLE
fix(sdk): export seedphrase ceremony services

### DIFF
--- a/.changeset/r179-seedphrase-services-public-surface.md
+++ b/.changeset/r179-seedphrase-services-public-surface.md
@@ -1,0 +1,6 @@
+---
+'@vultisig/sdk': patch
+'@vultisig/cli': patch
+---
+
+Export the seedphrase ceremony service family on the supported public SDK surfaces and publish a dedicated `@vultisig/sdk/services` subpath.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -151,6 +151,19 @@
       "require": "./dist/seedphrase/index.cjs",
       "default": "./dist/seedphrase/index.cjs"
     },
+    "./services": {
+      "types": "./dist/services/index.d.ts",
+      "browser": "./dist/services/index.js",
+      "worker": "./dist/services/index.js",
+      "react-native": "./dist/services/index.js",
+      "node": {
+        "import": "./dist/services/index.js",
+        "require": "./dist/services/index.cjs"
+      },
+      "import": "./dist/services/index.js",
+      "require": "./dist/services/index.cjs",
+      "default": "./dist/services/index.cjs"
+    },
     "./tools/decode": {
       "types": "./dist/tools/decode/index.d.ts",
       "browser": "./dist/tools/decode/index.js",

--- a/packages/sdk/rollup.platforms.config.js
+++ b/packages/sdk/rollup.platforms.config.js
@@ -348,6 +348,10 @@ const configs = {
       distBase: 'seedphrase',
     }),
     ...createSubpathConfigs({
+      input: './src/services/index.ts',
+      distBase: 'services',
+    }),
+    ...createSubpathConfigs({
       input: './src/tools/decode/index.ts',
       distBase: 'tools/decode',
     }),

--- a/packages/sdk/rollup.types.config.js
+++ b/packages/sdk/rollup.types.config.js
@@ -129,6 +129,7 @@ export default defineConfig([
   // Canonical seedphrase helpers and import/discovery services are published
   // as a narrow declaration surface alongside their dedicated runtime bundle.
   createSubpathTypesConfig('src/seedphrase/index.ts', 'dist/seedphrase/index.d.ts'),
+  createSubpathTypesConfig('src/services/index.ts', 'dist/services/index.d.ts'),
   createSubpathTypesConfig('src/tools/decode/index.ts', 'dist/tools/decode/index.d.ts'),
   createSubpathTypesConfig('src/tx/index.ts', 'dist/tx/index.d.ts'),
 ])

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -485,6 +485,9 @@ export type { PerformReshareParams } from './services/SecureVaultCreationService
 
 // QR payload parsing / generation (for programmatic multi-device coordination)
 export { buildKeygenPairingQrPayload } from './services/buildKeygenPairingQrPayload'
+export { FastVaultFromSeedphraseService } from './services/FastVaultFromSeedphraseService'
+export { JoinSecureVaultService } from './services/JoinSecureVaultService'
+export { SecureVaultFromSeedphraseService } from './services/SecureVaultFromSeedphraseService'
 export type { ParsedKeygenQR } from './utils/parseKeygenQR'
 export { parseKeygenQR } from './utils/parseKeygenQR'
 

--- a/packages/sdk/src/platforms/react-native/index.ts
+++ b/packages/sdk/src/platforms/react-native/index.ts
@@ -732,6 +732,8 @@ export { decodeCosmosTx, decodeEvmTx, decodeFromToolResult } from '../../tools/d
 // chain client dependency. Re-export them here so RN consumers do not have to
 // deep-import internal service/util paths.
 export { buildKeygenPairingQrPayload } from '../../services/buildKeygenPairingQrPayload'
+export { JoinSecureVaultService } from '../../services/JoinSecureVaultService'
+export { SecureVaultFromSeedphraseService } from '../../services/SecureVaultFromSeedphraseService'
 export { computeNotificationVaultId } from '../../utils/computeNotificationVaultId'
 export type {
   AmountDirection,

--- a/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
+++ b/packages/sdk/tests/unit/platforms/react-native/entry.test.ts
@@ -328,7 +328,7 @@ describe('RN entry exposes pure chain helpers and registry', () => {
     const parse = await import('../../../../src/tools/parse')
     const tx = await import('../../../../src/tx')
     const decode = await import('../../../../src/tools/decode')
-    const pairing = await import('../../../../src/services/buildKeygenPairingQrPayload')
+    const services = await import('../../../../src/services')
 
     expect(rn.parseChain).toBe(parse.parseChain)
     expect(rn.parseTicker).toBe(parse.parseTicker)
@@ -340,7 +340,10 @@ describe('RN entry exposes pure chain helpers and registry', () => {
     expect(rn.decodeFromToolResult).toBe(decode.decodeFromToolResult)
     expect(rn.decodeCosmosTx).toBe(decode.decodeCosmosTx)
     expect(rn.decodeEvmTx).toBe(decode.decodeEvmTx)
-    expect(rn.buildKeygenPairingQrPayload).toBe(pairing.buildKeygenPairingQrPayload)
+    expect(rn.buildKeygenPairingQrPayload).toBe(services.buildKeygenPairingQrPayload)
+    expect(rn.FastVaultFromSeedphraseService).toBe(services.FastVaultFromSeedphraseService)
+    expect(rn.JoinSecureVaultService).toBe(services.JoinSecureVaultService)
+    expect(rn.SecureVaultFromSeedphraseService).toBe(services.SecureVaultFromSeedphraseService)
   })
 
   it('re-exports canonical swap tracker URL helpers from the RN entrypoint', async () => {

--- a/packages/sdk/tests/unit/public-api/servicesSubpathExports.test.ts
+++ b/packages/sdk/tests/unit/public-api/servicesSubpathExports.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import * as services from '../../../src/services'
+
+const sdkRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..')
+const sdkPackageJson = JSON.parse(readFileSync(path.join(sdkRoot, 'package.json'), 'utf8'))
+const platformRollupConfig = readFileSync(path.join(sdkRoot, 'rollup.platforms.config.js'), 'utf8')
+const typesRollupConfig = readFileSync(path.join(sdkRoot, 'rollup.types.config.js'), 'utf8')
+
+describe('@vultisig/sdk/services public surface', () => {
+  it('publishes a dedicated conditional export for the services barrel', () => {
+    expect(sdkPackageJson.exports['./services']).toMatchObject({
+      types: './dist/services/index.d.ts',
+      browser: './dist/services/index.js',
+      worker: './dist/services/index.js',
+      'react-native': './dist/services/index.js',
+      node: {
+        import: './dist/services/index.js',
+        require: './dist/services/index.cjs',
+      },
+      import: './dist/services/index.js',
+      require: './dist/services/index.cjs',
+      default: './dist/services/index.cjs',
+    })
+    expect(JSON.stringify(sdkPackageJson.exports['./services'])).not.toContain('dist/index.node')
+  })
+
+  it('keeps dedicated runtime and declaration bundle generation wired', () => {
+    expect(platformRollupConfig).toContain("input: './src/services/index.ts'")
+    expect(platformRollupConfig).toContain("distBase: 'services'")
+    expect(typesRollupConfig).toContain(
+      "createSubpathTypesConfig('src/services/index.ts', 'dist/services/index.d.ts')"
+    )
+  })
+
+  it('exposes the seedphrase ceremony service family without deep imports', () => {
+    expect(services.buildKeygenPairingQrPayload).toBeTypeOf('function')
+    expect(services.FastVaultFromSeedphraseService).toBeTypeOf('function')
+    expect(services.JoinSecureVaultService).toBeTypeOf('function')
+    expect(services.SecureVaultFromSeedphraseService).toBeTypeOf('function')
+  })
+})

--- a/packages/sdk/tests/unit/utils/publicExports.test.ts
+++ b/packages/sdk/tests/unit/utils/publicExports.test.ts
@@ -363,10 +363,13 @@ describe('@vultisig/sdk public exports', () => {
   })
 
   it('exports the pairing-QR payload builder from the root SDK surface', async () => {
-    const services = await import('../../../src/services/buildKeygenPairingQrPayload')
+    const services = await import('../../../src/services')
 
     expect(typeof sdk.buildKeygenPairingQrPayload).toBe('function')
     expect(sdk.buildKeygenPairingQrPayload).toBe(services.buildKeygenPairingQrPayload)
+    expect(sdk.FastVaultFromSeedphraseService).toBe(services.FastVaultFromSeedphraseService)
+    expect(sdk.JoinSecureVaultService).toBe(services.JoinSecureVaultService)
+    expect(sdk.SecureVaultFromSeedphraseService).toBe(services.SecureVaultFromSeedphraseService)
   })
 
   it('exports generic CosmWasm amino and protobuf execute builders', () => {


### PR DESCRIPTION
## Summary
- export the seedphrase ceremony service family from the root SDK surface
- add React Native parity for the missing ceremony classes
- publish a dedicated `@vultisig/sdk/services` package subpath and regression coverage

Closes #2240

## Why
The SDK already owned these ceremony classes internally, but its supported package surface still hid them, pushing consumers toward deep imports and local wrappers.

## Test plan
- [x] `corepack yarn workspace @vultisig/sdk vitest run --config tests/unit/vitest.config.ts tests/unit/utils/publicExports.test.ts tests/unit/platforms/react-native/entry.test.ts tests/unit/public-api/servicesSubpathExports.test.ts`
- [x] `corepack yarn workspace @vultisig/sdk build:platform:node`
- [x] `corepack yarn workspace @vultisig/sdk build:platform:react-native`
- [x] `corepack yarn workspace @vultisig/sdk build:types`
- [x] `corepack yarn workspace @vultisig/sdk pack --out /tmp/sdk-r179-pack/vultisig-sdk-services.tgz`
- [x] fresh temp-consumer import smoke for both `@vultisig/sdk` and `@vultisig/sdk/services`

## Receipts
- Focused Vitest suite: **104 passed**.
- Bundles emitted new runtime outputs for `dist/services/index.{js,cjs}` and new declarations at `dist/services/index.d.ts`.
- Packed-consumer smoke output:

```json
{"root":["buildKeygenPairingQrPayload","FastVaultFromSeedphraseService","JoinSecureVaultService","SecureVaultFromSeedphraseService"],"services":["buildKeygenPairingQrPayload","FastVaultFromSeedphraseService","JoinSecureVaultService","SecureVaultFromSeedphraseService"]}
```

## Notes
- Full `corepack yarn build:sdk` on this clone still fails on the pre-existing Cardano typing error in `packages/core/mpc/keysign/signingInputs/resolvers/cardano.ts` (`auxiliaryData` not accepted by `ISigningInput`). This PR did not touch that area; the public-surface receipts above are from the targeted package builds/tests that exercised the changed boundary.
- Audit report mirror: https://gist.github.com/gomesalexandre/f4ce2a976dfde3209e5b04b405cbf470
